### PR TITLE
fix(middleware): preserve empty request cookies

### DIFF
--- a/docs/src/app/docs/middleware/page.md
+++ b/docs/src/app/docs/middleware/page.md
@@ -21,6 +21,7 @@ Data and headers written during middleware are request-scoped:
 | `ctx.data.set(key, value)` or `context.data.set(key, value)`         | Passes serializable, client-safe data to later middleware and page props.                     |
 | `ctx.locals.set(key, value)` or `context.set(key, value)`            | Passes server-only context to later middleware, layouts, pages, and nested Server Components. |
 | `ctx.headers.set(name, value)` or `context.headers.set(name, value)` | Adds headers to the final response.                                                           |
+| `ctx.cookies.get(name)`                                              | Reads decoded request cookies, including valid empty values.                                  |
 | `ctx.params` or `context.params`                                     | Contains params from the matched config matcher or route-scoped middleware path.              |
 | `return new Response(...)`                                           | Stops the chain and sends that response immediately.                                          |
 

--- a/packages/farm/src/__tests__/middleware.test.ts
+++ b/packages/farm/src/__tests__/middleware.test.ts
@@ -1035,12 +1035,14 @@ describe("Middleware Context", () => {
 
   it("should handle cookies", () => {
     const req = createMockRequest("/test");
-    req.headers.cookie = "session=abc123; user=john";
+    req.headers.cookie = "session=abc123; user=john; preview=";
     const res = createMockResponse();
     const ctx = createContext(req, res);
 
     expect(ctx.cookies.get("session")).toBe("abc123");
     expect(ctx.cookies.get("user")).toBe("john");
+    expect(ctx.cookies.get("preview")).toBe("");
+    expect(ctx.cookies.get("constructor")).toBeUndefined();
 
     ctx.cookies.set("new-cookie", "value123", { maxAge: 3600 });
     expect(res.setHeader).toHaveBeenCalled();

--- a/packages/farm/src/__tests__/production-middleware-http.test.ts
+++ b/packages/farm/src/__tests__/production-middleware-http.test.ts
@@ -109,6 +109,26 @@ describe("production middleware HTTP behavior", () => {
     expect(seen).toEqual({ track: "100%", session: "abc123" });
   });
 
+  it("preserves empty request cookies without inherited record values", async () => {
+    const seen: Record<string, string | undefined> = {};
+    const runner = createProductionMiddlewareRunner({
+      config: {
+        handler(ctx) {
+          seen.preview = ctx.cookies.get("preview");
+          seen.constructor = ctx.cookies.get("constructor");
+        },
+      },
+    });
+
+    await runner(
+      new Request("https://example.com/", {
+        headers: { cookie: "preview=" },
+      }),
+    );
+
+    expect(seen).toEqual({ preview: "", constructor: undefined });
+  });
+
   it("ignores forwarded client addresses unless trustProxy is enabled", async () => {
     const createRunner = (trustProxy: boolean) =>
       createProductionMiddlewareRunner({

--- a/packages/farm/src/middleware/context.ts
+++ b/packages/farm/src/middleware/context.ts
@@ -5,35 +5,7 @@
 import type { IncomingMessage, ServerResponse } from "http";
 import type { ViteDevServer } from "vite";
 import type { MiddlewareContext, CookieJar, CookieOptions } from "./types";
-
-/**
- * Parse cookies from Cookie header
- */
-function decodeCookieValue(value: string): string {
-  try {
-    return decodeURIComponent(value);
-  } catch {
-    // Cookies are not required to be percent-encoded; keep the raw value
-    // instead of failing the whole request on malformed encoding.
-    return value;
-  }
-}
-
-function parseCookies(cookieHeader?: string): Record<string, string> {
-  if (!cookieHeader) return {};
-
-  return cookieHeader.split(";").reduce(
-    (cookies, cookie) => {
-      const [name, ...rest] = cookie.split("=");
-      const value = rest.join("=").trim();
-      if (name && value) {
-        cookies[name.trim()] = decodeCookieValue(value);
-      }
-      return cookies;
-    },
-    {} as Record<string, string>,
-  );
-}
+import { parseMiddlewareCookieHeader } from "./cookie-header";
 
 /**
  * Serialize a cookie
@@ -85,7 +57,7 @@ class CookieJarImpl implements CookieJar {
     private req: IncomingMessage,
     private res: ServerResponse,
   ) {
-    this.cookies = parseCookies(req.headers.cookie);
+    this.cookies = parseMiddlewareCookieHeader(req.headers.cookie);
   }
 
   get(name: string): string | undefined {

--- a/packages/farm/src/middleware/cookie-header.ts
+++ b/packages/farm/src/middleware/cookie-header.ts
@@ -1,0 +1,27 @@
+function decodeCookieValue(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    // Cookies are not required to be percent-encoded; keep the raw value
+    // instead of failing the whole request on malformed encoding.
+    return value;
+  }
+}
+
+export function parseMiddlewareCookieHeader(cookieHeader?: string | null): Record<string, string> {
+  const cookies = Object.create(null) as Record<string, string>;
+  if (!cookieHeader) return cookies;
+
+  for (const cookie of cookieHeader.split(";")) {
+    const separator = cookie.indexOf("=");
+    if (separator < 0) continue;
+
+    const name = cookie.slice(0, separator).trim();
+    if (!name) continue;
+
+    const value = cookie.slice(separator + 1).trim();
+    cookies[name] = decodeCookieValue(value);
+  }
+
+  return cookies;
+}

--- a/packages/farm/src/middleware/production-runtime.ts
+++ b/packages/farm/src/middleware/production-runtime.ts
@@ -15,6 +15,7 @@ import { normalizeMiddlewareModule } from "./module";
 import { stripFarmLocaleFromPathname } from "../i18n/routing";
 import type { ResolvedFarmI18nConfig } from "../i18n/types";
 import type { ResolvedFarmServerConfig } from "../server-http";
+import { parseMiddlewareCookieHeader } from "./cookie-header";
 
 export interface ProductionMiddlewareModuleEntry {
   path: string;
@@ -103,32 +104,6 @@ class WebResponseHeaderMap extends Map<string, string> {
   }
 }
 
-function decodeCookieValue(value: string): string {
-  try {
-    return decodeURIComponent(value);
-  } catch {
-    // Cookies are not required to be percent-encoded; keep the raw value
-    // instead of failing the whole request on malformed encoding.
-    return value;
-  }
-}
-
-function parseCookies(cookieHeader?: string | null): Record<string, string> {
-  if (!cookieHeader) return {};
-
-  return cookieHeader.split(";").reduce(
-    (cookies, cookie) => {
-      const [name, ...rest] = cookie.split("=");
-      const value = rest.join("=").trim();
-      if (name && value) {
-        cookies[name.trim()] = decodeCookieValue(value);
-      }
-      return cookies;
-    },
-    {} as Record<string, string>,
-  );
-}
-
 function serializeCookie(name: string, value: string, options: CookieOptions = {}): string {
   let cookie = `${encodeURIComponent(name)}=${encodeURIComponent(value)}`;
 
@@ -152,7 +127,7 @@ class WebCookieJar implements CookieJar {
     request: Request,
     private headers: WebResponseHeaderMap,
   ) {
-    this.cookies = parseCookies(request.headers.get("cookie"));
+    this.cookies = parseMiddlewareCookieHeader(request.headers.get("cookie"));
   }
 
   get(name: string): string | undefined {


### PR DESCRIPTION
## Problem

A valid request cookie such as `preview=` is exposed as missing in middleware. Looking up an absent cookie named `constructor` or `toString` can also return an inherited object member instead of `undefined`.

## Root cause

Development and production each parse cookies into a normal object and only store pairs whose value is truthy.

## Change

Use one shared parser that accepts empty values, preserves embedded `=`, retains malformed percent-encoding as raw text, and stores entries in a null-prototype record.

## Safety and compatibility

Non-empty cookies keep their existing decoded values. Cookie serialization and response `Set-Cookie` handling are unchanged. Development and production now share identical parsing.

## Verification

- `pnpm --filter @farm.js/core test -- src/__tests__/middleware.test.ts src/__tests__/production-middleware-http.test.ts`
- `pnpm --filter @farm.js/core type-check`
- focused `oxfmt` and `oxlint`

The regression tests cover both Node development context and Web Request production middleware.

## Documentation and release

Added request-cookie behavior to the middleware API table.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes request cookie handling in middleware so empty values like `preview=` are preserved and names like `constructor` no longer return inherited object members.

- Introduces a shared cookie parser used by both development and production middleware.
- Accepts empty values, preserves embedded `=`, and keeps malformed percent-encoded values raw.
- Stores cookies in a null-prototype record to avoid inherited property lookups.
- Updates the middleware API docs table with `ctx.cookies.get`.

<sup>Written for commit 2725de02f8c33b3d6783b90aca26412a1814007c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/615?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

