### PR TITLE
fix(link): preserve native download behavior

### DIFF
--- a/docs/src/app/docs/routing/page.md
+++ b/docs/src/app/docs/routing/page.md
@@ -115,6 +115,8 @@ export const generateStaticParams: GenerateStaticParams<"/users/[id]"> = async (
 Farm writes the route union into the consolidated `src/farm.d.ts` declaration file. Link hrefs and route component props accept real routes without widening everything to plain string. Link hrefs can also include query strings and hash fragments.
 Changing only the fragment preserves SPA state, honors push versus replace history, and does not
 request route data again.
+Native anchor behavior still takes precedence: for example, a `Link` with a `download` attribute is
+handled by the browser instead of Farm's SPA router.
 
 **Client navigation**
 

--- a/packages/farm/src/__tests__/link.test.tsx
+++ b/packages/farm/src/__tests__/link.test.tsx
@@ -208,6 +208,34 @@ describe("Link", () => {
       });
     });
 
+    it("leaves internal download links to the browser", () => {
+      const el = render(
+        createElement(Link, { href: "/reports/latest.csv", download: "report.csv" }),
+      ) as HTMLAnchorElement;
+      const event = new MouseEvent("click", {
+        bubbles: true,
+        button: 0,
+        cancelable: true,
+      });
+      let farmPreventedDefault: boolean | undefined;
+      container.addEventListener(
+        "click",
+        (nativeEvent) => {
+          farmPreventedDefault = nativeEvent.defaultPrevented;
+          nativeEvent.preventDefault();
+        },
+        { once: true },
+      );
+
+      act(() => {
+        el.dispatchEvent(event);
+      });
+
+      expect(el.getAttribute("download")).toBe("report.csv");
+      expect(farmPreventedDefault).toBe(false);
+      expect(navigate).not.toHaveBeenCalled();
+    });
+
     it("replace and scroll false passed to navigate", () => {
       const el = render(
         createElement(Link, { href: "/settings", replace: true, scroll: false }),

--- a/packages/farm/src/client/link.tsx
+++ b/packages/farm/src/client/link.tsx
@@ -381,6 +381,7 @@ function LinkInner<TRoute extends string = DefaultRouteHref>(
       onClick?.(event);
       if (event.defaultPrevented) return;
       if (isExternal) return;
+      if (event.currentTarget.hasAttribute("download")) return;
       if (target && target !== "_self") return;
       if (isModifierEvent(event)) return;
       if (event.button !== 0) return;


### PR DESCRIPTION
## Problem

An internal Farm `<Link download>` cancels the anchor's default action and sends the URL through SPA navigation, so the browser never performs the requested download.

## Root cause

The click interceptor checks external URLs, targets, modifier keys, and mouse buttons, but not the native `download` attribute before calling `preventDefault()`.

## Change

Leave clicks on anchors carrying `download` to the browser. Add a DOM regression test that verifies Farm has not prevented the event or invoked the SPA router.

## Safety and compatibility

Ordinary internal links keep SPA navigation. External links, modified clicks, alternate targets, and user `onClick` cancellation are unchanged. Both boolean and filename-valued download attributes are covered by checking the rendered native attribute.

## Verification

- `pnpm --filter @farm.js/core test -- --run src/__tests__/link.test.tsx` (26 tests)
- `pnpm --filter @farm.js/core type-check`
- `pnpm exec oxlint packages/farm/src/client/link.tsx packages/farm/src/__tests__/link.test.tsx`
- `pnpm exec oxfmt --check packages/farm/src/client/link.tsx packages/farm/src/__tests__/link.test.tsx docs/src/app/docs/routing/page.md`
- `git diff --check`

The new DOM test sees `preventDefault()` and an SPA navigation before this change.

## Documentation and release

Documented that native anchor behavior such as `download` takes precedence over Farm SPA navigation.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix `Link` so clicks on anchors with a native `download` attribute are left to the browser instead of being routed through Farm's SPA navigation, which previously prevented the download.

Other click behavior — external links, modified clicks, alternate targets, and user `onClick` cancellation — is unchanged. Both boolean and filename-valued `download` attributes are covered by the check on the rendered attribute. Adds a DOM regression test verifying `preventDefault()` is not called and the router is not invoked, and documents that native anchor behavior takes precedence over SPA navigation.

<sup>Written for commit 4b0388f92f4950139f0921b689f4ba05d85a3d14. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/633?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

