### PR TITLE
fix(api): mount custom same-origin base paths

### DIFF
--- a/docs/src/app/docs/configuration/page.md
+++ b/docs/src/app/docs/configuration/page.md
@@ -311,6 +311,11 @@ and `basePath` is ignored. Both fields accept a string or a sync/async resolver 
 `{ root, mode, env }`. Farm resolves the function during configuration and only embeds the resulting
 public URL in the browser bundle.
 
+A root-relative API root is also mounted by Farm in development and production. For example,
+`api: { basePath: "/v2/api" }` makes a route declared at `app/api/users/route.ts` available at
+`/v2/api/users`. Farm treats an absolute `baseURL` as external and does not remount the current
+application's API routes for it.
+
 The option configures `createAPIClient()` automatically. An explicit per-client `baseURL` still
 takes precedence.
 

--- a/packages/farm/src/__tests__/api-config.test.ts
+++ b/packages/farm/src/__tests__/api-config.test.ts
@@ -6,6 +6,11 @@ import {
   resolveFarmAPIConfig,
   resolveFarmAPIRequestURL,
 } from "../api/config";
+import {
+  resolveFarmAPICanonicalPathname,
+  resolveFarmAPIServerBasePath,
+  resolveFarmAPIServerRoutePath,
+} from "../api/server-path";
 
 const context = {
   root: "/workspace/app",
@@ -87,5 +92,23 @@ describe("Farm API config", () => {
     expect(resolveFarmAPIRequestURL("/api/users", "https://api.example.com").href).toBe(
       "https://api.example.com/api/users",
     );
+  });
+
+  it("mounts root-relative API roots locally and leaves external origins at /api", () => {
+    expect(resolveFarmAPIServerBasePath({ baseURL: "/v2/api", basePath: "/v2/api" })).toBe(
+      "/v2/api",
+    );
+    expect(
+      resolveFarmAPIServerBasePath({
+        baseURL: "https://api.example.com/v2/api",
+        basePath: "/v2/api",
+      }),
+    ).toBe("/api");
+  });
+
+  it("translates between a local public API root and canonical route paths", () => {
+    expect(resolveFarmAPICanonicalPathname("/v2/api/users/42", "/v2/api")).toBe("/api/users/42");
+    expect(resolveFarmAPIServerRoutePath("/api/users/[id]", "/v2/api")).toBe("/v2/api/users/[id]");
+    expect(resolveFarmAPICanonicalPathname("/about", "/v2/api")).toBe("/about");
   });
 });

--- a/packages/farm/src/__tests__/api-route-manager.test.ts
+++ b/packages/farm/src/__tests__/api-route-manager.test.ts
@@ -40,6 +40,35 @@ describe("APIRouteManager", () => {
     expect(manager.getRoutes().get("/api/jsx")?.methods).toEqual(["GET"]);
   });
 
+  it("serves canonical routes through a custom same-origin API path", async () => {
+    const manager = new APIRouteManager("/tmp/farm-api-base-path-test", undefined, {
+      basePath: "/v2/api",
+    });
+    manager.getRoutes().set("/api/users/[id]", {
+      path: "/api/users/[id]",
+      filePath: "/tmp/farm-api-base-path-test/users/[id]/route.ts",
+      methods: ["GET"],
+      endpoints: {
+        GET: async (_request: Request, { params }: { params: Promise<{ id: string }> }) =>
+          Response.json(await params),
+      },
+    });
+
+    const response = await manager.getHandler()!(new Request("http://example.com/v2/api/users/42"));
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ id: "42" });
+    expect(manager.matchRoute("/v2/api/users/42")?.route.path).toBe("/api/users/[id]");
+
+    manager.getRoutes().set("/v2/api/users/[id]", {
+      path: "/v2/api/users/[id]",
+      filePath: "/tmp/farm-api-base-path-test/explicit/[id]/route.ts",
+      methods: ["GET"],
+      endpoints: { GET: async () => Response.json({ source: "explicit" }) },
+    });
+    expect(manager.matchRoute("/v2/api/users/42")?.route.path).toBe("/v2/api/users/[id]");
+  });
+
   it("uses GET for HEAD requests and strips the response body", async () => {
     const manager = new APIRouteManager("/tmp/farm-api-head-test");
     const getHandler = async () =>

--- a/packages/farm/src/__tests__/api-vite-plugin-rewrite.test.ts
+++ b/packages/farm/src/__tests__/api-vite-plugin-rewrite.test.ts
@@ -40,7 +40,10 @@ interface DevHarness {
  * middleware stub that mimics ctx.rewrite() by mutating req.url — exactly
  * what middleware/context.ts does.
  */
-async function createDevHarness(routes: Record<string, string>): Promise<DevHarness> {
+async function createDevHarness(
+  routes: Record<string, string>,
+  options: { basePath?: string } = {},
+): Promise<DevHarness> {
   const root = await mkdtemp(path.join(tmpdir(), "farm-api-rewrite-"));
   tempDirs.add(root);
 
@@ -50,7 +53,7 @@ async function createDevHarness(routes: Record<string, string>): Promise<DevHarn
     await writeFile(path.join(dir, "route.js"), source);
   }
 
-  const plugin = farmApiPlugin() as any;
+  const plugin = farmApiPlugin(options) as any;
   let handlerFn: ((req: any, res: any, next: () => void) => Promise<void>) | undefined;
 
   const server = {
@@ -125,6 +128,19 @@ async function createDevHarness(routes: Record<string, string>): Promise<DevHarn
 }
 
 describe("dev API dispatch after middleware rewrites", () => {
+  it("serves canonical routes through the configured local base path", async () => {
+    const harness = await createDevHarness(
+      {
+        users: `export const GET = async () => Response.json({ source: "custom-base" });\n`,
+      },
+      { basePath: "/v2/api" },
+    );
+
+    const result = await harness.dispatch("/v2/api/users");
+    expect(result.passedToNext).toBe(false);
+    expect(JSON.parse(result.body ?? "")).toEqual({ source: "custom-base" });
+  });
+
   it("dispatches the rewritten endpoint like production", async () => {
     const harness = await createDevHarness({
       "v1/users": `export const GET = async () => Response.json({ version: "v1" });\n`,

--- a/packages/farm/src/__tests__/route-runtime-deployment.test.ts
+++ b/packages/farm/src/__tests__/route-runtime-deployment.test.ts
@@ -95,6 +95,47 @@ describe("route runtime deployment manifest", () => {
     });
   });
 
+  it("publishes API runtime patterns at the configured local base path", async () => {
+    const root = createTempDir();
+    const apiPath = writeFile(root, "src/app/api/reports/[id]/route.ts");
+    const modules = new Map<string, Record<string, unknown>>([
+      [
+        apiPath,
+        {
+          maxDuration: 15,
+          GET: () => Response.json({ ok: true }),
+        },
+      ],
+    ]);
+    const config = createConfig(root, {
+      "/v2/api/**": { maxDuration: 20 },
+    });
+    config.api = { baseURL: "/v2/api", basePath: "/v2/api" };
+    const moduleServer = createModuleServer(root, modules);
+    const routeManager = new RouteManager(config, moduleServer);
+    const apiRouteManager = new APIRouteManager(path.join(root, "src/app"), moduleServer, {
+      throwOnLoadError: true,
+      basePath: "/v2/api",
+    });
+    await routeManager.discoverRoutes();
+    await apiRouteManager.discoverRoutes();
+
+    const manifest = await createFarmRouteRuntimeManifest({
+      config: config as ResolvedFarmConfig,
+      routeManager,
+      apiRouteManager,
+      root,
+    });
+
+    expect(manifest.routes).toContainEqual(
+      expect.objectContaining({
+        kind: "api",
+        pattern: "/v2/api/reports/[id]",
+        maxDuration: 15,
+      }),
+    );
+  });
+
   it("rejects incompatible runtimes and reports unsupported provider hints", () => {
     const manifest: FarmRouteRuntimeManifest = {
       version: 1,
@@ -256,6 +297,7 @@ function createConfig(root: string, routeRules: FarmConfig["routeRules"]): Requi
     root,
     srcDir: "src",
     routeRules,
+    api: { baseURL: "/api", basePath: "/api" },
     mdx: { markdownRoutes: true, className: "farm-markdown" },
   } as Required<FarmConfig>;
 }

--- a/packages/farm/src/api/config.ts
+++ b/packages/farm/src/api/config.ts
@@ -19,7 +19,7 @@ export interface FarmAPIConfig {
    * already has a path is used as-is. May be resolved from deployment context.
    */
   baseURL?: FarmAPIConfigValue;
-  /** Public API path used when `baseURL` has no path. @default "/api" */
+  /** Public API path and same-origin server mount used when `baseURL` has no path. @default "/api" */
   basePath?: FarmAPIConfigValue;
 }
 

--- a/packages/farm/src/api/route-manager.ts
+++ b/packages/farm/src/api/route-manager.ts
@@ -14,6 +14,7 @@ import { _runWithFarmI18nRequest, type FarmI18nRuntime } from "../i18n/server";
 import {
   getAllowedAPIRouteMethods,
   invokeAPIRouteEndpoint,
+  matchAPIRouteAtBasePath,
   matchAPIRoute,
   resolveAPIRouteEndpoint,
   type APIRouteMatch,
@@ -31,6 +32,8 @@ export interface APIRouteManagerOptions {
   throwOnLoadError?: boolean;
   i18n?: FarmI18nRuntime;
   bodySizeLimit?: number;
+  /** Same-origin path where canonical `/api` routes are served. */
+  basePath?: string;
 }
 
 export interface APIRouteHandlerOptions {
@@ -56,6 +59,7 @@ export class APIRouteManager {
   private throwOnLoadError: boolean;
   private i18n?: FarmI18nRuntime;
   private bodySizeLimit?: number;
+  private basePath?: string;
 
   constructor(
     appDir: string | readonly string[],
@@ -67,6 +71,7 @@ export class APIRouteManager {
     this.throwOnLoadError = options.throwOnLoadError === true;
     this.i18n = options.i18n;
     this.bodySizeLimit = options.bodySizeLimit;
+    this.basePath = options.basePath;
   }
 
   /**
@@ -306,7 +311,7 @@ export class APIRouteManager {
       const method = request.method.toUpperCase();
 
       // Find matching route
-      const match = matchAPIRoute(this.routes, pathname);
+      const match = matchAPIRouteAtBasePath(this.routes, pathname, this.basePath);
       if (!match) {
         return new Response(JSON.stringify({ error: "Not Found" }), {
           status: 404,
@@ -356,7 +361,7 @@ export class APIRouteManager {
   }
 
   matchRoute(pathname: string): APIRouteMatch<APIRoute> | null {
-    return matchAPIRoute(this.routes, pathname);
+    return matchAPIRouteAtBasePath(this.routes, pathname, this.basePath);
   }
 
   /**

--- a/packages/farm/src/api/runtime.ts
+++ b/packages/farm/src/api/runtime.ts
@@ -10,6 +10,8 @@ import {
   createFarmRequestBodyErrorResponse,
   DEFAULT_FARM_SERVER_BODY_SIZE_LIMIT,
 } from "../server-http";
+import { DEFAULT_FARM_API_BASE_PATH, normalizeFarmAPIBasePath } from "./config";
+import { resolveFarmAPICanonicalPathname } from "./server-path";
 
 export type APIRouteParamValue = string | string[];
 export type APIRouteParams = Record<string, APIRouteParamValue>;
@@ -69,6 +71,28 @@ export function matchAPIRoute<T extends { path: string }>(
   }
 
   return null;
+}
+
+/** Match canonical routes through a configurable same-origin public API path. */
+export function matchAPIRouteAtBasePath<T extends { path: string }>(
+  routes: Map<string, T>,
+  pathname: string,
+  serverBasePath = DEFAULT_FARM_API_BASE_PATH,
+): APIRouteMatch<T> | null {
+  const directMatch = matchAPIRoute(routes, pathname);
+  if (directMatch) return directMatch;
+
+  const canonicalPathname = resolveFarmAPICanonicalPathname(pathname, serverBasePath);
+  return canonicalPathname === pathname ? null : matchAPIRoute(routes, canonicalPathname);
+}
+
+/** Test whether a pathname belongs to the configured local API surface. */
+export function isFarmAPIPathname(
+  pathname: string,
+  serverBasePath = DEFAULT_FARM_API_BASE_PATH,
+): boolean {
+  const basePath = normalizeFarmAPIBasePath(serverBasePath);
+  return basePath !== "/" && (pathname === basePath || pathname.startsWith(`${basePath}/`));
 }
 
 export async function invokeAPIRouteEndpoint(

--- a/packages/farm/src/api/server-path.ts
+++ b/packages/farm/src/api/server-path.ts
@@ -1,0 +1,41 @@
+import {
+  DEFAULT_FARM_API_BASE_PATH,
+  normalizeFarmAPIBasePath,
+  resolveFarmAPIRequestURL,
+  type ResolvedFarmAPIConfig,
+} from "./config";
+
+/** Return the same-origin path served by this Farm application. */
+export function resolveFarmAPIServerBasePath(config: ResolvedFarmAPIConfig): string {
+  // Absolute API URLs belong to another origin and must not move local routes.
+  return config.baseURL.startsWith("/") ? config.basePath : DEFAULT_FARM_API_BASE_PATH;
+}
+
+/** Translate a public local API pathname back to Farm's canonical `/api` route table. */
+export function resolveFarmAPICanonicalPathname(
+  pathname: string,
+  serverBasePath = DEFAULT_FARM_API_BASE_PATH,
+): string {
+  const basePath = normalizeFarmAPIBasePath(serverBasePath);
+  if (basePath === DEFAULT_FARM_API_BASE_PATH) return pathname;
+
+  if (basePath === "/") {
+    return pathname === "/"
+      ? DEFAULT_FARM_API_BASE_PATH
+      : `${DEFAULT_FARM_API_BASE_PATH}${pathname.startsWith("/") ? pathname : `/${pathname}`}`;
+  }
+
+  if (pathname === basePath) return DEFAULT_FARM_API_BASE_PATH;
+  if (pathname.startsWith(`${basePath}/`)) {
+    return `${DEFAULT_FARM_API_BASE_PATH}${pathname.slice(basePath.length)}`;
+  }
+  return pathname;
+}
+
+/** Resolve a canonical `/api` route to the path served by this application. */
+export function resolveFarmAPIServerRoutePath(
+  routePath: string,
+  serverBasePath = DEFAULT_FARM_API_BASE_PATH,
+): string {
+  return resolveFarmAPIRequestURL(routePath, serverBasePath).pathname;
+}

--- a/packages/farm/src/api/vite-plugin.ts
+++ b/packages/farm/src/api/vite-plugin.ts
@@ -20,9 +20,9 @@ import {
   API_ROUTE_METHODS,
   getAllowedAPIRouteMethods,
   invokeAPIRouteEndpoint,
-  matchAPIRoute,
   resolveAPIRouteEndpoint,
 } from "./route-manager";
+import { matchAPIRouteAtBasePath } from "./runtime";
 import { sendWebResponse } from "../server/response";
 import { isFarmAPIRouteFileName } from "./route-files";
 import { _withAfterNodeMiddleware } from "../after";
@@ -43,6 +43,8 @@ export interface FarmApiPluginOptions {
   debug?: boolean;
   /** Maximum request body size, for example `"10mb"`. */
   bodySizeLimit?: number | string;
+  /** Same-origin path where canonical `/api` routes are served. @default "/api" */
+  basePath?: string;
 }
 
 export interface ApiRoute {
@@ -61,6 +63,7 @@ export function farmApiPlugin(options: FarmApiPluginOptions = {}): Plugin {
   const bodySizeLimit = resolveFarmServerConfig({
     bodySizeLimit: options.bodySizeLimit,
   }).bodySizeLimit;
+  const basePath = options.basePath;
 
   // API routes cache
   let apiRoutesCache: Map<string, ApiRoute> = new Map();
@@ -128,7 +131,7 @@ export function farmApiPlugin(options: FarmApiPluginOptions = {}): Plugin {
         const method = request.method.toUpperCase();
         const pathname = url.pathname;
 
-        const match = matchAPIRoute(apiRoutesCache, pathname);
+        const match = matchAPIRouteAtBasePath(apiRoutesCache, pathname, basePath);
         if (!match) {
           return new Response(JSON.stringify({ error: "Not Found" }), {
             status: 404,
@@ -333,7 +336,7 @@ export function farmApiPlugin(options: FarmApiPluginOptions = {}): Plugin {
               await discoveryPromise;
             }
 
-            if (!matchAPIRoute(apiRoutesCache, pathname)) {
+            if (!matchAPIRouteAtBasePath(apiRoutesCache, pathname, basePath)) {
               return next();
             }
 
@@ -362,7 +365,10 @@ export function farmApiPlugin(options: FarmApiPluginOptions = {}): Plugin {
               // reaches the API router.
               const currentUrl = req.url || url;
               const currentPathname = currentUrl.split("?")[0];
-              if (currentPathname !== pathname && !matchAPIRoute(apiRoutesCache, currentPathname)) {
+              if (
+                currentPathname !== pathname &&
+                !matchAPIRouteAtBasePath(apiRoutesCache, currentPathname, basePath)
+              ) {
                 // Rewritten off the API surface; let the page pipeline serve it.
                 return next();
               }

--- a/packages/farm/src/build/index.ts
+++ b/packages/farm/src/build/index.ts
@@ -10,6 +10,7 @@ import { existsSync } from "node:fs";
 import { logger } from "../utils";
 import { createFarmApp } from "../app";
 import { APIRouteManager } from "../api/route-manager";
+import { resolveFarmAPIServerBasePath } from "../api/server-path";
 import { getFarmAppDirectories } from "../layers";
 import { buildUniversal } from "../nitro/universal-build";
 import { getFarmDocsRouteTypeEntries } from "../docs";
@@ -191,6 +192,7 @@ async function buildWithProductionNodeEnv(inputConfig: ResolvedFarmConfig, optio
         throwOnLoadError: true,
         i18n: farmApp.getI18nRuntime(),
         bodySizeLimit: config.server.bodySizeLimit,
+        basePath: resolveFarmAPIServerBasePath(config.api),
       },
     );
     const [, apiDiscovery] = await Promise.allSettled([

--- a/packages/farm/src/nitro/index.ts
+++ b/packages/farm/src/nitro/index.ts
@@ -13,6 +13,7 @@ import {
   prepareFarmCronForNitro,
 } from "../cron";
 import { routeRulesToNitroRouteRules } from "../route-rules";
+import { resolveFarmAPIServerBasePath } from "../api/server-path";
 
 /**
  * Create Nitro configuration for Farm.js
@@ -26,6 +27,7 @@ export async function createNitroConfig(
   preset = "node-server",
 ): Promise<NitroConfig> {
   const root = config.root || process.cwd();
+  const apiBasePath = resolveFarmAPIServerBasePath(config.api);
   const srcDir = config.srcDir || "src";
   const distDir = ".farm";
   // Nitro build directory - where Nitro does its work (temporary)
@@ -86,12 +88,14 @@ export const farmRegistry: {
   env?: any;
   deploymentId?: string;
   basePath?: string;
+  apiBasePath?: string;
   clientManifest?: any;
   routePaths?: Record<string, string>;
 } = {
   env: ${JSON.stringify(config.env || { server: {}, public: {} }, null, 2)},
   deploymentId: ${JSON.stringify(config.deploymentId)},
   basePath: ${JSON.stringify(config.basePath)},
+  apiBasePath: ${JSON.stringify(apiBasePath)},
   routePaths: ${JSON.stringify(routePaths, null, 2)},
 };
 `,
@@ -116,11 +120,14 @@ export default defineEventHandler(async (event: H3Event) => {
   // Get URL using H3's abstraction (works in all environments)
   const url = getRequestURL(event);
   const urlPath = url.pathname;
+  const apiBasePath = farmRegistry.apiBasePath || '/api';
+  const isAPIPath = apiBasePath !== '/' &&
+    (urlPath === apiBasePath || urlPath.startsWith(apiBasePath + '/'));
   
   // Only handle API routes - for Vercel, Nitro routes /api/* to this handler
   // According to https://nitro.build/deploy/providers/vercel
   // This handler should process all /api/* routes
-  if (!urlPath.startsWith('/api/')) {
+  if (!isAPIPath) {
     // Return undefined to let Nitro's routing system handle non-API routes
     return undefined;
   }
@@ -291,6 +298,9 @@ export default defineEventHandler(async (event: H3Event) => {
     // Get URL from H3 event
     const url = getRequestURL(event);
     const pathname = url.pathname;
+    const apiBasePath = farmRegistry.apiBasePath || '/api';
+    const isAPIPath = apiBasePath !== '/' &&
+      (pathname === apiBasePath || pathname.startsWith(apiBasePath + '/'));
     const redirectMatch = routeManager.matchRedirect(pathname);
     if (redirectMatch) {
       setResponseStatus(event, redirectMatch.statusCode);
@@ -333,14 +343,14 @@ export default defineEventHandler(async (event: H3Event) => {
     }
 
     // Skip API routes - let the API handler process them
-    if (pathname.startsWith('/api/')) {
+    if (isAPIPath) {
       // Return undefined to let Nitro's API handler process
       return undefined;
     }
     
     // Skip static assets - let Nitro serve them
     // Only skip if it's clearly a static file (has extension and not in root)
-    if (pathname.startsWith('/assets/') || (pathname.includes('.') && !pathname.startsWith('/api/'))) {
+    if (pathname.startsWith('/assets/') || (pathname.includes('.') && !isAPIPath)) {
       // Check if it's a static file by extension
       const staticExtensions = ['.js', '.css', '.png', '.jpg', '.jpeg', '.gif', '.svg', '.ico', '.woff', '.woff2', '.ttf', '.eot'];
       const hasStaticExtension = staticExtensions.some(ext => pathname.toLowerCase().endsWith(ext));
@@ -588,14 +598,18 @@ export default defineEventHandler(async (event: H3Event) => {
       : [],
     // Route rules for Vercel
     routeRules: {
-      "/api/**": {
-        cors: true,
-        headers: {
-          "Access-Control-Allow-Origin": "*",
-          "Access-Control-Allow-Methods": "*",
-          "Access-Control-Allow-Headers": "*",
-        },
-      },
+      ...(apiBasePath === "/"
+        ? {}
+        : {
+            [`${apiBasePath}/**`]: {
+              cors: true,
+              headers: {
+                "Access-Control-Allow-Origin": "*",
+                "Access-Control-Allow-Methods": "*",
+                "Access-Control-Allow-Headers": "*",
+              },
+            },
+          }),
       "/**": {
         prerender: false,
       },

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -9,6 +9,7 @@ import {
 } from "./client-css-href";
 import type { RouteManager } from "../routing/route-manager";
 import type { APIRouteManager } from "../api/route-manager";
+import { resolveFarmAPIServerBasePath } from "../api/server-path";
 import type { ServerRenderer } from "../server/renderer";
 import type { FarmPlugin, PluginManager } from "../plugin";
 import {
@@ -3937,7 +3938,7 @@ function generateVirtualEntryCode(
     : "";
   const apiRouteHelpersImport =
     apiRoutes.length > 0
-      ? `import { getAllowedAPIRouteMethods, invokeAPIRouteEndpoint, matchAPIRoute, resolveAPIRouteEndpoint } from "@farm.js/core/api/runtime";`
+      ? `import { getAllowedAPIRouteMethods, invokeAPIRouteEndpoint, matchAPIRouteAtBasePath, resolveAPIRouteEndpoint } from "@farm.js/core/api/runtime";`
       : "";
   const productionRuntimeImport = `import {
   _runWithAfterRequest,
@@ -4074,7 +4075,11 @@ ${integrationRuntimeImport}
 const apiRouteMap = new Map(apiRoutes.map((route) => [route.path, route]));
 
 function matchLocalAPIRequest(request) {
-  return matchAPIRoute(apiRouteMap, new URL(request.url).pathname);
+  return matchAPIRouteAtBasePath(
+    apiRouteMap,
+    new URL(request.url).pathname,
+    farmLocalAPIBasePath
+  );
 }
 
 async function handleAPIRequest(request) {
@@ -4379,6 +4384,13 @@ const farmDocsAPIHandler = ${
 // API routes bundled at build time
 const apiRoutes = [${apiRegistrations.join(",")}
 ];
+const farmLocalAPIBasePath = ${JSON.stringify(resolveFarmAPIServerBasePath(config.api))};
+
+function isFarmLocalAPIPathname(pathname) {
+  return farmLocalAPIBasePath !== "/" &&
+    (pathname === farmLocalAPIBasePath ||
+      pathname.startsWith(farmLocalAPIBasePath + "/"));
+}
 
 // Page routes bundled at build time
 const pageRoutes = [${pageRegistrations.join(",")}
@@ -5394,14 +5406,12 @@ function getFarmPluginRequestOptions(request) {
     return { kind: "docs", route: { ...route, pattern: docsPath } };
   }
 
-  for (const apiRoute of apiRoutes) {
-    const params = matchRuntimePathPattern(apiRoute.path, pathname);
-    if (params !== null) {
-      return {
-        kind: "api",
-        route: { ...route, pattern: apiRoute.path, params },
-      };
-    }
+  const apiMatch = ${apiRoutes.length > 0 ? "matchLocalAPIRequest(request)" : "null"};
+  if (apiMatch) {
+    return {
+      kind: "api",
+      route: { ...route, pattern: apiMatch.route.path, params: apiMatch.params },
+    };
   }
 
   const metadataImageMatch = matchMetadataImageRequest(routePathname);
@@ -5440,7 +5450,7 @@ function getFarmPluginRequestOptions(request) {
     };
   }
 
-  if (pathname.startsWith("/api/")) {
+  if (isFarmLocalAPIPathname(pathname)) {
     return { kind: "api", route };
   }
 
@@ -5696,7 +5706,8 @@ async function handleFarmRequest(request) {
       }
       const response = await handleFarmRequestInContext(request, farmLocaleResolution);
       return applyFarmI18nResponse(response, farmLocaleResolution);
-    }
+    },
+    { redirect: !isFarmLocalAPIPathname(new URL(request.url).pathname) }
   )`
       : "handleFarmRequestInContext(request, null)"
   };
@@ -5911,15 +5922,19 @@ async function handleFarmRequestInContext(
       : ""
   }
 
-  // Preserve the explicit JSON 404 for /api/* misses.
-  if (pathname.startsWith("/api/")) {
-    if (farmDocsAPIHandler) {
-      const docsAPIResponse = await farmDocsAPIHandler(request.clone());
-      if (docsAPIResponse) {
-        return applyProductionMiddlewareHeaders(docsAPIResponse, middlewareHeaders);
-      }
+  ${
+    config.docs?.enabled
+      ? `if (farmDocsAPIHandler && isFarmDocsAPIRequest(pathname)) {
+    const docsAPIResponse = await farmDocsAPIHandler(request.clone());
+    if (docsAPIResponse) {
+      return applyProductionMiddlewareHeaders(docsAPIResponse, middlewareHeaders);
     }
+  }`
+      : ""
+  }
 
+  // Preserve the explicit JSON 404 for misses below the configured local API path.
+  if (isFarmLocalAPIPathname(pathname)) {
     return applyProductionMiddlewareHeaders(new Response(
       JSON.stringify({ error: "API route not found", pathname }),
       { status: 404, headers: { "Content-Type": "application/json" } }
@@ -7472,14 +7487,18 @@ export default async function farmNitroEventHandler(event) {
       },
     ],
     routeRules: {
-      "/api/**": {
-        cors: true,
-        headers: {
-          "Access-Control-Allow-Origin": "*",
-          "Access-Control-Allow-Methods": "*",
-          "Access-Control-Allow-Headers": "*",
-        },
-      },
+      ...(resolveFarmAPIServerBasePath(config.api) === "/"
+        ? {}
+        : {
+            [`${resolveFarmAPIServerBasePath(config.api)}/**`]: {
+              cors: true,
+              headers: {
+                "Access-Control-Allow-Origin": "*",
+                "Access-Control-Allow-Methods": "*",
+                "Access-Control-Allow-Headers": "*",
+              },
+            },
+          }),
       "/**": {
         prerender: false,
       },
@@ -7925,15 +7944,19 @@ async function postProcessVercelOutput(
     },
     ...runtimeRoutes,
     // API routes
-    {
-      src: "/api/(.*)",
-      dest: "/__nitro",
-      headers: {
-        "Access-Control-Allow-Origin": "*",
-        "Access-Control-Allow-Methods": "*",
-        "Access-Control-Allow-Headers": "*",
-      },
-    },
+    ...(resolveFarmAPIServerBasePath(config.api) === "/"
+      ? []
+      : [
+          {
+            src: `${resolveFarmAPIServerBasePath(config.api)}/(.*)`,
+            dest: "/__nitro",
+            headers: {
+              "Access-Control-Allow-Origin": "*",
+              "Access-Control-Allow-Methods": "*",
+              "Access-Control-Allow-Headers": "*",
+            },
+          },
+        ]),
     // All other routes go to the serverless function
     {
       src: "/(.*)",

--- a/packages/farm/src/route-runtime-manifest.ts
+++ b/packages/farm/src/route-runtime-manifest.ts
@@ -1,5 +1,6 @@
 import path from "path";
 import type { APIRouteManager } from "./api/route-manager";
+import { resolveFarmAPIServerBasePath, resolveFarmAPIServerRoutePath } from "./api/server-path";
 import type { ResolvedFarmConfig } from "./config";
 import { getFarmPresetRuntime, type FarmPresetRuntime } from "./deployment";
 import {
@@ -46,7 +47,11 @@ export async function createFarmRouteRuntimeManifest(options: {
   }
 
   for (const [pattern, route] of options.apiRouteManager.getRoutes()) {
-    const inherited = resolveFarmRouteRuleRuntimeConfig(pattern, options.config.routeRules);
+    const publicPattern = resolveFarmAPIServerRoutePath(
+      pattern,
+      resolveFarmAPIServerBasePath(options.config.api),
+    );
+    const inherited = resolveFarmRouteRuleRuntimeConfig(publicPattern, options.config.routeRules);
     const own = normalizeFarmRouteRuntimeConfig(
       getFarmRouteRuntimeConfig(route),
       `API route "${pattern}"`,
@@ -54,7 +59,7 @@ export async function createFarmRouteRuntimeManifest(options: {
 
     routes.push({
       kind: "api",
-      pattern,
+      pattern: publicPattern,
       rendering: "dynamic",
       source: normalizeManifestSource(root, route.filePath),
       ...resolveFarmRouteRuntimeConfig(

--- a/packages/farm/src/vite.ts
+++ b/packages/farm/src/vite.ts
@@ -7,6 +7,8 @@ import type { FarmPlugin, FarmPluginRuntimeSession, PluginManager } from "./plug
 import { generateFarmClientPluginEntryCode } from "./client-plugin-build";
 import { APIRouteManager } from "./api/route-manager";
 import { DEFAULT_FARM_API_BASE_PATH } from "./api/config";
+import { resolveFarmAPIServerBasePath } from "./api/server-path";
+import { isFarmAPIPathname } from "./api/runtime";
 import type { OpenAPIManager } from "./openapi/manager";
 import { MiddlewareManager } from "./middleware/manager";
 import { generateFarmTypeArtifacts, type GenerateFarmTypeArtifactsOptions } from "./type-artifacts";
@@ -732,6 +734,7 @@ export function farmPlugin(
       await farmApp.initialize();
 
       const farmConfig = farmApp.getConfig();
+      const apiServerBasePath = resolveFarmAPIServerBasePath(farmConfig.api);
       const serverConfig = resolveFarmServerConfig(farmConfig.server);
       let imageHandler: FarmImageHandler | null = null;
       if (farmConfig.images.provider !== "none") {
@@ -975,6 +978,7 @@ export function farmPlugin(
       apiRouteManager = new APIRouteManager(appDirs, server, {
         i18n: farmApp.getI18nRuntime(),
         bodySizeLimit: serverConfig.bodySizeLimit,
+        basePath: apiServerBasePath,
       });
       await apiRouteManager.discoverRoutes();
       let discoveredWorkflows: FarmDiscoveredWorkflow[] = [];
@@ -1630,7 +1634,7 @@ window.__FARM_MANIFEST__ = ${inlineValue({
           // Handle API routes first
           const matchedApiRoute = apiRouteManager.matchRoute(requestPathname);
           const hasMatchedApiRoute = Boolean(matchedApiRoute);
-          if (hasMatchedApiRoute || req.url?.startsWith("/api/")) {
+          if (hasMatchedApiRoute || isFarmAPIPathname(requestPathname, apiServerBasePath)) {
             const startTime = Date.now();
             const method = req.method || "GET";
             const urlPath = req.url || "/";


### PR DESCRIPTION
## Problem

A root-relative API configuration such as `api: { basePath: "/v2/api" }` changed the typed client URL to `/v2/api/users`, but Farm still matched and deployed the route only as `/api/users`. The generated client therefore received a 404 from the same application.

## Root cause

File and programmatic API routes intentionally use canonical `/api` paths internally. Development middleware, generated Nitro handlers, route-runtime manifests, and Vercel routing treated those canonical keys as public paths instead of translating the configured same-origin mount.

## Change

- Add one internal translation between the public same-origin API mount and canonical route keys.
- Apply it to the main dev server, standalone Vite API plugin, universal and legacy Nitro paths, API miss handling, and plugin request classification.
- Publish route-runtime and Vercel patterns at the configured public path and attach generated CORS rules there.
- Keep docs API handling independent and suppress locale redirects on the configured API surface.
- Document that root-relative API roots are locally mounted while absolute `baseURL` values are treated as external.

## Safety and compatibility

The default `/api` behavior is unchanged. Only root-relative resolved API URLs remount local routes; absolute URLs continue to target an external server while the application keeps its canonical local API mount. An explicitly registered route at the public path wins before canonical translation. Page routing remains available when the API root is `/` because only real API matches claim those requests.

## Verification

- `pnpm --filter @farm.js/core test -- --run src/__tests__/api-config.test.ts src/__tests__/api-route-manager.test.ts src/__tests__/api-vite-plugin-rewrite.test.ts src/__tests__/route-runtime-deployment.test.ts src/__tests__/i18n.test.ts` — 52 tests passed.
- `pnpm --filter @farm.js/core type-check`
- `pnpm --filter @farm.js/core build`
- `pnpm docs:check-navigation`
- Built a temporary Node-preset application with `api.basePath: "/v2/api"`; `GET /v2/api/status` returned 200 with the handler observing `/v2/api/status`, generated CORS headers were present, and `GET /` still rendered successfully.

## Documentation and release

Updated the API client base URL section of the configuration guide. No version or release-file changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes API route mounting so a root-relative `api.basePath` actually serves routes at that public path instead of only at `/api`. Previously `api: { basePath: "/v2/api" }` changed the generated client URL while Farm still matched and deployed routes as `/api/users`, so the client received 404s from the same app.

**What changed**
- Adds one internal translation between the public same-origin API mount and canonical `/api` route keys.
- Applies the translation to the dev server, standalone Vite plugin, Nitro builds, route-runtime manifests, Vercel routing, and API miss handling.
- Publishes runtime patterns and generated CORS rules at the configured public path.

**Compatibility**
- Default `/api` behavior is unchanged; absolute `baseURL` values stay external while only root-relative API roots are mounted locally.
- An explicitly registered route at the public path wins before canonical translation.
- Docs API handling stays independent and locale redirects are suppressed on the configured API surface.

<sup>Written for commit 20ddc8aea7d4acf5bada442222bbd7c253a0fed2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/617?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

