### PR TITLE
fix(middleware): keep helper response headers

### DIFF
--- a/packages/farm/src/__tests__/middleware.test.ts
+++ b/packages/farm/src/__tests__/middleware.test.ts
@@ -1364,6 +1364,20 @@ describe("Header Management Advanced", () => {
     expect(ctx.request.headers["existing-header"]).toBe("existing-value");
     expect(ctx.headers.has("existing-header")).toBe(false);
   });
+
+  it("applies response headers before a helper short-circuits", () => {
+    const req = createMockRequest("/test");
+    const res = createMockResponse();
+    const ctx = createContext(req, res);
+    ctx.headers.set("x-request-id", "req-123");
+
+    ctx.json({ ok: true });
+
+    expect(res.setHeader).toHaveBeenCalledWith("x-request-id", "req-123");
+    expect(res.writeHead).toHaveBeenCalledWith(200, {
+      "Content-Type": "application/json",
+    });
+  });
 });
 
 describe("Cookie Management Advanced", () => {

--- a/packages/farm/src/middleware/context.ts
+++ b/packages/farm/src/middleware/context.ts
@@ -111,6 +111,17 @@ export function createContext(
 
   let handled = false;
 
+  const applyResponseHeaders = () => {
+    for (const [key, value] of headers) {
+      try {
+        res.setHeader(key, value);
+      } catch {
+        // Keep helper behavior aligned with the middleware manager: an invalid
+        // optional header must not prevent the response itself from completing.
+      }
+    }
+  };
+
   const ctx: MiddlewareContext = {
     request: req,
     response: res,
@@ -142,6 +153,7 @@ export function createContext(
       ctx._handled = true;
       handled = true;
 
+      applyResponseHeaders();
       res.writeHead(status, {
         Location: redirectUrl,
         "Content-Type": "text/plain",
@@ -169,6 +181,7 @@ export function createContext(
       ctx._handled = true;
       handled = true;
 
+      applyResponseHeaders();
       res.writeHead(status, {
         "Content-Type": "application/json",
       });
@@ -184,6 +197,7 @@ export function createContext(
       ctx._handled = true;
       handled = true;
 
+      applyResponseHeaders();
       res.writeHead(status, {
         "Content-Type": "text/plain",
       });
@@ -199,6 +213,7 @@ export function createContext(
       ctx._handled = true;
       handled = true;
 
+      applyResponseHeaders();
       res.writeHead(status, {
         "Content-Type": "text/html",
       });


### PR DESCRIPTION
## Problem

In development middleware, headers added through `ctx.headers.set()` disappeared when the same middleware short-circuited with `ctx.json()`, `ctx.text()`, `ctx.html()`, or `ctx.redirect()`.

## Root cause

The helpers called `writeHead()` immediately with only their built-in headers. The middleware manager applies context headers later only when headers have not already been sent.

## Change

Apply the context response-header map to the Node response immediately before every short-circuit helper writes its status and helper-owned headers.

## Safety and compatibility

Helper Content-Type and Location values keep precedence through Node's normal `writeHead` behavior. Invalid optional context headers are ignored consistently with the middleware manager. Production middleware already merges these headers and is unchanged.

## Verification

- `pnpm --filter @farm.js/core test -- src/__tests__/middleware.test.ts src/__tests__/production-middleware-http.test.ts` — 96 passed
- `pnpm --filter @farm.js/core type-check`
- `pnpm exec oxlint packages/farm/src/middleware/context.ts packages/farm/src/__tests__/middleware.test.ts` — no errors; existing test-file warnings only
- `git diff --check`

The regression sets `x-request-id`, calls `ctx.json()`, and observes that main writes only Content-Type while this change preserves both.

## Documentation and release

None. The middleware guide already promises that context headers are added to the final response.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes development middleware dropping custom headers set via `ctx.headers.set()` when a middleware short-circuits with `ctx.json()`, `ctx.text()`, `ctx.html()`, or `ctx.redirect()`. The helpers now apply those context headers to the response before writing their status and helper-owned headers.

- Helper-owned `Content-Type` and `Location` headers keep precedence.
- Invalid optional context headers are ignored, matching middleware-manager behavior.
- Production middleware behavior is unchanged.

<sup>Written for commit 7ba634ee3569aec8a4e8f41e55fc9e81051f0f46. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/627?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

