### PR TITLE
fix(router): reject empty path parameters

### DIFF
--- a/docs/src/app/docs/routing/page.md
+++ b/docs/src/app/docs/routing/page.md
@@ -164,6 +164,9 @@ This returns `/docs/core/routing`. Optional catch-all params can be omitted, sta
 For navigation state, `router.isActive(pattern, pathname, { exact: false })` also matches
 descendants after dynamic segments, such as `/users/42/settings` for `/users/[id]`.
 
+Supplied path parameters must contain non-empty segments; omit an optional catch-all instead of
+passing an empty string.
+
 Client components can pass the same route list to `useRouter` when they want current route params:
 
 ```tsx

--- a/packages/farm/src/__tests__/router.test.ts
+++ b/packages/farm/src/__tests__/router.test.ts
@@ -59,6 +59,16 @@ describe("route helpers", () => {
     );
   });
 
+  it("rejects empty supplied path segments", () => {
+    expect(() => buildFarmRoutePath("/users/[id]", { id: "" })).toThrow(
+      'Route param "id" for /users/[id] cannot contain an empty path segment.',
+    );
+    expect(() => buildFarmRoutePath("/docs/[...slug]", { slug: ["core", ""] })).toThrow(
+      'Route param "slug" for /docs/[...slug] cannot contain an empty path segment.',
+    );
+    expect(buildFarmRoutePath("/docs/[[...slug]]")).toBe("/docs");
+  });
+
   it("checks active routes exactly or by static prefix", () => {
     expect(isFarmRouteActive("/docs", "/docs")).toBe(true);
     expect(isFarmRouteActive("/docs", "/docs/routing")).toBe(false);

--- a/packages/farm/src/router.ts
+++ b/packages/farm/src/router.ts
@@ -120,7 +120,16 @@ export function buildFarmRoutePath(
       throw new Error(`Route param "${segment.name}" for ${pattern} expects a single value.`);
     }
 
-    parts.push(...values.map((item) => encodePathSegment(String(item))));
+    const encodedValues = values.map((item) => {
+      const value = String(item);
+      if (!value) {
+        throw new Error(
+          `Route param "${segment.name}" for ${pattern} cannot contain an empty path segment.`,
+        );
+      }
+      return encodePathSegment(value);
+    });
+    parts.push(...encodedValues);
   }
 
   let pathname = parts.length ? `/${parts.join("/")}` : "/";


### PR DESCRIPTION
## Problem

Building `/users/[id]` with `{ id: '' }` returns `/users/`, but that URL cannot match the required `[id]` route. Empty entries in catch-all arrays similarly create collapsed, unmatchable paths.

## Root cause

The builder checks whether a parameter is present but does not validate each supplied path segment before joining and encoding it.

## Change

Reject empty supplied segments with an actionable route-and-parameter error. Optional catch-all parameters can still be omitted normally.

## Safety and compatibility

Non-empty string, number, boolean, and catch-all values are unchanged. This replaces silently invalid output with an early deterministic error.

## Verification

- `pnpm --filter @farm.js/core test -- src/__tests__/router.test.ts src/__tests__/link.test.tsx`
- `pnpm --filter @farm.js/core type-check`
- focused `oxfmt` and `oxlint`

Regression coverage includes a required dynamic segment, an empty catch-all entry, and an omitted optional catch-all.

## Documentation and release

Documented the non-empty segment requirement in the typed routing guide.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects empty path parameters in route building so `/users/[id]` with `{ id: '' }` throws a clear error instead of returning `/users/`, which can't match the required route.

**Bug Fixes**
- Optional catch-all parameters can still be omitted normally.
- Non-empty string, number, boolean, and catch-all values behave exactly as before.
- Documents the non-empty segment requirement in the typed routing guide.

<sup>Written for commit 65434ea7a654aff8d91ecf6edbb2287194f5d505. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/614?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

