### PR TITLE
fix(config): compile route patterns consistently

### DIFF
--- a/docs/src/app/docs/configuration/page.md
+++ b/docs/src/app/docs/configuration/page.md
@@ -560,6 +560,19 @@ export default async function BlogPage() {
 
 ## Route rules
 
+Farm's `redirects()`, `rewrites()`, and `headers()` config functions use the same source pattern
+syntax. `:name` captures one path segment, while `:name*` and plain `*` capture the remaining
+characters. Redirect and rewrite destinations can reuse named captures or use numbered captures
+such as `$1`. All other source characters are matched literally.
+
+```ts
+export default defineConfig({
+  async redirects() {
+    return [{ source: "/old/:path*", destination: "/new/:path*", permanent: true }];
+  },
+});
+```
+
 Use `routeRules` when behavior belongs to a URL pattern instead of one page file. Rules are normalized into Farm redirects/headers and passed to Nitro route rules for production adapters.
 
 ```ts

--- a/packages/farm/src/__tests__/config-route-plugins.test.ts
+++ b/packages/farm/src/__tests__/config-route-plugins.test.ts
@@ -1,0 +1,93 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { describe, expect, it, vi } from "vitest";
+import { createHeadersPlugin } from "../plugins/headers";
+import { createRedirectsPlugin } from "../plugins/redirects";
+import { createRewritesPlugin } from "../plugins/rewrites";
+
+function createRequest(url: string): IncomingMessage {
+  return {
+    url,
+    headers: { host: "localhost:3000" },
+  } as IncomingMessage;
+}
+
+function createResponse(): ServerResponse {
+  return {
+    setHeader: vi.fn(),
+    writeHead: vi.fn(),
+    end: vi.fn(),
+  } as unknown as ServerResponse;
+}
+
+async function runBeforeRequest(
+  plugin: ReturnType<typeof createRedirectsPlugin>,
+  req: IncomingMessage,
+  res: ServerResponse,
+): Promise<void> {
+  await (plugin.beforeRequest as any)(req, res, {});
+}
+
+describe("config route plugins", () => {
+  it("keeps named and plain redirect captures in source order", async () => {
+    const plugin = createRedirectsPlugin([
+      {
+        source: "/docs/:slug*/asset/*",
+        destination: "/new/:slug*/copy/*",
+      },
+    ]);
+    const req = createRequest("/docs/guides/start/asset/logo.svg");
+    const res = createResponse();
+
+    await runBeforeRequest(plugin, req, res);
+
+    expect(res.writeHead).toHaveBeenCalledWith(307, {
+      Location: "/new/guides/start/copy/logo.svg",
+    });
+  });
+
+  it("treats regular-expression characters as literals", async () => {
+    const plugin = createRedirectsPlugin([{ source: "/promo.html", destination: "/offer" }]);
+    const req = createRequest("/promoXhtml");
+    const res = createResponse();
+
+    await runBeforeRequest(plugin, req, res);
+
+    expect(res.writeHead).not.toHaveBeenCalled();
+  });
+
+  it("matches named parameters when applying response headers", async () => {
+    const plugin = createHeadersPlugin([
+      {
+        source: "/docs/:path*",
+        headers: [{ key: "x-docs", value: "yes" }],
+      },
+    ]);
+    const req = createRequest("/docs/guides/start");
+    const res = createResponse();
+
+    await runBeforeRequest(plugin, req, res);
+
+    expect(res.setHeader).toHaveBeenCalledWith("x-docs", "yes");
+  });
+
+  it("interpolates named and numbered rewrite captures", async () => {
+    const named = createRewritesPlugin([
+      {
+        source: "/api/:version*/assets/*",
+        destination: "/internal/:version*/files/*",
+      },
+    ]);
+    const namedRequest = createRequest("/api/v1/public/assets/logo.svg?download=1");
+
+    await runBeforeRequest(named, namedRequest, createResponse());
+
+    expect(namedRequest.url).toBe("/internal/v1/public/files/logo.svg?download=1");
+
+    const numbered = createRewritesPlugin([{ source: "/legacy/*", destination: "/current/$1" }]);
+    const numberedRequest = createRequest("/legacy/guide");
+
+    await runBeforeRequest(numbered, numberedRequest, createResponse());
+
+    expect(numberedRequest.url).toBe("/current/guide");
+  });
+});

--- a/packages/farm/src/plugins/headers.ts
+++ b/packages/farm/src/plugins/headers.ts
@@ -1,6 +1,7 @@
 import type { FarmPlugin, FarmPluginContext } from "../plugin";
 import type { HeaderConfig } from "../config";
 import type { FarmRequest, FarmResponse } from "../types";
+import { compileConfigRoutePattern } from "./route-pattern";
 
 export function createHeadersPlugin(
   headers: HeaderConfig[],
@@ -20,6 +21,11 @@ export function createHeadersPlugin(
     ) => void | Promise<void>;
   } = {},
 ): FarmPlugin {
+  const compiledHeaders = headers.map((config) => ({
+    config,
+    pattern: compileConfigRoutePattern(config.source),
+  }));
+
   return {
     name: "farm:headers",
     enforce: "pre",
@@ -31,13 +37,9 @@ export function createHeadersPlugin(
       const url = new URL(req.url || "/", `http://${req.headers.host}`);
       const pathname = url.pathname;
 
-      for (const headerConfig of headers) {
-        const sourceRegex = new RegExp(
-          "^" + headerConfig.source.replace(/\*/g, "(.*)").replace(/\//g, "\\/") + "$",
-        );
-
-        if (sourceRegex.test(pathname)) {
-          for (const header of headerConfig.headers) {
+      for (const { config, pattern } of compiledHeaders) {
+        if (pattern.regex.test(pathname)) {
+          for (const header of config.headers) {
             res.setHeader(header.key, header.value);
           }
         }

--- a/packages/farm/src/plugins/redirects.ts
+++ b/packages/farm/src/plugins/redirects.ts
@@ -1,6 +1,7 @@
 import type { FarmPlugin, FarmPluginContext } from "../plugin";
 import type { RedirectConfig } from "../config";
 import type { FarmRequest, FarmResponse } from "../types";
+import { compileConfigRoutePattern, interpolateConfigRouteDestination } from "./route-pattern";
 
 export function createRedirectsPlugin(
   redirects: RedirectConfig[],
@@ -20,6 +21,11 @@ export function createRedirectsPlugin(
     ) => void | Promise<void>;
   } = {},
 ): FarmPlugin {
+  const compiledRedirects = redirects.map((redirect) => ({
+    redirect,
+    pattern: compileConfigRoutePattern(redirect.source),
+  }));
+
   return {
     name: "farm:redirects",
     enforce: "pre",
@@ -30,37 +36,14 @@ export function createRedirectsPlugin(
       const url = new URL(req.url || "/", `http://${req.headers.host}`);
       const pathname = url.pathname;
 
-      for (const redirect of redirects) {
-        // Convert Next.js-style patterns to regex
-        // :param -> ([^/]+)
-        // :param* -> (.*)
-        // * -> (.*)
-        const pattern = redirect.source
-          .replace(/:\w+\*/g, "(.*)") // :param* -> (.*)
-          .replace(/:\w+/g, "([^/]+)") // :param -> ([^/]+)
-          .replace(/\*/g, "(.*)") // * -> (.*)
-          .replace(/\//g, "\\/"); // escape slashes
-
-        const sourceRegex = new RegExp(`^${pattern}$`);
-
-        if (sourceRegex.test(pathname)) {
-          // Replace captured groups in destination
-          let destination = redirect.destination;
-          const matches = pathname.match(sourceRegex);
-
-          if (matches) {
-            // Replace :param or :param* with captured values
-            const params = redirect.source.match(/:\w+\*?/g) || [];
-            params.forEach((param, index) => {
-              destination = destination.replace(param, matches[index + 1] || "");
-            });
-
-            // Also replace plain * with captured values
-            const stars = redirect.source.match(/(?<!:)\*/g) || [];
-            stars.forEach((_, index) => {
-              destination = destination.replace("*", matches[params.length + index + 1] || "");
-            });
-          }
+      for (const { redirect, pattern } of compiledRedirects) {
+        const match = pathname.match(pattern.regex);
+        if (match) {
+          const destination = interpolateConfigRouteDestination(
+            redirect.destination,
+            match,
+            pattern.tokens,
+          );
 
           const statusCode = redirect.statusCode || (redirect.permanent ? 308 : 307);
 

--- a/packages/farm/src/plugins/rewrites.ts
+++ b/packages/farm/src/plugins/rewrites.ts
@@ -1,6 +1,7 @@
 import type { FarmPlugin, FarmPluginContext } from "../plugin";
 import type { RewriteConfig } from "../config";
 import type { FarmRequest, FarmResponse } from "../types";
+import { compileConfigRoutePattern, interpolateConfigRouteDestination } from "./route-pattern";
 
 export function createRewritesPlugin(
   rewrites: RewriteConfig[],
@@ -20,6 +21,11 @@ export function createRewritesPlugin(
     ) => void | Promise<void>;
   } = {},
 ): FarmPlugin {
+  const compiledRewrites = rewrites.map((rewrite) => ({
+    rewrite,
+    pattern: compileConfigRoutePattern(rewrite.source),
+  }));
+
   return {
     name: "farm:rewrites",
     enforce: "pre",
@@ -31,13 +37,14 @@ export function createRewritesPlugin(
       const url = new URL(req.url || "/", `http://${req.headers.host}`);
       const pathname = url.pathname;
 
-      for (const rewrite of rewrites) {
-        const sourceRegex = new RegExp(
-          "^" + rewrite.source.replace(/\*/g, "(.*)").replace(/\//g, "\\/") + "$",
-        );
-
-        if (sourceRegex.test(pathname)) {
-          const newPath = pathname.replace(sourceRegex, rewrite.destination);
+      for (const { rewrite, pattern } of compiledRewrites) {
+        const match = pathname.match(pattern.regex);
+        if (match) {
+          const newPath = interpolateConfigRouteDestination(
+            rewrite.destination,
+            match,
+            pattern.tokens,
+          );
           req.url = newPath + url.search;
           break;
         }

--- a/packages/farm/src/plugins/route-pattern.ts
+++ b/packages/farm/src/plugins/route-pattern.ts
@@ -1,0 +1,93 @@
+type ConfigRoutePatternToken =
+  | { kind: "param"; name: string; captureIndex: number }
+  | { kind: "wildcard"; captureIndex: number };
+
+export interface CompiledConfigRoutePattern {
+  regex: RegExp;
+  tokens: ConfigRoutePatternToken[];
+}
+
+function escapeRegexCharacter(character: string): string {
+  return /[\\^$.*+?()[\]{}|]/.test(character) ? `\\${character}` : character;
+}
+
+export function compileConfigRoutePattern(source: string): CompiledConfigRoutePattern {
+  const tokens: ConfigRoutePatternToken[] = [];
+  let pattern = "";
+  let captureIndex = 1;
+
+  for (let index = 0; index < source.length; ) {
+    const rest = source.slice(index);
+    const parameter = rest.match(/^:([A-Za-z0-9_]+)(\*)?/);
+    if (parameter) {
+      tokens.push({ kind: "param", name: parameter[1], captureIndex });
+      pattern += parameter[2] ? "(.*)" : "([^/]+)";
+      captureIndex += 1;
+      index += parameter[0].length;
+      continue;
+    }
+
+    if (source[index] === "*") {
+      tokens.push({ kind: "wildcard", captureIndex });
+      pattern += "(.*)";
+      captureIndex += 1;
+      index += 1;
+      continue;
+    }
+
+    pattern += escapeRegexCharacter(source[index]);
+    index += 1;
+  }
+
+  return { regex: new RegExp(`^${pattern}$`), tokens };
+}
+
+export function interpolateConfigRouteDestination(
+  destination: string,
+  match: RegExpMatchArray,
+  tokens: readonly ConfigRoutePatternToken[],
+): string {
+  const namedCaptures = new Map<string, string>();
+  const wildcardCaptures: string[] = [];
+
+  for (const token of tokens) {
+    const value = match[token.captureIndex] || "";
+    if (token.kind === "param") {
+      namedCaptures.set(token.name, value);
+    } else {
+      wildcardCaptures.push(value);
+    }
+  }
+
+  let result = "";
+  let wildcardIndex = 0;
+  for (let index = 0; index < destination.length; ) {
+    const rest = destination.slice(index);
+    const parameter = rest.match(/^:([A-Za-z0-9_]+)(\*)?/);
+    if (parameter) {
+      const value = namedCaptures.get(parameter[1]);
+      result += value === undefined ? parameter[0] : value;
+      index += parameter[0].length;
+      continue;
+    }
+
+    const capture = rest.match(/^\$(\d+)/);
+    if (capture) {
+      result += match[Number(capture[1])] || "";
+      index += capture[0].length;
+      continue;
+    }
+
+    if (destination[index] === "*") {
+      result += wildcardCaptures[wildcardIndex] || "";
+      wildcardIndex += 1;
+      index += 1;
+      continue;
+    }
+
+    result += destination[index];
+    index += 1;
+  }
+
+  return result;
+}


### PR DESCRIPTION
## Problem

`redirects()`, `rewrites()`, and `headers()` compile equivalent route patterns differently. Redirect patterns can double-expand generated wildcard groups and shift captures, while header and rewrite patterns do not recognize named parameters. Regex punctuation in a source is also treated as executable syntax instead of a literal path character.

## Root cause

Each development server plugin performs its own chained string replacement. Generated regex fragments are processed again by later replacements, and there is no shared record of capture order for destination interpolation.

## Change

Add one route-pattern compiler that escapes literal characters and records named and plain wildcard captures in order. Use it in all three config plugins, compile patterns once at plugin creation, and support named, plain wildcard, and numbered destination interpolation.

## Safety and compatibility

Existing plain `*` and `$1` rewrite forms continue to work. Named `:param` and `:param*` patterns now behave consistently across redirects, rewrites, and headers. Source punctuation is matched literally instead of widening the route.

## Verification

- `pnpm --filter @farm.js/core test -- --run src/__tests__/config-route-plugins.test.ts` (4 tests)
- `pnpm --filter @farm.js/core type-check`
- `pnpm exec oxlint packages/farm/src/plugins/route-pattern.ts packages/farm/src/plugins/redirects.ts packages/farm/src/plugins/headers.ts packages/farm/src/plugins/rewrites.ts packages/farm/src/__tests__/config-route-plugins.test.ts`
- `pnpm exec oxfmt --check packages/farm/src/plugins/route-pattern.ts packages/farm/src/plugins/redirects.ts packages/farm/src/plugins/headers.ts packages/farm/src/plugins/rewrites.ts packages/farm/src/__tests__/config-route-plugins.test.ts docs/src/app/docs/configuration/page.md`
- `git diff --check`

The ordered mixed-capture redirect, named header, and named rewrite cases fail before this change.

## Documentation and release

Documented the shared config pattern and destination interpolation syntax.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies route pattern handling across `redirects()`, `rewrites()`, and `headers()` so named parameters, wildcards, and captures behave consistently instead of varying per plugin.

Previously, redirect patterns could shift or double-expand captured groups, while rewrite and header patterns ignored named parameters, and regex punctuation in sources acted as executable syntax. All three config functions now share a single compiler that escapes literal characters and records captures in source order, with patterns compiled once at plugin creation.

**Migration**
- Existing plain `*` and `$1` destination forms keep working; named `:param` and `:param*` interpolation is now available in all three config functions.

<sup>Written for commit b2dbda36c0d087c93962b3b9dbdb14d07b071193. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/631?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

