### PR TITLE
fix(router): match dynamic active descendants

### DIFF
--- a/docs/src/app/docs/routing/page.md
+++ b/docs/src/app/docs/routing/page.md
@@ -159,6 +159,8 @@ const href = router.build("/docs/[[...slug]]", {
 ```
 
 This returns `/docs/core/routing`. Optional catch-all params can be omitted, static routes win over dynamic routes, and route groups such as `(marketing)` do not appear in the URL.
+For navigation state, `router.isActive(pattern, pathname, { exact: false })` also matches
+descendants after dynamic segments, such as `/users/42/settings` for `/users/[id]`.
 
 Client components can pass the same route list to `useRouter` when they want current route params:
 

--- a/packages/farm/src/__tests__/router.test.ts
+++ b/packages/farm/src/__tests__/router.test.ts
@@ -64,4 +64,13 @@ describe("route helpers", () => {
     expect(isFarmRouteActive("/docs", "/docs/routing")).toBe(false);
     expect(isFarmRouteActive("/docs", "/docs/routing", { exact: false })).toBe(true);
   });
+
+  it("checks dynamic route descendants by their matched prefix", () => {
+    expect(isFarmRouteActive("/users/[id]", "/users/42/settings", { exact: false })).toBe(true);
+    expect(isFarmRouteActive("/(app)/users/[id]", "/users/42/settings", { exact: false })).toBe(
+      true,
+    );
+    expect(isFarmRouteActive("/users/[id]", "/users", { exact: false })).toBe(false);
+    expect(isFarmRouteActive("/users/[id]", "/projects/42/settings", { exact: false })).toBe(false);
+  });
 });

--- a/packages/farm/src/router.ts
+++ b/packages/farm/src/router.ts
@@ -141,9 +141,9 @@ export function isFarmRouteActive(
   if (matchFarmRoute(pattern, normalizedPathname)) return true;
   if (options.exact !== false) return false;
 
-  const normalizedPattern = normalizePathname(pattern);
-  if (normalizedPattern === "/") return normalizedPathname === "/";
-  return normalizedPathname.startsWith(`${normalizedPattern}/`);
+  const segments = parseRoutePattern(pattern);
+  if (segments.length === 0) return normalizedPathname === "/";
+  return matchSegments(segments, normalizedPathname, true) !== null;
 }
 
 function normalizeRouteInput<TMeta>(
@@ -216,7 +216,11 @@ function parseRoutePattern(pattern: string): RouterSegment[] {
     });
 }
 
-function matchSegments(segments: RouterSegment[], pathname: string): FarmRouterParams | null {
+function matchSegments(
+  segments: RouterSegment[],
+  pathname: string,
+  allowTrailingSegments = false,
+): FarmRouterParams | null {
   const parts = splitPathname(pathname);
   const params: FarmRouterParams = {};
 
@@ -247,7 +251,7 @@ function matchSegments(segments: RouterSegment[], pathname: string): FarmRouterP
     pathIndex++;
   }
 
-  return pathIndex === parts.length ? params : null;
+  return allowTrailingSegments || pathIndex === parts.length ? params : null;
 }
 
 function compareRoutes<TMeta>(


### PR DESCRIPTION
## Problem

`isFarmRouteActive('/users/[id]', '/users/42/settings', { exact: false })` returns false, so navigation items for dynamic parent routes lose their active state on descendant pages.

## Root cause

Exact matching understands Farm route segments, but non-exact matching falls back to a literal string prefix containing `[id]`.

## Change

Let the shared segment matcher optionally accept trailing pathname segments, and use that mode for non-exact active checks. Preserve the existing root-route behavior.

## Safety and compatibility

Exact matching is unchanged. Static prefixes keep their existing result while dynamic segments and route groups now follow the same matching semantics as normal routes.

## Verification

- `pnpm --filter @farm.js/core test -- src/__tests__/router.test.ts`
- `pnpm --filter @farm.js/core type-check`
- focused `oxfmt` and `oxlint`

Regression coverage includes a dynamic route, a route group, a missing required segment, and an unrelated path.

## Documentation and release

Documented non-exact dynamic descendant matching in the routing guide.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes non-exact active state for dynamic routes so parent navigation items stay highlighted on descendant pages. Previously `isFarmRouteActive('/users/[id]', '/users/42/settings', { exact: false })` compared the literal `[id]` prefix and returned false; it now matches dynamic segments and route groups like normal routes while preserving exact matching and root-route behavior.

Adds regression coverage for dynamic routes, route groups, missing required segments, and unrelated paths, and updates the routing guide.

<sup>Written for commit 6691aaa394e15822551be8a52cfce95a4118ee87. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/613?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

