### PR TITLE
fix(routing): match optional catch-all owners

### DIFF
--- a/packages/farm/src/__tests__/route-manager.test.ts
+++ b/packages/farm/src/__tests__/route-manager.test.ts
@@ -119,6 +119,30 @@ describe("RouteManager", () => {
       expect(result.layouts.length).toBeGreaterThan(0);
     });
 
+    it("includes optional catch-all layouts, boundaries, and slot owners at the parent path", async () => {
+      const { globFiles } = await import("../utils");
+      vi.mocked(globFiles).mockImplementation(async (pattern: string) => {
+        if (pattern.includes("page")) return ["docs/[[...slug]]/page.tsx"];
+        if (pattern.includes("layout")) {
+          return ["layout.tsx", "docs/[[...slug]]/layout.tsx"];
+        }
+        if (pattern.includes("loading")) return ["docs/[[...slug]]/loading.tsx"];
+        if (pattern.includes("error")) return ["docs/[[...slug]]/error.tsx"];
+        if (pattern.includes("default")) {
+          return ["docs/[[...slug]]/@panel/default.tsx"];
+        }
+        return [];
+      });
+      await routeManager.discoverRoutes();
+
+      expect(routeManager.matchRoute("/docs").layouts.map((layout) => layout.pattern)).toContain(
+        "/docs/[[...slug]]",
+      );
+      expect(routeManager.getMatchingLoading("/docs")?.pattern).toBe("/docs/[[...slug]]");
+      expect(routeManager.getMatchingError("/docs")?.pattern).toBe("/docs/[[...slug]]");
+      expect(routeManager.matchRoute("/docs").slots.map((slot) => slot.name)).toContain("panel");
+    });
+
     it("prefers exact and more specific dynamic routes regardless of discovery order", async () => {
       const { globFiles } = await import("../utils");
       vi.mocked(globFiles).mockImplementation(async (pattern: string) => {

--- a/packages/farm/src/__tests__/utils.test.ts
+++ b/packages/farm/src/__tests__/utils.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect } from "vitest";
 import {
   parseRoutePath,
   matchRoute,
+  matchRoutePrefix,
   segmentsToPattern,
   toPosixPath,
   toRootRelativeUrlPath,
@@ -188,6 +189,14 @@ describe("matchRoute", () => {
     const result = matchRoute("/docs", segments);
     expect(result.matches).toBe(true);
     expect(result.params).toEqual({ slug: "" });
+  });
+
+  it("matches optional catch-all route owners at their empty parent path", () => {
+    const segments = parseRoutePath("docs/[[...slug]]/layout.tsx").segments;
+
+    expect(matchRoutePrefix("/docs", segments)).toBe(true);
+    expect(matchRoutePrefix("/docs/guides/getting-started", segments)).toBe(true);
+    expect(matchRoutePrefix("/blog", segments)).toBe(false);
   });
 
   it("should not match incorrect routes", () => {

--- a/packages/farm/src/routing/route-manager.ts
+++ b/packages/farm/src/routing/route-manager.ts
@@ -8,6 +8,7 @@ import type {
 import {
   parseRoutePath,
   matchRoute,
+  matchRoutePrefix,
   resolveAppPath,
   globFiles,
   logger,
@@ -1084,27 +1085,13 @@ export class RouteManager {
    */
   private findMatchingLayouts(pathname: string): RouteEntry[] {
     const matchingLayouts: RouteEntry[] = [];
-    const pathSegments = pathname.split("/").filter(Boolean);
 
     const sortedLayouts = Array.from(this.layouts.values()).sort((a, b) => {
       return a.route.segments.length - b.route.segments.length;
     });
 
     for (const layoutEntry of sortedLayouts) {
-      if (layoutEntry.route.segments.length > pathSegments.length) {
-        continue;
-      }
-
-      let matches = true;
-      for (let i = 0; i < layoutEntry.route.segments.length; i++) {
-        const segment = layoutEntry.route.segments[i];
-        if (!segment.isDynamic && segment.segment !== pathSegments[i]) {
-          matches = false;
-          break;
-        }
-      }
-
-      if (matches) {
+      if (matchRoutePrefix(pathname, layoutEntry.route.segments)) {
         matchingLayouts.push(layoutEntry);
       }
     }
@@ -1185,14 +1172,7 @@ export class RouteManager {
   private matchesRoutePrefix(pathname: string, pattern: string): boolean {
     if (pattern === "/") return true;
     const patternSegments = parseRoutePath(`${pattern}/page.tsx`).segments;
-    const pathSegments = pathname.split("/").filter(Boolean);
-    if (patternSegments.length > pathSegments.length) return false;
-
-    for (let index = 0; index < patternSegments.length; index++) {
-      const segment = patternSegments[index]!;
-      if (!segment.isDynamic && segment.segment !== pathSegments[index]) return false;
-    }
-    return true;
+    return matchRoutePrefix(pathname, patternSegments);
   }
 
   private findNearestBoundary(
@@ -1200,33 +1180,10 @@ export class RouteManager {
     boundaries: Map<string, RouteEntry>,
   ): RouteEntry | null {
     const normalizedPath = pathname === "/" ? "/" : pathname.replace(/\/$/, "");
-    const pathSegments = normalizedPath.split("/").filter(Boolean);
     let bestMatch: RouteEntry | null = null;
 
     for (const boundaryEntry of boundaries.values()) {
-      if (boundaryEntry.route.segments.length > pathSegments.length) {
-        continue;
-      }
-
-      let matches = true;
-      for (let i = 0; i < boundaryEntry.route.segments.length; i++) {
-        const segment = boundaryEntry.route.segments[i];
-        const pathSegment = pathSegments[i];
-
-        if (!pathSegment) {
-          matches = false;
-          break;
-        }
-
-        if (!segment.isDynamic && segment.segment !== pathSegment) {
-          matches = false;
-          break;
-        }
-      }
-
-      if (!matches) {
-        continue;
-      }
+      if (!matchRoutePrefix(normalizedPath, boundaryEntry.route.segments)) continue;
 
       if (!bestMatch || boundaryEntry.route.segments.length > bestMatch.route.segments.length) {
         bestMatch = boundaryEntry;

--- a/packages/farm/src/utils.ts
+++ b/packages/farm/src/utils.ts
@@ -135,6 +135,25 @@ export function matchRoute(
   return { params, matches };
 }
 
+/** Match a route segment chain as an owner of the pathname or one of its descendants. */
+export function matchRoutePrefix(url: string, segments: RouteSegment[]): boolean {
+  const urlParts = url.split("/").filter(Boolean);
+  let urlIndex = 0;
+
+  for (const segment of segments) {
+    if (segment.isCatchAll) {
+      return segment.isOptional || urlIndex < urlParts.length;
+    }
+
+    const urlPart = urlParts[urlIndex];
+    if (urlPart === undefined) return false;
+    if (!segment.isDynamic && segment.segment !== urlPart) return false;
+    urlIndex++;
+  }
+
+  return true;
+}
+
 export function resolveAppPath(root: string, ...paths: string[]): string {
   return path.resolve(root, ...paths);
 }


### PR DESCRIPTION
## Problem

A layout, loading boundary, error boundary, or route-slot owner under `docs/[[...slug]]` was omitted at `/docs`, even though the optional catch-all page itself correctly matches that empty case.

## Root cause

Owner matching compared segment counts and treated every parsed segment as consuming one URL segment. Optional catch-alls can consume zero segments, so three separate prefix implementations rejected the parent path before matching it.

## Change

Add one route-aware prefix matcher and reuse it for layout ownership, nearest loading/error boundaries, and route-slot owner patterns. It handles static, dynamic, required catch-all, optional catch-all, and descendant paths consistently.

## Safety and compatibility

Required catch-alls still require at least one remaining segment. Static and ordinary dynamic owner behavior is unchanged. The helper only replaces duplicated prefix checks and is renderer-neutral.

## Verification

- `pnpm --filter @farm.js/core test -- src/__tests__/utils.test.ts src/__tests__/route-manager.test.ts` — 62 passed
- `pnpm --filter @farm.js/core type-check`
- `pnpm exec oxlint <changed files>` — zero warnings and errors
- `git diff --check`

The regression covers the optional catch-all layout, loading boundary, error boundary, and named slot at `/docs`; all are missing on main.

## Documentation and release

None. This aligns owner matching with the already documented optional catch-all route behavior.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes optional catch-all route owners so layouts, loading/error boundaries, and route-slot owners under `docs/[[...slug]]` match at the empty parent path (`/docs`) instead of being dropped.

- Replaces the three duplicated prefix checks in `route-manager.ts` with one route-aware `matchRoutePrefix` helper in `utils.ts`.
- Required catch-alls still require at least one remaining segment; static and plain dynamic owner matching is unchanged.

<sup>Written for commit 83dcd94013d384b6d0fbb54543985820ded28ff8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/621?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

