### PR TITLE
fix(api): keep HEAD responses bodyless

### DIFF
--- a/docs/src/app/docs/api-client/page.md
+++ b/docs/src/app/docs/api-client/page.md
@@ -67,6 +67,9 @@ if (result.error) {
 }
 ```
 
+A typed `HEAD` route is called with `.head()`. Its result keeps the same `{ data, error, key }`
+shape, with `data` set to `undefined` because HTTP HEAD responses do not have a body.
+
 ## Type-safe QUERY requests
 
 A route that exports `QUERY` becomes a `.query()` caller. Its body and response are inferred from

--- a/packages/farm/src/__tests__/api-client.test.ts
+++ b/packages/farm/src/__tests__/api-client.test.ts
@@ -12,6 +12,15 @@ import { PluginManager } from "../plugin";
 import { _runWithCurrentRequest } from "../server/request";
 
 type APIRouter = {
+  status: {
+    head: {
+      __types: {
+        body: never;
+        query: never;
+        response: never;
+      };
+    };
+  };
   search: {
     query: {
       __types: {
@@ -130,6 +139,20 @@ describe("createAPIClient", () => {
       "https://api.example.com/api/users?limit=5",
       expect.objectContaining({ credentials: "include" }),
     );
+  });
+
+  it("does not parse an empty HEAD response as JSON", async () => {
+    const fetchMock = vi.fn(async () => new Response(null, { status: 200 }));
+    globalThis.fetch = fetchMock as any;
+    const api = createAPIClient<APIRouter>({ baseURL: "https://api.example.com" });
+
+    const result = await api.status.head();
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.example.com/api/status",
+      expect.objectContaining({ method: "HEAD" }),
+    );
+    expect(result).toMatchObject({ data: undefined, error: null });
   });
 
   it("applies invalidations declared by the server response", async () => {

--- a/packages/farm/src/api/client.ts
+++ b/packages/farm/src/api/client.ts
@@ -448,6 +448,7 @@ export function createAPIClient<
   // Create a simple fetch-based client (browser compatible)
   const fetchClient = async (path: string, requestOptions: any = {}) => {
     const url = resolveFarmAPIRequestURL(path, baseURL);
+    const method = String(requestOptions.method || "GET").toUpperCase();
 
     // Handle query parameters
     if (requestOptions.query) {
@@ -465,7 +466,7 @@ export function createAPIClient<
       ...requestOptions.headers,
     };
     const fetchOptions: RequestInit = {
-      method: requestOptions.method || "GET",
+      method,
       headers,
       credentials: options.credentials,
     };
@@ -485,7 +486,7 @@ export function createAPIClient<
       decodeFarmCacheInvalidations(response.headers?.get?.(FARM_CACHE_INVALIDATION_HEADER)),
     );
     let data: any = undefined;
-    if (response.status !== 204 && response.status !== 205) {
+    if (method !== "HEAD" && response.status !== 204 && response.status !== 205) {
       data = isJSONStreamResponse(response) ? readJSONStream(response) : await response.json();
     }
 


### PR DESCRIPTION
## Problem

A successful typed API client HEAD request attempted `response.json()`. Since a conforming HEAD response has no body, the client returned a network_error instead of a successful result.

## Root cause

Body parsing was skipped for 204 and 205 statuses, but not based on the request method. The server already strips HEAD bodies; the client did not preserve that HTTP semantic.

## Change

Normalize the fetch method once and skip all response-body parsing for HEAD. Document that typed `.head()` callers return the normal result shape with undefined data.

## Safety and compatibility

Status, headers, cache invalidation headers, callbacks, and error handling still run. Other methods retain existing JSON and streaming parsing. Explicit and GET-backed HEAD routes behave identically from the client.

## Verification

- `pnpm --filter @farm.js/core test -- src/__tests__/api-client.test.ts` — 15 passed
- `pnpm --filter @farm.js/core type-check`
- `pnpm exec oxlint packages/farm/src/api/client.ts packages/farm/src/__tests__/api-client.test.ts` — no errors; one unrelated pre-existing warning
- `git diff --check`

The regression uses a native empty Response. Main reports network_error; this change returns `{ data: undefined, error: null }`.

## Documentation and release

Updated the API Client guide with the typed HEAD result behavior.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the typed API client so successful HEAD responses no longer attempt `response.json()` on an empty body and return a `network_error`.

- Successful `.head()` calls now return the standard `{ data, error, key }` shape with `data` set to `undefined`.
- Body parsing still runs for all other methods and for non-204/205 statuses.
- The API client guide now documents the typed HEAD result behavior.

<sup>Written for commit 3b1c817e661283a4016b3479d4f87273bdbd1d25. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/623?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

