### PR TITLE
fix(api): forward client credentials

### DIFF
--- a/docs/src/app/docs/api-client/page.md
+++ b/docs/src/app/docs/api-client/page.md
@@ -38,6 +38,19 @@ such as `https://api.example.com/v1`, uses that path directly. `baseURL` and `ba
 or async resolver functions; Farm evaluates them during config resolution and embeds only the
 resulting public URL.
 
+For a cross-origin API that uses cookies or HTTP authentication, pass the browser fetch credential
+mode when creating the client:
+
+```ts
+export const api = createAPIClient<APIRouter>({
+  baseURL: "https://api.example.com/v1",
+  credentials: "include",
+});
+```
+
+Farm forwards `credentials` to every route request from that client. The API must also allow the
+calling origin and credentialed requests through its CORS policy.
+
 ## Call a route
 
 **Browser usage**

--- a/packages/farm/src/__tests__/api-client.test.ts
+++ b/packages/farm/src/__tests__/api-client.test.ts
@@ -116,6 +116,22 @@ describe("createAPIClient", () => {
     );
   });
 
+  it("forwards configured credentials to fetch", async () => {
+    const fetchMock = vi.fn(async () => buildResponse({ users: [], total: 0 }));
+    globalThis.fetch = fetchMock as any;
+    const api = createAPIClient<APIRouter>({
+      baseURL: "https://api.example.com",
+      credentials: "include",
+    });
+
+    await api.users.get({ query: { limit: "5" } });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.example.com/api/users?limit=5",
+      expect.objectContaining({ credentials: "include" }),
+    );
+  });
+
   it("applies invalidations declared by the server response", async () => {
     const key = '["products","list"]';
     const cache = getFarmClientDataCache();

--- a/packages/farm/src/api/client.ts
+++ b/packages/farm/src/api/client.ts
@@ -467,6 +467,7 @@ export function createAPIClient<
     const fetchOptions: RequestInit = {
       method: requestOptions.method || "GET",
       headers,
+      credentials: options.credentials,
     };
 
     // Handle body


### PR DESCRIPTION
## Problem

`createAPIClient({ credentials: "include" })` accepted and typed the option but route requests never passed it to `fetch`. Cross-origin cookie or HTTP-auth APIs therefore behaved as if the option were absent.

## Root cause

The option was forwarded only to the integration client. The app-route fetch options contained method and headers but omitted credentials.

## Change

Forward the configured RequestCredentials value to every app-route fetch and document the cross-origin setup, including the corresponding CORS requirement.

## Safety and compatibility

When credentials is omitted, fetch keeps its native default behavior. Integration callers retain their existing forwarding. No server, renderer, cache, or same-origin behavior changes.

## Verification

- `pnpm --filter @farm.js/core test -- src/__tests__/api-client.test.ts` — 14 passed
- `pnpm --filter @farm.js/core type-check`
- `pnpm exec oxlint packages/farm/src/api/client.ts packages/farm/src/__tests__/api-client.test.ts` — no errors; one unrelated pre-existing warning
- `git diff --check`

The regression test observes that main omits `credentials` from the fetch init and this change forwards `include`.

## Documentation and release

Updated the API Client guide with credentialed cross-origin usage and its CORS requirement.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `createAPIClient` to forward the configured `credentials` option to every route request, so cross-origin APIs requiring cookies or HTTP auth now behave as documented. Previously the option was accepted and typed but never passed to `fetch`. The API client guide now includes the credentialed cross-origin usage and its CORS requirement.

<sup>Written for commit b41a0f08a3576864262cdf80bbd3f2312e9538ae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/622?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

