### PR TITLE
fix(images): honor Accept quality values

### DIFF
--- a/docs/src/app/docs/images/page.md
+++ b/docs/src/app/docs/images/page.md
@@ -141,7 +141,7 @@ export default defineConfig({
 | `deviceSizes`         | Responsive viewport widths accepted by the endpoint.                                                                     |
 | `imageSizes`          | Smaller fixed image widths accepted by the endpoint.                                                                     |
 | `qualities`           | Quality allowlist. `Image` selects the nearest configured value.                                                         |
-| `formats`             | Preferred modern output formats, negotiated through the request `Accept` header.                                         |
+| `formats`             | Preferred modern output formats, negotiated through the request `Accept` header and its quality values.                  |
 | `minimumCacheTTL`     | Browser and in-process transformed-image cache lifetime in seconds.                                                      |
 | `maximumResponseBody` | Maximum source and transformed body size. Accepts bytes or values such as `"10mb"`.                                      |
 | `maximumRedirects`    | Maximum remote redirects; every destination is checked again.                                                            |
@@ -153,6 +153,8 @@ Pass a `loader` prop when an application already uses an image CDN. The loader r
 ## Security model
 
 The optimizer accepts only configured widths and qualities. It does not forward browser cookies or authorization headers, limits response bodies, checks file signatures instead of trusting `Content-Type`, revalidates redirect destinations, and blocks loopback, link-local, and private network targets.
+Formats explicitly rejected with `q=0` are never emitted. Farm uses the configured format order to
+break equal-quality ties and keeps the source format when the client only sends wildcard ranges.
 
 SVG optimization and private-network sources are disabled by default. `dangerouslyAllowSVG` adds a restrictive content security policy but should still be enabled only for trusted files. `dangerouslyAllowLocalIP` is intended for controlled private deployments and weakens SSRF protection.
 

--- a/packages/farm/src/__tests__/image-server.test.ts
+++ b/packages/farm/src/__tests__/image-server.test.ts
@@ -6,6 +6,7 @@ import {
   createCloudflareImageTransformer,
   createFarmImageHandler,
   isPrivateImageAddress,
+  selectOutputFormat,
   type FarmImageTransformer,
 } from "../image-server";
 
@@ -242,6 +243,15 @@ describe("Farm image optimizer", () => {
 });
 
 describe("image runtime adapters", () => {
+  it("honors Accept quality values when selecting an output format", () => {
+    const formats = ["image/avif", "image/webp"] as const;
+
+    expect(selectOutputFormat("image/avif;q=0, image/webp;q=0.8", formats)).toBe("image/webp");
+    expect(selectOutputFormat("image/avif;q=0.5, image/webp;q=1", formats)).toBe("image/webp");
+    expect(selectOutputFormat("IMAGE/AVIF;Q=0.8, image/webp;q=0.8", formats)).toBe("image/avif");
+    expect(selectOutputFormat("image/*,*/*;q=0.8", formats)).toBeUndefined();
+  });
+
   it("uses Cloudflare's native image transform options", async () => {
     const fetcher = vi.fn(
       async () => new Response(PNG, { headers: { "content-type": "image/webp" } }),

--- a/packages/farm/src/image-server.ts
+++ b/packages/farm/src/image-server.ts
@@ -194,8 +194,35 @@ export function selectOutputFormat(
   accept: string,
   formats: readonly FarmImageFormat[],
 ): FarmImageFormat | undefined {
-  const normalizedAccept = accept.toLowerCase();
-  return formats.find((format) => normalizedAccept.includes(format));
+  const qualityByFormat = new Map<string, number>();
+
+  for (const range of accept.split(",")) {
+    const [rawType, ...parameters] = range.split(";");
+    const type = rawType.trim().toLowerCase();
+    if (!type) continue;
+
+    let quality = 1;
+    for (const parameter of parameters) {
+      const [rawName, rawValue] = parameter.split("=", 2);
+      if (rawName.trim().toLowerCase() !== "q") continue;
+      const parsed = Number(rawValue?.trim());
+      quality = Number.isFinite(parsed) && parsed >= 0 && parsed <= 1 ? parsed : 0;
+      break;
+    }
+
+    qualityByFormat.set(type, Math.max(qualityByFormat.get(type) ?? 0, quality));
+  }
+
+  let selected: FarmImageFormat | undefined;
+  let selectedQuality = 0;
+  for (const format of formats) {
+    const quality = qualityByFormat.get(format) ?? 0;
+    if (quality > selectedQuality) {
+      selected = format;
+      selectedQuality = quality;
+    }
+  }
+  return selected;
 }
 
 export function isPrivateImageAddress(address: string): boolean {


### PR DESCRIPTION
## Problem

Image output negotiation uses substring matching on the `Accept` header. A browser can explicitly reject AVIF with `image/avif;q=0`, but Farm still selects AVIF whenever it appears first in `images.formats`.

## Root cause

`selectOutputFormat` checks only whether a configured media type occurs in the raw header. It does not parse media ranges or quality parameters.

## Change

Parse exact Accept media ranges and their quality values, exclude zero/invalid quality values, select the highest accepted quality, and use configured format order for ties. Add regression coverage for rejection, preference, case-insensitive parameters, ties, and wildcard-only requests.

## Safety and compatibility

Normal browser headers without quality parameters retain quality 1. Config order remains the tie-breaker. Wildcard-only clients continue to preserve the source format, matching the existing Sharp fallback behavior.

## Verification

- `pnpm --filter @farm.js/core test -- --run src/__tests__/image-server.test.ts src/__tests__/image-sharp.test.ts` (27 tests)
- `pnpm --filter @farm.js/core type-check`
- `pnpm exec oxlint packages/farm/src/image-server.ts packages/farm/src/__tests__/image-server.test.ts` (one pre-existing no-control-regex warning outside this change)
- `pnpm exec oxfmt --check packages/farm/src/image-server.ts packages/farm/src/__tests__/image-server.test.ts docs/src/app/docs/images/page.md`
- `git diff --check`

The new `q=0` and weighted-preference assertions fail before this change.

## Documentation and release

Documented quality-weight negotiation, tie-breaking, rejection, and wildcard fallback behavior.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes image format negotiation so the `Accept` header's quality values are honored instead of relying on substring matching alone.

- Explicit rejections like `image/avif;q=0` no longer select AVIF.
- Higher quality values win, and configured format order breaks ties.
- Wildcard-only requests still preserve the source format as before.
- Documents the new negotiation rules and adds regression coverage.

<sup>Written for commit f8e216c42ec9da0441ec7e9f1bb250f2d007da95. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/634?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

