### PR TITLE
perf(react): refresh same-key windows in place

### DIFF
--- a/docs/src/app/docs/renderers/react/page.md
+++ b/docs/src/app/docs/renderers/react/page.md
@@ -1059,8 +1059,13 @@ computes every key, descriptor, binding snapshot, and detached host row before m
 tree. Duplicate incoming keys or collisions with existing keys therefore take complete
 reconciliation without a partial insertion. Valid rows are mounted in one document fragment;
 surrounding elements remain connected and only stored suffix indexes shift. Exact-window
-replacement removes only the proven old interval after every incoming row is prepared. A reused
-key takes complete reconciliation before mutation so React row identity is preserved. A single insertion
+replacement with fresh keys removes only the proven old interval after every incoming row is
+prepared. If the incoming interval has the same length and exactly the same keys in the same order,
+Farm first evaluates all keys and binding snapshots and resolves every changed target across the
+complete interval. It then patches only changed bindings in place and updates each stored row
+object, so later delegated or cached handlers observe the latest data. No descriptor or DOM row is
+created, and every row keeps its identity, focus, and text selection. Reordered, partially reused,
+mixed, or duplicate keys take complete reconciliation before fast-path mutation. A single insertion
 creates one row at that position. A removal cleans up and removes only the known row or contiguous
 range while preserving every
 surviving element. A same-key replacement patches that row in place; a new-key replacement creates
@@ -1071,9 +1076,9 @@ The proof requires compiler-owned host rows whose render and key do not observe 
 Effectful position expressions, runtime values that are fractional or otherwise not safe integers,
 dynamic, zero, negative, or fractional removal counts, other `toSpliced()` shapes, block-bodied
 updaters, unsafe incoming expressions, custom methods, queued uncommitted position updates,
-duplicate or reused incoming keys, collection-reading bindings, React-owned rows, nested host blocks, row
-conditionals, unrelated dirty dependencies, and failed runtime checks keep complete keyed
-reconciliation. Negative safe-integer positions and counts larger than the remaining suffix use the
+duplicate, reordered, mixed, or partially reused incoming keys, collection-reading bindings,
+React-owned rows, nested host blocks, row conditionals, unrelated dirty dependencies, and failed
+runtime checks keep complete keyed reconciliation. Negative safe-integer positions and counts larger than the remaining suffix use the
 native method's normal clamping rules. No new option or component is required. Reports expose
 emitted sites as `keyedArrayPositionHints`. Batch insertion and exact-window replacement select
 progressively separate optional runtime capabilities, so modules with only single-row operations
@@ -1958,8 +1963,10 @@ The package and example test suites verify more than generated code:
   preserve focused input and surrounding DOM identity, and cover native evaluation and coercion,
   clamping, unsafe runtime positions and counts, custom methods, queued updates,
   collection-reading rows, StrictMode hydration, and cleanup; targeted window tests additionally
-  require work to equal only the incoming window, preserve retained rows on both sides, and cover
-  empty spreads, key reuse, duplicate keys, delegated events, focus, selection, and queued fallback;
+  require fresh-key work to equal only the incoming window and a 4,096-row same-key refresh to
+  perform zero descriptor creation while preserving all 64 refreshed DOM rows; they also cover
+  atomic binding preparation, empty spreads, reordered and duplicate key fallback, latest delegated
+  event data, focus, selection, hydration, Strict Mode, and queued fallback;
 - 2,000 deterministic randomized reversals match normal React; a 4,096-row targeted test requires
   exactly `n - 1` connected DOM moves and zero key, descriptor, or binding reads, while fallback
   tests cover custom methods, queued updates, collection-reading rows, StrictMode hydration, and

--- a/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
+++ b/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
@@ -2,6 +2,30 @@
 
 Date: 2026-08-29
 
+## Same-key exact-window refresh follow-up — 2026-08-31
+
+The full bracketed production-browser run added a separate 10,000-row workload for refreshing 64
+new row objects whose keys remain identical and in the same order. One visible row changes so the
+run proves both data-to-DOM patching and the avoided 10,000-key scan. Both compiler builds emitted
+all seven expected `keyedArrayPositionHints` sites, preserved every one of the 64 row elements,
+updated the changed label and amount, produced zero owner executions, and passed every existing
+correctness, performance, persistence, and scalability gate without lowering a threshold.
+
+| Mode   | React median | Hinted refresh | Compiled control | vs React | vs control |
+| ------ | -----------: | -------------: | ---------------: | -------: | ---------: |
+| Static |     59.00 ms |        9.30 ms |         16.90 ms |    6.34x |      1.82x |
+| Hybrid |     59.00 ms |        7.40 ms |         16.40 ms |    7.97x |      2.22x |
+
+The package suite separately proves zero descriptors for a 64-row same-key refresh, retained DOM
+identity for every row, changed text and controlled-input value bindings, focus and selection,
+latest delegated event data, complete-window key/binding/target preparation before mutation,
+mixed/reordered/duplicate-key fallback, 1,000 differential updates, hydration, Strict Mode,
+queued-update fallback, unmount cleanup, native method behavior, and packaged React 18.3.1 and
+19.2.8 compatibility. The isolated exact-window
+fixture has a 13,104 B gzip compiler premium, 244 B above the previous recorded window runtime and
+inside its unchanged 256 B limit; direct and core-only output remain unchanged. The measured
+environment was Chrome 145.0.7632.6, Node.js 23.11.0, and Apple M1 macOS arm64.
+
 ## Exact-window keyed replacement follow-up — 2026-08-31
 
 The full bracketed production-browser run added an isolated 10,000-row workload for concise native

--- a/examples/react-compiler-dashboard/README.md
+++ b/examples/react-compiler-dashboard/README.md
@@ -100,7 +100,7 @@ native `toSpliced(position, 0, item)`, `toSpliced(position, 0, ...items)`, `toSp
 `toSpliced(position, 64)`, `toSpliced(position, 1, replacement)`, and
 `toSpliced(position, 64, ...replacements)` and `with(position, replacement)` updates use event-local
 runtime position variables and are measured against bracketed React and equivalent block-bodied
-compiled controls. The compiler report must contain all six dashboard `keyedArrayPositionHints`;
+compiled controls. The compiler report must contain all seven dashboard `keyedArrayPositionHints`;
 package tests separately require zero
 surviving key/descriptor/binding reads for removal, surrounding DOM identity, randomized
 differential correctness, runtime-position and count fallback, hydration, and cleanup. Both the
@@ -119,6 +119,15 @@ block-bodied compiled control. Package tests require work proportional only to t
 rows and cover empty spreads, negative positions, clamped counts, reused and duplicate keys,
 native custom-method behavior, queued fallback, controlled-input focus and selection, delegated
 events, 1,000 differential replacements, hydration, Strict Mode, and unmount cleanup.
+
+Same-key exact-window refresh has a separate 10,000-row gate. The benchmark replaces a 64-row
+snapshot with 64 new objects carrying the same keys in the same order and changes one visible row,
+which isolates the avoided full-list key scan without hiding the required binding update. All 64
+DOM rows must keep their identity and the changed label and amount must reach the DOM. Static and
+hybrid modes must remain at least 4x faster than React and 1.5x faster than the block-bodied
+compiled control. Package tests also require zero descriptors for a 64-row refresh, latest event
+data, focused-input selection, atomic preparation before mutation, hydration, Strict Mode, and
+mixed/reordered/duplicate-key fallback.
 
 Native keyed-array reversal has a separate 10,000-row comparison. Concise `toReversed()` is
 measured against bracketed React and an equivalent block-bodied compiled control. Both compiler

--- a/examples/react-compiler-dashboard/scripts/benchmark.mjs
+++ b/examples/react-compiler-dashboard/scripts/benchmark.mjs
@@ -143,7 +143,7 @@ async function inspectBuild(compilerMode) {
       "The compiler build did not emit a keyed-array prepend hint.",
     );
     assert(
-      compilerReport.summary.keyedArrayPositionHints >= 6,
+      compilerReport.summary.keyedArrayPositionHints >= 7,
       "The compiler build did not emit the keyed-array exact-position hints.",
     );
     assert(
@@ -678,6 +678,50 @@ async function measureTrial(browser, trial, compilerMode, port) {
                 table.querySelectorAll("tbody tr")[5_064] === after &&
                 !firstRemoved?.isConnected &&
                 !lastRemoved?.isConnected,
+            );
+          },
+        );
+
+        const tablePositionWindowRefresh = await measureTable(
+          async () => ensure10000(),
+          async () => {
+            const rows = table.querySelectorAll("tbody tr");
+            const retained = [...rows].slice(5_000, 5_064);
+            const changedLabel = retained[32]?.children[1]?.textContent;
+            const changedAmount = retained[32]?.children[3]?.textContent;
+            await runTableAction(
+              () => tableButton("table-position-window-refresh").click(),
+              () => {
+                const nextRows = table.querySelectorAll("tbody tr");
+                return (
+                  rowCount() === 10_000 &&
+                  retained.every((row, offset) => nextRows[5_000 + offset] === row) &&
+                  nextRows[5_032]?.children[1]?.textContent === `${changedLabel} refreshed` &&
+                  nextRows[5_032]?.children[3]?.textContent !== changedAmount
+                );
+              },
+            );
+          },
+        );
+
+        const tablePositionWindowRefreshSnapshot = await measureTable(
+          async () => ensure10000(),
+          async () => {
+            const rows = table.querySelectorAll("tbody tr");
+            const retained = [...rows].slice(5_000, 5_064);
+            const changedLabel = retained[32]?.children[1]?.textContent;
+            const changedAmount = retained[32]?.children[3]?.textContent;
+            await runTableAction(
+              () => tableButton("table-position-window-refresh-snapshot").click(),
+              () => {
+                const nextRows = table.querySelectorAll("tbody tr");
+                return (
+                  rowCount() === 10_000 &&
+                  retained.every((row, offset) => nextRows[5_000 + offset] === row) &&
+                  nextRows[5_032]?.children[1]?.textContent === `${changedLabel} refreshed` &&
+                  nextRows[5_032]?.children[3]?.textContent !== changedAmount
+                );
+              },
             );
           },
         );
@@ -1218,6 +1262,8 @@ async function measureTrial(browser, trial, compilerMode, port) {
             positionBatchInsertSnapshot: tablePositionBatchInsertSnapshot,
             positionWindowReplace: tablePositionWindowReplace,
             positionWindowReplaceSnapshot: tablePositionWindowReplaceSnapshot,
+            positionWindowRefresh: tablePositionWindowRefresh,
+            positionWindowRefreshSnapshot: tablePositionWindowRefreshSnapshot,
             positionInsert: tablePositionInsert,
             positionInsertSnapshot: tablePositionInsertSnapshot,
             positionRemove: tablePositionRemove,
@@ -1322,6 +1368,10 @@ async function measureTrial(browser, trial, compilerMode, port) {
         positionWindowReplaceSnapshot: timingSummary(
           result.table.positionWindowReplaceSnapshot,
         ),
+        positionWindowRefresh: timingSummary(result.table.positionWindowRefresh),
+        positionWindowRefreshSnapshot: timingSummary(
+          result.table.positionWindowRefreshSnapshot,
+        ),
         positionInsert: timingSummary(result.table.positionInsert),
         positionInsertSnapshot: timingSummary(result.table.positionInsertSnapshot),
         positionRemove: timingSummary(result.table.positionRemove),
@@ -1420,6 +1470,8 @@ const tableMetrics = [
   "positionBatchInsertSnapshot",
   "positionWindowReplace",
   "positionWindowReplaceSnapshot",
+  "positionWindowRefresh",
+  "positionWindowRefreshSnapshot",
   "positionInsert",
   "positionInsertSnapshot",
   "positionRemove",
@@ -1715,6 +1767,28 @@ const keyedWindowReplaceRegressions = keyedWindowReplaceResults.filter(
     !Number.isFinite(snapshotSpeedup) ||
     snapshotSpeedup < keyedWindowReplaceMinimumSnapshotSpeedup,
 );
+// A same-key exact window should retain every row and patch only the changed bindings. Keep this
+// gate separate from fresh-key replacement so descriptor/DOM work cannot hide a refresh regression.
+const keyedWindowRefreshMinimumSpeedup = 4;
+const keyedWindowRefreshMinimumSnapshotSpeedup = 1.5;
+const keyedWindowRefreshResults = ["static", "hybrid"].map((mode) => {
+  const refreshMedianMs = comparisons.table.positionWindowRefresh[mode].medianMs;
+  const snapshotMedianMs = comparisons.table.positionWindowRefreshSnapshot[mode].medianMs;
+  return {
+    mode,
+    refreshMedianMs,
+    snapshotMedianMs,
+    snapshotSpeedup: snapshotMedianMs / refreshMedianMs,
+    speedup: comparisons.table.positionWindowRefresh[`${mode}VsBaseline`].speedup,
+  };
+});
+const keyedWindowRefreshRegressions = keyedWindowRefreshResults.filter(
+  ({ snapshotSpeedup, speedup }) =>
+    !Number.isFinite(speedup) ||
+    speedup < keyedWindowRefreshMinimumSpeedup ||
+    !Number.isFinite(snapshotSpeedup) ||
+    snapshotSpeedup < keyedWindowRefreshMinimumSnapshotSpeedup,
+);
 // Native toSpliced()/with() calls with event-local runtime positions expose one exact insertion,
 // removal, or replacement position. The hinted runtime should beat both React and an equivalent
 // block-bodied compiled control while preserving the same row identities around the changed position.
@@ -1989,6 +2063,7 @@ const passed =
   keyedRollingWindowRegressions.length === 0 &&
   keyedBatchInsertRegressions.length === 0 &&
   keyedWindowReplaceRegressions.length === 0 &&
+  keyedWindowRefreshRegressions.length === 0 &&
   keyedPositionRegressions.length === 0 &&
   keyedRangeRemovalRegressions.length === 0 &&
   keyedReorderRegressions.length === 0 &&
@@ -2055,6 +2130,13 @@ const report = {
     regressions: keyedWindowReplaceRegressions,
     results: keyedWindowReplaceResults,
     status: keyedWindowReplaceRegressions.length === 0 ? "PASS" : "FAIL",
+  },
+  keyedWindowRefreshHintGate: {
+    minimumSnapshotSpeedup: keyedWindowRefreshMinimumSnapshotSpeedup,
+    minimumSpeedup: keyedWindowRefreshMinimumSpeedup,
+    regressions: keyedWindowRefreshRegressions,
+    results: keyedWindowRefreshResults,
+    status: keyedWindowRefreshRegressions.length === 0 ? "PASS" : "FAIL",
   },
   keyedPositionHintGate: {
     insertMinimumSnapshotSpeedup: keyedPositionInsertMinimumSnapshotSpeedup,

--- a/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
+++ b/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
@@ -349,6 +349,42 @@ export function StandardTableBenchmark() {
           Replace 64-row runtime window (snapshot control)
         </button>
         <button
+          data-action="table-position-window-refresh"
+          type="button"
+          onClick={() => {
+            const position = 5_000;
+            const replacements = rows.slice(position, position + 64).map((row, offset) =>
+              offset === 32
+                ? { ...row, amount: row.amount + 1, label: `${row.label} refreshed` }
+                : { ...row },
+            );
+            setRows((current) => current.toSpliced(position, 64, ...replacements));
+            setOperation("refresh 64-row same-key window");
+            setRevision((value) => value + 1);
+          }}
+        >
+          Refresh 64-row same-key window
+        </button>
+        <button
+          data-action="table-position-window-refresh-snapshot"
+          type="button"
+          onClick={() => {
+            const position = 5_000;
+            const replacements = rows.slice(position, position + 64).map((row, offset) =>
+              offset === 32
+                ? { ...row, amount: row.amount + 1, label: `${row.label} refreshed` }
+                : { ...row },
+            );
+            setRows((current) => {
+              return current.toSpliced(position, 64, ...replacements);
+            });
+            setOperation("refresh 64-row same-key window (snapshot control)");
+            setRevision((value) => value + 1);
+          }}
+        >
+          Refresh 64-row same-key window (snapshot control)
+        </button>
+        <button
           data-action="table-position-remove"
           type="button"
           onClick={() => {

--- a/packages/farm-react/README.md
+++ b/packages/farm-react/README.md
@@ -320,20 +320,23 @@ evaluates the position and remaining arguments once in their original order, exe
 native call, and records metadata only after validating the committed native source, result, and
 actual safe-integer position and clamped removal count. A batch requires at least two evaluated
 items at runtime. Exact-window replacement supports a safe spread that evaluates to zero, one, or
-many items. Farm creates every incoming key, descriptor, binding snapshot, and detached row before
-changing the live DOM, rejects key collisions, and mounts the complete incoming batch through one
-document fragment. It then removes only the replaced window. The runtime otherwise creates one inserted row,
+many items. A fresh-key window creates every incoming key, descriptor, binding snapshot, and
+detached row before changing the live DOM, rejects key collisions, and mounts the complete batch
+through one document fragment. It then removes only the replaced window. When the incoming window
+has the same length and the same keys in the same order, Farm prepares every binding read and
+changed DOM target across the complete window first, patches the existing rows in place, and
+updates the stored row objects used by later events. That path creates no descriptors or DOM rows,
+and preserves row identity, focus, and selection. The runtime otherwise creates one inserted row,
 removes only the known row or range, or patches/replaces one row at that position without rereading
 every existing key, descriptor, and binding. Surviving rows keep their DOM identity. Index-aware or
 collection-reading rows, custom methods, position expressions with user calls or mutations,
 runtime positions that are not safe integers, dynamic, zero, negative, or fractional removal
 counts, other `toSpliced()` forms, block-bodied updaters, unsafe incoming expressions, queued
-uncommitted updates, reused keys, nested or React-owned rows, and failed checks use complete keyed
-reconciliation. Reusing a key from the replaced window is valid React behavior, so it takes the
-complete keyed reconciliation path and preserves that row instance. Reports expose the site count
-as `keyedArrayPositionHints`. Batch insertion and exact-window replacement use progressively
-separate optional runtime capabilities, so existing single-position and batch-only bundles do not
-retain window validation or replacement code.
+uncommitted updates, reordered or partially reused windows, duplicate keys, nested or React-owned
+rows, and failed checks use complete keyed reconciliation before the fast path mutates the DOM.
+Reports expose the site count as `keyedArrayPositionHints`. Batch insertion and exact-window
+replacement use progressively separate optional runtime capabilities, so existing single-position
+and batch-only bundles do not retain window validation or replacement code.
 
 A direct native reverse can carry its complete permutation to a separate optional runtime:
 

--- a/packages/farm-react/RUNTIME_SIZE_RESULTS.json
+++ b/packages/farm-react/RUNTIME_SIZE_RESULTS.json
@@ -123,19 +123,19 @@
     },
     "keyedWindowPosition": {
       "compilerOff": {
-        "raw": 192941,
-        "gzip": 60102,
-        "brotli": 51748
+        "raw": 192958,
+        "gzip": 60097,
+        "brotli": 51786
       },
       "compilerOn": {
-        "raw": 239436,
-        "gzip": 72962,
-        "brotli": 62527
+        "raw": 240252,
+        "gzip": 73201,
+        "brotli": 62669
       },
       "compilerPremium": {
-        "raw": 46495,
-        "gzip": 12860,
-        "brotli": 10779
+        "raw": 47294,
+        "gzip": 13104,
+        "brotli": 10883
       }
     },
     "keyedReorder": {
@@ -213,18 +213,18 @@
         "brotli": 51666
       },
       "full": {
-        "raw": 283218,
-        "gzip": 79940,
-        "brotli": 68262
+        "raw": 284017,
+        "gzip": 80226,
+        "brotli": 68508
       },
       "coreOnly": {
         "raw": 204922,
         "gzip": 63685,
         "brotli": 54902
       },
-      "fullRuntimePremiumGzip": 20021,
+      "fullRuntimePremiumGzip": 20307,
       "coreRuntimePremiumGzip": 3766,
-      "gzipReductionPercent": 81.2
+      "gzipReductionPercent": 81.5
     }
   }
 }

--- a/packages/farm-react/RUNTIME_SIZE_RESULTS.md
+++ b/packages/farm-react/RUNTIME_SIZE_RESULTS.md
@@ -25,30 +25,33 @@ is enforced on every pull request instead of serving only as a manually recorded
 | ------------------------------------------------- | ----------------: | ---------------: | ---------------: |
 | Direct text, attribute, style, and event bindings |          60,043 B |         63,721 B |          3,678 B |
 | Keyed rows, LIS, scalar, Set, and Map targeting   |          60,179 B |         71,372 B |         11,193 B |
-| Keyed rows with append hints                      |          60,085 B |         71,694 B |         11,609 B |
+| Keyed rows with append hints                      |          60,085 B |         71,698 B |         11,613 B |
 | Keyed rows with prepend hints                     |          60,087 B |         72,080 B |         11,993 B |
 | Keyed rows with filter hints                      |          60,088 B |         72,298 B |         12,210 B |
 | Keyed rows with slice hints                       |          60,075 B |         72,335 B |         12,260 B |
-| Keyed rows with known-position hints              |          60,076 B |         72,264 B |         12,188 B |
+| Keyed rows with known-position hints              |          60,076 B |         72,361 B |         12,285 B |
+| Keyed rows with batch-position hints              |          60,091 B |         72,561 B |         12,470 B |
+| Keyed rows with exact-window hints                |          60,097 B |         73,201 B |         13,104 B |
 | Keyed rows with reverse hints                     |          60,058 B |         72,164 B |         12,106 B |
 | Keyed rows with sort hints                        |          60,077 B |         72,219 B |         12,142 B |
 | Keyed rows with rolling-window hints              |          60,098 B |         73,082 B |         12,984 B |
 
-The isolated compatibility runtime contributes 19,344 B gzip over the React control. The
-compiler-selected core contributes 3,766 B, an **80.5% reduction**. This comparison uses the same
+The isolated compatibility runtime contributes 20,307 B gzip over the React control. The
+compiler-selected core contributes 3,766 B, an **81.5% reduction**. This comparison uses the same
 hand-authored compiled definition and changes only the runtime entry used to create it.
 
 The keyed fixture retains `FarmCompiledKeyedRows` plus compiler-emitted `identityTarget`,
 `membershipTarget`, and `mapLookupTarget` metadata, plus Set/Map producer-delta helpers. It rejects
 the optional row-conditional and keyed-update runtimes. Separate append, prepend, and filter
 fixtures prove that recognized functional updates retain only the matching hinted runtime. Slice
-reuses the filter removal capability. Position-only and rolling-window modules select separate
-hint runtimes only when the compiler emits those update shapes. Reverse and sort share the
-optional reorder capability; the direct and isolated core results remain byte-for-byte unchanged.
-The position fixture pays a 995 B gzip premium, reverse pays 913 B, sort pays 949 B, slice pays
-1,067 B, and rolling-window pays 1,791 B over the ordinary keyed fixture. Unrelated bundles reject
-the optional position and reorder runtime markers, and the direct fixture rejects every structural
-runtime marker. The checked
+reuses the filter removal capability. Position-only, batch-position, exact-window, and
+rolling-window modules select separate hint runtimes only when the compiler emits those update
+shapes. Reverse and sort share the optional reorder capability; the direct and isolated core
+results remain byte-for-byte unchanged. Over the ordinary keyed fixture, position pays 1,092 B
+gzip, batch-position pays 1,277 B, exact-window pays 1,911 B, reverse pays 913 B, sort pays 949 B,
+slice pays 1,067 B, and rolling-window pays 1,791 B. The exact-window figure includes fresh-key
+replacement and atomic same-key binding refresh. Unrelated bundles reject the optional position
+and reorder runtime markers, and the direct fixture rejects every structural runtime marker. The checked
 machine-readable result is [`RUNTIME_SIZE_RESULTS.json`](./RUNTIME_SIZE_RESULTS.json).
 
 ## Existing production benchmark audit

--- a/packages/farm-react/fixtures/runtime-size/keyed-window-position.tsx
+++ b/packages/farm-react/fixtures/runtime-size/keyed-window-position.tsx
@@ -39,8 +39,8 @@ export function WindowPositionTable({ incoming }: WindowPositionTableProps) {
 createRoot(document.body).render(
   <WindowPositionTable
     incoming={[
-      { id: 4, label: "Delta" },
-      { id: 5, label: "Epsilon" },
+      { id: 2, label: "Beta refreshed" },
+      { id: 3, label: "Gamma refreshed" },
     ]}
   />,
 );

--- a/packages/farm-react/scripts/test-react-version.mjs
+++ b/packages/farm-react/scripts/test-react-version.mjs
@@ -94,6 +94,7 @@ const testSource = String.raw`
   let insertCompatibilityRows = () => undefined;
   let removeCompatibilityRow = () => undefined;
   let replaceCompatibilityRows = () => undefined;
+  let refreshCompatibilityRows = () => undefined;
   let sortCompatibilityRows = () => undefined;
   let reorderExecutions = 0;
   const ReorderRows = createCompiledComponent({
@@ -139,6 +140,17 @@ const testSource = String.raw`
             2,
             { id: "f", label: "Phi", rank: 6 },
             { id: "g", label: "Gamma two", rank: 7 },
+          ),
+        );
+      refreshCompatibilityRows = () =>
+        state[0].set((previous) =>
+          createCompilerKeyedArrayWindowReplace(
+            previous,
+            previous.toSpliced,
+            1,
+            2,
+            { id: "f", label: "Phi refreshed", rank: 8 },
+            { id: "g", label: "Gamma refreshed", rank: 9 },
           ),
         );
       sortCompatibilityRows = () =>
@@ -225,6 +237,16 @@ const testSource = String.raw`
   assert.equal(reorderContainer.querySelectorAll("li")[2].textContent, "Gamma two");
   assert.equal(reorderContainer.querySelector("li:first-child"), reorderBeta);
   assert.equal(reorderContainer.querySelector("li:last-child"), reorderAlpha);
+  assert.equal(reorderExecutions, 1);
+  const compatibilityPhi = reorderContainer.querySelector("[data-key='f']");
+  const compatibilityGamma = reorderContainer.querySelector("[data-key='g']");
+  refreshCompatibilityRows();
+  await Promise.resolve();
+  await Promise.resolve();
+  assert.equal(reorderContainer.querySelectorAll("li")[1], compatibilityPhi);
+  assert.equal(reorderContainer.querySelectorAll("li")[2], compatibilityGamma);
+  assert.equal(reorderContainer.querySelectorAll("li")[1].textContent, "Phi refreshed");
+  assert.equal(reorderContainer.querySelectorAll("li")[2].textContent, "Gamma refreshed");
   assert.equal(reorderExecutions, 1);
   flushSync(() => reorderRoot.unmount());
 

--- a/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-window-replace-hints.test.tsx
+++ b/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-window-replace-hints.test.tsx
@@ -70,6 +70,8 @@ function rowDescriptor(item: Item): CompilerKeyedRowElement {
 
 function createWindowHarness(initialItems: Item[]) {
   const counters = { executions: 0, renders: 0, keys: 0, descriptors: 0, bindings: 0 };
+  let bindingFailure: string | undefined;
+  let bindingTrace: string[] | undefined;
   let replace: (position: number, deleteCount: number, items: readonly Item[]) => void = () =>
     undefined;
   let queueTwo: (first: readonly Item[], second: readonly Item[]) => void = () => undefined;
@@ -132,7 +134,13 @@ function createWindowHarness(initialItems: Item[]) {
                   path: [],
                   read: (item) => {
                     counters.bindings += 1;
-                    return [(item as Item).label];
+                    const row = item as Item;
+                    bindingTrace?.push(`read:${row.id}`);
+                    if (bindingFailure === row.id) {
+                      bindingFailure = undefined;
+                      throw new Error(`binding failure for ${row.id}`);
+                    }
+                    return [row.label];
                   },
                 },
               ]}
@@ -148,9 +156,15 @@ function createWindowHarness(initialItems: Item[]) {
     Table,
     counters,
     customReplace: (items: readonly Item[]) => customReplace(items),
+    failNextBindingFor: (key: string) => {
+      bindingFailure = key;
+    },
     queueTwo: (first: readonly Item[], second: readonly Item[]) => queueTwo(first, second),
     replace: (position: number, deleteCount: number, items: readonly Item[]) =>
       replace(position, deleteCount, items),
+    traceBindings: (trace: string[] | undefined) => {
+      bindingTrace = trace;
+    },
   };
 }
 
@@ -232,6 +246,91 @@ describe("compiled keyed-array window replacement hints", () => {
     });
   });
 
+  it("refreshes a same-key exact window without descriptors or DOM replacement", async () => {
+    const initialItems = Array.from(
+      { length: 4_096 },
+      (_, index): Item => ({ id: `row-${index}`, label: `Row ${index}` }),
+    );
+    const harness = createWindowHarness(initialItems);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Table />));
+    const before = container.querySelector('[data-key="row-2047"]');
+    const refreshed = Array.from({ length: 64 }, (_, offset) =>
+      container.querySelector(`[data-key="row-${2_048 + offset}"]`),
+    );
+    const after = container.querySelector('[data-key="row-2112"]');
+    harness.counters.keys = 0;
+    harness.counters.descriptors = 0;
+    harness.counters.bindings = 0;
+    const incoming = initialItems.slice(2_048, 2_112).map((item, index) => ({
+      ...item,
+      label: `Refreshed ${index}`,
+    }));
+
+    await act(async () => {
+      harness.replace(2_048, 64, incoming);
+      await flushCompilerUpdates();
+    });
+
+    const rows = [...container.querySelectorAll("li")];
+    expect(rows[2_047]).toBe(before);
+    for (let offset = 0; offset < 64; offset += 1) {
+      expect(rows[2_048 + offset]).toBe(refreshed[offset]);
+      expect(rows[2_048 + offset]?.textContent).toBe(`Refreshed ${offset}`);
+    }
+    expect(rows[2_112]).toBe(after);
+    expect(rows).toHaveLength(4_096);
+    expect(harness.counters).toEqual({
+      executions: 1,
+      renders: 1,
+      keys: 64,
+      descriptors: 0,
+      bindings: 64,
+    });
+  });
+
+  it("prepares the complete same-key window before committing any binding", async () => {
+    const harness = createWindowHarness([
+      { id: "a", label: "Alpha" },
+      { id: "b", label: "Beta" },
+      { id: "c", label: "Gamma" },
+    ]);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Table />));
+    const trace: string[] = [];
+    const textContent = Object.getOwnPropertyDescriptor(Node.prototype, "textContent")!;
+    vi.spyOn(Node.prototype, "textContent", "set").mockImplementation(function (
+      this: Node,
+      value: string | null,
+    ) {
+      trace.push(`write:${value}`);
+      textContent.set!.call(this, value);
+    });
+    harness.traceBindings(trace);
+    harness.failNextBindingFor("b");
+
+    await act(async () => {
+      harness.replace(0, 3, [
+        { id: "a", label: "Alpha refreshed" },
+        { id: "b", label: "Beta refreshed" },
+        { id: "c", label: "Gamma refreshed" },
+      ]);
+      await flushCompilerUpdates();
+    });
+
+    const failedRead = trace.indexOf("read:b");
+    const firstWrite = trace.findIndex((entry) => entry.startsWith("write:"));
+    expect(failedRead).toBeGreaterThanOrEqual(0);
+    expect(firstWrite === -1 || firstWrite > failedRead).toBe(true);
+    expect(container.textContent).toBe("Alpha refreshedBeta refreshedGamma refreshed");
+  });
+
   it("supports empty incoming spreads, negative positions, and clamped delete counts", async () => {
     const harness = createWindowHarness([
       { id: "a", label: "Alpha" },
@@ -264,7 +363,7 @@ describe("compiled keyed-array window replacement hints", () => {
     expect(harness.counters.bindings).toBe(0);
   });
 
-  it("takes complete reconciliation before mutation for reused or duplicate keys", async () => {
+  it("takes complete reconciliation for reordered, mixed, or duplicate reused keys", async () => {
     vi.spyOn(console, "error").mockImplementation(() => undefined);
     const harness = createWindowHarness([
       { id: "a", label: "Alpha" },
@@ -351,6 +450,7 @@ describe("compiled keyed-array window replacement hints", () => {
     ];
     const calls: string[] = [];
     let replace = () => undefined;
+    let refresh = () => undefined;
     const InteractiveRows = createCompiledComponentWithFeatures(
       {
         displayName: "WindowInteractiveRows",
@@ -361,6 +461,13 @@ describe("compiled keyed-array window replacement hints", () => {
             state[0].set((previous) =>
               hintedWindowReplace(previous as Item[], 1, 2, [{ id: "e", label: "Epsilon" }]),
             );
+          refresh = () =>
+            state[0].set((previous) =>
+              hintedWindowReplace(previous as Item[], 1, 2, [
+                { id: "e", label: "Epsilon refreshed" },
+                { id: "d", label: "Delta refreshed" },
+              ]),
+            );
           return (
             <main>
               <blocks.KeyedRows
@@ -369,7 +476,8 @@ describe("compiled keyed-array window replacement hints", () => {
                 dependencies={[0]}
                 events={[
                   {
-                    invoke: (item, index) => calls.push(`${(item as Item).id}:${index}`),
+                    invoke: (item, index) =>
+                      calls.push(`${(item as Item).id}:${(item as Item).label}:${index}`),
                     name: "onClick",
                     path: [1],
                   },
@@ -384,7 +492,7 @@ describe("compiled keyed-array window replacement hints", () => {
                       <li data-key={item.id} key={item.id}>
                         <input aria-label={`Edit ${item.id}`} value={item.label} readOnly />
                         <button data-row-button={item.id} onClick={event(item, index, 0)}>
-                          Select
+                          Select {item.label}
                         </button>
                       </li>
                     ))}
@@ -415,12 +523,24 @@ describe("compiled keyed-array window replacement hints", () => {
                         tag: "button",
                         attributes: [{ name: "data-row-button", value: row.id }],
                         styles: [],
-                        children: ["Select"],
+                        children: [`Select ${row.label}`],
                       },
                     ],
                   };
                 }}
-                bindings={[]}
+                bindings={[
+                  {
+                    kind: "attribute",
+                    name: "value",
+                    path: [0],
+                    read: (item) => (item as Item).label,
+                  },
+                  {
+                    kind: "text",
+                    path: [1],
+                    read: (item) => ["Select ", (item as Item).label],
+                  },
+                ]}
               />
             </main>
           );
@@ -445,12 +565,28 @@ describe("compiled keyed-array window replacement hints", () => {
     expect(container.querySelector('[aria-label="Edit d"]')).toBe(input);
     expect(document.activeElement).toBe(input);
     expect([input.selectionStart, input.selectionEnd]).toEqual([1, 3]);
+    const epsilonRow = container.querySelector('[data-key="e"]');
+    const deltaRow = container.querySelector('[data-key="d"]');
+
+    await act(async () => {
+      refresh();
+      await flushCompilerUpdates();
+    });
+    expect(container.querySelector('[data-key="e"]')).toBe(epsilonRow);
+    expect(container.querySelector('[data-key="d"]')).toBe(deltaRow);
+    expect(container.querySelector('[aria-label="Edit d"]')).toBe(input);
+    expect(input.value).toBe("Delta refreshed");
+    expect(container.querySelector('[data-row-button="e"]')?.textContent).toBe(
+      "Select Epsilon refreshed",
+    );
+    expect(document.activeElement).toBe(input);
+    expect([input.selectionStart, input.selectionEnd]).toEqual([1, 3]);
 
     await act(async () => {
       (container.querySelector('[data-row-button="e"]') as HTMLButtonElement).click();
       (container.querySelector('[data-row-button="d"]') as HTMLButtonElement).click();
     });
-    expect(calls).toEqual(["e:1", "d:2"]);
+    expect(calls).toEqual(["e:Epsilon refreshed:1", "d:Delta refreshed:2"]);
   });
 
   it("matches normal React through 1,000 deterministic bounded replacements", async () => {
@@ -484,18 +620,25 @@ describe("compiled keyed-array window replacement hints", () => {
       reactRoot.render(<NormalTable />);
     });
 
-    // Each cycle performs and verifies two replacements: the fresh window and
-    // its restoration. Five hundred cycles therefore cover 1,000 updates.
+    // Each cycle performs and verifies two replacements. Even cycles refresh
+    // the same keys in place; odd cycles replace fresh keys. Their matching
+    // restorations exercise both paths again for 1,000 differential updates.
     for (let step = 0; step < 500; step += 1) {
       const count = (step % 5) + 1;
       const position = (step * 37) % (initialItems.length - count + 1);
-      const incoming = Array.from(
-        { length: (step % 4) + 1 },
-        (_, offset): Item => ({
-          id: `replace-${step}-${offset}`,
-          label: `Replace ${step}.${offset}`,
-        }),
-      );
+      const incoming =
+        step % 2 === 0
+          ? initialItems.slice(position, position + count).map((item, offset) => ({
+              ...item,
+              label: `Refresh ${step}.${offset}`,
+            }))
+          : Array.from(
+              { length: (step % 4) + 1 },
+              (_, offset): Item => ({
+                id: `replace-${step}-${offset}`,
+                label: `Replace ${step}.${offset}`,
+              }),
+            );
       const removed = initialItems.slice(position, position + count);
       await act(async () => {
         harness.replace(position, count, incoming);
@@ -543,15 +686,19 @@ describe("compiled keyed-array window replacement hints", () => {
       );
     });
     roots.push(root);
+    const beta = container.querySelector('[data-key="b"]');
+    const gamma = container.querySelector('[data-key="c"]');
 
     await act(async () => {
       harness.replace(1, 2, [
-        { id: "d", label: "Delta" },
-        { id: "e", label: "Epsilon" },
+        { id: "b", label: "Beta hydrated" },
+        { id: "c", label: "Gamma hydrated" },
       ]);
       await flushCompilerUpdates();
     });
-    expect(container.textContent).toBe("AlphaDeltaEpsilon");
+    expect(container.textContent).toBe("AlphaBeta hydratedGamma hydrated");
+    expect(container.querySelector('[data-key="b"]')).toBe(beta);
+    expect(container.querySelector('[data-key="c"]')).toBe(gamma);
     expect(recoverable).toEqual([]);
 
     roots.pop();

--- a/packages/farm-react/src/compiler-runtime.tsx
+++ b/packages/farm-react/src/compiler-runtime.tsx
@@ -2340,6 +2340,50 @@ function applyKeyedRowBinding(
   }
 }
 
+type CompilerPreparedKeyedRowBindingUpdate = readonly [
+  bindingIndex: number,
+  rawValue: unknown,
+  target: Element,
+  value: unknown,
+];
+
+function prepareKeyedRowBindingUpdates(
+  props: CompilerKeyedRowBindingSource,
+  instance: CompilerKeyedRowInstance,
+  item: unknown,
+  index: number,
+): CompilerPreparedKeyedRowBindingUpdate[] | undefined {
+  const updates: CompilerPreparedKeyedRowBindingUpdate[] = [];
+  for (let bindingIndex = 0; bindingIndex < props.bindings.length; bindingIndex += 1) {
+    const binding = props.bindings[bindingIndex];
+    const rawValue = binding.read(item, index);
+    const value = normalizedKeyedRowBindingValue(binding, rawValue);
+    if (Object.is(instance.values[bindingIndex], value)) continue;
+    const target = findCompilerHostTarget(instance.element, binding.path);
+    if (!target || (binding.kind !== "text" && !binding.name)) return undefined;
+    updates.push([bindingIndex, rawValue, target, value]);
+  }
+  return updates;
+}
+
+function applyPreparedKeyedRowBindingUpdates(
+  props: CompilerKeyedRowBindingSource,
+  instance: CompilerKeyedRowInstance,
+  updates: readonly CompilerPreparedKeyedRowBindingUpdate[],
+): void {
+  for (const [bindingIndex, rawValue, target, value] of updates) {
+    const binding = props.bindings[bindingIndex];
+    instance.values[bindingIndex] = value;
+    if (binding.kind === "text") {
+      target.textContent = value as string;
+    } else if (binding.kind === "style") {
+      updateStyle(target, binding.name!, rawValue);
+    } else {
+      updateAttribute(target, binding.name!, rawValue);
+    }
+  }
+}
+
 function keyedRowConditionalSnapshot(
   conditional: CompilerKeyedRowConditional,
   item: unknown,
@@ -4749,15 +4793,55 @@ function reconcileCompilerKeyedArrayWindowReplace(
     return undefined;
   }
 
-  const knownKeys = new Set(instances.keys());
-  const incoming: CompilerKeyedRowInstance[] = [];
+  const incomingItems: unknown[] = [];
+  const incomingKeys: string[] = [];
   try {
     for (let offset = 0; offset < update.insertedCount; offset += 1) {
       const index = update.position + offset;
       const item = finalValue[index];
       const key = keyedRowIdentity(props.rowKey(item, index));
-      // Reusing an existing key is valid React behavior, but it needs the
-      // complete keyed reconciliation path to preserve that row instance.
+      incomingItems.push(item);
+      incomingKeys.push(key);
+    }
+  } catch {
+    return undefined;
+  }
+
+  if (
+    update.insertedCount === update.removedCount &&
+    incomingKeys.every((key, offset) => key === removed[offset].key)
+  ) {
+    const prepared: CompilerPreparedKeyedRowBindingUpdate[][] = [];
+    try {
+      for (let offset = 0; offset < update.insertedCount; offset += 1) {
+        const updates = prepareKeyedRowBindingUpdates(
+          props,
+          removed[offset],
+          incomingItems[offset],
+          update.position + offset,
+        );
+        if (!updates) return undefined;
+        prepared.push(updates);
+      }
+    } catch {
+      return undefined;
+    }
+    for (let offset = 0; offset < update.insertedCount; offset += 1) {
+      applyPreparedKeyedRowBindingUpdates(props, removed[offset], prepared[offset]);
+      removed[offset].item = incomingItems[offset];
+    }
+    return instances;
+  }
+
+  const knownKeys = new Set(instances.keys());
+  const incoming: CompilerKeyedRowInstance[] = [];
+  try {
+    for (let offset = 0; offset < update.insertedCount; offset += 1) {
+      const index = update.position + offset;
+      const item = incomingItems[offset];
+      const key = incomingKeys[offset];
+      // Exact same-order reuse already returned above. Any remaining reuse is
+      // reordered or mixed and needs complete keyed reconciliation.
       if (knownKeys.has(key)) return undefined;
       knownKeys.add(key);
       const descriptor = props.create(item, index);


### PR DESCRIPTION
## Problem

Exact-window hints added in #611 avoid a full keyed reconciliation when a `toSpliced()` update replaces a known interval with fresh keys. Replacing the same interval with new row objects that keep exactly the same keys and order still falls back to a full-list key scan, even though React should retain every row.

## Root cause

The exact-window runtime treated every collision with an existing key as requiring complete reconciliation. It had no atomic preparation step for evaluating all same-key row bindings and resolving every changed target before committing the interval.

## Change

- Detect same-length replacement windows whose keys exactly match the removed keys in the same order.
- Prepare every key, binding value, and changed DOM target across the complete window before mutation, then patch only changed bindings and update each stored row object.
- Preserve the fresh-key exact-window path and complete reconciliation for reordered, mixed, duplicate, unsafe, or failed preparations.
- Add a separate production-browser benchmark and correctness control for 64-row same-key refreshes inside a 10,000-row table.
- Document the behavior, fallback contract, benchmark, and isolated runtime-size result.

## Safety and compatibility

The fast path remains limited to compiler-owned host rows already proven eligible for exact-window hints. Index-aware or collection-reading rows, custom methods, queued uncommitted updates, React-owned or nested rows, reordered or partially reused windows, duplicate keys, and failed runtime checks use complete reconciliation before fast-path DOM mutation.

All row keys and binding reads are evaluated before committing the refresh. Existing DOM identity, controlled-input focus and selection, hydration, Strict Mode, and delegated handlers reading the latest row object are covered. No public option, syntax, report counter, or non-React renderer behavior changes. Optional runtime selection remains tree-shakeable.

## Verification

- `pnpm --filter @farm.js/react test` — 68 files, 588 tests passed.
- `pnpm --filter @farm.js/react type-check` — passed.
- `pnpm --filter @farm.js/react test:compat` — packaged React 18.3.1 and 19.2.8 passed.
- `pnpm --filter @farm.js/react test:runtime-size` — passed; exact-window premium is 13,104 B gzip, +244 B within the unchanged 256 B allowance. Direct and core-only output are unchanged.
- `pnpm --filter farm-react-compiler-dashboard-example benchmark` — full production-browser run passed every existing and new gate. Same-key refresh measured 6.34x/7.97x versus React and 1.82x/2.22x versus the compiled control in static/hybrid modes, with zero owner executions.
- `pnpm --filter farm-react-compiler-dashboard-example build` — passed.
- `pnpm docs:build` — passed.
- Focused `oxfmt`, `oxlint`, dashboard type-check, script syntax, and `git diff --check` — passed.

Environment: Chrome 145.0.7632.6, Node.js 23.11.0, Apple M1 macOS arm64.

## Documentation and release

Updated the React renderer docs, package README, compiler dashboard README and benchmark record, and runtime-size records. No version, template, configuration, or generated-route changes.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes `toSpliced()` window replacements that keep the same keys refresh in place, so updating row data no longer falls back to a full-list key scan.

- Same-length windows with identical keys in the same order now evaluate every key and binding first, then patch only changed bindings and update stored row objects.
- DOM row identity, focus, selection, and delegated-event row data are preserved.
- Reordered, mixed, duplicate, unsafe, or failed preparations still take complete reconciliation.
- Adds a 64-row same-key refresh benchmark in a 10,000-row table plus matching correctness and packaged-React compatibility tests.
- The exact-window runtime premium grows 244 B gzip to 13,104 B, inside the unchanged 256 B allowance.

<sup>Written for commit 3f9e9efc77323df7dfb10ea5db521150128298b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/618?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

