### PR TITLE
fix(middleware): expose request bodies in development

### DIFF
--- a/docs/src/app/docs/middleware/page.md
+++ b/docs/src/app/docs/middleware/page.md
@@ -78,6 +78,9 @@ export async function middleware(
 ```
 
 Use either a default Farm handler or a named `middleware` export in one file, not both. The exported `config.matcher` uses the same matcher syntax as config middleware.
+The request uses the standard Web body APIs in both development and production, so named
+middleware can call `request.json()`, `request.text()`, or `request.formData()` when the request
+method permits a body.
 
 ### Server Component context
 

--- a/packages/farm/src/__tests__/middleware.test.ts
+++ b/packages/farm/src/__tests__/middleware.test.ts
@@ -1680,6 +1680,26 @@ describe("Named request middleware", () => {
     expect(ctx.headers.get("x-named-middleware")).toBe("yes");
   });
 
+  it("passes the Node request body to named middleware", async () => {
+    const normalized = normalizeMiddlewareModule(
+      {
+        async middleware(request: Request, context: RequestMiddlewareContext) {
+          context.set("payload", await request.json());
+        },
+      },
+      "/api",
+    );
+    const req = createMockRequest("/api/messages", "POST");
+    req.headers["content-type"] = "application/json";
+    req.push(JSON.stringify({ message: "hello" }));
+    req.push(null);
+    const ctx = createContext(req, createMockResponse());
+
+    await normalized!.handlers[0](ctx, async () => undefined);
+
+    expect(ctx.locals.get("payload")).toEqual({ message: "hello" });
+  });
+
   it("uses the same named-export runtime through the standalone Vite plugin", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "farm-named-middleware-"));
     const middlewareFile = path.join(root, "src", "app", "dashboard", "middleware.ts");

--- a/packages/farm/src/server/request.ts
+++ b/packages/farm/src/server/request.ts
@@ -1,4 +1,5 @@
 import { AsyncLocalStorage } from "node:async_hooks";
+import { Readable } from "node:stream";
 import type { FarmRequest } from "../types";
 import { _setCurrentRequestResolver } from "./request-bridge";
 
@@ -45,10 +46,18 @@ export function createWebRequestFromFarmRequest(req: FarmRequest): Request {
     headers.set(key, value);
   }
 
-  return new Request(fullUrl, {
+  const method = (req.method || "GET").toUpperCase();
+  const init: RequestInit & { duplex?: "half" } = {
     method: req.method,
     headers,
-  });
+  };
+
+  if (method !== "GET" && method !== "HEAD") {
+    init.body = Readable.toWeb(req) as ReadableStream<Uint8Array>;
+    init.duplex = "half";
+  }
+
+  return new Request(fullUrl, init);
 }
 
 export async function _runWithCurrentRequest<T>(


### PR DESCRIPTION
## Problem

Request-first named middleware receives a Web `Request`, but in Vite development POST and other body-capable requests expose an empty body. Calls such as `request.json()` therefore fail even though the same middleware works in production.

## Root cause

The Node-to-Web request bridge copied the URL, method, and headers but did not connect the incoming Node request stream to the Web Request body.

## Change

Attach the incoming stream for every method except GET and HEAD and set Node's required half-duplex request option. Add a regression test that parses JSON from a development request and document the body API contract.

## Safety and compatibility

GET and HEAD remain bodyless. Legacy middleware still receives the original Node request. Body-capable requests keep standard one-shot Web Request stream semantics, matching production.

## Verification

- `pnpm --filter @farm.js/core test -- --run src/__tests__/middleware.test.ts src/__tests__/production-middleware-http.test.ts` (98 tests)
- `pnpm --filter @farm.js/core type-check`
- `pnpm exec oxlint packages/farm/src/server/request.ts packages/farm/src/__tests__/middleware.test.ts`
- `pnpm exec oxfmt --check packages/farm/src/server/request.ts packages/farm/src/__tests__/middleware.test.ts docs/src/app/docs/middleware/page.md`
- `git diff --check`

The new regression test fails before this change because `request.json()` receives an empty body.

## Documentation and release

Updated the middleware guide to state that named middleware can use standard Web Request body readers in development and production.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes named middleware receiving empty request bodies in Vite development so `request.json()`, `request.text()`, and `request.formData()` work as they do in production.

- Attaches the incoming Node stream to the Web `Request` for every method except GET and HEAD.
- Sets Node's required half-duplex request option.
- Adds a regression test that parses JSON from a development request.
- Documents the Web body API contract in the middleware guide.
- GET and HEAD stay bodyless, and request bodies keep standard one-shot stream semantics matching production.

<sup>Written for commit b522b24cd0003bc79abda53d2d37d0f1ee037ad4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/629?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

