### PR TITLE
fix(routing): prefer earlier static segments

### DIFF
--- a/packages/farm/src/__tests__/api-route-manager.test.ts
+++ b/packages/farm/src/__tests__/api-route-manager.test.ts
@@ -69,6 +69,24 @@ describe("APIRouteManager", () => {
     expect(manager.matchRoute("/v2/api/users/42")?.route.path).toBe("/v2/api/users/[id]");
   });
 
+  it("prefers an earlier static segment when dynamic routes overlap", () => {
+    const manager = new APIRouteManager("/tmp/farm-api-specificity-test");
+    manager.getRoutes().set("/api/[category]/settings", {
+      path: "/api/[category]/settings",
+      filePath: "/tmp/farm-api-specificity-test/[category]/settings/route.ts",
+      methods: ["GET"],
+      endpoints: { GET: async () => Response.json({ source: "category" }) },
+    });
+    manager.getRoutes().set("/api/shop/[item]", {
+      path: "/api/shop/[item]",
+      filePath: "/tmp/farm-api-specificity-test/shop/[item]/route.ts",
+      methods: ["GET"],
+      endpoints: { GET: async () => Response.json({ source: "shop" }) },
+    });
+
+    expect(manager.matchRoute("/api/shop/settings")?.route.path).toBe("/api/shop/[item]");
+  });
+
   it("uses GET for HEAD requests and strips the response body", async () => {
     const manager = new APIRouteManager("/tmp/farm-api-head-test");
     const getHandler = async () =>

--- a/packages/farm/src/__tests__/route-manager.test.ts
+++ b/packages/farm/src/__tests__/route-manager.test.ts
@@ -137,6 +137,19 @@ describe("RouteManager", () => {
       expect(routeManager.matchRoute("/contact").route?.pattern).toBe("/[slug]");
     });
 
+    it("compares specificity at each route segment", async () => {
+      const { globFiles } = await import("../utils");
+      vi.mocked(globFiles).mockImplementation(async (pattern: string) => {
+        if (pattern.includes("page")) {
+          return ["[category]/settings/page.tsx", "shop/[item]/page.tsx"];
+        }
+        return [];
+      });
+      await routeManager.discoverRoutes();
+
+      expect(routeManager.matchRoute("/shop/settings").route?.pattern).toBe("/shop/[item]");
+    });
+
     it("prefers an exact page over an optional catch-all matching its empty case", async () => {
       const { globFiles } = await import("../utils");
       vi.mocked(globFiles).mockImplementation(async (pattern: string) => {

--- a/packages/farm/src/__tests__/router.test.ts
+++ b/packages/farm/src/__tests__/router.test.ts
@@ -14,10 +14,16 @@ describe("createFarmRouter", () => {
   });
 
   it("prefers more specific routes before dynamic routes", () => {
-    const router = createFarmRouter(["/users/[id]", "/users/settings"]);
+    const router = createFarmRouter([
+      "/users/[id]",
+      "/users/settings",
+      "/[category]/settings",
+      "/shop/[item]",
+    ]);
 
     expect(router.match("/users/settings")?.route.path).toBe("/users/settings");
     expect(router.match("/users/123")?.route.path).toBe("/users/[id]");
+    expect(router.match("/shop/settings")?.route.path).toBe("/shop/[item]");
   });
 
   it("supports optional catch-all and route group patterns", () => {

--- a/packages/farm/src/api/runtime.ts
+++ b/packages/farm/src/api/runtime.ts
@@ -12,6 +12,7 @@ import {
 } from "../server-http";
 import { DEFAULT_FARM_API_BASE_PATH, normalizeFarmAPIBasePath } from "./config";
 import { resolveFarmAPICanonicalPathname } from "./server-path";
+import { compareRouteSpecificity, type RouteSegmentSpecificity } from "../routing/specificity";
 
 export type APIRouteParamValue = string | string[];
 export type APIRouteParams = Record<string, APIRouteParamValue>;
@@ -63,14 +64,21 @@ export function matchAPIRoute<T extends { path: string }>(
     }
   }
 
+  let bestMatch: APIRouteMatch<T> | null = null;
+  let bestSpecificity: RouteSegmentSpecificity[] | null = null;
+
   for (const route of routes.values()) {
     const params = matchRoutePath(route.path, pathname);
-    if (params) {
-      return { route, params };
+    if (!params) continue;
+
+    const specificity = getAPIRouteSpecificity(route.path);
+    if (bestSpecificity === null || compareRouteSpecificity(specificity, bestSpecificity) < 0) {
+      bestMatch = { route, params };
+      bestSpecificity = specificity;
     }
   }
 
-  return null;
+  return bestMatch;
 }
 
 /** Match canonical routes through a configurable same-origin public API path. */
@@ -427,6 +435,15 @@ function getPathSegments(pathname: string): string[] {
   return normalizePathname(pathname)
     .split("/")
     .filter((segment) => segment.length > 0);
+}
+
+function getAPIRouteSpecificity(routePath: string): RouteSegmentSpecificity[] {
+  return getPathSegments(routePath).map((segment) => {
+    const dynamic = parseDynamicSegment(segment);
+    if (!dynamic) return "static";
+    if (!dynamic.catchAll) return "dynamic";
+    return dynamic.optional ? "optional-catch-all" : "catch-all";
+  });
 }
 
 function normalizePathname(pathname: string): string {

--- a/packages/farm/src/router.ts
+++ b/packages/farm/src/router.ts
@@ -1,3 +1,5 @@
+import { compareRouteSpecificity, type RouteSegmentSpecificity } from "./routing/specificity";
+
 export type FarmRouterPrimitiveParam = string | number | boolean;
 export type FarmRouterPathParam =
   | FarmRouterPrimitiveParam
@@ -59,7 +61,7 @@ type RouterSegment =
 interface NormalizedRouterRoute<TMeta> {
   route: FarmRouterRoute<TMeta>;
   segments: RouterSegment[];
-  score: number;
+  specificity: RouteSegmentSpecificity[];
   index: number;
 }
 
@@ -169,7 +171,7 @@ function normalizeRouteInput<TMeta>(
       path,
     },
     segments,
-    score: scoreSegments(segments),
+    specificity: segments.map(getRouterSegmentSpecificity),
     index,
   };
 }
@@ -267,16 +269,15 @@ function compareRoutes<TMeta>(
   left: NormalizedRouterRoute<TMeta>,
   right: NormalizedRouterRoute<TMeta>,
 ) {
-  if (right.score !== left.score) return right.score - left.score;
+  const specificity = compareRouteSpecificity(left.specificity, right.specificity);
+  if (specificity !== 0) return specificity;
   return left.index - right.index;
 }
 
-function scoreSegments(segments: RouterSegment[]) {
-  return segments.reduce((score, segment) => {
-    if (segment.type === "static") return score + 100;
-    if (!segment.catchAll) return score + 50;
-    return score + (segment.optional ? 5 : 10);
-  }, segments.length);
+function getRouterSegmentSpecificity(segment: RouterSegment): RouteSegmentSpecificity {
+  if (segment.type === "static") return "static";
+  if (!segment.catchAll) return "dynamic";
+  return segment.optional ? "optional-catch-all" : "catch-all";
 }
 
 function normalizePathname(value: string) {

--- a/packages/farm/src/routing/route-manager.ts
+++ b/packages/farm/src/routing/route-manager.ts
@@ -68,6 +68,7 @@ import type { ResolvedFarmI18nConfig } from "../i18n/types";
 import { createRouteSlotContainerId, parseRouteSlotFile } from "./route-slots";
 import { getFarmRendererComponentExtensions } from "../renderer";
 import type { ApplicationMetadataRouteKind } from "../metadata-route";
+import { compareRouteSpecificity, type RouteSegmentSpecificity } from "./specificity";
 
 interface RouteEntry {
   route: ParsedRoute;
@@ -167,15 +168,16 @@ interface RedirectEntry {
   definition: ProgrammaticRedirectRoute;
 }
 
-function routeSpecificity(entry: RouteEntry): number {
-  return entry.route.segments.reduce((score, segment) => {
-    if (!segment.isDynamic) return score + 100;
-    if (!segment.isCatchAll) return score + 50;
-    // An optional catch-all also matches its parent path (the empty case), so
-    // it must rank just below a page defined at that exact path: -2 nets out
-    // this segment's share of the length seed and one point more.
-    return score + (segment.isOptional ? -2 : 10);
-  }, entry.route.segments.length);
+function getRouteSpecificity(entry: RouteEntry): RouteSegmentSpecificity[] {
+  return entry.route.segments.map((segment) => {
+    if (!segment.isDynamic) return "static";
+    if (!segment.isCatchAll) return "dynamic";
+    return segment.isOptional ? "optional-catch-all" : "catch-all";
+  });
+}
+
+function compareRouteEntries(left: RouteEntry, right: RouteEntry): number {
+  return compareRouteSpecificity(getRouteSpecificity(left), getRouteSpecificity(right));
 }
 
 /**
@@ -239,13 +241,13 @@ export class RouteManager {
     }
 
     this.routes = new Map(
-      Array.from(this.routes.entries()).sort(
-        ([, left], [, right]) => routeSpecificity(right) - routeSpecificity(left),
+      Array.from(this.routes.entries()).sort(([, left], [, right]) =>
+        compareRouteEntries(left, right),
       ),
     );
     this.metadataRoutes = new Map(
-      Array.from(this.metadataRoutes.entries()).sort(
-        ([, left], [, right]) => routeSpecificity(right) - routeSpecificity(left),
+      Array.from(this.metadataRoutes.entries()).sort(([, left], [, right]) =>
+        compareRouteEntries(left, right),
       ),
     );
 
@@ -1143,7 +1145,7 @@ export class RouteManager {
           if (left.entry.interception !== right.entry.interception) {
             return left.entry.interception ? -1 : 1;
           }
-          return routeSpecificity(right.entry) - routeSpecificity(left.entry);
+          return compareRouteEntries(left.entry, right.entry);
         });
 
       const selected = candidates[0];

--- a/packages/farm/src/routing/specificity.ts
+++ b/packages/farm/src/routing/specificity.ts
@@ -1,0 +1,28 @@
+export type RouteSegmentSpecificity = "static" | "dynamic" | "catch-all" | "optional-catch-all";
+
+const SEGMENT_RANK: Record<RouteSegmentSpecificity, number> = {
+  static: 4,
+  dynamic: 3,
+  "catch-all": 1,
+  "optional-catch-all": 0,
+};
+
+// Ending a route is more specific than consuming the same path through a
+// catch-all, while a following static or dynamic segment remains more specific.
+const ROUTE_END_RANK = 2;
+
+/** Sort route patterns from the most specific segment sequence to the least specific. */
+export function compareRouteSpecificity(
+  left: readonly RouteSegmentSpecificity[],
+  right: readonly RouteSegmentSpecificity[],
+): number {
+  const length = Math.max(left.length, right.length);
+
+  for (let index = 0; index < length; index++) {
+    const leftRank = index < left.length ? SEGMENT_RANK[left[index]!] : ROUTE_END_RANK;
+    const rightRank = index < right.length ? SEGMENT_RANK[right[index]!] : ROUTE_END_RANK;
+    if (leftRank !== rightRank) return rightRank - leftRank;
+  }
+
+  return 0;
+}


### PR DESCRIPTION
## Problem

Overlapping dynamic routes with the same aggregate score were resolved by discovery order. For example, `/shop/settings` could match `/[category]/settings` instead of the more specific `/shop/[item]`. The same ambiguity affected the public router, file routes, route slots, metadata routes, and API routes.

## Root cause

Route specificity was calculated as a sum, so a static segment in a later position could cancel a dynamic segment in an earlier position. API matching did not rank dynamic candidates at all.

## Change

Add one shared segment-by-segment specificity comparator and use it across public, file, metadata, slot, and API route matching. Static segments win at the position where routes diverge; exact parents remain ahead of optional catch-alls.

## Safety and compatibility

Exact route lookup remains the fast path. Truly equivalent dynamic patterns retain stable input/discovery order. Catch-all and optional catch-all precedence remains compatible with the existing exact-parent behavior. The change is renderer-neutral and applies equally in development and production.

## Verification

- `pnpm --filter @farm.js/core test -- src/__tests__/router.test.ts src/__tests__/route-manager.test.ts src/__tests__/api-route-manager.test.ts` — 58 passed
- `pnpm --filter @farm.js/core type-check`
- `pnpm exec oxlint <changed files>`
- `git diff --check`

The new regressions reproduce the wrong match on main for the public router, RouteManager, and APIRouteManager.

## Documentation and release

None. This corrects existing route precedence semantics without changing the public API.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes overlapping dynamic routes with the same aggregate score being resolved by discovery order; now static segments are preferred at the first diverging position across public, file, metadata, slot, and API route matching. Catch-all and optional catch-all precedence is unchanged, and exact route lookup remains the fast path.

<sup>Written for commit 3bf80075f2460343c0dd595a9f9931402174a491. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/619?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

