### PR TITLE
fix(navigation): preserve same-page hash history

### DIFF
--- a/docs/src/app/docs/routing/page.md
+++ b/docs/src/app/docs/routing/page.md
@@ -113,6 +113,8 @@ export const generateStaticParams: GenerateStaticParams<"/users/[id]"> = async (
 ## Typed navigation
 
 Farm writes the route union into the consolidated `src/farm.d.ts` declaration file. Link hrefs and route component props accept real routes without widening everything to plain string. Link hrefs can also include query strings and hash fragments.
+Changing only the fragment preserves SPA state, honors push versus replace history, and does not
+request route data again.
 
 **Client navigation**
 

--- a/packages/farm/src/__tests__/spa-router-hash-navigation.test.ts
+++ b/packages/farm/src/__tests__/spa-router-hash-navigation.test.ts
@@ -1,0 +1,47 @@
+/** @vitest-environment jsdom */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SPARouter } from "../client/spa-router";
+
+describe("same-page hash navigation", () => {
+  beforeEach(() => {
+    window.history.replaceState({ existing: true }, "", "/guide#old");
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("can clear a fragment with push history semantics", async () => {
+    const router = new SPARouter({ scrollRestoration: false });
+    const historyLength = window.history.length;
+    const scrollTo = vi.spyOn(window, "scrollTo").mockImplementation(() => {});
+
+    await router.navigate("/guide");
+
+    expect(window.location.hash).toBe("");
+    expect(window.history.length).toBe(historyLength + 1);
+    expect(scrollTo).toHaveBeenCalledWith(0, 0);
+    expect(fetch).not.toHaveBeenCalled();
+    router.destroy();
+  });
+
+  it("replaces a fragment without adding a history entry", async () => {
+    const router = new SPARouter({ scrollRestoration: false });
+    const historyLength = window.history.length;
+    const target = document.createElement("h2");
+    target.id = "new";
+    target.scrollIntoView = vi.fn();
+    document.body.appendChild(target);
+
+    await router.navigate("/guide#new", { replace: true });
+
+    expect(window.location.hash).toBe("#new");
+    expect(window.history.length).toBe(historyLength);
+    expect(target.scrollIntoView).toHaveBeenCalledTimes(1);
+    expect(fetch).not.toHaveBeenCalled();
+    router.destroy();
+    target.remove();
+  });
+});

--- a/packages/farm/src/client/spa-router.ts
+++ b/packages/farm/src/client/spa-router.ts
@@ -269,10 +269,21 @@ export class SPARouter {
       return;
     }
 
-    // Same page navigation - just update hash/scroll
+    // Same page navigation - update fragment history without fetching route data.
     if (!refresh && pathname === window.location.pathname && search === window.location.search) {
-      if (url.hash) {
-        window.location.hash = url.hash;
+      if (url.hash === window.location.hash) return;
+
+      this.writePageState(
+        replace ? "replace" : "push",
+        state === undefined ? readPageState() : state,
+        url.toString(),
+      );
+      if (scroll) {
+        if (url.hash) {
+          getHashTargetElement(url.hash)?.scrollIntoView();
+        } else {
+          window.scrollTo(0, 0);
+        }
       }
       return;
     }

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -1991,7 +1991,17 @@ ${generateUniversalRouterStateProperties()}
     const action = options.action || (options.replace ? "replace" : "push");
     const to = url.pathname + url.search;
     if (!options.refresh && action !== "pop" && to === this.currentPath) {
-      if (url.hash) window.location.hash = url.hash;
+      if (url.hash === window.location.hash) return;
+      const pageState = options.state === undefined
+        ? window.history.state?.[FARM_PAGE_STATE_KEY]
+        : options.state;
+      const historyState = createHistoryState(to, pageState, window.history.state);
+      if (action === "replace") window.history.replaceState(historyState, "", url);
+      else window.history.pushState(historyState, "", url);
+      if (options.scroll !== false) {
+        if (url.hash) document.querySelector(url.hash)?.scrollIntoView();
+        else window.scrollTo(0, 0);
+      }
       return;
     }
     if (action === "pop" && to === this.currentPath) return;
@@ -2831,7 +2841,17 @@ ${generateUniversalRouterStateProperties()}
     const action = options.action || (options.replace ? "replace" : "push");
     const to = url.pathname + url.search;
     if (action !== "pop" && to === this.currentPath) {
-      if (url.hash) window.location.hash = url.hash;
+      if (url.hash === window.location.hash) return;
+      const pageState = options.state === undefined
+        ? window.history.state?.[FARM_PAGE_STATE_KEY]
+        : options.state;
+      const historyState = createHistoryState(to, pageState, window.history.state);
+      if (action === "replace") window.history.replaceState(historyState, "", url);
+      else window.history.pushState(historyState, "", url);
+      if (options.scroll !== false) {
+        if (url.hash) document.querySelector(url.hash)?.scrollIntoView();
+        else window.scrollTo(0, 0);
+      }
       return;
     }
     if (action === "pop" && to === this.currentPath) return;

--- a/packages/farm/src/vite.ts
+++ b/packages/farm/src/vite.ts
@@ -3715,9 +3715,18 @@ class LegacyManifestSPARouter {
       return;
     }
 
-    // Same page - just update hash
+    // Same page - update fragment history without loading route data.
     if (pathname === window.location.pathname && search === window.location.search) {
-      if (url.hash) window.location.hash = url.hash;
+      if (url.hash === window.location.hash) return;
+      if (replace) {
+        window.history.replaceState(window.history.state, '', url);
+      } else {
+        window.history.pushState(window.history.state, '', url);
+      }
+      if (scroll) {
+        if (url.hash) document.querySelector(url.hash)?.scrollIntoView();
+        else window.scrollTo(0, 0);
+      }
       return;
     }
 


### PR DESCRIPTION
## Problem

Navigating from `/guide#old` to `/guide` leaves the old fragment in place. `replace('/guide#new')` also assigns `location.hash`, which creates push-style history instead of replacing the current entry.

## Root cause

Same-path navigation bypasses Farm's history writer and only assigns non-empty hashes. It ignores fragment removal, the `replace` option, page state, and explicit scroll behavior.

## Change

Commit fragment-only changes through push/replace history state, preserve existing page state when no new state is supplied, and scroll to the fragment or top as requested. Apply equivalent behavior to Vite and universal production runtimes.

## Safety and compatibility

Fragment-only navigation still avoids page-data requests and route rendering. Repeating the current fragment remains a no-op. `scroll: false` remains respected.

## Verification

- `pnpm --filter @farm.js/core test -- src/__tests__/spa-router-hash-navigation.test.ts src/__tests__/spa-router-hash.test.ts`
- `pnpm --filter @farm.js/core type-check`
- focused `oxfmt` and `oxlint`

Regression coverage checks hash removal with push semantics and hash replacement without adding history.

## Documentation and release

Documented fragment-only navigation semantics in the typed navigation guide.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes same-page hash navigation so removing or replacing a fragment updates history correctly instead of leaving stale hashes or creating extra entries. Fragment-only changes now go through push/replace history state, preserve page state, and respect `scroll: false`.

**Behavior changes**  
- Clearing a hash pushes a new history entry; replacing a hash with `replace: true` does not add one.  
- Existing page state is preserved when no new state is passed.  
- Repeating the current fragment stays a no-op and never triggers route data requests.

**Coverage**  
- Applies to the client router, Vite legacy router, and universal production runtimes.  
- Adds regression tests for hash removal and replacement.

<sup>Written for commit 79a1ba69ae5ae4a70fc840e816657bfe5e8d6d19. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/612?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

