### PR TITLE
fix(api): preserve newer in-flight requests

### DIFF
--- a/docs/src/app/docs/api-client/page.md
+++ b/docs/src/app/docs/api-client/page.md
@@ -278,6 +278,10 @@ const product = await api.products.get(
 
 Structured keys use Farm's route-data key contract. Default API cache keys include the API origin and remain isolated from other clients.
 
+Set `cache.dedupeMs` to join identical requests started within that window. If an older request is
+still running after the window expires, the newer request becomes the cache owner; the older result
+still returns to its original caller but cannot replace the newer cached value.
+
 ## Optimistic cache updates
 
 Farm's cache lifecycle is intentionally familiar to React Query and TanStack Query users, but it is

--- a/packages/farm/src/__tests__/api-client.test.ts
+++ b/packages/farm/src/__tests__/api-client.test.ts
@@ -119,6 +119,57 @@ describe("createAPIClient", () => {
     );
   });
 
+  it("keeps a newer in-flight request registered after an older request settles", async () => {
+    let now = 0;
+    vi.spyOn(Date, "now").mockImplementation(() => now);
+    const firstResponse = createDeferred<ReturnType<typeof buildResponse>>();
+    const secondResponse = createDeferred<ReturnType<typeof buildResponse>>();
+    const fetchMock = vi
+      .fn()
+      .mockImplementationOnce(() => firstResponse.promise)
+      .mockImplementationOnce(() => secondResponse.promise);
+    globalThis.fetch = fetchMock as any;
+    const api = createAPIClient<APIRouter>({ baseURL: "http://example.com" });
+    const requestOptions = {
+      cache: {
+        policy: "network-only" as const,
+        dedupeMs: 10,
+        staleTime: 1_000,
+      },
+    };
+
+    const first = api.users.get({ query: { limit: "5" } }, requestOptions);
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    now = 20;
+    const second = api.users.get({ query: { limit: "5" } }, requestOptions);
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+
+    firstResponse.resolve(buildResponse({ users: [{ id: "old" }], total: 1, limit: 5, offset: 0 }));
+    await expect(first).resolves.toMatchObject({ data: { users: [{ id: "old" }] } });
+
+    now = 21;
+    const deduped = api.users.get({ query: { limit: "5" } }, requestOptions);
+    await Promise.resolve();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    secondResponse.resolve(
+      buildResponse({ users: [{ id: "new" }], total: 1, limit: 5, offset: 0 }),
+    );
+    await expect(Promise.all([second, deduped])).resolves.toEqual([
+      expect.objectContaining({ data: expect.objectContaining({ users: [{ id: "new" }] }) }),
+      expect.objectContaining({ data: expect.objectContaining({ users: [{ id: "new" }] }) }),
+    ]);
+
+    now = 22;
+    await expect(
+      api.users.get(
+        { query: { limit: "5" } },
+        { cache: { policy: "cache-first", staleTime: 1_000 } },
+      ),
+    ).resolves.toMatchObject({ data: { users: [{ id: "new" }] } });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
   it("uses a baseURL path as the API root", async () => {
     const fetchMock = vi.fn(async () => buildResponse({ users: [], total: 0 }));
     globalThis.fetch = fetchMock as any;

--- a/packages/farm/src/api/client.ts
+++ b/packages/farm/src/api/client.ts
@@ -701,12 +701,18 @@ export function createAPIClient<
         }
       })();
 
-      inflightState.set(cacheKey, { promise, startedAt: now });
+      const inflightEntry = { promise, startedAt: now };
+      inflightState.set(cacheKey, inflightEntry);
 
       try {
         const result = await promise;
 
-        if (!result.error && isCacheEnabled && !isFarmAPIStream(result.data)) {
+        if (
+          inflightState.get(cacheKey) === inflightEntry &&
+          !result.error &&
+          isCacheEnabled &&
+          !isFarmAPIStream(result.data)
+        ) {
           const updatedAt = Date.now();
           cacheState.set(cacheKey, {
             data: result.data,
@@ -731,7 +737,9 @@ export function createAPIClient<
 
         return result;
       } finally {
-        inflightState.delete(cacheKey);
+        if (inflightState.get(cacheKey) === inflightEntry) {
+          inflightState.delete(cacheKey);
+        }
       }
     };
 


### PR DESCRIPTION
## Problem

When a request outlived `dedupeMs`, a second request could replace its in-flight map entry. The older request's unconditional cleanup then deleted the newer entry, allowing another duplicate fetch; an older response could also overwrite the newer cache value.

## Root cause

In-flight state was keyed only by cache key. Cleanup and cache writes did not verify that the completing promise still owned that key.

## Change

Capture the exact in-flight entry for each network request. Only the current owner may populate the cache or delete the map entry.

## Safety and compatibility

Every caller still receives its own request result and callbacks. Requests inside the dedupe window still share one promise. The change only controls shared bookkeeping and cache ownership when requests overlap beyond the configured window.

## Verification

- `pnpm --filter @farm.js/core test -- src/__tests__/api-client.test.ts` — 17 passed
- `pnpm --filter @farm.js/core type-check`
- `pnpm exec oxlint packages/farm/src/api/client.ts packages/farm/src/__tests__/api-client.test.ts` — no errors; one unrelated pre-existing warning
- `git diff --check`

The regression starts a newer request after the dedupe window, resolves the older one first, and verifies a third caller still dedupes to the newer request and the newer response owns the cache.

## Documentation and release

Documented dedupe window and cache ownership behavior in the API Client guide.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes API client in-flight request handling so a newer request is no longer dropped when an older overlapping request settles first.

- Captures the exact in-flight entry for each request; only the current owner may populate the cache or delete the entry.
- Older responses still reach their original caller but cannot replace a newer cached value.
- Requests within the dedupe window still share a single promise.
- Updates the API client guide to describe dedupe window and cache ownership behavior.

<sup>Written for commit 7273f09dc6bce07515d28dae629a358f89923b3f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/626?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

