### PR TITLE
fix(api): reject malformed JSON bodies

### DIFF
--- a/docs/src/app/docs/api-routes/page.md
+++ b/docs/src/app/docs/api-routes/page.md
@@ -86,6 +86,8 @@ export const GET = createEndpoint(
 ```
 
 Farm parses and validates `body`, `query`, and `headers` before middleware or handler code runs. Header schema keys use the lower-case names exposed by the Fetch `Headers` API. Invalid input returns a `400` response with structured validation issues.
+Malformed `application/json` and `application/*+json` bodies also return `400` before endpoint
+middleware or handler code executes, including when the endpoint does not declare a body schema.
 
 ## HTTP QUERY
 

--- a/packages/farm/src/__tests__/endpoint-errors.test.ts
+++ b/packages/farm/src/__tests__/endpoint-errors.test.ts
@@ -76,6 +76,29 @@ describe("typed endpoint errors", () => {
     });
   });
 
+  it("rejects malformed JSON before an endpoint handler executes", async () => {
+    let executed = false;
+    const handler = (ctx: { body: unknown }) => {
+      executed = true;
+      return { body: ctx.body };
+    };
+    const response = await invokeAPIRouteEndpoint(
+      handler,
+      new Request("https://farm.test/api/products", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: "{",
+      }),
+    );
+
+    expect(executed).toBe(false);
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "Invalid request body",
+      message: "The request body is not valid JSON.",
+    });
+  });
+
   it("validates native urlencoded form submissions", async () => {
     const response = await invokeAPIRouteEndpoint(
       createProduct,

--- a/packages/farm/src/api/runtime.ts
+++ b/packages/farm/src/api/runtime.ts
@@ -163,7 +163,9 @@ async function invokeAPIRouteEndpointInContext(
 
   let body: any = undefined;
   if (request.method.toUpperCase() !== "GET" && request.method.toUpperCase() !== "HEAD") {
-    body = await readRequestBody(request);
+    const parsedBody = await readRequestBody(request);
+    if (parsedBody.error) return parsedBody.error;
+    body = parsedBody.body;
   }
 
   const headers = Object.fromEntries(request.headers.entries());
@@ -312,32 +314,51 @@ function isFarmContextHandler(endpoint: unknown): boolean {
   return firstParameter === "ctx" || firstParameter === "context" || firstParameter.startsWith("{");
 }
 
-async function readRequestBody(request: Request): Promise<unknown> {
+interface RequestBodyParseResult {
+  body?: unknown;
+  error?: Response;
+}
+
+async function readRequestBody(request: Request): Promise<RequestBodyParseResult> {
   const contentType = request.headers.get("content-type")?.split(";", 1)[0]?.trim().toLowerCase();
 
   try {
     if (contentType === "multipart/form-data") {
-      return formDataToObject(await request.clone().formData());
+      return { body: formDataToObject(await request.clone().formData()) };
     }
 
     const text = await request.clone().text();
-    if (!text) return undefined;
+    if (!text) return { body: undefined };
     if (contentType === "application/x-www-form-urlencoded") {
-      return searchParamsToObject(new URLSearchParams(text));
+      return { body: searchParamsToObject(new URLSearchParams(text)) };
     }
     if (contentType === "application/json" || contentType?.endsWith("+json")) {
-      return JSON.parse(text);
+      return { body: JSON.parse(text) };
     }
 
     // Preserve the previous permissive behavior for callers that omit the
     // content type but still send JSON.
-    return JSON.parse(text);
+    return { body: JSON.parse(text) };
   } catch {
+    if (contentType === "application/json" || contentType?.endsWith("+json")) {
+      return {
+        error: new Response(
+          JSON.stringify({
+            error: "Invalid request body",
+            message: "The request body is not valid JSON.",
+          }),
+          {
+            status: 400,
+            headers: { "Content-Type": "application/json" },
+          },
+        ),
+      };
+    }
     // The body format is unsupported or malformed. Schema validation below
     // will turn the missing value into a typed 400 response when applicable.
   }
 
-  return undefined;
+  return { body: undefined };
 }
 
 function formDataToObject(


### PR DESCRIPTION
## Problem

A malformed `application/json` request could be treated as a missing body. Without a body schema, endpoint middleware and the handler still executed and could return 200.

## Root cause

The body parser caught every parse failure and returned undefined, relying on optional schema validation to reject it.

## Change

Return a structured 400 response when declared JSON or `application/*+json` cannot be parsed, before endpoint middleware or handler execution. Keep empty bodies and the existing permissive fallback for undeclared/unsupported media types.

## Safety and compatibility

Valid JSON, form data, URL-encoded bodies, raw Request handlers, body size limits, and schema validation are unchanged. The response does not expose parser internals.

## Verification

- `pnpm --filter @farm.js/core test -- src/__tests__/endpoint-errors.test.ts src/__tests__/api-route-manager.test.ts src/__tests__/endpoint-transport.test.ts` — 25 passed
- `pnpm --filter @farm.js/core type-check`
- `pnpm exec oxlint packages/farm/src/api/runtime.ts packages/farm/src/__tests__/endpoint-errors.test.ts` — zero warnings and errors
- `git diff --check`

The regression confirms the handler executes and returns 200 on main; this change returns 400 and leaves it uncalled.

## Documentation and release

Updated the API Routes guide with malformed JSON behavior.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects malformed JSON request bodies with a structured 400 response before endpoint middleware or handlers execute. Previously, parse failures were treated as missing bodies, allowing handlers to run and return 200.

- Applies when the request declares `application/json` or `application/*+json`, including endpoints without a body schema.
- Empty bodies and the permissive fallback for undeclared or unsupported media types are unchanged.
- Valid JSON, form data, URL-encoded bodies, raw Request handlers, and body size limits are unaffected.
- Updates the API Routes guide with the new malformed JSON behavior.

<sup>Written for commit 99bb222a680cc32625e3f3f8863427da6cf2674f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/625?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

