### PR TITLE
feat(telemetry): detect production websites automatically

### DIFF
--- a/docs/prisma/schema.prisma
+++ b/docs/prisma/schema.prisma
@@ -42,3 +42,17 @@ model FarmTelemetryEvent {
   @@index([identityHash, createdAt])
   @@index([packageVersion, createdAt])
 }
+
+model FarmProductionSite {
+  id             String   @id @default(cuid())
+  url            String   @unique
+  packageName    String
+  packageVersion String
+  renderer       String
+  deployTarget   String
+  firstSeenAt    DateTime @default(now())
+  lastSeenAt     DateTime @default(now())
+
+  @@index([lastSeenAt])
+  @@index([packageVersion, lastSeenAt])
+}

--- a/docs/src/app/api/telemetry/v1/sites/route.test.ts
+++ b/docs/src/app/api/telemetry/v1/sites/route.test.ts
@@ -1,0 +1,63 @@
+// @vitest-environment node
+
+import { afterEach, describe, expect, it } from "vitest";
+import { POST } from "./route";
+
+const originalDatabaseUrl = process.env.DATABASE_URL;
+
+afterEach(() => {
+  if (originalDatabaseUrl === undefined) delete process.env.DATABASE_URL;
+  else process.env.DATABASE_URL = originalDatabaseUrl;
+});
+
+function sitePayload(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    schemaVersion: 1,
+    eventType: "production_site_active",
+    siteUrl: "https://example.com",
+    packageName: "@farm.js/core",
+    packageVersion: "1.0.0",
+    renderer: "react",
+    deployTarget: "vercel",
+    ...overrides,
+  };
+}
+
+function request(body: Record<string, unknown>): Request {
+  return new Request("https://farmjs.dev/api/telemetry/v1/sites", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("production-site telemetry ingestion", () => {
+  it("accepts a normalized detected origin without blocking on an unavailable database", async () => {
+    delete process.env.DATABASE_URL;
+
+    const response = await POST(request(sitePayload()));
+
+    expect(response.status).toBe(202);
+    await expect(response.json()).resolves.toEqual({
+      ok: true,
+      stored: false,
+      warning: "database_not_configured",
+    });
+  });
+
+  it("rejects request-level URL data", async () => {
+    const response = await POST(
+      request(sitePayload({ siteUrl: "https://example.com/private?token=secret" })),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ ok: false, error: "invalid_site" });
+  });
+
+  it("rejects fields outside the versioned schema", async () => {
+    const response = await POST(request(sitePayload({ requestPath: "/private" })));
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ ok: false, error: "invalid_site" });
+  });
+});

--- a/docs/src/app/api/telemetry/v1/sites/route.ts
+++ b/docs/src/app/api/telemetry/v1/sites/route.ts
@@ -1,0 +1,152 @@
+import { createHash } from "node:crypto";
+import {
+  FARM_PRODUCTION_SITE_TELEMETRY_EVENT_TYPE,
+  FARM_PRODUCTION_SITE_TELEMETRY_PACKAGE_NAME,
+  FARM_PRODUCTION_SITE_TELEMETRY_SCHEMA_VERSION,
+  normalizeFarmProductionSiteOrigin,
+} from "../../../../../../../packages/farm/src/product-telemetry";
+import { getPrisma } from "../../../../../lib/prisma";
+import { z } from "zod";
+
+const MAX_BODY_BYTES = 8 * 1024;
+const RATE_LIMIT_WINDOW_MS = 60_000;
+const GLOBAL_RATE_LIMIT = 1_000;
+const SITE_RATE_LIMIT = 30;
+const MAX_RATE_LIMIT_ENTRIES = 2_048;
+const PRUNE_INTERVAL_MS = 24 * 60 * 60 * 1_000;
+const DEFAULT_RETENTION_DAYS = 90;
+const SAFE_DETAIL_PATTERN = /^[0-9A-Za-z._-]{1,64}$/;
+
+const productionSiteSchema = z
+  .object({
+    schemaVersion: z.literal(FARM_PRODUCTION_SITE_TELEMETRY_SCHEMA_VERSION),
+    eventType: z.literal(FARM_PRODUCTION_SITE_TELEMETRY_EVENT_TYPE),
+    siteUrl: z
+      .string()
+      .min(1)
+      .max(2_048)
+      .refine((value) => normalizeFarmProductionSiteOrigin(value) === value),
+    packageName: z.literal(FARM_PRODUCTION_SITE_TELEMETRY_PACKAGE_NAME),
+    packageVersion: z.string().regex(SAFE_DETAIL_PATTERN),
+    renderer: z.string().regex(SAFE_DETAIL_PATTERN),
+    deployTarget: z.string().regex(SAFE_DETAIL_PATTERN),
+  })
+  .strict();
+
+type RateLimitBucket = { count: number; startedAt: number };
+
+const rateLimitBuckets = new Map<string, RateLimitBucket>();
+let lastPruneAt = 0;
+
+function json(body: Record<string, unknown>, status: number): Response {
+  return Response.json(body, {
+    status,
+    headers: {
+      "cache-control": "no-store",
+      "x-content-type-options": "nosniff",
+    },
+  });
+}
+
+function takeRateLimit(key: string, limit: number, now = Date.now()): boolean {
+  const current = rateLimitBuckets.get(key);
+  if (!current || now - current.startedAt >= RATE_LIMIT_WINDOW_MS) {
+    rateLimitBuckets.set(key, { count: 1, startedAt: now });
+    if (rateLimitBuckets.size > MAX_RATE_LIMIT_ENTRIES) {
+      for (const [bucketKey, bucket] of rateLimitBuckets) {
+        if (now - bucket.startedAt >= RATE_LIMIT_WINDOW_MS) rateLimitBuckets.delete(bucketKey);
+      }
+    }
+    return true;
+  }
+  if (current.count >= limit) return false;
+  current.count += 1;
+  return true;
+}
+
+function retentionDays(): number {
+  const configured = Number.parseInt(process.env.FARM_TELEMETRY_RETENTION_DAYS || "", 10);
+  return Number.isFinite(configured) && configured >= 1 && configured <= 3_650
+    ? configured
+    : DEFAULT_RETENTION_DAYS;
+}
+
+async function pruneInactiveSites(
+  prisma: Awaited<ReturnType<typeof getPrisma>>,
+  now = Date.now(),
+): Promise<void> {
+  if (now - lastPruneAt < PRUNE_INTERVAL_MS) return;
+  lastPruneAt = now;
+  const cutoff = new Date(now - retentionDays() * 24 * 60 * 60 * 1_000);
+  try {
+    await prisma.farmProductionSite.deleteMany({ where: { lastSeenAt: { lt: cutoff } } });
+  } catch (error) {
+    console.error("[farmjs.telemetry.site-prune]", error);
+  }
+}
+
+export async function POST(request: Request): Promise<Response> {
+  if (!takeRateLimit("global", GLOBAL_RATE_LIMIT)) {
+    return json({ ok: false, error: "rate_limited" }, 429);
+  }
+  const contentType = request.headers.get("content-type")?.toLowerCase() || "";
+  if (!contentType.startsWith("application/json")) {
+    return json({ ok: false, error: "content_type" }, 415);
+  }
+  const contentLength = Number.parseInt(request.headers.get("content-length") || "0", 10);
+  if (Number.isFinite(contentLength) && contentLength > MAX_BODY_BYTES) {
+    return json({ ok: false, error: "payload_too_large" }, 413);
+  }
+
+  let body: unknown;
+  try {
+    const text = await request.text();
+    if (new TextEncoder().encode(text).byteLength > MAX_BODY_BYTES) {
+      return json({ ok: false, error: "payload_too_large" }, 413);
+    }
+    body = JSON.parse(text);
+  } catch {
+    return json({ ok: false, error: "invalid_json" }, 400);
+  }
+
+  const parsed = productionSiteSchema.safeParse(body);
+  if (!parsed.success) {
+    return json({ ok: false, error: "invalid_site" }, 400);
+  }
+  const siteBucket = createHash("sha256").update(parsed.data.siteUrl).digest("hex");
+  if (!takeRateLimit(`site:${siteBucket}`, SITE_RATE_LIMIT)) {
+    return json({ ok: false, error: "rate_limited" }, 429);
+  }
+  if (!process.env.DATABASE_URL) {
+    return json({ ok: true, stored: false, warning: "database_not_configured" }, 202);
+  }
+
+  try {
+    const prisma = await getPrisma();
+    const now = new Date();
+    await prisma.farmProductionSite.upsert({
+      where: { url: parsed.data.siteUrl },
+      update: {
+        packageName: parsed.data.packageName,
+        packageVersion: parsed.data.packageVersion,
+        renderer: parsed.data.renderer,
+        deployTarget: parsed.data.deployTarget,
+        lastSeenAt: now,
+      },
+      create: {
+        url: parsed.data.siteUrl,
+        packageName: parsed.data.packageName,
+        packageVersion: parsed.data.packageVersion,
+        renderer: parsed.data.renderer,
+        deployTarget: parsed.data.deployTarget,
+        firstSeenAt: now,
+        lastSeenAt: now,
+      },
+    });
+    await pruneInactiveSites(prisma, now.getTime());
+    return json({ ok: true, stored: true }, 202);
+  } catch (error) {
+    console.error("[farmjs.telemetry.site-ingest]", error);
+    return json({ ok: true, stored: false, warning: "database_unavailable" }, 202);
+  }
+}

--- a/docs/src/app/docs/configuration/page.md
+++ b/docs/src/app/docs/configuration/page.md
@@ -261,6 +261,7 @@ mount, and shortcut together.
 | docs          | Serving the built-in docs runtime and docs API.                                   |
 | md            | Restricting or disabling automatic markdown mirrors like /pricing.md.             |
 | mdx           | Rendering `page.md` and `page.mdx` app routes, plus MDX components.               |
+| telemetry     | Controlling automatic production-site reporting to Farm's usage dashboard.        |
 | deploy        | Selecting a target, preset, and output directory.                                 |
 | deploymentId  | Detecting stale browser requests during rolling deployments.                      |
 | trailingSlash | Choosing the canonical URL shape for application page routes and links.           |
@@ -677,6 +678,23 @@ farm migrate
 ```
 
 Each command runs from the project root unless it sets `cwd`. Commands run in order and the CLI stops on the first failure.
+
+## Production-site telemetry
+
+Farm production server runtimes automatically detect their public HTTPS origin from incoming
+requests and report it to Farm's production-sites dashboard. No URL configuration is required. To
+disable this product telemetry for a deployment:
+
+```ts title="farm.config.ts"
+export default defineConfig({
+  telemetry: false,
+});
+```
+
+Farm schedules a small check-in after the first non-health production request and never waits for it
+before returning the application response. Only the detected origin, Farm version, renderer, and
+deployment target are sent. See [Product telemetry](/docs/telemetry) for validation, privacy,
+retention, preview-environment, opt-out, and static-export details.
 
 ## Deployment config
 

--- a/docs/src/app/docs/telemetry/page.md
+++ b/docs/src/app/docs/telemetry/page.md
@@ -1,23 +1,26 @@
 ---
-title: "Anonymous telemetry"
-description: "Understand and control Farm.js anonymous product telemetry."
+title: "Product telemetry"
+description: "Understand and control Farm.js CLI and production-site telemetry."
 section: "Reference"
 ---
 
-# Anonymous telemetry
+# Product telemetry
 
-Farm.js includes optional anonymous product telemetry in both published CLI packages:
-`@farm.js/cli` (`farm`) and `@farm.js/create-app` (the generator behind commands such as
-`pnpm create @farm.js/app`). Telemetry is **enabled by default** for interactive local commands. It
-helps the maintainers understand which coarse framework paths are useful and where compatibility
-work should be focused.
+Farm.js has two separately controlled product-telemetry paths:
+
+- Anonymous command telemetry in `@farm.js/cli` (`farm`) and `@farm.js/create-app` is **enabled by
+  default** for interactive local commands.
+- Production website reporting is **enabled by default** in built server runtimes and automatically
+  reduces incoming production request URLs to their public HTTPS origin.
+
+These signals help the maintainers understand which coarse framework paths are useful, where
+compatibility work should be focused, and which websites are running Farm in production.
 
 This is separate from [application observability](/docs/observability). OpenTelemetry describes what
-your application does and is configured by the application owner. Farm.js product telemetry only
-describes use of Farm's own CLI and starter generator, and is sent to Farm's infrastructure after
-the CLI displays its one-time notice unless you opt out.
+your application does and is configured by the application owner. Farm.js product telemetry never
+includes application spans, logs, visitor analytics, or request contents.
 
-## Control telemetry
+## Control CLI telemetry
 
 ```bash
 farm telemetry status
@@ -32,13 +35,13 @@ across upgrades.
 
 Environment variables can provide an explicit per-process or organization-wide policy:
 
-| Variable                    | Behavior                                                            |
-| --------------------------- | ------------------------------------------------------------------- |
-| `FARM_TELEMETRY=1`          | Enables telemetry, including non-interactive and CI commands.       |
-| `FARM_TELEMETRY=0`          | Disables telemetry for the process.                                 |
-| `FARM_TELEMETRY_DISABLED=1` | Disables telemetry for the process.                                 |
-| `DO_NOT_TRACK=1`            | Disables telemetry and takes precedence over Farm's enable setting. |
-| `FARM_TELEMETRY_DEBUG=1`    | Prints delivery status without event contents or identifiers.       |
+| Variable                    | Behavior                                                                |
+| --------------------------- | ----------------------------------------------------------------------- |
+| `FARM_TELEMETRY=1`          | Enables CLI telemetry, including non-interactive and CI commands.       |
+| `FARM_TELEMETRY=0`          | Disables CLI and production-site telemetry for the process.             |
+| `FARM_TELEMETRY_DISABLED=1` | Disables CLI and production-site telemetry for the process.             |
+| `DO_NOT_TRACK=1`            | Disables all telemetry and takes precedence over Farm's enable setting. |
+| `FARM_TELEMETRY_DEBUG=1`    | Prints delivery status without event contents, origins, or identifiers. |
 
 Without the explicit `FARM_TELEMETRY=1` override, Farm skips test, CI, and non-interactive
 processes even when the saved local preference is enabled.
@@ -49,24 +52,64 @@ The preference file is stored at:
 - Linux: `$XDG_CONFIG_HOME/farmjs/telemetry.json`, or `~/.config/farmjs/telemetry.json`
 - Windows: `%APPDATA%\farmjs\telemetry.json`
 
+## Automatic production-site detection
+
+No site URL configuration is required. After the first non-health request reaches a built Farm
+server runtime, Farm reads the request URL and reduces it to an origin. For example,
+`https://shop.example.com/private/orders?token=secret` becomes only
+`https://shop.example.com` before telemetry delivery.
+
+Farm accepts detected origins only when they use HTTPS and a public hostname. HTTP, localhost, IP,
+single-label, and `.local` origins are ignored. Request paths, query strings, hashes, and credentials
+are discarded and never included in the check-in.
+
+To disable production-site reporting in `farm.config.ts`:
+
+```ts title="farm.config.ts"
+import { defineConfig } from "@farm.js/core";
+
+export default defineConfig({
+  telemetry: false,
+});
+```
+
+Set `FARM_TELEMETRY=0` or `FARM_TELEMETRY_DISABLED=1` only in selected deployment environments
+when, for example, previews should be excluded while production remains enabled.
+
+After the first non-health production request, Farm schedules a check-in through the deployment
+runtime's background-work hook. It does not wait for the network before handling or returning the
+application response. A running instance checks in at most once every 24 hours, and a failed request
+is eligible for a later best-effort retry. Multiple instances update the same site record.
+
+The check-in contains only the detected origin, `@farm.js/core` version, renderer name, and deploy
+target. It does not contain a visitor or installation identifier, the full request URL beyond the
+reported origin, headers, cookies, IP address, user-agent string, or application data. Fully static
+exports have no server runtime and therefore do not send production-site check-ins. Public preview
+deployments can report their own HTTPS origin; disable telemetry in the preview environment if those
+should not appear.
+
+Set `telemetry: false` and redeploy to stop future check-ins. An inactive site disappears from the
+maintainer dashboard after the retention window.
+
 ## Data that is sent
 
-Farm currently sends two versioned event types across both CLI packages:
+Farm currently sends three versioned event types:
 
-| Event             | Fields                                                                                                  |
-| ----------------- | ------------------------------------------------------------------------------------------------------- |
-| `command_invoked` | Allowlisted command from `farm` or `create-farm-app`, package/version, optional deploy target, runtime. |
-| `project_created` | Allowlisted starter, renderer, package manager, TypeScript/install booleans, runtime fields.            |
+| Event                    | Fields                                                                                                  |
+| ------------------------ | ------------------------------------------------------------------------------------------------------- |
+| `command_invoked`        | Allowlisted command from `farm` or `create-farm-app`, package/version, optional deploy target, runtime. |
+| `project_created`        | Allowlisted starter, renderer, package manager, TypeScript/install booleans, runtime fields.            |
+| `production_site_active` | Automatically detected HTTPS origin, core version, renderer, and deploy target.                         |
 
 The `farm` binary records each actionable command path, including nested commands such as
 `auth:migrate`, `cron:list`, `cron:run`, and `add:integration`. The app generator records `create`
 or `list-templates`, and a completed scaffold also records `project_created`. Help, version, and the
 `farm telemetry` privacy-control commands do not emit events.
 
-Every request also has a random event ID for deduplication and the random local installation ID.
+Every CLI event also has a random event ID for deduplication and the random local installation ID.
 The server immediately converts the installation ID into an HMAC hash using a server-only salt;
-the raw ID is not stored. Receipt time is assigned by the server instead of trusting a client
-timestamp.
+the raw ID is not stored. Production-site check-ins have neither identifier and are upserted by the
+detected origin. Receipt time is assigned by the server instead of trusting a client timestamp.
 
 Farm does **not** collect or store:
 
@@ -75,24 +118,28 @@ Farm does **not** collect or store:
 - environment variable names or values, database URLs, credentials, tokens, or other secrets;
 - IP addresses or user-agent strings.
 
-The client schedules delivery in the background so telemetry does not delay command execution, and
-network delivery does not keep a short-lived process open. A request has a three-second timeout and
-transient network, rate-limit, and server failures receive two bounded retries while the process
+The CLI client schedules delivery in the background so telemetry does not delay command execution,
+and network delivery does not keep a short-lived process open. A request has a three-second timeout
+and transient network, rate-limit, and server failures receive two bounded retries while the process
 remains alive. Telemetry can never make a Farm command fail, and there is no persistent retry queue.
 
 ## Endpoint, validation, and retention
 
-Events are posted to `https://farmjs.dev/api/telemetry/v1/events`. The endpoint accepts a strict,
-versioned JSON schema, rejects unknown fields and bodies larger than 8 KiB, rate-limits traffic,
-and deduplicates event IDs.
+CLI events are posted to `https://farmjs.dev/api/telemetry/v1/events`; production-site check-ins are
+posted to `https://farmjs.dev/api/telemetry/v1/sites`. Both endpoints accept a strict, versioned JSON
+schema, reject unknown fields and bodies larger than 8 KiB, and rate-limit traffic. CLI events are
+deduplicated by event ID, while production sites are upserted by their normalized origin.
+Because the public clients contain no ingestion secret, dashboard origins are usage signals rather
+than verified domain-ownership records.
 
-Raw telemetry events are retained for 90 days by default and are pruned by the ingestion service.
-Aggregated package-download counts remain available independently through npm's public download
-statistics. A deployment operator can shorten the event retention window with
-`FARM_TELEMETRY_RETENTION_DAYS`.
+Raw telemetry events and inactive production-site records are retained for 90 days by default and
+are pruned by the ingestion service. Aggregated package-download counts remain available
+independently through npm's public download statistics. A deployment operator can change the
+retention window with `FARM_TELEMETRY_RETENTION_DAYS`.
 
-For local endpoint development only, `FARM_TELEMETRY_ENDPOINT` can point at an HTTPS URL or an HTTP
-localhost address. Released clients use the Farm-owned endpoint by default.
+For local endpoint development only, `FARM_TELEMETRY_ENDPOINT` and
+`FARM_TELEMETRY_SITE_ENDPOINT` can point at an HTTPS URL or an HTTP localhost address. Released
+clients use the Farm-owned endpoints by default.
 
 ## Maintainer deployment setup
 
@@ -103,11 +150,12 @@ The Farm-owned docs deployment uses four server-only environment variables:
 | `DATABASE_URL`                   | Pooled Postgres connection used by Prisma.                           |
 | `FARM_TELEMETRY_IDENTITY_SALT`   | Long random secret used to HMAC-hash local anonymous IDs.            |
 | `FARM_TELEMETRY_DASHBOARD_TOKEN` | Long random secret used to open the internal `/telemetry` dashboard. |
-| `FARM_TELEMETRY_RETENTION_DAYS`  | Optional raw-event retention window; defaults to `90`.               |
+| `FARM_TELEMETRY_RETENTION_DAYS`  | Optional event and inactive-site retention window; defaults to `90`. |
 
 These values must be encrypted deployment variables and must never use a `PUBLIC_` prefix or be
-committed to the repository. The public CLI does not contain an ingestion secret; the endpoint is
-protected with strict validation, body limits, rate limits, and idempotent event IDs instead.
+committed to the repository. Public telemetry clients do not contain an ingestion secret; the
+endpoints use strict validation, body limits, rate limits, event deduplication, and site upserts
+instead.
 
 After connecting Postgres, generate the Prisma client and apply the schema from the repository:
 

--- a/docs/src/app/telemetry/page.tsx
+++ b/docs/src/app/telemetry/page.tsx
@@ -7,6 +7,7 @@ import {
   Boxes,
   Database,
   Fingerprint,
+  Globe2,
   PackageCheck,
   Terminal,
 } from "lucide-react";
@@ -17,7 +18,7 @@ export const revalidate = 0;
 
 export const metadata = {
   title: "Farm.js telemetry",
-  description: "Internal anonymous product-health metrics for Farm.js.",
+  description: "Internal product-health metrics and automatically detected production sites.",
 } satisfies Metadata;
 
 type TelemetryPageProps = {
@@ -46,6 +47,17 @@ type RecentEvent = {
   createdAt: Date;
 };
 
+type ProductionSite = {
+  id: string;
+  url: string;
+  packageName: string;
+  packageVersion: string;
+  renderer: string;
+  deployTarget: string;
+  firstSeenAt: Date;
+  lastSeenAt: Date;
+};
+
 type TelemetryData =
   | {
       status: "ready";
@@ -53,6 +65,8 @@ type TelemetryData =
       eventsLast24h: number;
       uniqueInstallations: number;
       projectsCreated: number;
+      productionSiteCount: number;
+      productionSites: ProductionSite[];
       recentEvents: RecentEvent[];
       eventTypes: GroupCount[];
       packages: GroupCount[];
@@ -144,6 +158,8 @@ async function loadTelemetryData(limit: number): Promise<TelemetryData> {
       eventsLast24h,
       uniqueInstallations,
       projectsCreated,
+      productionSiteCount,
+      productionSites,
       recentEvents,
       eventTypeRows,
       packageRows,
@@ -161,6 +177,21 @@ async function loadTelemetryData(limit: number): Promise<TelemetryData> {
         select: { identityHash: true },
       }),
       prisma.farmTelemetryEvent.count({ where: { eventType: "project_created" } }),
+      prisma.farmProductionSite.count(),
+      prisma.farmProductionSite.findMany({
+        orderBy: { lastSeenAt: "desc" },
+        take: 250,
+        select: {
+          id: true,
+          url: true,
+          packageName: true,
+          packageVersion: true,
+          renderer: true,
+          deployTarget: true,
+          firstSeenAt: true,
+          lastSeenAt: true,
+        },
+      }),
       prisma.farmTelemetryEvent.findMany({
         orderBy: { createdAt: "desc" },
         take: limit,
@@ -232,6 +263,8 @@ async function loadTelemetryData(limit: number): Promise<TelemetryData> {
       eventsLast24h,
       uniqueInstallations: uniqueInstallations.length,
       projectsCreated,
+      productionSiteCount,
+      productionSites,
       recentEvents,
       eventTypes: groups(
         eventTypeRows.map((row) => ({ ...row, key: row.eventType })) as GroupRow[],
@@ -359,6 +392,73 @@ function GroupTable({ title, rows }: { title: string; rows: GroupCount[] }) {
   );
 }
 
+function ProductionSitesTable({ sites }: { sites: ProductionSite[] }) {
+  return (
+    <section className="border border-white/10 bg-black">
+      <header className="flex items-center justify-between border-b border-white/10 px-4 py-3">
+        <div className="flex items-center gap-2">
+          <Globe2 className="size-4 text-white/45" strokeWidth={1.7} aria-hidden="true" />
+          <h2 className="text-sm font-medium">Production websites</h2>
+        </div>
+        <span className="font-mono text-[10px] uppercase tracking-[0.16em] text-white/35">
+          automatic detection
+        </span>
+      </header>
+      <div className="overflow-x-auto">
+        <table className="w-full min-w-[900px] text-left">
+          <thead className="bg-white/[0.025] font-mono text-[10px] uppercase tracking-[0.14em] text-white/35">
+            <tr>
+              <th className="px-4 py-2 font-normal">Website</th>
+              <th className="px-4 py-2 font-normal">Framework</th>
+              <th className="px-4 py-2 font-normal">Renderer</th>
+              <th className="px-4 py-2 font-normal">Target</th>
+              <th className="px-4 py-2 text-right font-normal">First seen</th>
+              <th className="px-4 py-2 text-right font-normal">Last seen</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-white/10">
+            {sites.length ? (
+              sites.map((site) => (
+                <tr key={site.id}>
+                  <td className="px-4 py-2.5 font-mono text-xs">
+                    <a
+                      href={site.url}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="text-white/80 underline decoration-white/20 underline-offset-4 hover:text-white"
+                    >
+                      {site.url}
+                    </a>
+                  </td>
+                  <td className="px-4 py-2.5 font-mono text-xs text-white/65">
+                    {site.packageName}@{site.packageVersion}
+                  </td>
+                  <td className="px-4 py-2.5 font-mono text-xs text-white/55">{site.renderer}</td>
+                  <td className="px-4 py-2.5 font-mono text-xs text-white/55">
+                    {site.deployTarget}
+                  </td>
+                  <td className="whitespace-nowrap px-4 py-2.5 text-right font-mono text-[11px] text-white/40">
+                    {formatDate(site.firstSeenAt)}
+                  </td>
+                  <td className="whitespace-nowrap px-4 py-2.5 text-right font-mono text-[11px] text-white/40">
+                    {formatDate(site.lastSeenAt)}
+                  </td>
+                </tr>
+              ))
+            ) : (
+              <tr>
+                <td colSpan={6} className="px-4 py-8 text-center text-sm text-white/40">
+                  No production websites have been detected yet.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}
+
 function StatusPanel({ data }: { data: Exclude<TelemetryData, { status: "ready" }> }) {
   return (
     <main className="relative flex min-h-dvh items-center justify-center overflow-hidden bg-black px-5 py-16 text-white">
@@ -450,14 +550,15 @@ export default async function TelemetryPage({ searchParams }: TelemetryPageProps
             <div>
               <div className="flex items-center gap-2 font-mono text-[10px] uppercase tracking-[0.18em] text-white/45">
                 <Activity className="size-3.5" strokeWidth={1.7} aria-hidden="true" />
-                Product health / anonymous
+                Product health / privacy-preserving
               </div>
               <h1 className="mt-4 text-3xl font-medium tracking-[-0.045em] sm:text-4xl">
                 Farm.js telemetry
               </h1>
               <p className="mt-3 max-w-2xl text-sm leading-6 text-white/50">
-                Coarse, anonymous CLI and project-creation signals. No paths, repositories, source,
-                credentials, user identities, IP addresses, or user-agent strings are stored.
+                Coarse, anonymous CLI signals plus public origins automatically detected by Farm
+                production server runtimes. No request paths, repositories, source, credentials,
+                visitor identities, IP addresses, or user-agent strings are stored.
               </p>
             </div>
             <p className="font-mono text-[11px] text-white/40">
@@ -477,7 +578,7 @@ export default async function TelemetryPage({ searchParams }: TelemetryPageProps
           </div>
         </header>
 
-        <section className="mt-3 grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+        <section className="mt-3 grid gap-3 sm:grid-cols-2 xl:grid-cols-5">
           <StatCard label="Total events" value={formatNumber(data.totalEvents)} icon={Database} />
           <StatCard
             label="Last 24 hours"
@@ -494,6 +595,15 @@ export default async function TelemetryPage({ searchParams }: TelemetryPageProps
             value={formatNumber(data.projectsCreated)}
             icon={PackageCheck}
           />
+          <StatCard
+            label="Production websites"
+            value={formatNumber(data.productionSiteCount)}
+            icon={Globe2}
+          />
+        </section>
+
+        <section className="mt-3">
+          <ProductionSitesTable sites={data.productionSites} />
         </section>
 
         <section className="mt-3 grid gap-3 xl:grid-cols-2 2xl:grid-cols-3">

--- a/docs/src/lib/api.generated.ts
+++ b/docs/src/lib/api.generated.ts
@@ -8,6 +8,7 @@
 
 import type { POST as POST_telemetry_dashboard_session } from "../app/api/telemetry/dashboard/session/route";
 import type { POST as POST_telemetry_v1_events } from "../app/api/telemetry/v1/events/route";
+import type { POST as POST_telemetry_v1_sites } from "../app/api/telemetry/v1/sites/route";
 import type { POST as POST_waitlist } from "../app/api/waitlist/route";
 
 // Type-only representation of your API routes
@@ -21,6 +22,9 @@ export type APIRouter = {
     v1: {
       events: {
         post: typeof POST_telemetry_v1_events;
+      };
+      sites: {
+        post: typeof POST_telemetry_v1_sites;
       };
     };
   };

--- a/packages/farm/package.json
+++ b/packages/farm/package.json
@@ -157,6 +157,9 @@
       "internal/production-runtime": [
         "./dist/internal/production-runtime.d.ts"
       ],
+      "internal/product-telemetry-runtime": [
+        "./dist/internal/product-telemetry-runtime.d.ts"
+      ],
       "internal/metadata-image-runtime": [
         "./dist/internal/metadata-image-runtime.d.ts"
       ],
@@ -545,6 +548,11 @@
       "types": "./dist/internal/production-runtime.d.ts",
       "import": "./dist/internal/production-runtime.mjs",
       "require": "./dist/internal/production-runtime.cjs"
+    },
+    "./internal/product-telemetry-runtime": {
+      "types": "./dist/internal/product-telemetry-runtime.d.ts",
+      "import": "./dist/internal/product-telemetry-runtime.mjs",
+      "require": "./dist/internal/product-telemetry-runtime.cjs"
     },
     "./internal/metadata-image-runtime": {
       "types": "./dist/internal/metadata-image-runtime.d.ts",

--- a/packages/farm/src/__tests__/config.test.ts
+++ b/packages/farm/src/__tests__/config.test.ts
@@ -74,6 +74,14 @@ describe("config helpers", () => {
     });
   });
 
+  it("enables automatic production-site telemetry unless disabled", async () => {
+    const configured = await resolveConfig({}, "production");
+    const disabled = await resolveConfig({ telemetry: false }, "production");
+
+    expect(configured.telemetry).toBe(true);
+    expect(disabled.telemetry).toBe(false);
+  });
+
   it("warns instead of silently accepting TypeScript build settings", async () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
 

--- a/packages/farm/src/__tests__/product-telemetry.test.ts
+++ b/packages/farm/src/__tests__/product-telemetry.test.ts
@@ -1,0 +1,195 @@
+// @vitest-environment node
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  createFarmProductionSiteReporter,
+  detectFarmProductionSiteOrigin,
+  normalizeFarmProductionSiteOrigin,
+} from "../product-telemetry";
+import { FARM_VERSION } from "../version";
+
+const originalEnvironment = {
+  DO_NOT_TRACK: process.env.DO_NOT_TRACK,
+  FARM_TELEMETRY: process.env.FARM_TELEMETRY,
+  FARM_TELEMETRY_DISABLED: process.env.FARM_TELEMETRY_DISABLED,
+};
+
+afterEach(() => {
+  for (const [key, value] of Object.entries(originalEnvironment)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+});
+
+describe("production-site origin detection", () => {
+  it("automatically reduces a production request URL to its HTTPS origin", () => {
+    expect(detectFarmProductionSiteOrigin("https://Example.com/private?token=secret#section")).toBe(
+      "https://example.com",
+    );
+    expect(detectFarmProductionSiteOrigin(new URL("https://www.example.com:8443/products"))).toBe(
+      "https://www.example.com:8443",
+    );
+    expect(normalizeFarmProductionSiteOrigin("https://Example.com/")).toBe("https://example.com");
+  });
+
+  it.each([
+    "http://example.com/products",
+    "https://intranet/products",
+    "https://localhost/products",
+    "https://preview.localhost/products",
+    "https://service.local/products",
+    "https://127.0.0.1/products",
+    "https://[::1]/products",
+  ])("ignores a non-public production request URL: %s", (requestUrl) => {
+    expect(detectFarmProductionSiteOrigin(requestUrl)).toBeUndefined();
+  });
+
+  it.each([
+    "https://user:secret@example.com",
+    "https://example.com/products",
+    "https://example.com/?campaign=private",
+    "https://example.com/#private",
+  ])("rejects a non-origin ingestion value: %s", (siteUrl) => {
+    expect(normalizeFarmProductionSiteOrigin(siteUrl)).toBeUndefined();
+  });
+});
+
+describe("production-site telemetry reporting", () => {
+  it("hands delivery to waitUntil without waiting for the network", async () => {
+    let finishRequest: ((response: Response) => void) | undefined;
+    const response = new Promise<Response>((resolve) => {
+      finishRequest = resolve;
+    });
+    const send = vi.fn(() => response) as unknown as typeof fetch;
+    const waitUntil = vi.fn<(promise: Promise<unknown>) => void>();
+    const reporter = createFarmProductionSiteReporter({
+      renderer: "react",
+      deployTarget: "vercel",
+      endpoint: "http://127.0.0.1:43199/sites",
+      fetch: send,
+      now: () => 1_000,
+    });
+
+    reporter.report("https://example.com/customers/acme?token=secret", waitUntil);
+
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(waitUntil).toHaveBeenCalledTimes(1);
+    expect(send).toHaveBeenCalledWith(
+      "http://127.0.0.1:43199/sites",
+      expect.objectContaining({
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          schemaVersion: 1,
+          eventType: "production_site_active",
+          siteUrl: "https://example.com",
+          packageName: "@farm.js/core",
+          packageVersion: FARM_VERSION,
+          renderer: "react",
+          deployTarget: "vercel",
+        }),
+        signal: expect.any(AbortSignal),
+      }),
+    );
+
+    finishRequest?.(new Response(null, { status: 202 }));
+    await waitUntil.mock.calls[0]![0];
+  });
+
+  it("tracks the report interval independently for each detected origin", async () => {
+    let now = 10_000;
+    const send = vi.fn<typeof fetch>().mockResolvedValue(new Response(null, { status: 202 }));
+    const deliveries: Promise<unknown>[] = [];
+    const reporter = createFarmProductionSiteReporter({
+      renderer: "react",
+      endpoint: "http://localhost:43199/sites",
+      fetch: send,
+      now: () => now,
+      reportIntervalMs: 60_000,
+      retryIntervalMs: 5_000,
+    });
+
+    reporter.report("https://one.example.com/a", (promise) => deliveries.push(promise));
+    reporter.report("https://two.example.com/b", (promise) => deliveries.push(promise));
+    await Promise.all(deliveries);
+    expect(send).toHaveBeenCalledTimes(2);
+
+    reporter.report("https://one.example.com/c", (promise) => deliveries.push(promise));
+    expect(send).toHaveBeenCalledTimes(2);
+
+    now += 60_000;
+    reporter.report("https://one.example.com/d", (promise) => deliveries.push(promise));
+    expect(send).toHaveBeenCalledTimes(3);
+  });
+
+  it("retries a check-in that was accepted without being stored", async () => {
+    let now = 10_000;
+    const send = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(Response.json({ ok: true, stored: false }, { status: 202 }))
+      .mockResolvedValueOnce(new Response(null, { status: 202 }));
+    const deliveries: Promise<unknown>[] = [];
+    const reporter = createFarmProductionSiteReporter({
+      renderer: "react",
+      endpoint: "http://localhost:43199/sites",
+      fetch: send,
+      now: () => now,
+      reportIntervalMs: 60_000,
+      retryIntervalMs: 5_000,
+    });
+
+    reporter.report("https://example.com", (promise) => deliveries.push(promise));
+    await deliveries.at(-1);
+
+    now += 4_999;
+    reporter.report("https://example.com", (promise) => deliveries.push(promise));
+    expect(send).toHaveBeenCalledTimes(1);
+
+    now += 1;
+    reporter.report("https://example.com", (promise) => deliveries.push(promise));
+    await deliveries.at(-1);
+    expect(send).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not report local requests", () => {
+    const send = vi.fn<typeof fetch>();
+    const reporter = createFarmProductionSiteReporter({ renderer: "react", fetch: send });
+
+    reporter.report("http://localhost:3000/products");
+    reporter.report("https://preview.localhost/products");
+
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("bounds automatically detected origins per running instance", async () => {
+    const send = vi.fn<typeof fetch>().mockResolvedValue(new Response(null, { status: 202 }));
+    const deliveries: Promise<unknown>[] = [];
+    const reporter = createFarmProductionSiteReporter({ renderer: "react", fetch: send });
+
+    for (let index = 0; index < 33; index += 1) {
+      reporter.report(`https://site-${index}.example.com/path`, (promise) =>
+        deliveries.push(promise),
+      );
+    }
+    await Promise.all(deliveries);
+
+    expect(send).toHaveBeenCalledTimes(32);
+  });
+
+  it.each([
+    ["DO_NOT_TRACK", "1"],
+    ["FARM_TELEMETRY_DISABLED", "true"],
+    ["FARM_TELEMETRY", "0"],
+  ])("honors the %s environment opt-out", (key, value) => {
+    delete process.env.DO_NOT_TRACK;
+    delete process.env.FARM_TELEMETRY_DISABLED;
+    delete process.env.FARM_TELEMETRY;
+    process.env[key] = value;
+    const send = vi.fn<typeof fetch>();
+    const reporter = createFarmProductionSiteReporter({ renderer: "react", fetch: send });
+
+    reporter.report("https://example.com");
+
+    expect(send).not.toHaveBeenCalled();
+  });
+});

--- a/packages/farm/src/__tests__/production-prebuilt-ssr.test.ts
+++ b/packages/farm/src/__tests__/production-prebuilt-ssr.test.ts
@@ -227,6 +227,73 @@ async function expectNitroFallback(root: string): Promise<void> {
 }
 
 describe("production prebuilt SSR output", () => {
+  it("bundles automatic production-site discovery on the server only", async () => {
+    const root = await createProductionFixture();
+
+    try {
+      const config = await resolveConfig(
+        {
+          root,
+          srcDir: "src",
+          images: { provider: "none" },
+          generateBuildId: () => "production-site-telemetry-test",
+        },
+        "production",
+      );
+
+      await build(config, { root, preset: "node-server" });
+
+      const serverDir = path.join(root, ".farm", ".output", "server");
+      const serverPackage = JSON.parse(
+        await fs.readFile(path.join(serverDir, "package.json"), "utf8"),
+      );
+      const mappedEntry = serverPackage.imports?.["#farm-ssr-entry"];
+      expect(mappedEntry).toMatch(/^\.\/farm-ssr\//);
+      const serverJavaScript = await fs.readFile(
+        path.join(serverDir, mappedEntry.slice("./".length)),
+        "utf8",
+      );
+      const clientJavaScript = await readAllClientJavaScript(root);
+      expect(serverJavaScript).toContain("production_site_active");
+      expect(clientJavaScript).not.toContain("production_site_active");
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  }, 120_000);
+
+  it("omits production-site discovery when product telemetry is disabled", async () => {
+    const root = await createProductionFixture();
+
+    try {
+      const config = await resolveConfig(
+        {
+          root,
+          srcDir: "src",
+          images: { provider: "none" },
+          telemetry: false,
+          generateBuildId: () => "production-site-telemetry-disabled-test",
+        },
+        "production",
+      );
+
+      await build(config, { root, preset: "node-server" });
+
+      const serverDir = path.join(root, ".farm", ".output", "server");
+      const serverPackage = JSON.parse(
+        await fs.readFile(path.join(serverDir, "package.json"), "utf8"),
+      );
+      const mappedEntry = serverPackage.imports?.["#farm-ssr-entry"];
+      expect(mappedEntry).toMatch(/^\.\/farm-ssr\//);
+      const serverJavaScript = await fs.readFile(
+        path.join(serverDir, mappedEntry.slice("./".length)),
+        "utf8",
+      );
+      expect(serverJavaScript).not.toContain("production_site_active");
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  }, 120_000);
+
   it("isolates a client leaf without shipping its server layout", async () => {
     const root = await createProductionFixture();
     const baselineRoot = await createProductionFixture();

--- a/packages/farm/src/app.ts
+++ b/packages/farm/src/app.ts
@@ -189,6 +189,7 @@ export class FarmApp {
       md: resolveMarkdownConfig(config.md),
       mdx: resolveMdxConfig(config.mdx),
       observability: config.observability ?? false,
+      telemetry: config.telemetry !== false,
       devtools: resolveFarmDevtoolsConfig(
         config.devtools,
         process.env.NODE_ENV === "production" ? "production" : "development",

--- a/packages/farm/src/config.ts
+++ b/packages/farm/src/config.ts
@@ -316,7 +316,6 @@ export interface FarmUserConfig extends Omit<BaseFarmConfig, "vite" | "docs" | "
   md?: FarmMarkdownUserConfig | boolean;
   mdx?: FarmMdxUserConfig;
   observability?: FarmObservabilityUserConfig;
-
   trailingSlash?: boolean;
   redirects?: () => Promise<RedirectConfig[]> | RedirectConfig[];
   rewrites?: () => Promise<RewriteConfig[]> | RewriteConfig[];
@@ -953,6 +952,7 @@ export async function resolveConfig(
     workflows: resolveWorkflowsConfig(userConfig.workflows),
     api,
     observability: userConfig.observability ?? false,
+    telemetry: userConfig.telemetry !== false,
     devtools: resolveFarmDevtoolsConfig(userConfig.devtools, mode),
     storage: userConfig.storage || {},
     cache: userConfig.cache || {},

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -3986,6 +3986,9 @@ function generateVirtualEntryCode(
   stripFarmLocaleFromPathname,
   withFarmRouteContext,
 } from "@farm.js/core/internal/production-runtime";`;
+  const productionSiteTelemetryImport = config.telemetry
+    ? `import { createFarmProductionSiteReporter } from "@farm.js/core/internal/product-telemetry-runtime";`
+    : "";
   const metadataImageRuntimeImport = hasGeneratedMetadataImages
     ? `import { createFarmMetadataImageResponse } from "@farm.js/core/internal/metadata-image-runtime";`
     : "";
@@ -4181,6 +4184,7 @@ ${middlewareImports.join("\n")}
 ${notFoundImport}
 ${apiRouteHelpersImport}
 ${productionRuntimeImport}
+${productionSiteTelemetryImport}
 ${metadataImageRuntimeImport}
 ${pluginRuntimeImport}
 ${i18nServerImport}
@@ -4198,6 +4202,14 @@ import { farmFontPreloadHeader } from "virtual:farm-font-runtime";
 ${rendererServerImports}
 
 const farmPreloadConfig = ${JSON.stringify(config.performance.preload)};
+const farmProductionSiteTelemetry = ${
+    config.telemetry
+      ? `createFarmProductionSiteReporter({
+  renderer: ${JSON.stringify(config.renderer.name)},
+  deployTarget: ${JSON.stringify(config.deploy.target || "custom")},
+})`
+      : "null"
+  };
 
 // Custom 404 page component (if provided)
 const hasCustomNotFound = ${notFoundPath ? "true" : "false"};
@@ -6937,6 +6949,11 @@ async function applyFarmPreloadBudget(response, pathname) {
 export async function fetch(request, context) {
   const healthResponse = await farmProductionLifecycle.handleHealthRequest(request);
   if (healthResponse) return healthResponse;
+
+  farmProductionSiteTelemetry?.report(
+    request.url,
+    typeof context?.waitUntil === "function" ? context.waitUntil.bind(context) : undefined,
+  );
 
   return farmProductionLifecycle.runRequest(
     () =>

--- a/packages/farm/src/product-telemetry.ts
+++ b/packages/farm/src/product-telemetry.ts
@@ -1,0 +1,226 @@
+import { FARM_VERSION } from "./version";
+
+export const FARM_PRODUCTION_SITE_TELEMETRY_SCHEMA_VERSION = 1 as const;
+export const FARM_PRODUCTION_SITE_TELEMETRY_EVENT_TYPE = "production_site_active" as const;
+export const FARM_PRODUCTION_SITE_TELEMETRY_PACKAGE_NAME = "@farm.js/core" as const;
+
+const DEFAULT_SITE_TELEMETRY_ENDPOINT = "https://farmjs.dev/api/telemetry/v1/sites";
+const REQUEST_TIMEOUT_MS = 3_000;
+const REPORT_INTERVAL_MS = 24 * 60 * 60 * 1_000;
+const RETRY_INTERVAL_MS = 5 * 60 * 1_000;
+const MAX_ORIGINS_PER_INSTANCE = 32;
+const SAFE_DETAIL_PATTERN = /^[0-9A-Za-z._-]{1,64}$/;
+
+export interface FarmProductionSiteTelemetryPayload {
+  schemaVersion: typeof FARM_PRODUCTION_SITE_TELEMETRY_SCHEMA_VERSION;
+  eventType: typeof FARM_PRODUCTION_SITE_TELEMETRY_EVENT_TYPE;
+  siteUrl: string;
+  packageName: typeof FARM_PRODUCTION_SITE_TELEMETRY_PACKAGE_NAME;
+  packageVersion: string;
+  renderer: string;
+  deployTarget: string;
+}
+
+interface FarmProductionSiteReporterOptions {
+  renderer: string;
+  deployTarget?: string;
+  endpoint?: string;
+  fetch?: typeof fetch;
+  now?: () => number;
+  reportIntervalMs?: number;
+  retryIntervalMs?: number;
+}
+
+interface OriginReportState {
+  pending?: Promise<void>;
+  nextReportAt: number;
+}
+
+export interface FarmProductionSiteReporter {
+  report(requestUrl: string | URL, waitUntil?: (promise: Promise<unknown>) => void): void;
+}
+
+/**
+ * Reduce an automatically observed request URL to a public HTTPS origin.
+ * Request paths, query strings, hashes, and credentials are never returned.
+ */
+export function detectFarmProductionSiteOrigin(value: string | URL): string | undefined {
+  try {
+    const url = value instanceof URL ? value : new URL(value);
+    return normalizeFarmProductionSiteOrigin(url.origin);
+  } catch {
+    return undefined;
+  }
+}
+
+/** Normalize and validate the origin-only value accepted by the ingestion service. */
+export function normalizeFarmProductionSiteOrigin(value: string): string | undefined {
+  const candidate = value.trim();
+  if (!candidate || candidate.length > 2_048) return undefined;
+
+  try {
+    const url = new URL(candidate);
+    const hostname = url.hostname.toLowerCase();
+    const isIpv4 = /^\d{1,3}(?:\.\d{1,3}){3}$/.test(hostname);
+    const isIpv6 = hostname.startsWith("[") && hostname.endsWith("]");
+    const isLocal =
+      hostname === "localhost" || hostname.endsWith(".localhost") || hostname.endsWith(".local");
+    const isSingleLabel = !hostname.includes(".");
+
+    if (
+      url.protocol !== "https:" ||
+      url.username ||
+      url.password ||
+      url.search ||
+      url.hash ||
+      url.pathname !== "/" ||
+      isIpv4 ||
+      isIpv6 ||
+      isLocal ||
+      isSingleLabel ||
+      hostname.endsWith(".")
+    ) {
+      return undefined;
+    }
+
+    return url.origin;
+  } catch {
+    return undefined;
+  }
+}
+
+export function createFarmProductionSiteReporter(
+  options: FarmProductionSiteReporterOptions,
+): FarmProductionSiteReporter {
+  const now = options.now ?? Date.now;
+  const reportIntervalMs = options.reportIntervalMs ?? REPORT_INTERVAL_MS;
+  const retryIntervalMs = options.retryIntervalMs ?? RETRY_INTERVAL_MS;
+  const send = options.fetch ?? globalThis.fetch;
+  const reportStates = new Map<string, OriginReportState>();
+
+  return {
+    report(requestUrl, waitUntil) {
+      if (productionTelemetryDisabled()) return;
+
+      const siteUrl = detectFarmProductionSiteOrigin(requestUrl);
+      if (!siteUrl) return;
+
+      let state = reportStates.get(siteUrl);
+      if (!state) {
+        if (reportStates.size >= MAX_ORIGINS_PER_INSTANCE) return;
+        state = { nextReportAt: 0 };
+        reportStates.set(siteUrl, state);
+      }
+
+      const attemptedAt = now();
+      if (state.pending || attemptedAt < state.nextReportAt) return;
+
+      state.nextReportAt = attemptedAt + reportIntervalMs;
+      const payload: FarmProductionSiteTelemetryPayload = {
+        schemaVersion: FARM_PRODUCTION_SITE_TELEMETRY_SCHEMA_VERSION,
+        eventType: FARM_PRODUCTION_SITE_TELEMETRY_EVENT_TYPE,
+        siteUrl,
+        packageName: FARM_PRODUCTION_SITE_TELEMETRY_PACKAGE_NAME,
+        packageVersion: sanitizeDetail(FARM_VERSION, "unknown"),
+        renderer: sanitizeDetail(options.renderer, "custom"),
+        deployTarget: sanitizeDetail(options.deployTarget, "custom"),
+      };
+      state.pending = deliver(send, resolveSiteTelemetryEndpoint(options.endpoint), payload)
+        .then((delivered) => {
+          if (!delivered) state.nextReportAt = now() + retryIntervalMs;
+        })
+        .catch(() => {
+          state.nextReportAt = now() + retryIntervalMs;
+        })
+        .finally(() => {
+          state.pending = undefined;
+        });
+
+      if (waitUntil) {
+        try {
+          waitUntil(state.pending);
+        } catch {
+          // Delivery remains best-effort if a platform rejects background work.
+        }
+      } else {
+        void state.pending;
+      }
+    },
+  };
+}
+
+async function deliver(
+  send: typeof fetch,
+  endpoint: string,
+  payload: FarmProductionSiteTelemetryPayload,
+): Promise<boolean> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  timeout.unref?.();
+  try {
+    const response = await send(endpoint, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(payload),
+      signal: controller.signal,
+    });
+    if (!response.ok) {
+      debug(`production-site check-in rejected with HTTP ${response.status}`);
+      return false;
+    }
+    try {
+      const result = (await response.json()) as { stored?: unknown };
+      if (result && result.stored === false) {
+        debug("production-site check-in was accepted but not stored");
+        return false;
+      }
+    } catch {
+      // A successful empty response is also a valid acknowledgement.
+    }
+    return true;
+  } catch {
+    debug("production-site check-in failed");
+    return false;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function resolveSiteTelemetryEndpoint(explicit?: string): string {
+  const candidate = explicit || process.env.FARM_TELEMETRY_SITE_ENDPOINT;
+  if (!candidate) return DEFAULT_SITE_TELEMETRY_ENDPOINT;
+
+  try {
+    const url = new URL(candidate);
+    const isLocal = ["localhost", "127.0.0.1", "::1"].includes(url.hostname);
+    if (url.protocol === "https:" || (url.protocol === "http:" && isLocal)) {
+      return url.toString();
+    }
+  } catch {
+    // Fall through to the Farm-owned endpoint.
+  }
+  return DEFAULT_SITE_TELEMETRY_ENDPOINT;
+}
+
+function productionTelemetryDisabled(): boolean {
+  if (process.env.DO_NOT_TRACK !== undefined && !isFalse(process.env.DO_NOT_TRACK)) return true;
+  if (isTrue(process.env.FARM_TELEMETRY_DISABLED)) return true;
+  return isFalse(process.env.FARM_TELEMETRY);
+}
+
+function sanitizeDetail(value: string | undefined, fallback: string): string {
+  return value && SAFE_DETAIL_PATTERN.test(value) ? value : fallback;
+}
+
+function isTrue(value: string | undefined): boolean {
+  return value !== undefined && ["1", "true", "yes", "on"].includes(value.toLowerCase());
+}
+
+function isFalse(value: string | undefined): boolean {
+  return value !== undefined && ["0", "false", "no", "off"].includes(value.toLowerCase());
+}
+
+function debug(message: string): void {
+  if (!isTrue(process.env.FARM_TELEMETRY_DEBUG)) return;
+  process.stderr.write(`[farm.telemetry] ${message}\n`);
+}

--- a/packages/farm/src/types.ts
+++ b/packages/farm/src/types.ts
@@ -222,6 +222,8 @@ export interface FarmConfig {
   md?: FarmMarkdownUserConfig | FarmMarkdownResolvedConfig | boolean;
   mdx?: FarmMdxUserConfig | FarmMdxResolvedConfig;
   observability?: FarmObservabilityUserConfig;
+  /** Farm product telemetry for deployed server runtimes. Set to false to disable. */
+  telemetry?: boolean;
   /** Development-only runtime inspector. Enabled by default during `farm dev`. */
   devtools?: FarmDevtoolsUserConfig;
   /** Development-only browser feedback for build and HMR activity. */

--- a/packages/farm/tsup.config.ts
+++ b/packages/farm/tsup.config.ts
@@ -63,6 +63,7 @@ export const farmPackageBuildOptions = {
     "internal/client-runtime": "src/client/production-runtime.ts",
     "internal/isolated-boundary": "src/client/isolated-boundary.ts",
     "internal/production-runtime": "src/nitro/production-runtime.ts",
+    "internal/product-telemetry-runtime": "src/product-telemetry.ts",
     "internal/metadata-image-runtime": "src/metadata-image.ts",
     "internal/build-runtime": "src/nitro/build-runtime.ts",
     "internal/config-runtime": "src/config-runtime.ts",


### PR DESCRIPTION
## Problem

Farm telemetry measures CLI activity but cannot show which deployed websites run Farm. Requiring each app to configure its own production URL would make the signal incomplete and easy to miss.

## Root cause

The production runtime did not derive a sanitized public origin from incoming requests, and the telemetry ingestion and dashboard only handled CLI events.

## Change

- Detect public HTTPS origins from production server requests automatically.
- Schedule reporting with the runtime waitUntil hook when available, with a bounded background fallback.
- Rate-limit reports per origin, retry transient failures, and cap in-memory origin tracking.
- Add strict ingestion, additive Prisma storage, retention pruning, and a production-site table on the telemetry dashboard.
- Put the reporter behind a dedicated internal entry so telemetry: false removes it from server and browser bundles.
- Document automatic collection, preview behavior, the transmitted fields, and all opt-outs.

## Safety and compatibility

- Reports only origin, Farm version, renderer, and deployment target. Paths, queries, headers, cookies, and request bodies are never sent.
- Localhost, local/private-style hostnames, IP addresses, malformed URLs, and non-HTTPS origins are ignored.
- Reporting never blocks the response and failures do not affect startup, requests, or shutdown.
- Fully static exports do not report because no production server request runs.
- Apps can disable this with telemetry: false, FARM_TELEMETRY_DISABLED=1, FARM_TELEMETRY=0, or DO_NOT_TRACK=1.
- Public origins are documented as unverified usage signals.

## Verification

- pnpm --filter @farm.js/core exec vitest run src/__tests__/product-telemetry.test.ts src/__tests__/config.test.ts
- pnpm --filter @farm.js/core exec vitest run --root ../.. docs/src/app/api/telemetry/v1/sites/route.test.ts
- pnpm --filter @farm.js/core exec vitest run src/__tests__/production-prebuilt-ssr.test.ts
- pnpm --filter @farm.js/core type-check
- NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @farm.js/core build
- pnpm --dir docs prisma:generate
- pnpm --dir docs exec farm generate --check
- pnpm docs:check-navigation
- pnpm --dir docs build
- pnpm exec oxfmt on all changed source and documentation files
- pnpm exec oxlint on all changed JavaScript and TypeScript files
- git diff --check

The full production prebuilt suite passes 23/23 across Node and Cloudflare output. The focused telemetry/configuration suite passes 71/71 and the ingestion suite passes 3/3.

## Documentation and release

Telemetry and configuration docs, the generated API declaration, dashboard, and Prisma schema are updated. No package version is edited; the repository's coordinated release workflow remains authoritative.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds automatic production-site detection to Farm telemetry. Built server runtimes now derive a public HTTPS origin from incoming requests and report it in the background; previously telemetry covered only CLI events.

**Reporting**
- Reports only the origin, `@farm.js/core` version, renderer, and deploy target; paths, queries, headers, cookies, and bodies are never sent.
- Ignores localhost, private hostnames, IPs, malformed URLs, and non-HTTPS origins.
- Delivers through `waitUntil` when available and never blocks requests, startup, or shutdown.
- Adds `telemetry: false`; `FARM_TELEMETRY=0`, `FARM_TELEMETRY_DISABLED`, and `DO_NOT_TRACK` still opt out.
- Fully static exports send nothing because no production server request runs.

**Ingestion and dashboard**
- New `/api/telemetry/v1/sites` endpoint enforces a strict versioned schema, rate-limits per origin, and upserts with daily retention pruning; dashboard origins are documented as unverified signals.
- Adds the production-sites table and count to the docs dashboard and updates telemetry and configuration docs.

<sup>Written for commit b575cecdc300759c92bc7e7e315ff22ccd8d9fd9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/630?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

