### PR TITLE
fix(middleware): preserve cookies across handlers

### DIFF
--- a/docs/src/app/docs/middleware/page.md
+++ b/docs/src/app/docs/middleware/page.md
@@ -25,6 +25,9 @@ Data and headers written during middleware are request-scoped:
 | `ctx.params` or `context.params`                                     | Contains params from the matched config matcher or route-scoped middleware path.              |
 | `return new Response(...)`                                           | Stops the chain and sends that response immediately.                                          |
 
+Cookies set by multiple matching middleware handlers are accumulated into separate `Set-Cookie`
+headers; a later handler does not replace cookies already written by an earlier handler.
+
 ## Route middleware
 
 Middleware can live near the routes it protects. Use it for auth, request metadata, A/B flags, rate limit checks, or headers that belong to an area of the app.

--- a/packages/farm/src/__tests__/middleware.test.ts
+++ b/packages/farm/src/__tests__/middleware.test.ts
@@ -1381,6 +1381,26 @@ describe("Header Management Advanced", () => {
 });
 
 describe("Cookie Management Advanced", () => {
+  it("preserves cookies set by earlier middleware contexts", () => {
+    const req = createMockRequest("/test");
+    const res = createMockResponse();
+    let setCookieHeader: string | string[] | undefined;
+    vi.mocked(res.setHeader).mockImplementation((name, value) => {
+      if (String(name).toLowerCase() === "set-cookie") {
+        setCookieHeader = value as string | string[];
+      }
+      return res;
+    });
+    vi.spyOn(res, "getHeader").mockImplementation((name) =>
+      String(name).toLowerCase() === "set-cookie" ? setCookieHeader : undefined,
+    );
+
+    createContext(req, res).cookies.set("first", "1");
+    createContext(req, res).cookies.set("second", "2");
+
+    expect(setCookieHeader).toEqual(["first=1; Path=/", "second=2; Path=/"]);
+  });
+
   it("should preserve Max-Age=0 when expiring a cookie", () => {
     const req = createMockRequest("/test");
     const res = createMockResponse();

--- a/packages/farm/src/middleware/context.ts
+++ b/packages/farm/src/middleware/context.ts
@@ -51,13 +51,19 @@ function serializeCookie(name: string, value: string, options: CookieOptions = {
  */
 class CookieJarImpl implements CookieJar {
   private cookies: Record<string, string>;
-  private setCookies: string[] = [];
+  private setCookies: string[];
 
   constructor(
     private req: IncomingMessage,
     private res: ServerResponse,
   ) {
     this.cookies = parseMiddlewareCookieHeader(req.headers.cookie);
+    const existing = res.getHeader("Set-Cookie");
+    this.setCookies = Array.isArray(existing)
+      ? existing.map(String)
+      : existing === undefined
+        ? []
+        : [String(existing)];
   }
 
   get(name: string): string | undefined {


### PR DESCRIPTION
## Problem

When two matching development middleware handlers each set a cookie, the second handler replaced the first handler's Set-Cookie header.

## Root cause

Farm creates a context and CookieJar for each matched middleware entry. Every CookieJar started with an empty response-cookie list even when the shared Node response already contained cookies.

## Change

Initialize each CookieJar from the response's existing Set-Cookie header before appending new cookies. Document accumulation across matching middleware.

## Safety and compatibility

Request cookie reads remain request-based. Existing response cookies are preserved whether Node exposes them as a string or string array. Same-handler set/delete behavior and production middleware behavior are unchanged.

## Verification

- `pnpm --filter @farm.js/core test -- src/__tests__/middleware.test.ts src/__tests__/production-middleware-http.test.ts` — 97 passed
- `pnpm --filter @farm.js/core type-check`
- `pnpm exec oxlint packages/farm/src/middleware/context.ts packages/farm/src/__tests__/middleware.test.ts` — no errors; existing test-file warnings only
- `git diff --check`

The regression creates two contexts over the same response. Main ends with only `second=2`; this change emits both cookies in order.

## Documentation and release

Updated the middleware guide with multi-handler cookie accumulation.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes development middleware so cookies set by multiple matching handlers accumulate instead of the later handler replacing the earlier handler's `Set-Cookie` header. Each middleware context now initializes its cookie jar from the response's existing `Set-Cookie` header before appending new cookies, and the middleware guide documents the accumulation.

Request cookie reads are unchanged. Existing response cookies are preserved whether the header is a string or string array; same-handler set/delete behavior and production middleware are unaffected.

<sup>Written for commit 5f5b06d777047755c3b93bc91aadc0276ea64db0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/628?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

