### PR TITLE
perf(react): replace exact keyed windows

### DIFF
--- a/docs/src/app/docs/renderers/react/page.md
+++ b/docs/src/app/docs/renderers/react/page.md
@@ -373,7 +373,8 @@ the compiler proved a direct keyed array prepend and can hand the new prefix to 
 `keyedArraySliceHints` counts direct keyed-array slices whose build-time bounds identify one exact
 retained interval.
 `keyedArrayPositionHints` counts compiler-proven native keyed-array insertions, single or
-contiguous-range removals, and replacements with an exact guarded position.
+contiguous-range removals, single-row replacements, and exact-window replacements with a guarded
+position.
 `keyedArrayReorderHints` counts direct native keyed-array reversals whose complete permutation is
 known at build time.
 `keyedArraySortHints` counts direct native keyed-array sorts whose resulting permutation can be
@@ -1030,6 +1031,7 @@ setItems((current) => current.toSpliced(selectedIndex, 0, ...incomingItems));
 setItems((current) => current.toSpliced(selectedIndex, 1));
 setItems((current) => current.toSpliced(selectedIndex, 25));
 setItems((current) => current.toSpliced(selectedIndex, 1, replacement));
+setItems((current) => current.toSpliced(selectedIndex, 25, ...replacements));
 setItems((current) => current.with(selectedIndex, replacement));
 ```
 
@@ -1038,10 +1040,14 @@ safe-integer literal or a compiler-safe runtime expression. Identifiers, propert
 side-effect-free arithmetic and conditionals, and safe `Math` calls are supported. User-defined
 calls, assignments, update expressions, and other effectful forms are not transformed.
 `toSpliced()` must insert compiler-safe items with a zero delete count, remove one item or a
-contiguous range using a positive safe-integer literal delete count, or replace exactly one item
-with a delete count of one; `with()` must replace exactly one item. An explicit pair or a safe
-spread such as `...incomingItems` selects the batch path when at least two items are produced at
-runtime. Farm preserves the original method lookup,
+contiguous range using a positive safe-integer literal delete count, replace exactly one item with
+a delete count of one, or replace a positive safe-integer literal window with compiler-safe
+explicit items or a safe spread; `with()` must replace exactly one item. A zero delete count with
+an explicit pair or a safe spread such as `...incomingItems` selects the batch insertion path when
+at least two items are produced at runtime. A delete count above one with any incoming item, or a
+positive delete count with multiple items or a spread, selects exact-window replacement; the spread
+may evaluate to zero, one, or many items. Farm
+preserves the original method lookup,
 evaluates every argument once in its original order, and preserves the native call, return value,
 coercion, and thrown errors. If the method is not native, the evaluated position is not already a
 safe integer, or the removal count is dynamic or unsafe, the update still runs normally but no
@@ -1052,7 +1058,9 @@ position, clamped removal count, and any incoming key before changing the DOM. F
 computes every key, descriptor, binding snapshot, and detached host row before mutating the live
 tree. Duplicate incoming keys or collisions with existing keys therefore take complete
 reconciliation without a partial insertion. Valid rows are mounted in one document fragment;
-surrounding elements remain connected and only stored suffix indexes shift. A single insertion
+surrounding elements remain connected and only stored suffix indexes shift. Exact-window
+replacement removes only the proven old interval after every incoming row is prepared. A reused
+key takes complete reconciliation before mutation so React row identity is preserved. A single insertion
 creates one row at that position. A removal cleans up and removes only the known row or contiguous
 range while preserving every
 surviving element. A same-key replacement patches that row in place; a new-key replacement creates
@@ -1063,13 +1071,13 @@ The proof requires compiler-owned host rows whose render and key do not observe 
 Effectful position expressions, runtime values that are fractional or otherwise not safe integers,
 dynamic, zero, negative, or fractional removal counts, other `toSpliced()` shapes, block-bodied
 updaters, unsafe incoming expressions, custom methods, queued uncommitted position updates,
-duplicate or reused keys, collection-reading bindings, React-owned rows, nested host blocks, row
+duplicate or reused incoming keys, collection-reading bindings, React-owned rows, nested host blocks, row
 conditionals, unrelated dirty dependencies, and failed runtime checks keep complete keyed
 reconciliation. Negative safe-integer positions and counts larger than the remaining suffix use the
 native method's normal clamping rules. No new option or component is required. Reports expose
-emitted sites as `keyedArrayPositionHints`. Batch insertions select a separate optional runtime
-capability, so modules with only the existing single-row position operations retain their previous
-runtime size.
+emitted sites as `keyedArrayPositionHints`. Batch insertion and exact-window replacement select
+progressively separate optional runtime capabilities, so modules with only single-row operations
+or batch insertion retain no window-replacement runtime.
 
 #### Keyed array reorder hints
 
@@ -1944,12 +1952,14 @@ The package and example test suites verify more than generated code:
 - 2,000 deterministic randomized keyed-array removals match normal React; targeted tests require
   zero surviving descriptor and binding reads, preserve DOM identity, and cover queued filters,
   unhinted-chain fallback, collection-reading rows, StrictMode hydration, and unmount cleanup;
-- 1,000 deterministic exact-position insertions, single and contiguous-range removals, and
-  replacements match normal React; compiler tests cover literal counts and guarded runtime
+- 1,000 deterministic exact-position insertions, single and contiguous-range removals, single-row
+  replacements, and exact-window replacements match normal React; compiler tests cover literal counts and guarded runtime
   positions, while targeted removal tests require zero surviving key, descriptor, or binding reads,
   preserve focused input and surrounding DOM identity, and cover native evaluation and coercion,
   clamping, unsafe runtime positions and counts, custom methods, queued updates,
-  collection-reading rows, StrictMode hydration, and cleanup;
+  collection-reading rows, StrictMode hydration, and cleanup; targeted window tests additionally
+  require work to equal only the incoming window, preserve retained rows on both sides, and cover
+  empty spreads, key reuse, duplicate keys, delegated events, focus, selection, and queued fallback;
 - 2,000 deterministic randomized reversals match normal React; a 4,096-row targeted test requires
   exactly `n - 1` connected DOM moves and zero key, descriptor, or binding reads, while fallback
   tests cover custom methods, queued updates, collection-reading rows, StrictMode hydration, and

--- a/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
+++ b/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
@@ -2,6 +2,28 @@
 
 Date: 2026-08-29
 
+## Exact-window keyed replacement follow-up — 2026-08-31
+
+The full bracketed production-browser run added an isolated 10,000-row workload for concise native
+`toSpliced(position, 64, ...replacements)` updates. Both compiler builds emitted all six expected
+`keyedArrayPositionHints` sites, preserved retained DOM nodes on both sides, disconnected the exact
+old window, produced zero owner executions, and passed every existing performance, persistence,
+correctness, and scalability gate without lowering a threshold.
+
+| Mode   | React median | Hinted window | Compiled control | vs React | vs control |
+| ------ | -----------: | ------------: | ---------------: | -------: | ---------: |
+| Static |     55.00 ms |       8.40 ms |         19.80 ms |    6.55x |      2.36x |
+| Hybrid |     55.00 ms |       7.80 ms |         19.10 ms |    7.05x |      2.45x |
+
+Package tests separately prove work proportional to the incoming window, preparation before live
+DOM mutation, retained-row identity, empty-spread removal, native negative-position and clamped
+count behavior, reused-key complete reconciliation, duplicate-key fallback, native custom-method
+results and errors, queued-update fallback, controlled-input focus and selection, delegated event
+indexes, 1,000 differential replacements, hydration, Strict Mode, and unmount cleanup. React
+18.3.1 and 19.2.8 both pass the packaged compatibility suite. The isolated window fixture has a
+12,860 B gzip compiler premium; direct and core-only fixtures remain unchanged, and single-row and
+batch-only output do not retain the window runtime feature.
+
 ## Exact-position batch insertion follow-up — 2026-08-30
 
 The full bracketed production-browser run added an isolated 10,000-row workload for concise native

--- a/examples/react-compiler-dashboard/README.md
+++ b/examples/react-compiler-dashboard/README.md
@@ -98,9 +98,10 @@ work proportional only to the incoming suffix.
 Exact-position insertions, removals, and replacements have separate 10,000-row comparisons. Concise
 native `toSpliced(position, 0, item)`, `toSpliced(position, 0, ...items)`, `toSpliced(position, 1)`,
 `toSpliced(position, 64)`, `toSpliced(position, 1, replacement)`, and
-`with(position, replacement)` updates use event-local runtime position variables and are measured
-against bracketed React and equivalent block-bodied compiled controls. The compiler report must
-contain all five dashboard `keyedArrayPositionHints`; package tests separately require zero
+`toSpliced(position, 64, ...replacements)` and `with(position, replacement)` updates use event-local
+runtime position variables and are measured against bracketed React and equivalent block-bodied
+compiled controls. The compiler report must contain all six dashboard `keyedArrayPositionHints`;
+package tests separately require zero
 surviving key/descriptor/binding reads for removal, surrounding DOM identity, randomized
 differential correctness, runtime-position and count fallback, hydration, and cleanup. Both the
 single-row and 64-row removal gates must remain at least 4x faster than React and 1.5x faster than
@@ -110,6 +111,14 @@ The batch insertion case mounts 64 new rows at the middle of a 10,000-row table.
 both surrounding DOM nodes, add no owner executions, remain at least 4x faster than React, and stay
 at least 1.5x faster than the equivalent block-bodied compiled control. This gate is independent of
 the older single-row position gates, so a batch regression cannot hide inside their aggregate.
+
+The exact-window replacement case swaps 64 rows in the middle of a 10,000-row table. It must
+preserve both retained boundary nodes, disconnect both removed boundaries, add no owner
+executions, remain at least 4x faster than React, and stay at least 1.5x faster than the equivalent
+block-bodied compiled control. Package tests require work proportional only to the 64 incoming
+rows and cover empty spreads, negative positions, clamped counts, reused and duplicate keys,
+native custom-method behavior, queued fallback, controlled-input focus and selection, delegated
+events, 1,000 differential replacements, hydration, Strict Mode, and unmount cleanup.
 
 Native keyed-array reversal has a separate 10,000-row comparison. Concise `toReversed()` is
 measured against bracketed React and an equivalent block-bodied compiled control. Both compiler

--- a/examples/react-compiler-dashboard/scripts/benchmark.mjs
+++ b/examples/react-compiler-dashboard/scripts/benchmark.mjs
@@ -143,7 +143,7 @@ async function inspectBuild(compilerMode) {
       "The compiler build did not emit a keyed-array prepend hint.",
     );
     assert(
-      compilerReport.summary.keyedArrayPositionHints >= 5,
+      compilerReport.summary.keyedArrayPositionHints >= 6,
       "The compiler build did not emit the keyed-array exact-position hints.",
     );
     assert(
@@ -638,6 +638,46 @@ async function measureTrial(browser, trial, compilerMode, port) {
                 rowCount() === 10_064 &&
                 table.querySelectorAll("tbody tr")[4_999] === before &&
                 table.querySelectorAll("tbody tr")[5_064] === previousAtPosition,
+            );
+          },
+        );
+
+        const tablePositionWindowReplace = await measureTable(
+          async () => ensure10000(),
+          async () => {
+            const rows = table.querySelectorAll("tbody tr");
+            const before = rows[4_999];
+            const firstRemoved = rows[5_000];
+            const lastRemoved = rows[5_063];
+            const after = rows[5_064];
+            await runTableAction(
+              () => tableButton("table-position-window-replace").click(),
+              () =>
+                rowCount() === 10_000 &&
+                table.querySelectorAll("tbody tr")[4_999] === before &&
+                table.querySelectorAll("tbody tr")[5_064] === after &&
+                !firstRemoved?.isConnected &&
+                !lastRemoved?.isConnected,
+            );
+          },
+        );
+
+        const tablePositionWindowReplaceSnapshot = await measureTable(
+          async () => ensure10000(),
+          async () => {
+            const rows = table.querySelectorAll("tbody tr");
+            const before = rows[4_999];
+            const firstRemoved = rows[5_000];
+            const lastRemoved = rows[5_063];
+            const after = rows[5_064];
+            await runTableAction(
+              () => tableButton("table-position-window-replace-snapshot").click(),
+              () =>
+                rowCount() === 10_000 &&
+                table.querySelectorAll("tbody tr")[4_999] === before &&
+                table.querySelectorAll("tbody tr")[5_064] === after &&
+                !firstRemoved?.isConnected &&
+                !lastRemoved?.isConnected,
             );
           },
         );
@@ -1176,6 +1216,8 @@ async function measureTrial(browser, trial, compilerMode, port) {
             prependSnapshot: tablePrependSnapshot,
             positionBatchInsert: tablePositionBatchInsert,
             positionBatchInsertSnapshot: tablePositionBatchInsertSnapshot,
+            positionWindowReplace: tablePositionWindowReplace,
+            positionWindowReplaceSnapshot: tablePositionWindowReplaceSnapshot,
             positionInsert: tablePositionInsert,
             positionInsertSnapshot: tablePositionInsertSnapshot,
             positionRemove: tablePositionRemove,
@@ -1276,6 +1318,10 @@ async function measureTrial(browser, trial, compilerMode, port) {
         prependSnapshot: timingSummary(result.table.prependSnapshot),
         positionBatchInsert: timingSummary(result.table.positionBatchInsert),
         positionBatchInsertSnapshot: timingSummary(result.table.positionBatchInsertSnapshot),
+        positionWindowReplace: timingSummary(result.table.positionWindowReplace),
+        positionWindowReplaceSnapshot: timingSummary(
+          result.table.positionWindowReplaceSnapshot,
+        ),
         positionInsert: timingSummary(result.table.positionInsert),
         positionInsertSnapshot: timingSummary(result.table.positionInsertSnapshot),
         positionRemove: timingSummary(result.table.positionRemove),
@@ -1372,6 +1418,8 @@ const tableMetrics = [
   "prependSnapshot",
   "positionBatchInsert",
   "positionBatchInsertSnapshot",
+  "positionWindowReplace",
+  "positionWindowReplaceSnapshot",
   "positionInsert",
   "positionInsertSnapshot",
   "positionRemove",
@@ -1643,6 +1691,29 @@ const keyedBatchInsertRegressions = keyedBatchInsertResults.filter(
     speedup < keyedBatchInsertMinimumSpeedup ||
     !Number.isFinite(snapshotSpeedup) ||
     snapshotSpeedup < keyedBatchInsertMinimumSnapshotSpeedup,
+);
+// A compiler-proven toSpliced(position, count, ...items) replacement can validate the retained
+// prefix and suffix, prepare the incoming rows, and swap only that exact DOM window. Keep this
+// 10,000-row/64-row workload independent from the insertion and single-position gates.
+const keyedWindowReplaceMinimumSpeedup = 4;
+const keyedWindowReplaceMinimumSnapshotSpeedup = 1.5;
+const keyedWindowReplaceResults = ["static", "hybrid"].map((mode) => {
+  const windowMedianMs = comparisons.table.positionWindowReplace[mode].medianMs;
+  const snapshotMedianMs = comparisons.table.positionWindowReplaceSnapshot[mode].medianMs;
+  return {
+    mode,
+    snapshotMedianMs,
+    snapshotSpeedup: snapshotMedianMs / windowMedianMs,
+    speedup: comparisons.table.positionWindowReplace[`${mode}VsBaseline`].speedup,
+    windowMedianMs,
+  };
+});
+const keyedWindowReplaceRegressions = keyedWindowReplaceResults.filter(
+  ({ snapshotSpeedup, speedup }) =>
+    !Number.isFinite(speedup) ||
+    speedup < keyedWindowReplaceMinimumSpeedup ||
+    !Number.isFinite(snapshotSpeedup) ||
+    snapshotSpeedup < keyedWindowReplaceMinimumSnapshotSpeedup,
 );
 // Native toSpliced()/with() calls with event-local runtime positions expose one exact insertion,
 // removal, or replacement position. The hinted runtime should beat both React and an equivalent
@@ -1917,6 +1988,7 @@ const passed =
   keyedSliceRegressions.length === 0 &&
   keyedRollingWindowRegressions.length === 0 &&
   keyedBatchInsertRegressions.length === 0 &&
+  keyedWindowReplaceRegressions.length === 0 &&
   keyedPositionRegressions.length === 0 &&
   keyedRangeRemovalRegressions.length === 0 &&
   keyedReorderRegressions.length === 0 &&
@@ -1976,6 +2048,13 @@ const report = {
     regressions: keyedBatchInsertRegressions,
     results: keyedBatchInsertResults,
     status: keyedBatchInsertRegressions.length === 0 ? "PASS" : "FAIL",
+  },
+  keyedWindowReplaceHintGate: {
+    minimumSnapshotSpeedup: keyedWindowReplaceMinimumSnapshotSpeedup,
+    minimumSpeedup: keyedWindowReplaceMinimumSpeedup,
+    regressions: keyedWindowReplaceRegressions,
+    results: keyedWindowReplaceResults,
+    status: keyedWindowReplaceRegressions.length === 0 ? "PASS" : "FAIL",
   },
   keyedPositionHintGate: {
     insertMinimumSnapshotSpeedup: keyedPositionInsertMinimumSnapshotSpeedup,

--- a/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
+++ b/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
@@ -317,6 +317,38 @@ export function StandardTableBenchmark() {
           Insert 64 at runtime position (snapshot control)
         </button>
         <button
+          data-action="table-position-window-replace"
+          type="button"
+          onClick={() => {
+            const nextSeed = seed + 1;
+            const replacements = buildRows(64, nextSeed);
+            const position = 5_000;
+            setSeed(nextSeed);
+            setRows((current) => current.toSpliced(position, 64, ...replacements));
+            setOperation("replace 64-row runtime window");
+            setRevision((value) => value + 1);
+          }}
+        >
+          Replace 64-row runtime window
+        </button>
+        <button
+          data-action="table-position-window-replace-snapshot"
+          type="button"
+          onClick={() => {
+            const nextSeed = seed + 1;
+            const replacements = buildRows(64, nextSeed);
+            const position = 5_000;
+            setSeed(nextSeed);
+            setRows((current) => {
+              return current.toSpliced(position, 64, ...replacements);
+            });
+            setOperation("replace 64-row runtime window (snapshot control)");
+            setRevision((value) => value + 1);
+          }}
+        >
+          Replace 64-row runtime window (snapshot control)
+        </button>
+        <button
           data-action="table-position-remove"
           type="button"
           onClick={() => {

--- a/packages/farm-react/README.md
+++ b/packages/farm-react/README.md
@@ -306,29 +306,34 @@ setItems((current) => current.toSpliced(selectedIndex, 0, ...incomingItems));
 setItems((current) => current.toSpliced(selectedIndex, 1));
 setItems((current) => current.toSpliced(selectedIndex, 25));
 setItems((current) => current.toSpliced(selectedIndex, 1, replacement));
+setItems((current) => current.toSpliced(selectedIndex, 25, ...replacements));
 setItems((current) => current.with(selectedIndex, replacement));
 ```
 
 The compiler recognizes only a concise functional setter and either a safe-integer literal or a
 compiler-safe runtime position expression, such as an identifier, property read, arithmetic,
 conditional, or safe `Math` call. The update must insert one or more compiler-safe items with zero
-removals, remove one item or a fixed positive safe-integer literal range, or replace one item
-through either `toSpliced()` or `with()`. Farm preserves method lookup,
+removals, remove one item or a fixed positive safe-integer literal range, replace one item through
+either `toSpliced()` or `with()`, or replace a fixed positive safe-integer literal window with
+compiler-safe explicit items or a safe spread. Farm preserves method lookup,
 evaluates the position and remaining arguments once in their original order, executes the ordinary
 native call, and records metadata only after validating the committed native source, result, and
 actual safe-integer position and clamped removal count. A batch requires at least two evaluated
-items at runtime. Farm creates every incoming key, descriptor, binding snapshot, and detached row
-before changing the live DOM, rejects key collisions, and inserts the complete batch through one
-document fragment. The runtime otherwise creates one inserted row,
+items at runtime. Exact-window replacement supports a safe spread that evaluates to zero, one, or
+many items. Farm creates every incoming key, descriptor, binding snapshot, and detached row before
+changing the live DOM, rejects key collisions, and mounts the complete incoming batch through one
+document fragment. It then removes only the replaced window. The runtime otherwise creates one inserted row,
 removes only the known row or range, or patches/replaces one row at that position without rereading
 every existing key, descriptor, and binding. Surviving rows keep their DOM identity. Index-aware or
 collection-reading rows, custom methods, position expressions with user calls or mutations,
 runtime positions that are not safe integers, dynamic, zero, negative, or fractional removal
 counts, other `toSpliced()` forms, block-bodied updaters, unsafe incoming expressions, queued
 uncommitted updates, reused keys, nested or React-owned rows, and failed checks use complete keyed
-reconciliation. Reports expose the site count as `keyedArrayPositionHints`. Batch insertion uses a
-separate optional runtime capability, so existing single-position and non-position bundles do not
-retain its validation or fragment-mounting code.
+reconciliation. Reusing a key from the replaced window is valid React behavior, so it takes the
+complete keyed reconciliation path and preserves that row instance. Reports expose the site count
+as `keyedArrayPositionHints`. Batch insertion and exact-window replacement use progressively
+separate optional runtime capabilities, so existing single-position and batch-only bundles do not
+retain window validation or replacement code.
 
 A direct native reverse can carry its complete permutation to a separate optional runtime:
 
@@ -668,7 +673,8 @@ reasons aggregated by count. Its summary and per-module `optimizations` also rep
 `keyedArrayFilterHints`, the number of compiler-proven direct keyed-array filter sites; and
 `keyedArrayPrependHints`, the number of compiler-proven direct keyed-array prepend sites; and
 `keyedArrayPositionHints`, the number of compiler-proven native exact-position insertion, single or
-contiguous-range removal, or replacement sites, including guarded compiler-safe runtime positions;
+contiguous-range removal, single-row replacement, or exact-window replacement sites, including
+guarded compiler-safe runtime positions;
 and
 `keyedArrayReorderHints`, the number of compiler-proven direct native keyed-array reverse sites; and
 `keyedArraySortHints`, the number of compiler-proven direct native keyed-array sort sites; and

--- a/packages/farm-react/RUNTIME_SIZE_RESULTS.json
+++ b/packages/farm-react/RUNTIME_SIZE_RESULTS.json
@@ -43,14 +43,14 @@
         "brotli": 51772
       },
       "compilerOn": {
-        "raw": 233831,
-        "gzip": 71694,
-        "brotli": 61471
+        "raw": 233851,
+        "gzip": 71698,
+        "brotli": 61472
       },
       "compilerPremium": {
-        "raw": 40930,
-        "gzip": 11609,
-        "brotli": 9699
+        "raw": 40950,
+        "gzip": 11613,
+        "brotli": 9700
       }
     },
     "keyedFilter": {
@@ -94,14 +94,14 @@
         "brotli": 51741
       },
       "compilerOn": {
-        "raw": 236016,
-        "gzip": 72264,
-        "brotli": 61915
+        "raw": 236212,
+        "gzip": 72361,
+        "brotli": 61947
       },
       "compilerPremium": {
-        "raw": 43118,
-        "gzip": 12188,
-        "brotli": 10174
+        "raw": 43314,
+        "gzip": 12285,
+        "brotli": 10206
       }
     },
     "keyedBatchPosition": {
@@ -119,6 +119,23 @@
         "raw": 44543,
         "gzip": 12470,
         "brotli": 10463
+      }
+    },
+    "keyedWindowPosition": {
+      "compilerOff": {
+        "raw": 192941,
+        "gzip": 60102,
+        "brotli": 51748
+      },
+      "compilerOn": {
+        "raw": 239436,
+        "gzip": 72962,
+        "brotli": 62527
+      },
+      "compilerPremium": {
+        "raw": 46495,
+        "gzip": 12860,
+        "brotli": 10779
       }
     },
     "keyedReorder": {
@@ -196,18 +213,18 @@
         "brotli": 51666
       },
       "full": {
-        "raw": 281382,
-        "gzip": 79585,
-        "brotli": 68029
+        "raw": 283218,
+        "gzip": 79940,
+        "brotli": 68262
       },
       "coreOnly": {
         "raw": 204922,
         "gzip": 63685,
         "brotli": 54902
       },
-      "fullRuntimePremiumGzip": 19666,
+      "fullRuntimePremiumGzip": 20021,
       "coreRuntimePremiumGzip": 3766,
-      "gzipReductionPercent": 80.9
+      "gzipReductionPercent": 81.2
     }
   }
 }

--- a/packages/farm-react/fixtures/runtime-size/keyed-window-position.tsx
+++ b/packages/farm-react/fixtures/runtime-size/keyed-window-position.tsx
@@ -1,0 +1,46 @@
+import { useState } from "react";
+import { createRoot } from "react-dom/client";
+
+declare global {
+  interface Array<T> {
+    toSpliced(start: number, deleteCount: number, ...items: T[]): T[];
+  }
+}
+
+interface Row {
+  id: number;
+  label: string;
+}
+
+interface WindowPositionTableProps {
+  incoming: Row[];
+}
+
+export function WindowPositionTable({ incoming }: WindowPositionTableProps) {
+  const [rows, setRows] = useState<Row[]>([
+    { id: 1, label: "Alpha" },
+    { id: 2, label: "Beta" },
+    { id: 3, label: "Gamma" },
+  ]);
+  return (
+    <main>
+      <button onClick={() => setRows((current) => current.toSpliced(1, 2, ...incoming))}>
+        Replace rows
+      </button>
+      <ul>
+        {rows.map((row) => (
+          <li key={row.id}>{row.label}</li>
+        ))}
+      </ul>
+    </main>
+  );
+}
+
+createRoot(document.body).render(
+  <WindowPositionTable
+    incoming={[
+      { id: 4, label: "Delta" },
+      { id: 5, label: "Epsilon" },
+    ]}
+  />,
+);

--- a/packages/farm-react/scripts/benchmark-runtime-size.mjs
+++ b/packages/farm-react/scripts/benchmark-runtime-size.mjs
@@ -63,6 +63,8 @@ const [
   keyedPositionOn,
   keyedBatchPositionOff,
   keyedBatchPositionOn,
+  keyedWindowPositionOff,
+  keyedWindowPositionOn,
   keyedReorderOff,
   keyedReorderOn,
   keyedSortOff,
@@ -89,6 +91,8 @@ const [
   bundle("keyed-position.tsx", true),
   bundle("keyed-batch-position.tsx", false),
   bundle("keyed-batch-position.tsx", true),
+  bundle("keyed-window-position.tsx", false),
+  bundle("keyed-window-position.tsx", true),
   bundle("keyed-reorder.tsx", false),
   bundle("keyed-reorder.tsx", true),
   bundle("keyed-sort.tsx", false),
@@ -191,9 +195,22 @@ if (
 }
 if (
   keyedPositionOn.code.includes("keyed-rows:batch-position-hinted") ||
-  keyedPositionOn.code.includes("createCompilerKeyedArrayBatchInsert")
+  keyedPositionOn.code.includes("createCompilerKeyedArrayBatchInsert") ||
+  keyedPositionOn.code.includes("keyed-rows:window-position-hinted")
 ) {
-  throw new Error("Single-row position fixture retained the optional batch-insertion runtime.");
+  throw new Error("Single-row position fixture retained an optional multi-row runtime.");
+}
+if (keyedBatchPositionOn.code.includes("keyed-rows:window-position-hinted")) {
+  throw new Error("Batch-position fixture retained the optional window-replacement runtime.");
+}
+if (
+  !keyedWindowPositionOn.code.includes("FarmCompiledKeyedRows") ||
+  !keyedWindowPositionOn.code.includes("keyed-rows:window-position-hinted") ||
+  !keyedWindowPositionOn.code.includes("positionIndexIndependent")
+) {
+  throw new Error(
+    `Keyed window-position fixture did not retain its isolated window runtime: rows=${keyedWindowPositionOn.code.includes("FarmCompiledKeyedRows")}, feature=${keyedWindowPositionOn.code.includes("keyed-rows:window-position-hinted")}, proof=${keyedWindowPositionOn.code.includes("positionIndexIndependent")}.`,
+  );
 }
 if (
   !keyedReorderOn.code.includes("FarmCompiledKeyedRows") ||
@@ -362,6 +379,23 @@ const results = {
         brotli: keyedBatchPositionOn.brotli - keyedBatchPositionOff.brotli,
       },
     },
+    keyedWindowPosition: {
+      compilerOff: {
+        raw: keyedWindowPositionOff.raw,
+        gzip: keyedWindowPositionOff.gzip,
+        brotli: keyedWindowPositionOff.brotli,
+      },
+      compilerOn: {
+        raw: keyedWindowPositionOn.raw,
+        gzip: keyedWindowPositionOn.gzip,
+        brotli: keyedWindowPositionOn.brotli,
+      },
+      compilerPremium: {
+        raw: keyedWindowPositionOn.raw - keyedWindowPositionOff.raw,
+        gzip: keyedWindowPositionOn.gzip - keyedWindowPositionOff.gzip,
+        brotli: keyedWindowPositionOn.brotli - keyedWindowPositionOff.brotli,
+      },
+    },
     keyedReorder: {
       compilerOff: {
         raw: keyedReorderOff.raw,
@@ -486,6 +520,13 @@ if (checkOnly) {
       maximum:
         (reference.fixtures.keyedBatchPosition?.compilerPremium.gzip ??
           results.fixtures.keyedBatchPosition.compilerPremium.gzip) + 256,
+    },
+    {
+      name: "keyed window-position compiler premium",
+      current: results.fixtures.keyedWindowPosition.compilerPremium.gzip,
+      maximum:
+        (reference.fixtures.keyedWindowPosition?.compilerPremium.gzip ??
+          results.fixtures.keyedWindowPosition.compilerPremium.gzip) + 256,
     },
     {
       name: "keyed reorder compiler premium",

--- a/packages/farm-react/scripts/test-react-version.mjs
+++ b/packages/farm-react/scripts/test-react-version.mjs
@@ -50,6 +50,7 @@ const testSource = String.raw`
     createCompilerKeyedArrayReorder,
     createCompilerKeyedArraySort,
     createCompilerKeyedArraySlice,
+    createCompilerKeyedArrayWindowReplace,
     createCompilerKeyedMapUpdate,
   } = await import(
     "@farm.js/react/compiler-runtime"
@@ -92,6 +93,7 @@ const testSource = String.raw`
   let reverseCompatibilityRows = () => undefined;
   let insertCompatibilityRows = () => undefined;
   let removeCompatibilityRow = () => undefined;
+  let replaceCompatibilityRows = () => undefined;
   let sortCompatibilityRows = () => undefined;
   let reorderExecutions = 0;
   const ReorderRows = createCompiledComponent({
@@ -126,6 +128,17 @@ const testSource = String.raw`
             1,
             { id: "d", label: "Delta", rank: 4 },
             { id: "e", label: "Epsilon", rank: 5 },
+          ),
+        );
+      replaceCompatibilityRows = () =>
+        state[0].set((previous) =>
+          createCompilerKeyedArrayWindowReplace(
+            previous,
+            previous.toSpliced,
+            1,
+            2,
+            { id: "f", label: "Phi", rank: 6 },
+            { id: "g", label: "Gamma two", rank: 7 },
           ),
         );
       sortCompatibilityRows = () =>
@@ -201,6 +214,15 @@ const testSource = String.raw`
   assert.equal(reorderContainer.querySelectorAll("li").length, 4);
   assert.equal(reorderContainer.querySelectorAll("li")[1].textContent, "Delta");
   assert.equal(reorderContainer.querySelectorAll("li")[2].textContent, "Epsilon");
+  assert.equal(reorderContainer.querySelector("li:first-child"), reorderBeta);
+  assert.equal(reorderContainer.querySelector("li:last-child"), reorderAlpha);
+  assert.equal(reorderExecutions, 1);
+  replaceCompatibilityRows();
+  await Promise.resolve();
+  await Promise.resolve();
+  assert.equal(reorderContainer.querySelectorAll("li").length, 4);
+  assert.equal(reorderContainer.querySelectorAll("li")[1].textContent, "Phi");
+  assert.equal(reorderContainer.querySelectorAll("li")[2].textContent, "Gamma two");
   assert.equal(reorderContainer.querySelector("li:first-child"), reorderBeta);
   assert.equal(reorderContainer.querySelector("li:last-child"), reorderAlpha);
   assert.equal(reorderExecutions, 1);

--- a/packages/farm-react/src/__tests__/compiler-keyed-array-position-hints.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-keyed-array-position-hints.test.ts
@@ -65,6 +65,28 @@ describe("React AOT keyed-array position hints", () => {
     expect(result.code).toContain("createCompilerKeyedArrayBatchInsert");
     expect(result.code).toContain("keyedRowsBatchPositionHintedRuntimeFeature");
     expect(result.code).not.toContain("createCompilerKeyedArrayPositionUpdate");
+    expect(result.code).not.toContain("createCompilerKeyedArrayWindowReplace");
+  });
+
+  it("records exact-window replacements without retaining older position helpers", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Table({ first, second, incoming, offset }) {
+        const [rows, setRows] = useState([{ id: "a", label: "Alpha" }]);
+        return <section>
+          <button onClick={() => setRows((current) => current.toSpliced(offset, 2, first, second))}>Replace pair</button>
+          <button onClick={() => setRows((current) => current.toSpliced(offset, 2, first))}>Replace with one</button>
+          <button onClick={() => setRows((current) => current.toSpliced(-3, 4, ...incoming))}>Replace window</button>
+          <ul>{rows.map((row) => <li key={row.id}>{row.label}</li>)}</ul>
+        </section>;
+      }
+    `);
+
+    expect(result.optimizations.keyedArrayPositionHints).toBe(3);
+    expect(result.code).toContain("createCompilerKeyedArrayWindowReplace");
+    expect(result.code).toContain("keyedRowsWindowPositionHintedRuntimeFeature");
+    expect(result.code).not.toContain("createCompilerKeyedArrayPositionUpdate");
+    expect(result.code).not.toContain("createCompilerKeyedArrayBatchInsert");
   });
 
   it("records compiler-safe runtime position expressions", async () => {
@@ -144,9 +166,9 @@ describe("React AOT keyed-array position hints", () => {
       update: "current.slice().toSpliced(0, 1)",
     },
     {
-      name: "a multi-item replacement",
+      name: "a dynamic replacement count",
       row: "row => <li key={row.id}>{row.label}</li>",
-      update: "current.toSpliced(0, 1, next, next)",
+      update: "current.toSpliced(0, deleteCount, next, next)",
     },
     {
       name: "an unsafe incoming spread call",
@@ -187,5 +209,7 @@ describe("React AOT keyed-array position hints", () => {
 
     expect(result.optimizations.keyedArrayPositionHints).toBe(0);
     expect(result.code).not.toContain("createCompilerKeyedArrayPositionUpdate");
+    expect(result.code).not.toContain("createCompilerKeyedArrayBatchInsert");
+    expect(result.code).not.toContain("createCompilerKeyedArrayWindowReplace");
   });
 });

--- a/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-window-replace-hints.test.tsx
+++ b/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-window-replace-hints.test.tsx
@@ -1,0 +1,565 @@
+import React, { StrictMode, useState } from "react";
+import { act } from "react";
+import { createRoot, hydrateRoot, type Root } from "react-dom/client";
+import { renderToString } from "react-dom/server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createCompiledComponentWithFeatures,
+  createCompilerKeyedArrayWindowReplace,
+  keyedRowsWindowPositionHintedRuntimeFeature,
+  type CompilerKeyedRowElement,
+} from "../compiler-runtime";
+
+declare global {
+  var IS_REACT_ACT_ENVIRONMENT: boolean;
+}
+
+interface Item {
+  id: string;
+  label: string;
+}
+
+type WindowArray = Item[] & {
+  toSpliced(start: number, deleteCount: number, ...items: Item[]): Item[];
+};
+
+const roots: Root[] = [];
+
+beforeEach(() => {
+  globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+afterEach(async () => {
+  await act(async () => {
+    for (const root of roots.splice(0)) root.unmount();
+  });
+  document.body.replaceChildren();
+  vi.restoreAllMocks();
+});
+
+async function flushCompilerUpdates(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+function hintedWindowReplace(
+  previous: Item[],
+  position: number,
+  deleteCount: number,
+  items: readonly Item[],
+): Item[] {
+  const source = previous as WindowArray;
+  return createCompilerKeyedArrayWindowReplace(
+    source,
+    source.toSpliced,
+    position,
+    deleteCount,
+    ...items,
+  ) as Item[];
+}
+
+function rowDescriptor(item: Item): CompilerKeyedRowElement {
+  return {
+    kind: "element",
+    tag: "li",
+    attributes: [{ name: "data-key", value: item.id }],
+    styles: [],
+    children: [item.label],
+  };
+}
+
+function createWindowHarness(initialItems: Item[]) {
+  const counters = { executions: 0, renders: 0, keys: 0, descriptors: 0, bindings: 0 };
+  let replace: (position: number, deleteCount: number, items: readonly Item[]) => void = () =>
+    undefined;
+  let queueTwo: (first: readonly Item[], second: readonly Item[]) => void = () => undefined;
+  let customReplace: (items: readonly Item[]) => void = () => undefined;
+  const Table = createCompiledComponentWithFeatures(
+    {
+      displayName: "WindowReplaceTable",
+      initialize: () => [initialItems],
+      render(_props: Record<string, never>, state, blocks) {
+        counters.executions += 1;
+        const items = () => state[0].get() as Item[];
+        replace = (position, deleteCount, incoming) =>
+          state[0].set((previous) =>
+            hintedWindowReplace(previous as Item[], position, deleteCount, incoming),
+          );
+        queueTwo = (first, second) => {
+          state[0].set((previous) => hintedWindowReplace(previous as Item[], 1, 2, first));
+          state[0].set((previous) => hintedWindowReplace(previous as Item[], 2, 1, second));
+        };
+        customReplace = (incoming) =>
+          state[0].set((previous) => {
+            const source = previous as Item[];
+            const method = function (this: Item[], start: number, remove: number, ...next: Item[]) {
+              return [...this.slice(0, start), ...next, ...this.slice(start + remove)].reverse();
+            };
+            return createCompilerKeyedArrayWindowReplace(source, method, 1, 2, ...incoming);
+          });
+        return (
+          <section>
+            <blocks.KeyedRows
+              collectionDependency={0}
+              dependencies={[0]}
+              id={0}
+              items={items}
+              positionIndexIndependent
+              structureDependencies={[0]}
+              render={() => {
+                counters.renders += 1;
+                return (
+                  <ul>
+                    {items().map((item) => (
+                      <li data-key={item.id} key={item.id}>
+                        {item.label}
+                      </li>
+                    ))}
+                  </ul>
+                );
+              }}
+              rowKey={(item) => {
+                counters.keys += 1;
+                return (item as Item).id;
+              }}
+              create={(item) => {
+                counters.descriptors += 1;
+                return rowDescriptor(item as Item);
+              }}
+              bindings={[
+                {
+                  kind: "text",
+                  path: [],
+                  read: (item) => {
+                    counters.bindings += 1;
+                    return [(item as Item).label];
+                  },
+                },
+              ]}
+            />
+          </section>
+        );
+      },
+      bindings: [{ kind: "block", id: 0, dependencies: [0] }],
+    },
+    [keyedRowsWindowPositionHintedRuntimeFeature],
+  );
+  return {
+    Table,
+    counters,
+    customReplace: (items: readonly Item[]) => customReplace(items),
+    queueTwo: (first: readonly Item[], second: readonly Item[]) => queueTwo(first, second),
+    replace: (position: number, deleteCount: number, items: readonly Item[]) =>
+      replace(position, deleteCount, items),
+  };
+}
+
+describe("compiled keyed-array window replacement hints", () => {
+  it("preserves native method arguments, return values, and errors", () => {
+    const source = [
+      { id: "a", label: "Alpha" },
+      { id: "b", label: "Beta" },
+    ];
+    const first = { id: "c", label: "Gamma" };
+    const second = { id: "d", label: "Delta" };
+    const calls: unknown[][] = [];
+    const custom = function (this: Item[], ...args: unknown[]) {
+      calls.push([this, ...args]);
+      return { custom: true };
+    };
+
+    expect(createCompilerKeyedArrayWindowReplace(source, custom, -1, 9, first, second)).toEqual({
+      custom: true,
+    });
+    expect(calls).toEqual([[source, -1, 9, first, second]]);
+
+    const error = new Error("custom window failure");
+    expect(() =>
+      createCompilerKeyedArrayWindowReplace(
+        source,
+        () => {
+          throw error;
+        },
+        0,
+        1,
+        first,
+      ),
+    ).toThrow(error);
+  });
+
+  it("replaces one exact window without reading or replacing retained rows", async () => {
+    const initialItems = Array.from(
+      { length: 4_096 },
+      (_, index): Item => ({ id: `row-${index}`, label: `Row ${index}` }),
+    );
+    const harness = createWindowHarness(initialItems);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Table />));
+    const before = container.querySelector('[data-key="row-2047"]');
+    const firstRemoved = container.querySelector('[data-key="row-2048"]');
+    const lastRemoved = container.querySelector('[data-key="row-2111"]');
+    const after = container.querySelector('[data-key="row-2112"]');
+    harness.counters.keys = 0;
+    harness.counters.descriptors = 0;
+    harness.counters.bindings = 0;
+    const incoming = Array.from(
+      { length: 64 },
+      (_, index): Item => ({ id: `replace-${index}`, label: `Replace ${index}` }),
+    );
+
+    await act(async () => {
+      harness.replace(2_048, 64, incoming);
+      await flushCompilerUpdates();
+    });
+
+    const rows = [...container.querySelectorAll("li")];
+    expect(rows[2_047]).toBe(before);
+    expect(rows[2_048]?.textContent).toBe("Replace 0");
+    expect(rows[2_111]?.textContent).toBe("Replace 63");
+    expect(rows[2_112]).toBe(after);
+    expect(firstRemoved?.isConnected).toBe(false);
+    expect(lastRemoved?.isConnected).toBe(false);
+    expect(rows).toHaveLength(4_096);
+    expect(harness.counters).toEqual({
+      executions: 1,
+      renders: 1,
+      keys: 64,
+      descriptors: 64,
+      bindings: 64,
+    });
+  });
+
+  it("supports empty incoming spreads, negative positions, and clamped delete counts", async () => {
+    const harness = createWindowHarness([
+      { id: "a", label: "Alpha" },
+      { id: "b", label: "Beta" },
+      { id: "c", label: "Gamma" },
+      { id: "d", label: "Delta" },
+      { id: "e", label: "Epsilon" },
+    ]);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Table />));
+    const alpha = container.querySelector('[data-key="a"]');
+    const beta = container.querySelector('[data-key="b"]');
+    harness.counters.keys = 0;
+    harness.counters.descriptors = 0;
+    harness.counters.bindings = 0;
+
+    await act(async () => {
+      harness.replace(-3, 99, []);
+      await flushCompilerUpdates();
+    });
+
+    expect(container.textContent).toBe("AlphaBeta");
+    expect(container.querySelector('[data-key="a"]')).toBe(alpha);
+    expect(container.querySelector('[data-key="b"]')).toBe(beta);
+    expect(harness.counters.keys).toBe(0);
+    expect(harness.counters.descriptors).toBe(0);
+    expect(harness.counters.bindings).toBe(0);
+  });
+
+  it("takes complete reconciliation before mutation for reused or duplicate keys", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const harness = createWindowHarness([
+      { id: "a", label: "Alpha" },
+      { id: "b", label: "Beta" },
+      { id: "c", label: "Gamma" },
+      { id: "d", label: "Delta" },
+    ]);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Table />));
+    const gamma = container.querySelector('[data-key="c"]');
+    harness.counters.keys = 0;
+
+    await act(async () => {
+      harness.replace(1, 2, [
+        { id: "c", label: "Gamma retained" },
+        { id: "e", label: "Epsilon" },
+      ]);
+      await flushCompilerUpdates();
+    });
+    expect(container.querySelector('[data-key="c"]')).toBe(gamma);
+    expect(gamma?.textContent).toBe("Gamma retained");
+    expect(harness.counters.keys).toBeGreaterThan(2);
+
+    harness.counters.keys = 0;
+    await act(async () => {
+      harness.replace(1, 2, [
+        { id: "f", label: "Phi one" },
+        { id: "f", label: "Phi two" },
+      ]);
+      await flushCompilerUpdates();
+    });
+    expect(container.textContent).toBe("AlphaPhi onePhi twoDelta");
+    expect(harness.counters.keys).toBeGreaterThan(2);
+    expect(console.error).toHaveBeenCalled();
+  });
+
+  it("falls back for custom methods and two queued window updates", async () => {
+    const harness = createWindowHarness([
+      { id: "a", label: "Alpha" },
+      { id: "b", label: "Beta" },
+      { id: "c", label: "Gamma" },
+      { id: "d", label: "Delta" },
+    ]);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Table />));
+
+    await act(async () => {
+      harness.customReplace([
+        { id: "e", label: "Epsilon" },
+        { id: "f", label: "Phi" },
+      ]);
+      await flushCompilerUpdates();
+    });
+    expect(container.textContent).toBe("DeltaPhiEpsilonAlpha");
+
+    await act(async () => {
+      harness.queueTwo(
+        [
+          { id: "g", label: "Gamma two" },
+          { id: "h", label: "Eta" },
+        ],
+        [
+          { id: "i", label: "Iota" },
+          { id: "j", label: "Jota" },
+        ],
+      );
+      await flushCompilerUpdates();
+    });
+    expect(container.textContent).toBe("DeltaGamma twoIotaJotaAlpha");
+  });
+
+  it("preserves controlled-input focus and delegated indexes across the window", async () => {
+    const initialItems: Item[] = [
+      { id: "a", label: "Alpha" },
+      { id: "b", label: "Beta" },
+      { id: "c", label: "Gamma" },
+      { id: "d", label: "Delta" },
+    ];
+    const calls: string[] = [];
+    let replace = () => undefined;
+    const InteractiveRows = createCompiledComponentWithFeatures(
+      {
+        displayName: "WindowInteractiveRows",
+        initialize: () => [initialItems],
+        render(_props: Record<string, never>, state, blocks) {
+          const items = () => state[0].get() as Item[];
+          replace = () =>
+            state[0].set((previous) =>
+              hintedWindowReplace(previous as Item[], 1, 2, [{ id: "e", label: "Epsilon" }]),
+            );
+          return (
+            <main>
+              <blocks.KeyedRows
+                collectionDependency={0}
+                delegateEvents
+                dependencies={[0]}
+                events={[
+                  {
+                    invoke: (item, index) => calls.push(`${(item as Item).id}:${index}`),
+                    name: "onClick",
+                    path: [1],
+                  },
+                ]}
+                id={0}
+                items={items}
+                positionIndexIndependent
+                structureDependencies={[0]}
+                render={(event) => (
+                  <ul>
+                    {items().map((item, index) => (
+                      <li data-key={item.id} key={item.id}>
+                        <input aria-label={`Edit ${item.id}`} value={item.label} readOnly />
+                        <button data-row-button={item.id} onClick={event(item, index, 0)}>
+                          Select
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+                rowKey={(item) => (item as Item).id}
+                create={(item) => {
+                  const row = item as Item;
+                  return {
+                    kind: "element",
+                    tag: "li",
+                    attributes: [{ name: "data-key", value: row.id }],
+                    styles: [],
+                    children: [
+                      {
+                        kind: "element",
+                        tag: "input",
+                        attributes: [
+                          { name: "aria-label", value: `Edit ${row.id}` },
+                          { name: "value", value: row.label },
+                          { name: "readOnly", value: true },
+                        ],
+                        styles: [],
+                        children: [],
+                      },
+                      {
+                        kind: "element",
+                        tag: "button",
+                        attributes: [{ name: "data-row-button", value: row.id }],
+                        styles: [],
+                        children: ["Select"],
+                      },
+                    ],
+                  };
+                }}
+                bindings={[]}
+              />
+            </main>
+          );
+        },
+        bindings: [{ kind: "block", id: 0, dependencies: [0] }],
+      },
+      [keyedRowsWindowPositionHintedRuntimeFeature],
+    );
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<InteractiveRows />));
+    const input = container.querySelector('[aria-label="Edit d"]') as HTMLInputElement;
+    input.focus();
+    input.setSelectionRange(1, 3);
+
+    await act(async () => {
+      replace();
+      await flushCompilerUpdates();
+    });
+    expect(container.querySelector('[aria-label="Edit d"]')).toBe(input);
+    expect(document.activeElement).toBe(input);
+    expect([input.selectionStart, input.selectionEnd]).toEqual([1, 3]);
+
+    await act(async () => {
+      (container.querySelector('[data-row-button="e"]') as HTMLButtonElement).click();
+      (container.querySelector('[data-row-button="d"]') as HTMLButtonElement).click();
+    });
+    expect(calls).toEqual(["e:1", "d:2"]);
+  });
+
+  it("matches normal React through 1,000 deterministic bounded replacements", async () => {
+    const initialItems = Array.from(
+      { length: 24 },
+      (_, index): Item => ({ id: `row-${index}`, label: `Row ${index}` }),
+    );
+    const harness = createWindowHarness(initialItems);
+    let replaceReact: (position: number, count: number, incoming: readonly Item[]) => void = () =>
+      undefined;
+    function NormalTable() {
+      const [items, setItems] = useState(initialItems);
+      replaceReact = (position, count, incoming) =>
+        setItems((previous) => (previous as WindowArray).toSpliced(position, count, ...incoming));
+      return (
+        <ol>
+          {items.map((item) => (
+            <li key={item.id}>{item.label}</li>
+          ))}
+        </ol>
+      );
+    }
+    const compiledContainer = document.createElement("div");
+    const reactContainer = document.createElement("div");
+    document.body.append(compiledContainer, reactContainer);
+    const compiledRoot = createRoot(compiledContainer);
+    const reactRoot = createRoot(reactContainer);
+    roots.push(compiledRoot, reactRoot);
+    await act(async () => {
+      compiledRoot.render(<harness.Table />);
+      reactRoot.render(<NormalTable />);
+    });
+
+    // Each cycle performs and verifies two replacements: the fresh window and
+    // its restoration. Five hundred cycles therefore cover 1,000 updates.
+    for (let step = 0; step < 500; step += 1) {
+      const count = (step % 5) + 1;
+      const position = (step * 37) % (initialItems.length - count + 1);
+      const incoming = Array.from(
+        { length: (step % 4) + 1 },
+        (_, offset): Item => ({
+          id: `replace-${step}-${offset}`,
+          label: `Replace ${step}.${offset}`,
+        }),
+      );
+      const removed = initialItems.slice(position, position + count);
+      await act(async () => {
+        harness.replace(position, count, incoming);
+        replaceReact(position, count, incoming);
+        await flushCompilerUpdates();
+      });
+      expect(compiledContainer.querySelector("ul")?.textContent).toBe(
+        reactContainer.querySelector("ol")?.textContent,
+      );
+      await act(async () => {
+        harness.replace(position, incoming.length, removed);
+        replaceReact(position, incoming.length, removed);
+        await flushCompilerUpdates();
+      });
+      expect(compiledContainer.querySelector("ul")?.textContent).toBe(
+        reactContainer.querySelector("ol")?.textContent,
+      );
+    }
+    expect(harness.counters.executions).toBe(1);
+    expect(harness.counters.renders).toBe(1);
+  }, 15_000);
+
+  it("hydrates in StrictMode and drops a queued replacement after unmount", async () => {
+    const harness = createWindowHarness([
+      { id: "a", label: "Alpha" },
+      { id: "b", label: "Beta" },
+      { id: "c", label: "Gamma" },
+    ]);
+    const container = document.createElement("div");
+    container.innerHTML = renderToString(
+      <StrictMode>
+        <harness.Table />
+      </StrictMode>,
+    );
+    document.body.append(container);
+    const recoverable: unknown[] = [];
+    let root!: Root;
+    await act(async () => {
+      root = hydrateRoot(
+        container,
+        <StrictMode>
+          <harness.Table />
+        </StrictMode>,
+        { onRecoverableError: (error) => recoverable.push(error) },
+      );
+    });
+    roots.push(root);
+
+    await act(async () => {
+      harness.replace(1, 2, [
+        { id: "d", label: "Delta" },
+        { id: "e", label: "Epsilon" },
+      ]);
+      await flushCompilerUpdates();
+    });
+    expect(container.textContent).toBe("AlphaDeltaEpsilon");
+    expect(recoverable).toEqual([]);
+
+    roots.pop();
+    act(() => {
+      harness.replace(0, 2, [{ id: "f", label: "Phi" }]);
+      root.unmount();
+    });
+    await flushCompilerUpdates();
+    expect(container.innerHTML).toBe("");
+  });
+});

--- a/packages/farm-react/src/compiler-runtime.tsx
+++ b/packages/farm-react/src/compiler-runtime.tsx
@@ -60,6 +60,15 @@ interface CompilerKeyedArrayBatchInsertHint {
   readonly position: number;
 }
 
+interface CompilerKeyedArrayWindowReplaceHint {
+  readonly sourceToken: object;
+  readonly sourceLength: number;
+  readonly resultLength: number;
+  readonly position: number;
+  readonly removedCount: number;
+  readonly insertedCount: number;
+}
+
 interface CompilerKeyedArrayReorderHint {
   readonly kind: "reverse" | "sort";
   readonly sourceToken: object;
@@ -110,6 +119,10 @@ const COMPILER_KEYED_ARRAY_POSITIONS = /* @__PURE__ */ new WeakMap<
 const COMPILER_KEYED_ARRAY_BATCH_INSERTS = /* @__PURE__ */ new WeakMap<
   object,
   CompilerKeyedArrayBatchInsertHint
+>();
+const COMPILER_KEYED_ARRAY_WINDOW_REPLACEMENTS = /* @__PURE__ */ new WeakMap<
+  object,
+  CompilerKeyedArrayWindowReplaceHint
 >();
 const COMPILER_KEYED_ARRAY_REORDERS = /* @__PURE__ */ new WeakMap<
   object,
@@ -367,6 +380,31 @@ function compilerKeyedArrayBatchInsert(
     update.resultLength < expectedLength + 2 ||
     update.position < 0 ||
     update.position > expectedLength
+  ) {
+    return undefined;
+  }
+  return update;
+}
+
+function compilerKeyedArrayWindowReplace(
+  value: unknown,
+  sourceToken: object | undefined,
+  expectedLength: number,
+): CompilerKeyedArrayWindowReplaceHint | undefined {
+  const target = compilerObject(value);
+  if (!target || !sourceToken || !Array.isArray(value)) return undefined;
+  const update = COMPILER_KEYED_ARRAY_WINDOW_REPLACEMENTS.get(target);
+  if (
+    !update ||
+    update.sourceToken !== sourceToken ||
+    update.sourceLength !== expectedLength ||
+    update.resultLength !== value.length ||
+    update.position < 0 ||
+    update.position >= expectedLength ||
+    update.removedCount < 1 ||
+    update.position + update.removedCount > expectedLength ||
+    update.insertedCount < 0 ||
+    update.resultLength !== expectedLength - update.removedCount + update.insertedCount
   ) {
     return undefined;
   }
@@ -827,6 +865,63 @@ export function createCompilerKeyedArrayBatchInsert(
         position < 0
           ? Math.max(previous.length + position, 0)
           : Math.min(position, previous.length),
+    });
+  } catch {
+    // Metadata must never change the result of a successful native update.
+  }
+  return value;
+}
+
+/** @internal Executes a native exact-window replacement and records it. */
+export function createCompilerKeyedArrayWindowReplace(
+  previous: unknown,
+  method: unknown,
+  position: number,
+  deleteCount: number,
+  ...items: readonly unknown[]
+): unknown {
+  const value = NATIVE_REFLECT_APPLY(
+    method as (...values: readonly unknown[]) => unknown,
+    previous,
+    [position, deleteCount, ...items],
+  );
+
+  try {
+    const previousTarget = compilerObject(previous);
+    const valueTarget = compilerObject(value);
+    if (
+      !previousTarget ||
+      !valueTarget ||
+      !COMPILER_KEYED_COMMITTED_COLLECTIONS.has(previousTarget) ||
+      !Array.isArray(previous) ||
+      !Array.isArray(value) ||
+      Object.getPrototypeOf(previous) !== NATIVE_ARRAY_PROTOTYPE ||
+      Object.getPrototypeOf(value) !== NATIVE_ARRAY_PROTOTYPE ||
+      method !== NATIVE_ARRAY_TO_SPLICED ||
+      !Number.isSafeInteger(position) ||
+      !Number.isSafeInteger(deleteCount) ||
+      deleteCount <= 0
+    ) {
+      return value;
+    }
+    for (let index = 0; index < previous.length; index += 1) {
+      if (!Object.prototype.hasOwnProperty.call(previous, index)) return value;
+    }
+    const normalizedPosition =
+      position < 0 ? Math.max(previous.length + position, 0) : Math.min(position, previous.length);
+    const removedCount = Math.min(deleteCount, previous.length - normalizedPosition);
+    if (removedCount < 1 || value.length !== previous.length - removedCount + items.length) {
+      return value;
+    }
+    const sourceToken = compilerKeyedCollectionToken(previousTarget);
+    if (!sourceToken) return value;
+    COMPILER_KEYED_ARRAY_WINDOW_REPLACEMENTS.set(valueTarget, {
+      sourceToken,
+      sourceLength: previous.length,
+      resultLength: value.length,
+      position: normalizedPosition,
+      removedCount,
+      insertedCount: items.length,
     });
   } catch {
     // Metadata must never change the result of a successful native update.
@@ -4149,6 +4244,11 @@ const keyedBatchPositionUpdateRuntime: KeyedUpdateRuntime = {
   position: reconcileCompilerKeyedArrayPositionWithBatch,
 };
 
+const keyedWindowPositionUpdateRuntime: KeyedUpdateRuntime = {
+  ...keyedUpdateRuntime,
+  position: reconcileCompilerKeyedArrayPositionWithWindow,
+};
+
 const keyedReorderUpdateRuntime: KeyedUpdateRuntime = {
   ...keyedUpdateRuntime,
   reorder: reconcileCompilerKeyedArrayReorder,
@@ -4168,6 +4268,11 @@ const keyedEveryUpdateRuntime: KeyedUpdateRuntime = {
 const keyedBatchEveryUpdateRuntime: KeyedUpdateRuntime = {
   ...keyedEveryUpdateRuntime,
   position: reconcileCompilerKeyedArrayPositionWithBatch,
+};
+
+const keyedWindowEveryUpdateRuntime: KeyedUpdateRuntime = {
+  ...keyedEveryUpdateRuntime,
+  position: reconcileCompilerKeyedArrayPositionWithWindow,
 };
 
 interface KeyedRowsRuntimeOptions {
@@ -4591,11 +4696,119 @@ function reconcileCompilerKeyedArrayBatchInsert(
   return new Map(previousInstances.map((instance) => [instance.key, instance]));
 }
 
+function reconcileCompilerKeyedArrayWindowReplace(
+  props: CompilerKeyedRowsBlockProps,
+  dirtyState: ReadonlySet<number>,
+  collectionToken: object | undefined,
+  instances: ReadonlyMap<string, CompilerKeyedRowInstance>,
+  root: Element,
+  reactOwnedRows: boolean,
+): ReadonlyMap<string, CompilerKeyedRowInstance> | undefined {
+  if (
+    reactOwnedRows ||
+    props.hostBlocks ||
+    (props.conditionals?.length || 0) > 0 ||
+    !props.positionIndexIndependent ||
+    props.collectionDependency === undefined
+  ) {
+    return undefined;
+  }
+  const collectionDependency = props.collectionDependency;
+  if (props.bindings.some((binding) => binding.dependencies?.includes(collectionDependency))) {
+    return undefined;
+  }
+  const dependencies = props.dependencies || props.structureDependencies;
+  const relevantDirty = (dependencies || []).filter((index) => dirtyState.has(index));
+  if (relevantDirty.length !== 1 || relevantDirty[0] !== collectionDependency) {
+    return undefined;
+  }
+
+  const finalValue = props.items();
+  const update = compilerKeyedArrayWindowReplace(finalValue, collectionToken, instances.size);
+  if (!update || !Array.isArray(finalValue)) return undefined;
+  const previousInstances = [...instances.values()];
+  const removedEnd = update.position + update.removedCount;
+  for (let sourceIndex = 0; sourceIndex < update.sourceLength; sourceIndex += 1) {
+    const instance = previousInstances[sourceIndex];
+    if (!instance || instance.index !== sourceIndex) return undefined;
+    if (sourceIndex >= update.position && sourceIndex < removedEnd) continue;
+    const resultIndex =
+      sourceIndex < update.position
+        ? sourceIndex
+        : sourceIndex - update.removedCount + update.insertedCount;
+    if (!Object.is(instance.item, finalValue[resultIndex])) return undefined;
+  }
+
+  const removed = previousInstances.slice(update.position, removedEnd);
+  const anchor = previousInstances[removedEnd]?.element;
+  if (
+    removed.length !== update.removedCount ||
+    removed.some((instance) => instance.element.parentNode !== root) ||
+    (anchor && anchor.parentNode !== root)
+  ) {
+    return undefined;
+  }
+
+  const knownKeys = new Set(instances.keys());
+  const incoming: CompilerKeyedRowInstance[] = [];
+  try {
+    for (let offset = 0; offset < update.insertedCount; offset += 1) {
+      const index = update.position + offset;
+      const item = finalValue[index];
+      const key = keyedRowIdentity(props.rowKey(item, index));
+      // Reusing an existing key is valid React behavior, but it needs the
+      // complete keyed reconciliation path to preserve that row instance.
+      if (knownKeys.has(key)) return undefined;
+      knownKeys.add(key);
+      const descriptor = props.create(item, index);
+      incoming.push({
+        key,
+        element: createCompilerHostElement(root.ownerDocument, descriptor),
+        values: readKeyedRowBindingValues(props, item, index),
+        item,
+        index,
+        conditionalValues: EMPTY_KEYED_ROW_CONDITIONAL_VALUES,
+      });
+    }
+  } catch {
+    return undefined;
+  }
+
+  for (const instance of removed) {
+    instance.scope?.cleanup();
+    instance.element.remove();
+  }
+  if (incoming.length > 0) {
+    const fragment = root.ownerDocument.createDocumentFragment();
+    for (const instance of incoming) fragment.append(instance.element);
+    root.insertBefore(fragment, anchor || null);
+  }
+  previousInstances.splice(update.position, update.removedCount, ...incoming);
+  for (
+    let index = update.position + update.insertedCount;
+    index < previousInstances.length;
+    index += 1
+  ) {
+    previousInstances[index].index = index;
+  }
+  return new Map(previousInstances.map((instance) => [instance.key, instance]));
+}
+
 function reconcileCompilerKeyedArrayPositionWithBatch(
   ...args: Parameters<typeof reconcileCompilerKeyedArrayPosition>
 ): ReadonlyMap<string, CompilerKeyedRowInstance> | undefined {
   return (
     reconcileCompilerKeyedArrayBatchInsert(...args) || reconcileCompilerKeyedArrayPosition(...args)
+  );
+}
+
+function reconcileCompilerKeyedArrayPositionWithWindow(
+  ...args: Parameters<typeof reconcileCompilerKeyedArrayPosition>
+): ReadonlyMap<string, CompilerKeyedRowInstance> | undefined {
+  return (
+    reconcileCompilerKeyedArrayWindowReplace(...args) ||
+    reconcileCompilerKeyedArrayBatchInsert(...args) ||
+    reconcileCompilerKeyedArrayPosition(...args)
   );
 }
 
@@ -6568,6 +6781,15 @@ export const keyedRowsBatchPositionHintedRuntimeFeature: CompilerRuntimeFeature 
   }),
 };
 
+export const keyedRowsWindowPositionHintedRuntimeFeature: CompilerRuntimeFeature = {
+  name: "keyed-rows:window-position-hinted",
+  create: (owner) => ({
+    KeyedRows: createKeyedRowsBlockComponent(owner, {
+      keyedUpdates: keyedWindowPositionUpdateRuntime,
+    }),
+  }),
+};
+
 export const keyedRowsReorderHintedRuntimeFeature: CompilerRuntimeFeature = {
   name: "keyed-rows:reorder-hinted",
   create: (owner) => ({
@@ -6600,6 +6822,15 @@ export const keyedRowsBatchEveryHintedRuntimeFeature: CompilerRuntimeFeature = {
   create: (owner) => ({
     KeyedRows: createKeyedRowsBlockComponent(owner, {
       keyedUpdates: keyedBatchEveryUpdateRuntime,
+    }),
+  }),
+};
+
+export const keyedRowsWindowEveryHintedRuntimeFeature: CompilerRuntimeFeature = {
+  name: "keyed-rows:window-every-hinted",
+  create: (owner) => ({
+    KeyedRows: createKeyedRowsBlockComponent(owner, {
+      keyedUpdates: keyedWindowEveryUpdateRuntime,
     }),
   }),
 };
@@ -6670,6 +6901,16 @@ export const keyedRowsConditionalBatchPositionHintedRuntimeFeature: CompilerRunt
   }),
 };
 
+export const keyedRowsConditionalWindowPositionHintedRuntimeFeature: CompilerRuntimeFeature = {
+  name: "keyed-rows:conditional:window-position-hinted",
+  create: (owner) => ({
+    KeyedRows: createKeyedRowsBlockComponent(owner, {
+      conditionals: createKeyedRowConditionalRuntime(),
+      keyedUpdates: keyedWindowPositionUpdateRuntime,
+    }),
+  }),
+};
+
 export const keyedRowsConditionalReorderHintedRuntimeFeature: CompilerRuntimeFeature = {
   name: "keyed-rows:conditional:reorder-hinted",
   create: (owner) => ({
@@ -6706,6 +6947,16 @@ export const keyedRowsConditionalBatchEveryHintedRuntimeFeature: CompilerRuntime
     KeyedRows: createKeyedRowsBlockComponent(owner, {
       conditionals: createKeyedRowConditionalRuntime(),
       keyedUpdates: keyedBatchEveryUpdateRuntime,
+    }),
+  }),
+};
+
+export const keyedRowsConditionalWindowEveryHintedRuntimeFeature: CompilerRuntimeFeature = {
+  name: "keyed-rows:conditional:window-every-hinted",
+  create: (owner) => ({
+    KeyedRows: createKeyedRowsBlockComponent(owner, {
+      conditionals: createKeyedRowConditionalRuntime(),
+      keyedUpdates: keyedWindowEveryUpdateRuntime,
     }),
   }),
 };
@@ -6779,6 +7030,16 @@ export const keyedRowsHostBatchPositionHintedRuntimeFeature: CompilerRuntimeFeat
   }),
 };
 
+export const keyedRowsHostWindowPositionHintedRuntimeFeature: CompilerRuntimeFeature = {
+  name: "keyed-rows:host:window-position-hinted",
+  create: (owner) => ({
+    KeyedRows: createKeyedRowsBlockComponent(owner, {
+      hostBlocks: createKeyedRowHostRuntime(),
+      keyedUpdates: keyedWindowPositionUpdateRuntime,
+    }),
+  }),
+};
+
 export const keyedRowsHostReorderHintedRuntimeFeature: CompilerRuntimeFeature = {
   name: "keyed-rows:host:reorder-hinted",
   create: (owner) => ({
@@ -6815,6 +7076,16 @@ export const keyedRowsHostBatchEveryHintedRuntimeFeature: CompilerRuntimeFeature
     KeyedRows: createKeyedRowsBlockComponent(owner, {
       hostBlocks: createKeyedRowHostRuntime(),
       keyedUpdates: keyedBatchEveryUpdateRuntime,
+    }),
+  }),
+};
+
+export const keyedRowsHostWindowEveryHintedRuntimeFeature: CompilerRuntimeFeature = {
+  name: "keyed-rows:host:window-every-hinted",
+  create: (owner) => ({
+    KeyedRows: createKeyedRowsBlockComponent(owner, {
+      hostBlocks: createKeyedRowHostRuntime(),
+      keyedUpdates: keyedWindowEveryUpdateRuntime,
     }),
   }),
 };
@@ -6892,6 +7163,17 @@ export const keyedRowsCompleteBatchPositionHintedRuntimeFeature: CompilerRuntime
   }),
 };
 
+export const keyedRowsCompleteWindowPositionHintedRuntimeFeature: CompilerRuntimeFeature = {
+  name: "keyed-rows:complete:window-position-hinted",
+  create: (owner) => ({
+    KeyedRows: createKeyedRowsBlockComponent(owner, {
+      conditionals: createKeyedRowConditionalRuntime(),
+      hostBlocks: createKeyedRowHostRuntime(),
+      keyedUpdates: keyedWindowPositionUpdateRuntime,
+    }),
+  }),
+};
+
 export const keyedRowsCompleteReorderHintedRuntimeFeature: CompilerRuntimeFeature = {
   name: "keyed-rows:complete:reorder-hinted",
   create: (owner) => ({
@@ -6932,6 +7214,17 @@ export const keyedRowsCompleteBatchEveryHintedRuntimeFeature: CompilerRuntimeFea
       conditionals: createKeyedRowConditionalRuntime(),
       hostBlocks: createKeyedRowHostRuntime(),
       keyedUpdates: keyedBatchEveryUpdateRuntime,
+    }),
+  }),
+};
+
+export const keyedRowsCompleteWindowEveryHintedRuntimeFeature: CompilerRuntimeFeature = {
+  name: "keyed-rows:complete:window-every-hinted",
+  create: (owner) => ({
+    KeyedRows: createKeyedRowsBlockComponent(owner, {
+      conditionals: createKeyedRowConditionalRuntime(),
+      hostBlocks: createKeyedRowHostRuntime(),
+      keyedUpdates: keyedWindowEveryUpdateRuntime,
     }),
   }),
 };
@@ -7551,7 +7844,7 @@ const COMPLETE_RUNTIME_FEATURES: readonly CompilerRuntimeFeature[] = [
   hostConditionalRuntimeFeature,
   conditionalRangesRuntimeFeature,
   keyedListRuntimeFeature,
-  keyedRowsCompleteBatchEveryHintedRuntimeFeature,
+  keyedRowsCompleteWindowEveryHintedRuntimeFeature,
   keyedRangesRuntimeFeature,
   mixedRangesRuntimeFeature,
   componentRuntimeFeature,

--- a/packages/farm-react/src/compiler.ts
+++ b/packages/farm-react/src/compiler.ts
@@ -369,10 +369,12 @@ type CompilerRuntimeFeatureName =
   | "keyed-rows-hinted"
   | "keyed-rows-position-hinted"
   | "keyed-rows-batch-position-hinted"
+  | "keyed-rows-window-position-hinted"
   | "keyed-rows-reorder-hinted"
   | "keyed-rows-all-hinted"
   | "keyed-rows-every-hinted"
   | "keyed-rows-batch-every-hinted"
+  | "keyed-rows-window-every-hinted"
   | "keyed-rows-filter-hinted"
   | "keyed-rows-prepend-hinted"
   | "keyed-rows-filter-prepend-hinted"
@@ -380,10 +382,12 @@ type CompilerRuntimeFeatureName =
   | "keyed-rows-conditional-hinted"
   | "keyed-rows-conditional-position-hinted"
   | "keyed-rows-conditional-batch-position-hinted"
+  | "keyed-rows-conditional-window-position-hinted"
   | "keyed-rows-conditional-reorder-hinted"
   | "keyed-rows-conditional-all-hinted"
   | "keyed-rows-conditional-every-hinted"
   | "keyed-rows-conditional-batch-every-hinted"
+  | "keyed-rows-conditional-window-every-hinted"
   | "keyed-rows-conditional-filter-hinted"
   | "keyed-rows-conditional-prepend-hinted"
   | "keyed-rows-conditional-filter-prepend-hinted"
@@ -391,10 +395,12 @@ type CompilerRuntimeFeatureName =
   | "keyed-rows-host-hinted"
   | "keyed-rows-host-position-hinted"
   | "keyed-rows-host-batch-position-hinted"
+  | "keyed-rows-host-window-position-hinted"
   | "keyed-rows-host-reorder-hinted"
   | "keyed-rows-host-all-hinted"
   | "keyed-rows-host-every-hinted"
   | "keyed-rows-host-batch-every-hinted"
+  | "keyed-rows-host-window-every-hinted"
   | "keyed-rows-host-filter-hinted"
   | "keyed-rows-host-prepend-hinted"
   | "keyed-rows-host-filter-prepend-hinted"
@@ -402,10 +408,12 @@ type CompilerRuntimeFeatureName =
   | "keyed-rows-complete-hinted"
   | "keyed-rows-complete-position-hinted"
   | "keyed-rows-complete-batch-position-hinted"
+  | "keyed-rows-complete-window-position-hinted"
   | "keyed-rows-complete-reorder-hinted"
   | "keyed-rows-complete-all-hinted"
   | "keyed-rows-complete-every-hinted"
   | "keyed-rows-complete-batch-every-hinted"
+  | "keyed-rows-complete-window-every-hinted"
   | "keyed-rows-complete-filter-hinted"
   | "keyed-rows-complete-prepend-hinted"
   | "keyed-rows-complete-filter-prepend-hinted"
@@ -422,10 +430,12 @@ const COMPILER_RUNTIME_FEATURE_EXPORTS: Record<CompilerRuntimeFeatureName, strin
   "keyed-rows-hinted": "keyedRowsHintedRuntimeFeature",
   "keyed-rows-position-hinted": "keyedRowsPositionHintedRuntimeFeature",
   "keyed-rows-batch-position-hinted": "keyedRowsBatchPositionHintedRuntimeFeature",
+  "keyed-rows-window-position-hinted": "keyedRowsWindowPositionHintedRuntimeFeature",
   "keyed-rows-reorder-hinted": "keyedRowsReorderHintedRuntimeFeature",
   "keyed-rows-all-hinted": "keyedRowsAllHintedRuntimeFeature",
   "keyed-rows-every-hinted": "keyedRowsEveryHintedRuntimeFeature",
   "keyed-rows-batch-every-hinted": "keyedRowsBatchEveryHintedRuntimeFeature",
+  "keyed-rows-window-every-hinted": "keyedRowsWindowEveryHintedRuntimeFeature",
   "keyed-rows-filter-hinted": "keyedRowsFilterHintedRuntimeFeature",
   "keyed-rows-prepend-hinted": "keyedRowsPrependHintedRuntimeFeature",
   "keyed-rows-filter-prepend-hinted": "keyedRowsFilterPrependHintedRuntimeFeature",
@@ -434,10 +444,14 @@ const COMPILER_RUNTIME_FEATURE_EXPORTS: Record<CompilerRuntimeFeatureName, strin
   "keyed-rows-conditional-position-hinted": "keyedRowsConditionalPositionHintedRuntimeFeature",
   "keyed-rows-conditional-batch-position-hinted":
     "keyedRowsConditionalBatchPositionHintedRuntimeFeature",
+  "keyed-rows-conditional-window-position-hinted":
+    "keyedRowsConditionalWindowPositionHintedRuntimeFeature",
   "keyed-rows-conditional-reorder-hinted": "keyedRowsConditionalReorderHintedRuntimeFeature",
   "keyed-rows-conditional-all-hinted": "keyedRowsConditionalAllHintedRuntimeFeature",
   "keyed-rows-conditional-every-hinted": "keyedRowsConditionalEveryHintedRuntimeFeature",
   "keyed-rows-conditional-batch-every-hinted": "keyedRowsConditionalBatchEveryHintedRuntimeFeature",
+  "keyed-rows-conditional-window-every-hinted":
+    "keyedRowsConditionalWindowEveryHintedRuntimeFeature",
   "keyed-rows-conditional-filter-hinted": "keyedRowsConditionalFilterHintedRuntimeFeature",
   "keyed-rows-conditional-prepend-hinted": "keyedRowsConditionalPrependHintedRuntimeFeature",
   "keyed-rows-conditional-filter-prepend-hinted":
@@ -446,10 +460,12 @@ const COMPILER_RUNTIME_FEATURE_EXPORTS: Record<CompilerRuntimeFeatureName, strin
   "keyed-rows-host-hinted": "keyedRowsHostHintedRuntimeFeature",
   "keyed-rows-host-position-hinted": "keyedRowsHostPositionHintedRuntimeFeature",
   "keyed-rows-host-batch-position-hinted": "keyedRowsHostBatchPositionHintedRuntimeFeature",
+  "keyed-rows-host-window-position-hinted": "keyedRowsHostWindowPositionHintedRuntimeFeature",
   "keyed-rows-host-reorder-hinted": "keyedRowsHostReorderHintedRuntimeFeature",
   "keyed-rows-host-all-hinted": "keyedRowsHostAllHintedRuntimeFeature",
   "keyed-rows-host-every-hinted": "keyedRowsHostEveryHintedRuntimeFeature",
   "keyed-rows-host-batch-every-hinted": "keyedRowsHostBatchEveryHintedRuntimeFeature",
+  "keyed-rows-host-window-every-hinted": "keyedRowsHostWindowEveryHintedRuntimeFeature",
   "keyed-rows-host-filter-hinted": "keyedRowsHostFilterHintedRuntimeFeature",
   "keyed-rows-host-prepend-hinted": "keyedRowsHostPrependHintedRuntimeFeature",
   "keyed-rows-host-filter-prepend-hinted": "keyedRowsHostFilterPrependHintedRuntimeFeature",
@@ -457,10 +473,13 @@ const COMPILER_RUNTIME_FEATURE_EXPORTS: Record<CompilerRuntimeFeatureName, strin
   "keyed-rows-complete-hinted": "keyedRowsCompleteHintedRuntimeFeature",
   "keyed-rows-complete-position-hinted": "keyedRowsCompletePositionHintedRuntimeFeature",
   "keyed-rows-complete-batch-position-hinted": "keyedRowsCompleteBatchPositionHintedRuntimeFeature",
+  "keyed-rows-complete-window-position-hinted":
+    "keyedRowsCompleteWindowPositionHintedRuntimeFeature",
   "keyed-rows-complete-reorder-hinted": "keyedRowsCompleteReorderHintedRuntimeFeature",
   "keyed-rows-complete-all-hinted": "keyedRowsCompleteAllHintedRuntimeFeature",
   "keyed-rows-complete-every-hinted": "keyedRowsCompleteEveryHintedRuntimeFeature",
   "keyed-rows-complete-batch-every-hinted": "keyedRowsCompleteBatchEveryHintedRuntimeFeature",
+  "keyed-rows-complete-window-every-hinted": "keyedRowsCompleteWindowEveryHintedRuntimeFeature",
   "keyed-rows-complete-filter-hinted": "keyedRowsCompleteFilterHintedRuntimeFeature",
   "keyed-rows-complete-prepend-hinted": "keyedRowsCompletePrependHintedRuntimeFeature",
   "keyed-rows-complete-filter-prepend-hinted": "keyedRowsCompleteFilterPrependHintedRuntimeFeature",
@@ -476,6 +495,7 @@ function runtimeFeaturesForPlans(
   keyedArrayPrependHints: boolean,
   keyedArrayPositionHints: boolean,
   keyedArrayBatchInsertHints: boolean,
+  keyedArrayWindowReplaceHints: boolean,
   keyedArrayReorderHints: boolean,
   keyedArrayRollingWindowHints: boolean,
 ): CompilerRuntimeFeatureName[] {
@@ -503,28 +523,32 @@ function runtimeFeaturesForPlans(
             : "keyed-rows";
     const arrayRangeHints =
       keyedArrayRollingWindowHints || keyedArrayFilterHints || keyedArrayPrependHints;
-    const hintSuffix = keyedArrayBatchInsertHints
+    const hintSuffix = keyedArrayWindowReplaceHints
       ? arrayRangeHints || keyedArrayReorderHints
-        ? "-batch-every-hinted"
-        : "-batch-position-hinted"
-      : (keyedArrayPositionHints && (arrayRangeHints || keyedArrayReorderHints)) ||
-          (keyedArrayReorderHints && arrayRangeHints)
-        ? "-every-hinted"
-        : keyedArrayRollingWindowHints
-          ? "-all-hinted"
-          : keyedArrayPositionHints
-            ? "-position-hinted"
-            : keyedArrayReorderHints
-              ? "-reorder-hinted"
-              : keyedArrayFilterHints && keyedArrayPrependHints
-                ? "-filter-prepend-hinted"
-                : keyedArrayFilterHints
-                  ? "-filter-hinted"
-                  : keyedArrayPrependHints
-                    ? "-prepend-hinted"
-                    : keyedMapUpdateHints
-                      ? "-hinted"
-                      : "";
+        ? "-window-every-hinted"
+        : "-window-position-hinted"
+      : keyedArrayBatchInsertHints
+        ? arrayRangeHints || keyedArrayReorderHints
+          ? "-batch-every-hinted"
+          : "-batch-position-hinted"
+        : (keyedArrayPositionHints && (arrayRangeHints || keyedArrayReorderHints)) ||
+            (keyedArrayReorderHints && arrayRangeHints)
+          ? "-every-hinted"
+          : keyedArrayRollingWindowHints
+            ? "-all-hinted"
+            : keyedArrayPositionHints
+              ? "-position-hinted"
+              : keyedArrayReorderHints
+                ? "-reorder-hinted"
+                : keyedArrayFilterHints && keyedArrayPrependHints
+                  ? "-filter-prepend-hinted"
+                  : keyedArrayFilterHints
+                    ? "-filter-hinted"
+                    : keyedArrayPrependHints
+                      ? "-prepend-hinted"
+                      : keyedMapUpdateHints
+                        ? "-hinted"
+                        : "";
     features.add(`${keyedRowsFeature}${hintSuffix}` as CompilerRuntimeFeatureName);
   }
   return [...features].sort();
@@ -1614,11 +1638,13 @@ function rewriteKeyedArrayPositionHints(
   statesBySetter: ReadonlyMap<string, StateBinding>,
   helperIdentifier: t.Identifier,
   batchInsertHelperIdentifier: t.Identifier,
+  windowReplaceHelperIdentifier: t.Identifier,
   safeGlobals: ReadonlySet<string>,
 ): {
   root: t.JSXElement;
   count: number;
   batchInsertCount: number;
+  windowReplaceCount: number;
   stateIndices: ReadonlySet<number>;
 } {
   if (hintedStateIndices.size === 0) {
@@ -1626,6 +1652,7 @@ function rewriteKeyedArrayPositionHints(
       root: t.cloneNode(root, true),
       count: 0,
       batchInsertCount: 0,
+      windowReplaceCount: 0,
       stateIndices: new Set(),
     };
   }
@@ -1633,6 +1660,7 @@ function rewriteKeyedArrayPositionHints(
   const stateIndices = new Set<number>();
   let count = 0;
   let batchInsertCount = 0;
+  let windowReplaceCount = 0;
   traverse(file, {
     CallExpression(path) {
       const callee = path.get("callee");
@@ -1659,35 +1687,46 @@ function rewriteKeyedArrayPositionHints(
 
       const methodName = updater.body.callee.property.name;
       const args = updater.body.arguments;
+      const toSplicedDeleteCount =
+        methodName === "toSpliced" && args.length >= 2 && t.isNumericLiteral(args[1])
+          ? args[1].value
+          : undefined;
       const isBatchInsert =
         methodName === "toSpliced" &&
         args.length >= 3 &&
         t.isNumericLiteral(args[1], { value: 0 }) &&
         (args.length > 3 || t.isSpreadElement(args[2]));
-      const toSplicedDeleteCount =
-        methodName === "toSpliced" && args.length === 2 && t.isNumericLiteral(args[1])
-          ? args[1].value
-          : undefined;
+      const isWindowReplace =
+        methodName === "toSpliced" &&
+        args.length >= 3 &&
+        toSplicedDeleteCount !== undefined &&
+        Number.isSafeInteger(toSplicedDeleteCount) &&
+        toSplicedDeleteCount > 0 &&
+        (toSplicedDeleteCount !== 1 || args.length > 3 || t.isSpreadElement(args[2]));
       const kind = isBatchInsert
         ? "batch-insert"
-        : methodName === "with" && args.length === 2
-          ? "replace"
-          : methodName === "toSpliced" &&
-              args.length === 3 &&
-              t.isNumericLiteral(args[1], { value: 0 })
-            ? "insert"
+        : isWindowReplace
+          ? "window-replace"
+          : methodName === "with" && args.length === 2
+            ? "replace"
             : methodName === "toSpliced" &&
                 args.length === 3 &&
-                t.isNumericLiteral(args[1], { value: 1 })
-              ? "replace"
-              : toSplicedDeleteCount !== undefined &&
-                  Number.isSafeInteger(toSplicedDeleteCount) &&
-                  toSplicedDeleteCount > 0
-                ? "remove"
-                : undefined;
+                t.isNumericLiteral(args[1], { value: 0 })
+              ? "insert"
+              : methodName === "toSpliced" &&
+                  args.length === 3 &&
+                  t.isNumericLiteral(args[1], { value: 1 })
+                ? "replace"
+                : args.length === 2 &&
+                    toSplicedDeleteCount !== undefined &&
+                    Number.isSafeInteger(toSplicedDeleteCount) &&
+                    toSplicedDeleteCount > 0
+                  ? "remove"
+                  : undefined;
       if (!kind || !t.isExpression(args[0])) return;
       const position = args[0];
-      const incoming = kind === "batch-insert" ? args.slice(2) : [args.at(-1)];
+      const incoming =
+        kind === "batch-insert" || kind === "window-replace" ? args.slice(2) : [args.at(-1)];
       if (
         validateKeyedArrayPositionExpression(position, safeGlobals) !== undefined ||
         (kind !== "remove" &&
@@ -1724,17 +1763,26 @@ function rewriteKeyedArrayPositionHints(
                   t.cloneNode(position, true),
                   ...args.slice(2).map((argument) => t.cloneNode(argument, true)),
                 ])
-              : t.callExpression(t.cloneNode(helperIdentifier), [
-                  t.cloneNode(previous),
-                  t.cloneNode(method),
-                  t.stringLiteral(kind),
-                  ...args.map((argument) => t.cloneNode(argument, true)),
-                ]),
+              : kind === "window-replace"
+                ? t.callExpression(t.cloneNode(windowReplaceHelperIdentifier), [
+                    t.cloneNode(previous),
+                    t.cloneNode(method),
+                    t.cloneNode(position, true),
+                    t.cloneNode(args[1], true),
+                    ...args.slice(2).map((argument) => t.cloneNode(argument, true)),
+                  ])
+                : t.callExpression(t.cloneNode(helperIdentifier), [
+                    t.cloneNode(previous),
+                    t.cloneNode(method),
+                    t.stringLiteral(kind),
+                    ...args.map((argument) => t.cloneNode(argument, true)),
+                  ]),
           ),
         ]),
       );
       count += 1;
       if (kind === "batch-insert") batchInsertCount += 1;
+      if (kind === "window-replace") windowReplaceCount += 1;
       stateIndices.add(state.index);
       path.skip();
     },
@@ -1743,6 +1791,7 @@ function rewriteKeyedArrayPositionHints(
     root: (file.program.body[0] as t.ExpressionStatement).expression as t.JSXElement,
     count,
     batchInsertCount,
+    windowReplaceCount,
     stateIndices,
   };
 }
@@ -6786,6 +6835,7 @@ function compileCandidate(
   keyedArrayPrependIdentifier: t.Identifier,
   keyedArrayPositionIdentifier: t.Identifier,
   keyedArrayBatchInsertIdentifier: t.Identifier,
+  keyedArrayWindowReplaceIdentifier: t.Identifier,
   keyedArrayReorderIdentifier: t.Identifier,
   keyedArraySortIdentifier: t.Identifier,
   keyedArrayRollingWindowIdentifier: t.Identifier,
@@ -6809,7 +6859,10 @@ function compileCandidate(
     keyedMembershipTargets: number;
     keyedMapUpdateHints: number;
   },
-  compilerUsage: { keyedArrayBatchInsertHints: number },
+  compilerUsage: {
+    keyedArrayBatchInsertHints: number;
+    keyedArrayWindowReplaceHints: number;
+  },
   useStateNames: ReadonlySet<string>,
   reactNames: ReadonlySet<string>,
   listNames: ReadonlySet<string>,
@@ -7237,10 +7290,12 @@ function compileCandidate(
     statesBySetter,
     keyedArrayPositionIdentifier,
     keyedArrayBatchInsertIdentifier,
+    keyedArrayWindowReplaceIdentifier,
     safeGlobals,
   );
   let appliedKeyedArrayPositionHints = 0;
   let appliedKeyedArrayBatchInsertHints = 0;
+  let appliedKeyedArrayWindowReplaceHints = 0;
   let appliedPositionHintedStateIndices: ReadonlySet<number> = new Set();
   if (positionHintedRoot.count > 0) {
     const hintedBlockAnalysis = analyzeComposableBlocks(
@@ -7265,9 +7320,11 @@ function compileCandidate(
       analysis = hintedAnalysis;
       appliedKeyedArrayPositionHints = positionHintedRoot.count;
       appliedKeyedArrayBatchInsertHints = positionHintedRoot.batchInsertCount;
+      appliedKeyedArrayWindowReplaceHints = positionHintedRoot.windowReplaceCount;
       appliedPositionHintedStateIndices = positionHintedRoot.stateIndices;
       optimizationCounts.keyedArrayPositionHints += positionHintedRoot.count;
       compilerUsage.keyedArrayBatchInsertHints += positionHintedRoot.batchInsertCount;
+      compilerUsage.keyedArrayWindowReplaceHints += positionHintedRoot.windowReplaceCount;
     }
   }
   const reorderHintedRoot = rewriteKeyedArrayReorderHints(
@@ -7506,6 +7563,7 @@ function compileCandidate(
     appliedKeyedArrayPrependHints > 0,
     appliedKeyedArrayPositionHints > 0,
     appliedKeyedArrayBatchInsertHints > 0,
+    appliedKeyedArrayWindowReplaceHints > 0,
     appliedKeyedArrayReorderHints > 0 || appliedKeyedArraySortHints > 0,
     appliedKeyedArrayRollingWindowHints > 0,
   );
@@ -7716,7 +7774,10 @@ export async function compileReactModule(
     keyedMembershipTargets: 0,
     keyedMapUpdateHints: 0,
   };
-  const compilerUsage = { keyedArrayBatchInsertHints: 0 };
+  const compilerUsage = {
+    keyedArrayBatchInsertHints: 0,
+    keyedArrayWindowReplaceHints: 0,
+  };
   const plugin = (): PluginObj => ({
     name: "farm-react-aot",
     visitor: {
@@ -7772,6 +7833,9 @@ export async function compileReactModule(
         const keyedArrayBatchInsertIdentifier = programPath.scope.generateUidIdentifier(
           "createCompilerKeyedArrayBatchInsert",
         );
+        const keyedArrayWindowReplaceIdentifier = programPath.scope.generateUidIdentifier(
+          "createCompilerKeyedArrayWindowReplace",
+        );
         const keyedArrayReorderIdentifier = programPath.scope.generateUidIdentifier(
           "createCompilerKeyedArrayReorder",
         );
@@ -7817,6 +7881,7 @@ export async function compileReactModule(
             keyedArrayPrependIdentifier,
             keyedArrayPositionIdentifier,
             keyedArrayBatchInsertIdentifier,
+            keyedArrayWindowReplaceIdentifier,
             keyedArrayReorderIdentifier,
             keyedArraySortIdentifier,
             keyedArrayRollingWindowIdentifier,
@@ -7886,7 +7951,8 @@ export async function compileReactModule(
                     ]
                   : []),
                 ...(optimizationCounts.keyedArrayPositionHints >
-                compilerUsage.keyedArrayBatchInsertHints
+                compilerUsage.keyedArrayBatchInsertHints +
+                  compilerUsage.keyedArrayWindowReplaceHints
                   ? [
                       t.importSpecifier(
                         keyedArrayPositionIdentifier,
@@ -7899,6 +7965,14 @@ export async function compileReactModule(
                       t.importSpecifier(
                         keyedArrayBatchInsertIdentifier,
                         t.identifier("createCompilerKeyedArrayBatchInsert"),
+                      ),
+                    ]
+                  : []),
+                ...(compilerUsage.keyedArrayWindowReplaceHints > 0
+                  ? [
+                      t.importSpecifier(
+                        keyedArrayWindowReplaceIdentifier,
+                        t.identifier("createCompilerKeyedArrayWindowReplace"),
                       ),
                     ]
                   : []),


### PR DESCRIPTION
## Problem

Concise keyed updates such as `current.toSpliced(position, 64, ...replacements)` already reveal one exact changed window at build time, but the compiler still sent them through complete keyed reconciliation. Large tables therefore reread and reconcile unaffected rows even though the native operation identifies the replacement position and fixed removal count.

## Root cause

The position-hint compiler recognized insertion, contiguous removal, and single-row replacement shapes only. The runtime had no metadata contract or atomic fast path for a positive fixed delete count plus a variable incoming window.

## Change

- Recognize compiler-safe exact-window `toSpliced()` replacements and preserve the original method lookup, argument order, return value, and thrown errors.
- Record metadata only for a committed ordinary dense array, the captured native method, safe integer position/count, and a result with the expected shape.
- Validate retained prefix/suffix identities, live DOM ownership, incoming keys, descriptors, binding snapshots, and detached host rows before mutation.
- Replace only the proven DOM window with one fragment. Retained rows on both sides preserve identity and only suffix indexes shift.
- Route reused or duplicate keys, queued metadata, custom methods, ambiguous ownership, unsupported syntax, and failed validation through complete keyed reconciliation.
- Isolate the optional window runtime from single-position and batch-insertion-only bundles.
- Add an executable 10,000-row benchmark/control pair and document the syntax, guarantees, fallbacks, and results.

## Safety and compatibility

The native array update always executes first. The fast path is limited to compiler-owned, position-independent host rows whose only dirty dependency is the collection. Incoming keys must be fresh; key reuse deliberately falls back so React instance identity is preserved. React-owned rows, nested host blocks, row conditionals, collection-reading bindings, sparse/subclassed collections, dynamic or unsafe counts, unsafe incoming expressions, custom methods, queued updates, and any runtime proof failure keep the existing complete fallback.

There is no new public option, component, report counter, or non-React behavior. Existing sites continue to report through `keyedArrayPositionHints`. React 18.3.1 and 19.2.8 both pass the packaged compatibility suite.

## Verification

- `pnpm --filter @farm.js/react test` — 68 files and 586 tests passed.
- `pnpm --filter @farm.js/react type-check` — passed.
- `pnpm --filter @farm.js/react test:compat` — React 18.3.1 and 19.2.8 passed from the packed package.
- `pnpm --filter @farm.js/react test:runtime-size` — passed; direct/core-only premiums are unchanged, single-position and batch-only bundles exclude the window feature, the isolated window fixture is 12,860 B gzip compiler-on premium, and the full compatibility runtime grows by 355 B gzip.
- `pnpm --filter farm-react-compiler-dashboard-example type-check` and production build — passed.
- `pnpm --filter farm-react-compiler-dashboard-example benchmark` — correctness, performance, persistence, scalability, and every existing specialized gate passed. Static exact-window replacement measured 8.40 ms versus 55.00 ms React and 19.80 ms compiled control (6.55x / 2.36x). Hybrid measured 7.80 ms versus 55.00 ms and 19.10 ms (7.05x / 2.45x). Both compiler modes kept table owner executions at zero.
- `pnpm --dir docs exec farm generate --check`, `pnpm docs:check-navigation`, and `pnpm docs:build` — passed.
- Focused `oxfmt`, `oxlint`, and `git diff --check` — passed.

Environment: Chromium 145.0.7632.6, Apple M1, macOS arm64, Node 23.11.0.

## Documentation and release

Updated the React renderer docs, package README, compiler dashboard example, benchmark gate, recorded benchmark results, React compatibility fixture, and runtime-size fixture. No versions, templates, lockfiles, or release configuration changed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a compile-time-exact-window replacement path for native `toSpliced(position, count, ...replacements)` keyed updates, so large tables no longer reread and reconcile unaffected rows.

**What changed**
- The compiler recognizes only fixed positive literal delete counts with compiler-safe items; all other shapes keep the existing position, batch, or complete paths.
- It records metadata only for a committed ordinary dense array and a native `toSpliced()` result with the expected shape.
- It validates retained prefix/suffix identity, DOM ownership, incoming keys, descriptors, binding snapshots, and host rows before mutation.
- It removes only the proven old interval and mounts incoming rows through one document fragment; retained rows keep their DOM identity and only suffix indexes shift.
- Reused or duplicate incoming keys deliberately fall back so React row identity is preserved.
- A 10,000-row benchmark measured 8.40 ms versus 55.00 ms React and 19.80 ms compiled control (6.55x / 2.36x).

**Safety and compatibility**
- The native array call always runs first, preserving method lookup, argument order, return value, coercion, and thrown errors.
- Custom methods, queued uncommitted updates, collection-reading bindings, React-owned or nested rows, row conditionals, sparse collections, and failed proofs fall back to complete reconciliation.
- No new public option, component, or report counter; existing `keyedArrayPositionHints` still counts these sites.
- React 18.3.1 and 19.2.8 pass; the full runtime grows 355 B gzip, and single-row and batch-only bundles exclude the window feature.

<sup>Written for commit f19a6d6f90fe5422804466cac78e8fe01501264e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/611?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

