### PR TITLE
fix(api): repeat array query parameters

### DIFF
--- a/docs/src/app/docs/api-client/page.md
+++ b/docs/src/app/docs/api-client/page.md
@@ -70,6 +70,15 @@ if (result.error) {
 A typed `HEAD` route is called with `.head()`. Its result keeps the same `{ data, error, key }`
 shape, with `data` set to `undefined` because HTTP HEAD responses do not have a body.
 
+Array-valued query inputs use repeated URL parameters. For example,
+
+```ts
+await api.posts.get({ query: { tag: ["react", "vite"] } });
+// GET /api/posts?tag=react&tag=vite
+```
+
+This is the same array representation that API route query schemas receive.
+
 ## Type-safe QUERY requests
 
 A route that exports `QUERY` becomes a `.query()` caller. Its body and response are inferred from

--- a/packages/farm/src/__tests__/api-client.test.ts
+++ b/packages/farm/src/__tests__/api-client.test.ts
@@ -12,6 +12,15 @@ import { PluginManager } from "../plugin";
 import { _runWithCurrentRequest } from "../server/request";
 
 type APIRouter = {
+  posts: {
+    get: {
+      __types: {
+        body: never;
+        query: { tag: string[] };
+        response: { posts: unknown[] };
+      };
+    };
+  };
   status: {
     head: {
       __types: {
@@ -121,6 +130,19 @@ describe("createAPIClient", () => {
 
     expect(fetchMock).toHaveBeenCalledWith(
       "https://api.example.com/gateway/v1/users?limit=5",
+      expect.objectContaining({ method: "GET" }),
+    );
+  });
+
+  it("serializes array query inputs as repeated parameters", async () => {
+    const fetchMock = vi.fn(async () => buildResponse({ posts: [] }));
+    globalThis.fetch = fetchMock as any;
+    const api = createAPIClient<APIRouter>({ baseURL: "https://api.example.com" });
+
+    await api.posts.get({ query: { tag: ["react", "vite"] } });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.example.com/api/posts?tag=react&tag=vite",
       expect.objectContaining({ method: "GET" }),
     );
   });

--- a/packages/farm/src/api/client.ts
+++ b/packages/farm/src/api/client.ts
@@ -453,8 +453,11 @@ export function createAPIClient<
     // Handle query parameters
     if (requestOptions.query) {
       Object.entries(requestOptions.query).forEach(([key, value]) => {
-        if (value !== undefined && value !== null) {
-          url.searchParams.set(key, String(value));
+        if (value === undefined || value === null) return;
+        url.searchParams.delete(key);
+        const values = Array.isArray(value) ? value : [value];
+        for (const item of values) {
+          if (item !== undefined && item !== null) url.searchParams.append(key, String(item));
         }
       });
     }


### PR DESCRIPTION
## Problem

Typed API client array query values were coerced with `String(value)`, producing one comma-separated value such as `tag=react%2Cvite`. API routes therefore could not receive the repeated-value array represented by their query schema.

## Root cause

The route client used URLSearchParams.set once per key, while Farm's route builders and server parser use repeated keys for arrays.

## Change

Replace each supplied query key and append one URL parameter per non-null array item. Document the repeated-parameter representation.

## Safety and compatibility

Scalar values retain the existing single-parameter form. Null and undefined values remain omitted. Deleting the key first preserves the prior override behavior if the base URL already contains that query key.

## Verification

- `pnpm --filter @farm.js/core test -- src/__tests__/api-client.test.ts` — 16 passed
- `pnpm --filter @farm.js/core type-check`
- `pnpm exec oxlint packages/farm/src/api/client.ts packages/farm/src/__tests__/api-client.test.ts` — no errors; one unrelated pre-existing warning
- `git diff --check`

The regression expects `tag=react&tag=vite`; main emits `tag=react%2Cvite`.

## Documentation and release

Updated the API Client guide with array query serialization.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the typed API client so array query values are sent as repeated parameters (`tag=react&tag=vite`) instead of one comma-joined value (`tag=react%2Cvite`), matching how Farm's server parses array query schemas.

- Scalar values still serialize the same way.
- Null and undefined array items are skipped.
- Existing base URL query keys are overridden before appending.

<sup>Written for commit 4d3582f11a7b85edd36c72f4d85fa59d36688c05. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/624?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

