### PR TITLE
fix(navigation): ignore stale page responses

### DIFF
--- a/packages/farm/src/__tests__/spa-router-concurrency.test.ts
+++ b/packages/farm/src/__tests__/spa-router-concurrency.test.ts
@@ -1,0 +1,56 @@
+/** @vitest-environment jsdom */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { SPARouter } from "../client/spa-router";
+
+interface PendingResponse {
+  signal?: AbortSignal;
+  resolve(response: Response): void;
+}
+
+describe("SPA router concurrent navigation", () => {
+  afterEach(() => {
+    window.history.replaceState(null, "", "/");
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("keeps the newest navigation when an older response finishes last", async () => {
+    window.history.replaceState(null, "", "/start");
+    const pending = new Map<string, PendingResponse>();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((input: string | URL | Request, init?: RequestInit) => {
+        const path = new URL(String(input), window.location.origin).searchParams.get("path")!;
+        return new Promise<Response>((resolve) => {
+          pending.set(path, { resolve, signal: init?.signal ?? undefined });
+        });
+      }),
+    );
+
+    const rendered: string[] = [];
+    const router = new SPARouter({ scrollRestoration: false });
+    router.setNavigationHandler(async (data) => {
+      rendered.push(data.metadata?.title ?? "");
+    });
+
+    const slowNavigation = router.navigate("/slow", { scroll: false });
+    await vi.waitFor(() => expect(pending.has("/slow")).toBe(true));
+    const fastNavigation = router.navigate("/fast", { scroll: false });
+    await vi.waitFor(() => expect(pending.has("/fast")).toBe(true));
+
+    expect(pending.get("/slow")?.signal?.aborted).toBe(true);
+    pending
+      .get("/fast")!
+      .resolve(Response.json({ props: {}, metadata: { title: "Fast" }, modulePath: "/fast.tsx" }));
+    await fastNavigation;
+    pending
+      .get("/slow")!
+      .resolve(Response.json({ props: {}, metadata: { title: "Slow" }, modulePath: "/slow.tsx" }));
+    await slowNavigation;
+
+    expect(rendered).toEqual(["Fast"]);
+    expect(window.location.pathname).toBe("/fast");
+    expect(document.title).toBe("Fast");
+    router.destroy();
+  });
+});

--- a/packages/farm/src/client/spa-router.ts
+++ b/packages/farm/src/client/spa-router.ts
@@ -156,6 +156,11 @@ export class SPARouter {
   private currentHistoryPath: string | null = null;
   private currentHistoryIndex: number | null = null;
   private suppressNextPopState = false;
+  private navigationSequence = 0;
+  private activeNavigation?: {
+    id: number;
+    controller: AbortController;
+  };
   private scrollElements: Map<string, HTMLElement> = new Map();
   private options: Required<Omit<RouterOptions, "deploymentId">> &
     Pick<RouterOptions, "deploymentId">;
@@ -224,6 +229,7 @@ export class SPARouter {
   /** Remove global listeners. Intended for tests and teardown. */
   destroy(): void {
     if (typeof window === "undefined") return;
+    this.cancelActiveNavigation();
     window.removeEventListener("popstate", this.onPopState);
     window.removeEventListener("beforeunload", this.onBeforeUnload);
   }
@@ -265,6 +271,7 @@ export class SPARouter {
       isFarmLocaleChangeHref(url.toString()) ||
       this.options.shouldUseDocumentNavigation(pathname)
     ) {
+      this.cancelActiveNavigation();
       if (replace) window.location.replace(url.toString());
       else window.location.assign(url.toString());
       return;
@@ -272,6 +279,7 @@ export class SPARouter {
 
     // Same page navigation - update fragment history without fetching route data.
     if (!refresh && pathname === window.location.pathname && search === window.location.search) {
+      this.cancelActiveNavigation();
       if (url.hash === window.location.hash) return;
 
       this.writePageState(
@@ -305,7 +313,7 @@ export class SPARouter {
       this.saveScrollPosition(window.location.pathname + window.location.search);
     }
 
-    this.startNavigation({
+    const navigation = this.startNavigation({
       from,
       to: createNavigationLocation(url),
       action: replace ? "replace" : "push",
@@ -318,35 +326,48 @@ export class SPARouter {
         to: url,
         action: replace ? "replace" : "push",
       });
+      if (!this.isCurrentNavigation(navigation, clientNavigation)) return;
 
       // Fetch page data (from cache or server)
-      const pageData = await this.fetchPageData(fullPath, true, from, refresh);
+      const pageData = await this.fetchPageData(
+        fullPath,
+        true,
+        from,
+        refresh,
+        navigation.controller.signal,
+      );
+      if (!this.isCurrentNavigation(navigation, clientNavigation)) return;
       if (clientNavigation) {
         await this.clientPlugins?.markNavigationLoaded(clientNavigation, pageData);
       }
+      if (!this.isCurrentNavigation(navigation, clientNavigation)) return;
 
       await this.runViewTransition(viewTransition, () =>
-        this.commitNavigation({
-          fullPath,
-          pageData,
-          pathname,
-          replace,
-          scroll,
-          state,
-          url,
-        }),
+        this.isCurrentNavigation(navigation, clientNavigation)
+          ? this.commitNavigation({
+              fullPath,
+              pageData,
+              pathname,
+              replace,
+              scroll,
+              state,
+              url,
+            })
+          : Promise.resolve(),
       );
+      if (!this.isCurrentNavigation(navigation, clientNavigation)) return;
 
       if (clientNavigation) {
         await this.clientPlugins?.resolveNavigation(clientNavigation);
         void this.clientPlugins?.scheduleNavigationRendered(clientNavigation);
       }
-      this.finishNavigation();
+      this.finishNavigation(navigation);
     } catch (error) {
+      if (!this.isCurrentNavigation(navigation, clientNavigation)) return;
       if (clientNavigation) {
         await this.clientPlugins?.failNavigation(clientNavigation, error);
       }
-      this.finishNavigation();
+      this.finishNavigation(navigation);
       console.error("[Farm.js] Navigation error:", error);
       // Fall back to full page navigation
       window.location.href = href;
@@ -570,6 +591,7 @@ export class SPARouter {
     recover = true,
     interceptFrom?: string,
     fresh = false,
+    signal?: AbortSignal,
   ): Promise<PageData> {
     const cacheKey = getPageDataCacheKey(path, interceptFrom);
     // Check cache first
@@ -582,6 +604,7 @@ export class SPARouter {
     // shell HTML from the fragment without inspecting component source.
     const activeLayoutChain = getActiveLayoutChainHeader();
     const response = await fetch(`/__farm/page-data?path=${encodeURIComponent(path)}`, {
+      signal,
       headers: createFarmDeploymentRequestHeaders(this.options.deploymentId, {
         Accept: "application/x-farm-deferred+json, application/json",
         "X-Farm-SPA": "1",
@@ -681,7 +704,7 @@ export class SPARouter {
     this.currentHistoryPath = path;
     this.currentHistoryIndex = readHistoryIndex(event.state);
 
-    this.startNavigation({
+    const navigation = this.startNavigation({
       from,
       to: createNavigationLocation(new URL(window.location.href)),
       action: "pop",
@@ -694,14 +717,23 @@ export class SPARouter {
         to: window.location.href,
         action: "pop",
       });
+      if (!this.isCurrentNavigation(navigation, clientNavigation)) return;
       const interceptFrom =
         typeof event.state?.[FARM_INTERCEPT_FROM_KEY] === "string"
           ? event.state[FARM_INTERCEPT_FROM_KEY]
           : undefined;
-      const pageData = await this.fetchPageData(path, true, interceptFrom);
+      const pageData = await this.fetchPageData(
+        path,
+        true,
+        interceptFrom,
+        false,
+        navigation.controller.signal,
+      );
+      if (!this.isCurrentNavigation(navigation, clientNavigation)) return;
       if (clientNavigation) {
         await this.clientPlugins?.markNavigationLoaded(clientNavigation, pageData);
       }
+      if (!this.isCurrentNavigation(navigation, clientNavigation)) return;
 
       // Update document title
       if (pageData.metadata?.title) {
@@ -724,12 +756,13 @@ export class SPARouter {
         await this.clientPlugins?.resolveNavigation(clientNavigation);
         void this.clientPlugins?.scheduleNavigationRendered(clientNavigation);
       }
-      this.finishNavigation();
+      this.finishNavigation(navigation);
     } catch (error) {
+      if (!this.isCurrentNavigation(navigation, clientNavigation)) return;
       if (clientNavigation) {
         await this.clientPlugins?.failNavigation(clientNavigation, error);
       }
-      this.finishNavigation();
+      this.finishNavigation(navigation);
       console.error("[Farm.js] Popstate navigation error:", error);
       // Reload the page as fallback
       window.location.reload();
@@ -764,7 +797,13 @@ export class SPARouter {
     from: string;
     to: FarmNavigationLocation;
     action: FarmNavigationBlockerContext["action"];
-  }): void {
+  }): { id: number; controller: AbortController } {
+    this.activeNavigation?.controller.abort("superseded");
+    const navigation = {
+      id: ++this.navigationSequence,
+      controller: new AbortController(),
+    };
+    this.activeNavigation = navigation;
     this.setNavigationState({
       state: "loading",
       pending: true,
@@ -773,9 +812,30 @@ export class SPARouter {
       action: options.action,
       startedAt: Date.now(),
     });
+    return navigation;
   }
 
-  private finishNavigation(): void {
+  private isCurrentNavigation(
+    navigation: { id: number; controller: AbortController },
+    clientNavigation?: FarmClientNavigationSession,
+  ): boolean {
+    return (
+      this.activeNavigation?.id === navigation.id &&
+      !navigation.controller.signal.aborted &&
+      !clientNavigation?.signal.aborted
+    );
+  }
+
+  private finishNavigation(navigation: { id: number; controller: AbortController }): void {
+    if (this.activeNavigation?.id !== navigation.id) return;
+    this.activeNavigation = undefined;
+    this.setNavigationState(IDLE_NAVIGATION_STATE);
+  }
+
+  private cancelActiveNavigation(): void {
+    if (!this.activeNavigation) return;
+    this.activeNavigation.controller.abort("superseded");
+    this.activeNavigation = undefined;
     this.setNavigationState(IDLE_NAVIGATION_STATE);
   }
 


### PR DESCRIPTION
## Problem

Two overlapping SPA navigations could commit out of order. If the older page-data request finished last, it replaced the newer URL, title, and rendered route.

## Root cause

The router did not own a navigation generation or abort signal. The optional client plugin lifecycle aborted superseded plugin sessions, but the router never checked that state before committing and applications without client plugins had no protection.

## Change

Track one active router navigation, abort its page-data request when a newer navigation starts, and check ownership after every asynchronous boundary before committing history, metadata, rendering, lifecycle hooks, or fallback navigation. Popstate navigations use the same mechanism, and same-page/document navigations cancel pending SPA work.

## Safety and compatibility

A fetch implementation that ignores AbortSignal is still safe because the generation check drops its stale response. Prefetching remains independent. Navigation state only returns to idle when the active generation finishes, so an older request cannot clear the pending state of a newer one.

## Verification

- `pnpm --filter @farm.js/core test -- src/__tests__/spa-router-concurrency.test.ts src/__tests__/client-plugin-router.test.ts src/__tests__/spa-router-popstate.test.ts src/__tests__/spa-router-hash-navigation.test.ts src/__tests__/spa-router-scroll-query.test.ts` — 8 passed
- `pnpm --filter @farm.js/core type-check`
- `pnpm exec oxlint packages/farm/src/client/spa-router.ts packages/farm/src/__tests__/spa-router-concurrency.test.ts` — no errors; one pre-existing warning
- `git diff --check`

The regression test resolves the newer response first and then the older response. On main the page renders Fast and then incorrectly ends on Slow; this change keeps Fast and confirms the older request signal is aborted.

## Documentation and release

None. This preserves the existing newest-navigation-wins contract.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the SPA router from committing out-of-order page data when two navigations overlap. The router now tracks one active navigation, aborts its page-data request when a newer navigation starts, and checks ownership after every asynchronous boundary before committing history, metadata, rendering, hooks, or fallback navigation.

- Popstate navigations use the same mechanism, and same-page and document navigations cancel pending SPA work.
- Fetch implementations that ignore `AbortSignal` are still safe because the generation check drops the stale response.
- Prefetching is unaffected, and navigation state only returns to idle when the active generation finishes.
- Adds a regression test where the older response resolves last.

<sup>Written for commit d876e4b0a94a9be1c02703b70080aad4e67a41d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/620?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

