### PR TITLE
fix(cache): retain invalidations during generation

### DIFF
--- a/docs/src/app/docs/cache-ppr/page.md
+++ b/docs/src/app/docs/cache-ppr/page.md
@@ -130,6 +130,9 @@ Endpoints accept the same `{ key }`, `{ tag }`, and `{ path }` targets. Imperati
 when calling outside a Farm action/endpoint request; Farm action requests automatically wait for
 registered distributed invalidations before completing.
 
+If a tag is invalidated while its value is still being generated, that caller can finish with the
+generated value, but Farm keeps the stored entry stale so the next read regenerates it.
+
 ## Adapter contract
 
 Custom adapters implement asynchronous entry persistence plus optional shared tag versions:

--- a/packages/farm/src/__tests__/cache.test.ts
+++ b/packages/farm/src/__tests__/cache.test.ts
@@ -346,6 +346,34 @@ describe("server cache primitives", () => {
     expect(calls).toBe(1);
   });
 
+  it("does not make a local value fresh when its tag is invalidated during generation", async () => {
+    const cache = new FarmDataCache();
+    let finishGeneration!: () => void;
+    const generationGate = new Promise<void>((resolve) => {
+      finishGeneration = resolve;
+    });
+    let calls = 0;
+
+    const firstGeneration = cache.getOrSet(
+      "featured",
+      async () => {
+        calls++;
+        await generationGate;
+        return { calls };
+      },
+      { tags: ["products"] },
+    );
+
+    await vi.waitFor(() => expect(calls).toBe(1));
+    cache.revalidateTag("products");
+    finishGeneration();
+    await expect(firstGeneration).resolves.toEqual({ calls: 1 });
+
+    await expect(
+      cache.getOrSet("featured", async () => ({ calls: ++calls }), { tags: ["products"] }),
+    ).resolves.toEqual({ calls: 2 });
+  });
+
   it("shares entries and tag invalidation through a distributed adapter", async () => {
     const adapter = new TestSharedCacheAdapter();
     const first = new FarmDataCache({ adapter, namespace: "catalog" });

--- a/packages/farm/src/cache.ts
+++ b/packages/farm/src/cache.ts
@@ -411,6 +411,16 @@ export class FarmDataCache {
     options: FarmCacheSetOptions = {},
     tagVersions?: Readonly<Record<string, number>>,
   ): Promise<FarmCacheEntry<T>> {
+    return this.writeAsync(key, value, options, tagVersions);
+  }
+
+  private async writeAsync<T>(
+    key: string,
+    value: T,
+    options: FarmCacheSetOptions,
+    tagVersions?: Readonly<Record<string, number>>,
+    createdVersion?: number,
+  ): Promise<FarmCacheEntry<T>> {
     const tags = normalizeCacheOptionsTags(options);
     const capturedVersions =
       tagVersions ?? (await this.getAdapterTagVersions(Array.from(tags.values())));
@@ -420,7 +430,7 @@ export class FarmDataCache {
       tags: Array.from(tags),
       tagVersions: capturedVersions,
       createdAt: options.createdAt ?? Date.now(),
-      createdVersion: ++this.version,
+      createdVersion: createdVersion ?? ++this.version,
       revalidate: normalizeRevalidate(options.revalidate),
     };
 
@@ -619,9 +629,10 @@ export class FarmDataCache {
     }
 
     try {
+      const initialCreatedVersion = this.version;
       const initialTagVersions = await this.getAdapterTagVersions(tags);
       const value = await producer();
-      await this.setAsync(key, value, options, initialTagVersions);
+      await this.writeAsync(key, value, options, initialTagVersions, initialCreatedVersion);
       return value;
     } finally {
       if (leaseToken && this.adapter?.releaseLease) {


### PR DESCRIPTION
## Problem

A local cache fill can start, have one of its tags invalidated while the producer is still running, and then be stored as fresh. The next read incorrectly serves the pre-invalidation result.

## Root cause

Local freshness used the version assigned when `setAsync` completed. Because that version was newer than the invalidation, it erased the fact that generation began before the tag changed. Distributed fills already capture tag versions before running the producer.

## Change

Capture the local cache version at the start of generation and carry it into the stored entry through a private async write helper. Add the local equivalent of the existing distributed invalidation-during-generation regression test.

## Safety and compatibility

Direct `setAsync` calls keep their existing write-time version behavior. Only generated values retain their generation-start version. The in-flight caller still receives its completed result; subsequent reads correctly regenerate after an intervening invalidation.

## Verification

- `pnpm --filter @farm.js/core test -- --run src/__tests__/cache.test.ts` (24 tests)
- `pnpm --filter @farm.js/core type-check`
- `pnpm exec oxlint packages/farm/src/cache.ts packages/farm/src/__tests__/cache.test.ts`
- `pnpm exec oxfmt --check packages/farm/src/cache.ts packages/farm/src/__tests__/cache.test.ts docs/src/app/docs/cache-ppr/page.md`
- `git diff --check`

The new local race test returns the first generated value twice before this change.

## Documentation and release

Documented the invalidation-during-generation behavior in the cache guide.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a local cache race where a tag invalidated during generation was overwritten when the value completed, so the next read served pre-invalidation data. Generated entries now keep the version from when generation started, making an intervening invalidation trigger a regenerate.

- Direct `setAsync` calls keep their existing write-time version behavior.

<sup>Written for commit b48213b0cb0c9f6df3b13baffdbdcaf5570fba73. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/632?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

