### PR TITLE
fix(cache): normalize revalidation fragments

### DIFF
--- a/docs/src/app/docs/cache-ppr/page.md
+++ b/docs/src/app/docs/cache-ppr/page.md
@@ -66,6 +66,9 @@ revalidateTag("products");
 revalidatePath("/pricing");
 ```
 
+`revalidatePath()` accepts a pathname or an HTTP(S) URL. Query strings and fragments do not change
+the cache path and are removed during normalization.
+
 ## PPR shell
 
 **src/app/dashboard/page.tsx**

--- a/packages/farm/src/__tests__/cache.test.ts
+++ b/packages/farm/src/__tests__/cache.test.ts
@@ -474,6 +474,8 @@ describe("server cache primitives", () => {
 
   it("normalizes paths and stable cache keys", () => {
     expect(normalizeRevalidatePath("https://example.com/docs/?q=1")).toBe("/docs");
+    expect(normalizeRevalidatePath("HTTPS://example.com/docs?tab=api#intro")).toBe("/docs");
+    expect(normalizeRevalidatePath("/docs#intro")).toBe("/docs");
     expect(normalizeRevalidatePath("docs///intro/")).toBe("/docs/intro");
     expect(createFarmCacheKey([{ b: 1, a: 2 }])).toBe(createFarmCacheKey([{ a: 2, b: 1 }]));
   });

--- a/packages/farm/src/cache.ts
+++ b/packages/farm/src/cache.ts
@@ -865,14 +865,14 @@ export function normalizeRevalidatePath(routePath: string): string {
   }
 
   try {
-    if (/^https?:\/\//.test(normalized)) {
+    if (/^https?:\/\//i.test(normalized)) {
       normalized = new URL(normalized).pathname;
     }
   } catch {
     // Keep the original path if URL parsing fails.
   }
 
-  normalized = normalized.split("?")[0] ?? normalized;
+  normalized = normalized.split(/[?#]/, 1)[0] ?? normalized;
   normalized = normalized.startsWith("/") ? normalized : `/${normalized}`;
   normalized = normalized.replace(/\/{2,}/g, "/");
   if (normalized.length > 1) {


### PR DESCRIPTION
## Problem

`revalidatePath('/docs#intro')` creates a different cache tag from `/docs`, and uppercase HTTP schemes such as `HTTPS://example.com/docs` normalize into malformed local paths.

## Root cause

Relative normalization removes only query strings, not fragments, and absolute URL detection treats the HTTP scheme as case-sensitive.

## Change

Recognize HTTP(S) schemes case-insensitively and remove both query and fragment components before path canonicalization.

## Safety and compatibility

Existing normalized paths and lowercase HTTP URLs keep the same output. Query-specific cache invalidation was never supported; the function consistently targets route path cache entries.

## Verification

- `pnpm --filter @farm.js/core test -- src/__tests__/cache.test.ts`
- `pnpm --filter @farm.js/core type-check`
- focused `oxfmt` and `oxlint`

Regression coverage includes a root-relative fragment and an uppercase absolute URL with query and fragment.

## Documentation and release

Documented accepted inputs and query/fragment normalization on the cache page.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `normalizeRevalidatePath` so cache keys stay consistent for paths with fragments and uppercase HTTP schemes. Previously `/docs#intro` produced a different cache tag than `/docs`, and `HTTPS://example.com/docs` normalized into a malformed local path; now fragments and query strings are both stripped, and HTTP(S) scheme detection is case-insensitive.

- Query-specific cache invalidation is not a supported use case; the function always targets route path cache entries.
- Documents that `revalidatePath()` accepts a pathname or an HTTP(S) URL and removes query strings and fragments.

<sup>Written for commit 2fffcc2a44175a1b8fe6f40a6f2e52fabf26e2c3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/616?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

