### PR TITLE
perf(react): compose queued exact-window refreshes

### DIFF
--- a/docs/src/app/docs/renderers/react/page.md
+++ b/docs/src/app/docs/renderers/react/page.md
@@ -1033,6 +1033,10 @@ setItems((current) => current.toSpliced(selectedIndex, 25));
 setItems((current) => current.toSpliced(selectedIndex, 1, replacement));
 setItems((current) => current.toSpliced(selectedIndex, 25, ...replacements));
 setItems((current) => current.with(selectedIndex, replacement));
+
+// Two same-key windows may be queued before one compiler flush.
+setItems((current) => current.toSpliced(firstIndex, 25, ...firstRefresh));
+setItems((current) => current.toSpliced(secondIndex, 25, ...secondRefresh));
 ```
 
 At build time, Farm recognizes only concise functional setters whose position is either a
@@ -1064,8 +1068,12 @@ prepared. If the incoming interval has the same length and exactly the same keys
 Farm first evaluates all keys and binding snapshots and resolves every changed target across the
 complete interval. It then patches only changed bindings in place and updates each stored row
 object, so later delegated or cached handlers observe the latest data. No descriptor or DOM row is
-created, and every row keeps its identity, focus, and text selection. Reordered, partially reused,
-mixed, or duplicate keys take complete reconciliation before fast-path mutation. A single insertion
+created, and every row keeps its identity, focus, and text selection. Multiple length-preserving
+same-key windows queued before one compiler flush compose into one atomic refresh. Disjoint and
+overlapping windows are supported; an overlapping position uses the last queued value. Farm
+validates the complete chain and prepares every touched key, binding value, and DOM target before
+applying any write. Reordered, partially reused, mixed, or duplicate keys take complete
+reconciliation before fast-path mutation. A single insertion
 creates one row at that position. A removal cleans up and removes only the known row or contiguous
 range while preserving every
 surviving element. A same-key replacement patches that row in place; a new-key replacement creates
@@ -1075,12 +1083,13 @@ and bindings are not reread.
 The proof requires compiler-owned host rows whose render and key do not observe the row index.
 Effectful position expressions, runtime values that are fractional or otherwise not safe integers,
 dynamic, zero, negative, or fractional removal counts, other `toSpliced()` shapes, block-bodied
-updaters, unsafe incoming expressions, custom methods, queued uncommitted position updates,
-duplicate, reordered, mixed, or partially reused incoming keys, collection-reading bindings,
-React-owned rows, nested host blocks, row conditionals, unrelated dirty dependencies, and failed
-runtime checks keep complete keyed reconciliation. Negative safe-integer positions and counts larger than the remaining suffix use the
-native method's normal clamping rules. No new option or component is required. Reports expose
-emitted sites as `keyedArrayPositionHints`. Batch insertion and exact-window replacement select
+updaters, unsafe incoming expressions, custom methods, queued chains containing a structural
+window or unhinted intermediate update, duplicate, reordered, mixed, or partially reused incoming
+keys, collection-reading bindings, React-owned rows, nested host blocks, row conditionals,
+unrelated dirty dependencies, and failed runtime checks keep complete keyed reconciliation.
+Negative safe-integer positions and counts larger than the remaining suffix use the native
+method's normal clamping rules. No new option or component is required. Reports expose emitted
+sites as `keyedArrayPositionHints`. Batch insertion and exact-window replacement select
 progressively separate optional runtime capabilities, so modules with only single-row operations
 or batch insertion retain no window-replacement runtime.
 
@@ -1966,7 +1975,9 @@ The package and example test suites verify more than generated code:
   require fresh-key work to equal only the incoming window and a 4,096-row same-key refresh to
   perform zero descriptor creation while preserving all 64 refreshed DOM rows; they also cover
   atomic binding preparation, empty spreads, reordered and duplicate key fallback, latest delegated
-  event data, focus, selection, hydration, Strict Mode, and queued fallback;
+  event data, focus, selection, hydration, Strict Mode, and queued structural fallback; another
+  1,000 deterministic queued same-key window refreshes match normal React while disjoint and
+  overlapping targeted tests preserve row identity and perform no descriptor work;
 - 2,000 deterministic randomized reversals match normal React; a 4,096-row targeted test requires
   exactly `n - 1` connected DOM moves and zero key, descriptor, or binding reads, while fallback
   tests cover custom methods, queued updates, collection-reading rows, StrictMode hydration, and

--- a/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
+++ b/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
@@ -2,6 +2,28 @@
 
 Date: 2026-08-29
 
+## Queued same-key exact-window refresh follow-up — 2026-08-31
+
+The full bracketed production-browser run added a separate 10,000-row workload that queues two
+32-row same-key refreshes before one compiler flush. Both compiler builds emitted all nine expected
+`keyedArrayPositionHints` sites, preserved every one of the 64 touched DOM rows, updated the changed
+label and amount in both windows, produced zero owner executions, and passed every existing
+correctness, performance, persistence, and scalability gate without lowering a threshold.
+
+| Mode   | React median | Queued refresh | Compiled control | vs React | vs control |
+| ------ | -----------: | -------------: | ---------------: | -------: | ---------: |
+| Static |     60.70 ms |       14.00 ms |         28.30 ms |    4.34x |      2.02x |
+| Hybrid |     60.70 ms |        9.20 ms |         18.30 ms |    6.60x |      1.99x |
+
+The independent gate requires at least 4x versus React and 1.5x versus the block-bodied compiled
+control in both modes. Package tests additionally compare 1,000 deterministic queued updates with
+normal React and cover disjoint and overlapping windows, last-update-wins behavior, complete-chain
+preparation before mutation, structural and key-changing fallback, controlled-input focus and
+selection, delegated events, hydration, Strict Mode, and unmount cleanup. The isolated exact-window
+fixture has a 13,358 B gzip compiler premium, 254 B above the previous result and inside its
+unchanged 256 B allowance. Direct, core-only, and unrelated hint fixtures remain unchanged. The
+measured environment was Chrome 145.0.7632.6, Node.js 23.11.0, and Apple M1 macOS arm64.
+
 ## Same-key exact-window refresh follow-up — 2026-08-31
 
 The full bracketed production-browser run added a separate 10,000-row workload for refreshing 64

--- a/examples/react-compiler-dashboard/README.md
+++ b/examples/react-compiler-dashboard/README.md
@@ -100,7 +100,7 @@ native `toSpliced(position, 0, item)`, `toSpliced(position, 0, ...items)`, `toSp
 `toSpliced(position, 64)`, `toSpliced(position, 1, replacement)`, and
 `toSpliced(position, 64, ...replacements)` and `with(position, replacement)` updates use event-local
 runtime position variables and are measured against bracketed React and equivalent block-bodied
-compiled controls. The compiler report must contain all seven dashboard `keyedArrayPositionHints`;
+compiled controls. The compiler report must contain every dashboard `keyedArrayPositionHints` site;
 package tests separately require zero
 surviving key/descriptor/binding reads for removal, surrounding DOM identity, randomized
 differential correctness, runtime-position and count fallback, hydration, and cleanup. Both the
@@ -128,6 +128,15 @@ hybrid modes must remain at least 4x faster than React and 1.5x faster than the 
 compiled control. Package tests also require zero descriptors for a 64-row refresh, latest event
 data, focused-input selection, atomic preparation before mutation, hydration, Strict Mode, and
 mixed/reordered/duplicate-key fallback.
+
+Queued same-key exact-window refresh has its own 10,000-row gate. One event queues two separate
+32-row refreshes before the compiler flushes, and the benchmark requires all 64 DOM rows to retain
+identity while both changed labels and amounts reach the DOM. Static and hybrid modes must remain
+at least 4x faster than React and 1.5x faster than the equivalent block-bodied compiled control.
+Together with the existing position workloads, the compiler report must contain all nine dashboard
+`keyedArrayPositionHints`. Package tests compare 1,000 deterministic queued updates with React and
+cover disjoint windows, overlap with last-update-wins semantics, atomic preparation, structural and
+key-changing fallback, controlled-input selection, events, Strict Mode hydration, and cleanup.
 
 Native keyed-array reversal has a separate 10,000-row comparison. Concise `toReversed()` is
 measured against bracketed React and an equivalent block-bodied compiled control. Both compiler
@@ -203,6 +212,9 @@ The default JSON report is `/tmp/farm-react-dashboard-benchmark.json`; change it
   tests cover the equivalent `with()` replacement path too.
   They verify surrounding DOM identity and isolate the saved full keyed scan for one insertion,
   one replacement, or a single/contiguous-range removal.
+- The queued same-key control issues two concise native window replacements before one flush. Its
+  block-bodied pair performs the same array and DOM-visible work through complete reconciliation,
+  isolating the benefit of combining both validated windows into one targeted refresh.
 - The reverse control compares concise native `toReversed()` with an equivalent block-bodied
   compiled update. Both paths move the same keyed DOM rows; the hint isolates the saved key,
   descriptor, binding, and generic LIS work.

--- a/examples/react-compiler-dashboard/scripts/benchmark.mjs
+++ b/examples/react-compiler-dashboard/scripts/benchmark.mjs
@@ -143,7 +143,7 @@ async function inspectBuild(compilerMode) {
       "The compiler build did not emit a keyed-array prepend hint.",
     );
     assert(
-      compilerReport.summary.keyedArrayPositionHints >= 7,
+      compilerReport.summary.keyedArrayPositionHints >= 9,
       "The compiler build did not emit the keyed-array exact-position hints.",
     );
     assert(
@@ -726,6 +726,44 @@ async function measureTrial(browser, trial, compilerMode, port) {
           },
         );
 
+        const measureQueuedWindowRefresh = async (action) => {
+          const rows = table.querySelectorAll("tbody tr");
+          const firstRetained = [...rows].slice(2_500, 2_532);
+          const secondRetained = [...rows].slice(7_500, 7_532);
+          const firstLabel = firstRetained[16]?.children[1]?.textContent;
+          const firstAmount = firstRetained[16]?.children[3]?.textContent;
+          const secondLabel = secondRetained[16]?.children[1]?.textContent;
+          const secondAmount = secondRetained[16]?.children[3]?.textContent;
+          await runTableAction(action, () => {
+            const nextRows = table.querySelectorAll("tbody tr");
+            return (
+              rowCount() === 10_000 &&
+              firstRetained.every((row, offset) => nextRows[2_500 + offset] === row) &&
+              secondRetained.every((row, offset) => nextRows[7_500 + offset] === row) &&
+              nextRows[2_516]?.children[1]?.textContent === `${firstLabel} queued` &&
+              nextRows[2_516]?.children[3]?.textContent !== firstAmount &&
+              nextRows[7_516]?.children[1]?.textContent === `${secondLabel} queued` &&
+              nextRows[7_516]?.children[3]?.textContent !== secondAmount
+            );
+          });
+        };
+
+        const tablePositionWindowRefreshQueued = await measureTable(
+          async () => ensure10000(),
+          async () =>
+            measureQueuedWindowRefresh(() =>
+              tableButton("table-position-window-refresh-queued").click(),
+            ),
+        );
+
+        const tablePositionWindowRefreshQueuedSnapshot = await measureTable(
+          async () => ensure10000(),
+          async () =>
+            measureQueuedWindowRefresh(() =>
+              tableButton("table-position-window-refresh-queued-snapshot").click(),
+            ),
+        );
+
         const tablePositionRemove = await measureTable(
           async () => ensure10000(),
           async () => {
@@ -1263,6 +1301,8 @@ async function measureTrial(browser, trial, compilerMode, port) {
             positionWindowReplace: tablePositionWindowReplace,
             positionWindowReplaceSnapshot: tablePositionWindowReplaceSnapshot,
             positionWindowRefresh: tablePositionWindowRefresh,
+            positionWindowRefreshQueued: tablePositionWindowRefreshQueued,
+            positionWindowRefreshQueuedSnapshot: tablePositionWindowRefreshQueuedSnapshot,
             positionWindowRefreshSnapshot: tablePositionWindowRefreshSnapshot,
             positionInsert: tablePositionInsert,
             positionInsertSnapshot: tablePositionInsertSnapshot,
@@ -1369,6 +1409,10 @@ async function measureTrial(browser, trial, compilerMode, port) {
           result.table.positionWindowReplaceSnapshot,
         ),
         positionWindowRefresh: timingSummary(result.table.positionWindowRefresh),
+        positionWindowRefreshQueued: timingSummary(result.table.positionWindowRefreshQueued),
+        positionWindowRefreshQueuedSnapshot: timingSummary(
+          result.table.positionWindowRefreshQueuedSnapshot,
+        ),
         positionWindowRefreshSnapshot: timingSummary(
           result.table.positionWindowRefreshSnapshot,
         ),
@@ -1471,6 +1515,8 @@ const tableMetrics = [
   "positionWindowReplace",
   "positionWindowReplaceSnapshot",
   "positionWindowRefresh",
+  "positionWindowRefreshQueued",
+  "positionWindowRefreshQueuedSnapshot",
   "positionWindowRefreshSnapshot",
   "positionInsert",
   "positionInsertSnapshot",
@@ -1789,6 +1835,30 @@ const keyedWindowRefreshRegressions = keyedWindowRefreshResults.filter(
     !Number.isFinite(snapshotSpeedup) ||
     snapshotSpeedup < keyedWindowRefreshMinimumSnapshotSpeedup,
 );
+// Two length-preserving same-key windows queued before one flush should compose into one atomic
+// targeted refresh. Protect this batched path independently so it cannot regress to complete list
+// reconciliation while the existing single-window gate continues to pass.
+const keyedQueuedWindowRefreshMinimumSpeedup = 4;
+const keyedQueuedWindowRefreshMinimumSnapshotSpeedup = 1.5;
+const keyedQueuedWindowRefreshResults = ["static", "hybrid"].map((mode) => {
+  const refreshMedianMs = comparisons.table.positionWindowRefreshQueued[mode].medianMs;
+  const snapshotMedianMs =
+    comparisons.table.positionWindowRefreshQueuedSnapshot[mode].medianMs;
+  return {
+    mode,
+    refreshMedianMs,
+    snapshotMedianMs,
+    snapshotSpeedup: snapshotMedianMs / refreshMedianMs,
+    speedup: comparisons.table.positionWindowRefreshQueued[`${mode}VsBaseline`].speedup,
+  };
+});
+const keyedQueuedWindowRefreshRegressions = keyedQueuedWindowRefreshResults.filter(
+  ({ snapshotSpeedup, speedup }) =>
+    !Number.isFinite(speedup) ||
+    speedup < keyedQueuedWindowRefreshMinimumSpeedup ||
+    !Number.isFinite(snapshotSpeedup) ||
+    snapshotSpeedup < keyedQueuedWindowRefreshMinimumSnapshotSpeedup,
+);
 // Native toSpliced()/with() calls with event-local runtime positions expose one exact insertion,
 // removal, or replacement position. The hinted runtime should beat both React and an equivalent
 // block-bodied compiled control while preserving the same row identities around the changed position.
@@ -2064,6 +2134,7 @@ const passed =
   keyedBatchInsertRegressions.length === 0 &&
   keyedWindowReplaceRegressions.length === 0 &&
   keyedWindowRefreshRegressions.length === 0 &&
+  keyedQueuedWindowRefreshRegressions.length === 0 &&
   keyedPositionRegressions.length === 0 &&
   keyedRangeRemovalRegressions.length === 0 &&
   keyedReorderRegressions.length === 0 &&
@@ -2137,6 +2208,13 @@ const report = {
     regressions: keyedWindowRefreshRegressions,
     results: keyedWindowRefreshResults,
     status: keyedWindowRefreshRegressions.length === 0 ? "PASS" : "FAIL",
+  },
+  keyedQueuedWindowRefreshHintGate: {
+    minimumSnapshotSpeedup: keyedQueuedWindowRefreshMinimumSnapshotSpeedup,
+    minimumSpeedup: keyedQueuedWindowRefreshMinimumSpeedup,
+    regressions: keyedQueuedWindowRefreshRegressions,
+    results: keyedQueuedWindowRefreshResults,
+    status: keyedQueuedWindowRefreshRegressions.length === 0 ? "PASS" : "FAIL",
   },
   keyedPositionHintGate: {
     insertMinimumSnapshotSpeedup: keyedPositionInsertMinimumSnapshotSpeedup,

--- a/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
+++ b/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
@@ -385,6 +385,58 @@ export function StandardTableBenchmark() {
           Refresh 64-row same-key window (snapshot control)
         </button>
         <button
+          data-action="table-position-window-refresh-queued"
+          type="button"
+          onClick={() => {
+            const firstPosition = 2_500;
+            const secondPosition = 7_500;
+            const first = rows.slice(firstPosition, firstPosition + 32).map((row, offset) =>
+              offset === 16
+                ? { ...row, amount: row.amount + 1, label: `${row.label} queued` }
+                : { ...row },
+            );
+            const second = rows.slice(secondPosition, secondPosition + 32).map((row, offset) =>
+              offset === 16
+                ? { ...row, amount: row.amount + 1, label: `${row.label} queued` }
+                : { ...row },
+            );
+            setRows((current) => current.toSpliced(firstPosition, 32, ...first));
+            setRows((current) => current.toSpliced(secondPosition, 32, ...second));
+            setOperation("refresh two queued same-key windows");
+            setRevision((value) => value + 1);
+          }}
+        >
+          Refresh two queued same-key windows
+        </button>
+        <button
+          data-action="table-position-window-refresh-queued-snapshot"
+          type="button"
+          onClick={() => {
+            const firstPosition = 2_500;
+            const secondPosition = 7_500;
+            const first = rows.slice(firstPosition, firstPosition + 32).map((row, offset) =>
+              offset === 16
+                ? { ...row, amount: row.amount + 1, label: `${row.label} queued` }
+                : { ...row },
+            );
+            const second = rows.slice(secondPosition, secondPosition + 32).map((row, offset) =>
+              offset === 16
+                ? { ...row, amount: row.amount + 1, label: `${row.label} queued` }
+                : { ...row },
+            );
+            setRows((current) => {
+              return current.toSpliced(firstPosition, 32, ...first);
+            });
+            setRows((current) => {
+              return current.toSpliced(secondPosition, 32, ...second);
+            });
+            setOperation("refresh two queued same-key windows (snapshot control)");
+            setRevision((value) => value + 1);
+          }}
+        >
+          Refresh two queued same-key windows (snapshot control)
+        </button>
+        <button
           data-action="table-position-remove"
           type="button"
           onClick={() => {

--- a/packages/farm-react/README.md
+++ b/packages/farm-react/README.md
@@ -308,6 +308,10 @@ setItems((current) => current.toSpliced(selectedIndex, 25));
 setItems((current) => current.toSpliced(selectedIndex, 1, replacement));
 setItems((current) => current.toSpliced(selectedIndex, 25, ...replacements));
 setItems((current) => current.with(selectedIndex, replacement));
+
+// Two same-key windows may be queued before one compiler flush.
+setItems((current) => current.toSpliced(firstIndex, 25, ...firstRefresh));
+setItems((current) => current.toSpliced(secondIndex, 25, ...secondRefresh));
 ```
 
 The compiler recognizes only a concise functional setter and either a safe-integer literal or a
@@ -326,14 +330,19 @@ through one document fragment. It then removes only the replaced window. When th
 has the same length and the same keys in the same order, Farm prepares every binding read and
 changed DOM target across the complete window first, patches the existing rows in place, and
 updates the stored row objects used by later events. That path creates no descriptors or DOM rows,
-and preserves row identity, focus, and selection. The runtime otherwise creates one inserted row,
+and preserves row identity, focus, and selection. Multiple length-preserving same-key windows
+queued before one compiler flush compose into one atomic refresh. Disjoint and overlapping windows
+are both supported; overlapping positions use the last queued value. Farm validates the complete
+chain and prepares every touched key, binding value, and DOM target before applying any write. The
+runtime otherwise creates one inserted row,
 removes only the known row or range, or patches/replaces one row at that position without rereading
 every existing key, descriptor, and binding. Surviving rows keep their DOM identity. Index-aware or
 collection-reading rows, custom methods, position expressions with user calls or mutations,
 runtime positions that are not safe integers, dynamic, zero, negative, or fractional removal
 counts, other `toSpliced()` forms, block-bodied updaters, unsafe incoming expressions, queued
-uncommitted updates, reordered or partially reused windows, duplicate keys, nested or React-owned
-rows, and failed checks use complete keyed reconciliation before the fast path mutates the DOM.
+chains containing a structural window or unhinted intermediate update, reordered or partially
+reused windows, duplicate keys, nested or React-owned rows, and failed checks use complete keyed
+reconciliation before the fast path mutates the DOM.
 Reports expose the site count as `keyedArrayPositionHints`. Batch insertion and exact-window
 replacement use progressively separate optional runtime capabilities, so existing single-position
 and batch-only bundles do not retain window validation or replacement code.

--- a/packages/farm-react/RUNTIME_SIZE_RESULTS.json
+++ b/packages/farm-react/RUNTIME_SIZE_RESULTS.json
@@ -123,19 +123,19 @@
     },
     "keyedWindowPosition": {
       "compilerOff": {
-        "raw": 192958,
-        "gzip": 60097,
-        "brotli": 51786
+        "raw": 193010,
+        "gzip": 60119,
+        "brotli": 51744
       },
       "compilerOn": {
-        "raw": 240252,
-        "gzip": 73201,
-        "brotli": 62669
+        "raw": 241158,
+        "gzip": 73477,
+        "brotli": 63060
       },
       "compilerPremium": {
-        "raw": 47294,
-        "gzip": 13104,
-        "brotli": 10883
+        "raw": 48148,
+        "gzip": 13358,
+        "brotli": 11316
       }
     },
     "keyedReorder": {
@@ -213,18 +213,18 @@
         "brotli": 51666
       },
       "full": {
-        "raw": 284017,
-        "gzip": 80226,
-        "brotli": 68508
+        "raw": 284720,
+        "gzip": 80470,
+        "brotli": 68747
       },
       "coreOnly": {
         "raw": 204922,
         "gzip": 63685,
         "brotli": 54902
       },
-      "fullRuntimePremiumGzip": 20307,
+      "fullRuntimePremiumGzip": 20551,
       "coreRuntimePremiumGzip": 3766,
-      "gzipReductionPercent": 81.5
+      "gzipReductionPercent": 81.7
     }
   }
 }

--- a/packages/farm-react/RUNTIME_SIZE_RESULTS.md
+++ b/packages/farm-react/RUNTIME_SIZE_RESULTS.md
@@ -31,13 +31,13 @@ is enforced on every pull request instead of serving only as a manually recorded
 | Keyed rows with slice hints                       |          60,075 B |         72,335 B |         12,260 B |
 | Keyed rows with known-position hints              |          60,076 B |         72,361 B |         12,285 B |
 | Keyed rows with batch-position hints              |          60,091 B |         72,561 B |         12,470 B |
-| Keyed rows with exact-window hints                |          60,097 B |         73,201 B |         13,104 B |
+| Keyed rows with exact-window hints                |          60,119 B |         73,477 B |         13,358 B |
 | Keyed rows with reverse hints                     |          60,058 B |         72,164 B |         12,106 B |
 | Keyed rows with sort hints                        |          60,077 B |         72,219 B |         12,142 B |
 | Keyed rows with rolling-window hints              |          60,098 B |         73,082 B |         12,984 B |
 
-The isolated compatibility runtime contributes 20,307 B gzip over the React control. The
-compiler-selected core contributes 3,766 B, an **81.5% reduction**. This comparison uses the same
+The isolated compatibility runtime contributes 20,551 B gzip over the React control. The
+compiler-selected core contributes 3,766 B, an **81.7% reduction**. This comparison uses the same
 hand-authored compiled definition and changes only the runtime entry used to create it.
 
 The keyed fixture retains `FarmCompiledKeyedRows` plus compiler-emitted `identityTarget`,
@@ -48,11 +48,12 @@ reuses the filter removal capability. Position-only, batch-position, exact-windo
 rolling-window modules select separate hint runtimes only when the compiler emits those update
 shapes. Reverse and sort share the optional reorder capability; the direct and isolated core
 results remain byte-for-byte unchanged. Over the ordinary keyed fixture, position pays 1,092 B
-gzip, batch-position pays 1,277 B, exact-window pays 1,911 B, reverse pays 913 B, sort pays 949 B,
+gzip, batch-position pays 1,277 B, exact-window pays 2,155 B, reverse pays 913 B, sort pays 949 B,
 slice pays 1,067 B, and rolling-window pays 1,791 B. The exact-window figure includes fresh-key
-replacement and atomic same-key binding refresh. Unrelated bundles reject the optional position
-and reorder runtime markers, and the direct fixture rejects every structural runtime marker. The checked
-machine-readable result is [`RUNTIME_SIZE_RESULTS.json`](./RUNTIME_SIZE_RESULTS.json).
+replacement, atomic same-key binding refresh, and queued same-key window composition. Unrelated
+bundles reject the optional position and reorder runtime markers, and the direct fixture rejects
+every structural runtime marker. The checked machine-readable result is
+[`RUNTIME_SIZE_RESULTS.json`](./RUNTIME_SIZE_RESULTS.json).
 
 ## Existing production benchmark audit
 

--- a/packages/farm-react/fixtures/runtime-size/keyed-window-position.tsx
+++ b/packages/farm-react/fixtures/runtime-size/keyed-window-position.tsx
@@ -13,10 +13,11 @@ interface Row {
 }
 
 interface WindowPositionTableProps {
-  incoming: Row[];
+  first: Row[];
+  second: Row[];
 }
 
-export function WindowPositionTable({ incoming }: WindowPositionTableProps) {
+export function WindowPositionTable({ first, second }: WindowPositionTableProps) {
   const [rows, setRows] = useState<Row[]>([
     { id: 1, label: "Alpha" },
     { id: 2, label: "Beta" },
@@ -24,8 +25,13 @@ export function WindowPositionTable({ incoming }: WindowPositionTableProps) {
   ]);
   return (
     <main>
-      <button onClick={() => setRows((current) => current.toSpliced(1, 2, ...incoming))}>
-        Replace rows
+      <button
+        onClick={() => {
+          setRows((current) => current.toSpliced(1, 1, ...first));
+          setRows((current) => current.toSpliced(2, 1, ...second));
+        }}
+      >
+        Refresh queued windows
       </button>
       <ul>
         {rows.map((row) => (
@@ -38,9 +44,7 @@ export function WindowPositionTable({ incoming }: WindowPositionTableProps) {
 
 createRoot(document.body).render(
   <WindowPositionTable
-    incoming={[
-      { id: 2, label: "Beta refreshed" },
-      { id: 3, label: "Gamma refreshed" },
-    ]}
+    first={[{ id: 2, label: "Beta refreshed" }]}
+    second={[{ id: 3, label: "Gamma refreshed" }]}
   />,
 );

--- a/packages/farm-react/scripts/test-react-version.mjs
+++ b/packages/farm-react/scripts/test-react-version.mjs
@@ -142,17 +142,26 @@ const testSource = String.raw`
             { id: "g", label: "Gamma two", rank: 7 },
           ),
         );
-      refreshCompatibilityRows = () =>
+      refreshCompatibilityRows = () => {
         state[0].set((previous) =>
           createCompilerKeyedArrayWindowReplace(
             previous,
             previous.toSpliced,
             1,
-            2,
+            1,
             { id: "f", label: "Phi refreshed", rank: 8 },
+          ),
+        );
+        state[0].set((previous) =>
+          createCompilerKeyedArrayWindowReplace(
+            previous,
+            previous.toSpliced,
+            2,
+            1,
             { id: "g", label: "Gamma refreshed", rank: 9 },
           ),
         );
+      };
       sortCompatibilityRows = () =>
         state[0].set((previous) =>
           createCompilerKeyedArraySort(

--- a/packages/farm-react/src/__tests__/compiler-keyed-array-position-hints.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-keyed-array-position-hints.test.ts
@@ -89,6 +89,31 @@ describe("React AOT keyed-array position hints", () => {
     expect(result.code).not.toContain("createCompilerKeyedArrayBatchInsert");
   });
 
+  it("records multiple exact-window replacements queued by one event", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Table({ firstWindow, secondWindow }) {
+        const [rows, setRows] = useState([
+          { id: "a", label: "Alpha" },
+          { id: "b", label: "Beta" },
+          { id: "c", label: "Gamma" },
+          { id: "d", label: "Delta" },
+        ]);
+        return <section>
+          <button onClick={() => {
+            setRows((current) => current.toSpliced(0, 2, ...firstWindow));
+            setRows((current) => current.toSpliced(2, 2, ...secondWindow));
+          }}>Refresh windows</button>
+          <ul>{rows.map((row) => <li key={row.id}>{row.label}</li>)}</ul>
+        </section>;
+      }
+    `);
+
+    expect(result.optimizations.keyedArrayPositionHints).toBe(2);
+    expect(result.code.match(/createCompilerKeyedArrayWindowReplace\(/g)).toHaveLength(2);
+    expect(result.code).toContain("keyedRowsWindowPositionHintedRuntimeFeature");
+  });
+
   it("records compiler-safe runtime position expressions", async () => {
     const result = await compile(`
       import { useState } from "react";

--- a/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-window-replace-hints.test.tsx
+++ b/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-window-replace-hints.test.tsx
@@ -75,6 +75,14 @@ function createWindowHarness(initialItems: Item[]) {
   let replace: (position: number, deleteCount: number, items: readonly Item[]) => void = () =>
     undefined;
   let queueTwo: (first: readonly Item[], second: readonly Item[]) => void = () => undefined;
+  let queueRefreshes: (
+    firstPosition: number,
+    first: readonly Item[],
+    secondPosition: number,
+    second: readonly Item[],
+  ) => void = () => undefined;
+  let queueWithUnhinted: (first: readonly Item[], second: readonly Item[]) => void = () =>
+    undefined;
   let customReplace: (items: readonly Item[]) => void = () => undefined;
   const Table = createCompiledComponentWithFeatures(
     {
@@ -90,6 +98,22 @@ function createWindowHarness(initialItems: Item[]) {
         queueTwo = (first, second) => {
           state[0].set((previous) => hintedWindowReplace(previous as Item[], 1, 2, first));
           state[0].set((previous) => hintedWindowReplace(previous as Item[], 2, 1, second));
+        };
+        queueRefreshes = (firstPosition, first, secondPosition, second) => {
+          state[0].set((previous) =>
+            hintedWindowReplace(previous as Item[], firstPosition, first.length, first),
+          );
+          state[0].set((previous) =>
+            hintedWindowReplace(previous as Item[], secondPosition, second.length, second),
+          );
+        };
+        queueWithUnhinted = (first, second) => {
+          state[0].set((previous) =>
+            hintedWindowReplace(previous as Item[], 0, first.length, first),
+          );
+          state[0].set((previous) =>
+            (previous as WindowArray).toSpliced(2, second.length, ...second),
+          );
         };
         customReplace = (incoming) =>
           state[0].set((previous) => {
@@ -160,6 +184,14 @@ function createWindowHarness(initialItems: Item[]) {
       bindingFailure = key;
     },
     queueTwo: (first: readonly Item[], second: readonly Item[]) => queueTwo(first, second),
+    queueRefreshes: (
+      firstPosition: number,
+      first: readonly Item[],
+      secondPosition: number,
+      second: readonly Item[],
+    ) => queueRefreshes(firstPosition, first, secondPosition, second),
+    queueWithUnhinted: (first: readonly Item[], second: readonly Item[]) =>
+      queueWithUnhinted(first, second),
     replace: (position: number, deleteCount: number, items: readonly Item[]) =>
       replace(position, deleteCount, items),
     traceBindings: (trace: string[] | undefined) => {
@@ -292,6 +324,101 @@ describe("compiled keyed-array window replacement hints", () => {
     });
   });
 
+  it("combines queued same-key windows without descriptors or DOM replacement", async () => {
+    const initialItems = Array.from(
+      { length: 4_096 },
+      (_, index): Item => ({ id: `row-${index}`, label: `Row ${index}` }),
+    );
+    const harness = createWindowHarness(initialItems);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Table />));
+    const firstRows = Array.from({ length: 32 }, (_, offset) =>
+      container.querySelector(`[data-key="row-${1_024 + offset}"]`),
+    );
+    const secondRows = Array.from({ length: 32 }, (_, offset) =>
+      container.querySelector(`[data-key="row-${3_072 + offset}"]`),
+    );
+    harness.counters.keys = 0;
+    harness.counters.descriptors = 0;
+    harness.counters.bindings = 0;
+
+    await act(async () => {
+      harness.queueRefreshes(
+        1_024,
+        initialItems.slice(1_024, 1_056).map((item, offset) => ({
+          ...item,
+          label: `First ${offset}`,
+        })),
+        3_072,
+        initialItems.slice(3_072, 3_104).map((item, offset) => ({
+          ...item,
+          label: `Second ${offset}`,
+        })),
+      );
+      await flushCompilerUpdates();
+    });
+
+    const rows = [...container.querySelectorAll("li")];
+    for (let offset = 0; offset < 32; offset += 1) {
+      expect(rows[1_024 + offset]).toBe(firstRows[offset]);
+      expect(rows[1_024 + offset]?.textContent).toBe(`First ${offset}`);
+      expect(rows[3_072 + offset]).toBe(secondRows[offset]);
+      expect(rows[3_072 + offset]?.textContent).toBe(`Second ${offset}`);
+    }
+    expect(rows).toHaveLength(4_096);
+    expect(harness.counters).toEqual({
+      executions: 1,
+      renders: 1,
+      keys: 64,
+      descriptors: 0,
+      bindings: 64,
+    });
+  });
+
+  it("collapses overlapping queued refreshes and applies the last value", async () => {
+    const initialItems = Array.from(
+      { length: 128 },
+      (_, index): Item => ({ id: `row-${index}`, label: `Row ${index}` }),
+    );
+    const harness = createWindowHarness(initialItems);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Table />));
+    const retained = Array.from({ length: 72 }, (_, offset) =>
+      container.querySelector(`[data-key="row-${32 + offset}"]`),
+    );
+    harness.counters.keys = 0;
+    harness.counters.descriptors = 0;
+    harness.counters.bindings = 0;
+
+    await act(async () => {
+      harness.queueRefreshes(
+        32,
+        initialItems.slice(32, 80).map((item) => ({ ...item, label: `First ${item.id}` })),
+        56,
+        initialItems.slice(56, 104).map((item) => ({ ...item, label: `Second ${item.id}` })),
+      );
+      await flushCompilerUpdates();
+    });
+
+    const rows = [...container.querySelectorAll("li")];
+    for (let offset = 0; offset < 72; offset += 1) {
+      const index = 32 + offset;
+      expect(rows[index]).toBe(retained[offset]);
+      expect(rows[index]?.textContent).toBe(
+        index < 56 ? `First row-${index}` : `Second row-${index}`,
+      );
+    }
+    expect(harness.counters.keys).toBe(72);
+    expect(harness.counters.descriptors).toBe(0);
+    expect(harness.counters.bindings).toBe(72);
+  });
+
   it("prepares the complete same-key window before committing any binding", async () => {
     const harness = createWindowHarness([
       { id: "a", label: "Alpha" },
@@ -329,6 +456,53 @@ describe("compiled keyed-array window replacement hints", () => {
     expect(failedRead).toBeGreaterThanOrEqual(0);
     expect(firstWrite === -1 || firstWrite > failedRead).toBe(true);
     expect(container.textContent).toBe("Alpha refreshedBeta refreshedGamma refreshed");
+  });
+
+  it("prepares every queued window before committing any binding", async () => {
+    const harness = createWindowHarness([
+      { id: "a", label: "Alpha" },
+      { id: "b", label: "Beta" },
+      { id: "c", label: "Gamma" },
+      { id: "d", label: "Delta" },
+    ]);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Table />));
+    const trace: string[] = [];
+    const textContent = Object.getOwnPropertyDescriptor(Node.prototype, "textContent")!;
+    vi.spyOn(Node.prototype, "textContent", "set").mockImplementation(function (
+      this: Node,
+      value: string | null,
+    ) {
+      trace.push(`write:${value}`);
+      textContent.set!.call(this, value);
+    });
+    harness.traceBindings(trace);
+    harness.failNextBindingFor("c");
+
+    await act(async () => {
+      harness.queueRefreshes(
+        0,
+        [
+          { id: "a", label: "Alpha queued" },
+          { id: "b", label: "Beta queued" },
+        ],
+        2,
+        [
+          { id: "c", label: "Gamma queued" },
+          { id: "d", label: "Delta queued" },
+        ],
+      );
+      await flushCompilerUpdates();
+    });
+
+    const failedRead = trace.indexOf("read:c");
+    const firstWrite = trace.findIndex((entry) => entry.startsWith("write:"));
+    expect(failedRead).toBeGreaterThanOrEqual(0);
+    expect(firstWrite === -1 || firstWrite > failedRead).toBe(true);
+    expect(container.textContent).toBe("Alpha queuedBeta queuedGamma queuedDelta queued");
   });
 
   it("supports empty incoming spreads, negative positions, and clamped delete counts", async () => {
@@ -403,7 +577,7 @@ describe("compiled keyed-array window replacement hints", () => {
     expect(console.error).toHaveBeenCalled();
   });
 
-  it("falls back for custom methods and two queued window updates", async () => {
+  it("falls back for custom methods and queued structural window changes", async () => {
     const harness = createWindowHarness([
       { id: "a", label: "Alpha" },
       { id: "b", label: "Beta" },
@@ -441,6 +615,61 @@ describe("compiled keyed-array window replacement hints", () => {
     expect(container.textContent).toBe("DeltaGamma twoIotaJotaAlpha");
   });
 
+  it("falls back atomically when any queued window changes row identity", async () => {
+    const harness = createWindowHarness([
+      { id: "a", label: "Alpha" },
+      { id: "b", label: "Beta" },
+      { id: "c", label: "Gamma" },
+      { id: "d", label: "Delta" },
+    ]);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Table />));
+    const beta = container.querySelector('[data-key="b"]');
+    const delta = container.querySelector('[data-key="d"]');
+    harness.counters.keys = 0;
+
+    await act(async () => {
+      harness.queueRefreshes(0, [{ id: "e", label: "Epsilon" }], 2, [{ id: "f", label: "Phi" }]);
+      await flushCompilerUpdates();
+    });
+
+    expect(container.textContent).toBe("EpsilonBetaPhiDelta");
+    expect(container.querySelector('[data-key="b"]')).toBe(beta);
+    expect(container.querySelector('[data-key="d"]')).toBe(delta);
+    expect(harness.counters.keys).toBeGreaterThan(2);
+  });
+
+  it("falls back when an unhinted update breaks the queued chain", async () => {
+    const harness = createWindowHarness([
+      { id: "a", label: "Alpha" },
+      { id: "b", label: "Beta" },
+      { id: "c", label: "Gamma" },
+      { id: "d", label: "Delta" },
+    ]);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Table />));
+    const rows = [...container.querySelectorAll("li")];
+    harness.counters.keys = 0;
+
+    await act(async () => {
+      harness.queueWithUnhinted(
+        [{ id: "a", label: "Alpha refreshed" }],
+        [{ id: "c", label: "Gamma refreshed" }],
+      );
+      await flushCompilerUpdates();
+    });
+
+    expect(container.textContent).toBe("Alpha refreshedBetaGamma refreshedDelta");
+    [...container.querySelectorAll("li")].forEach((row, index) => expect(row).toBe(rows[index]));
+    expect(harness.counters.keys).toBe(4);
+  });
+
   it("preserves controlled-input focus and delegated indexes across the window", async () => {
     const initialItems: Item[] = [
       { id: "a", label: "Alpha" },
@@ -461,13 +690,18 @@ describe("compiled keyed-array window replacement hints", () => {
             state[0].set((previous) =>
               hintedWindowReplace(previous as Item[], 1, 2, [{ id: "e", label: "Epsilon" }]),
             );
-          refresh = () =>
+          refresh = () => {
             state[0].set((previous) =>
-              hintedWindowReplace(previous as Item[], 1, 2, [
+              hintedWindowReplace(previous as Item[], 1, 1, [
                 { id: "e", label: "Epsilon refreshed" },
+              ]),
+            );
+            state[0].set((previous) =>
+              hintedWindowReplace(previous as Item[], 2, 1, [
                 { id: "d", label: "Delta refreshed" },
               ]),
             );
+          };
           return (
             <main>
               <blocks.KeyedRows
@@ -661,6 +895,90 @@ describe("compiled keyed-array window replacement hints", () => {
     expect(harness.counters.renders).toBe(1);
   }, 15_000);
 
+  it("matches normal React through 1,000 queued same-key window refreshes", async () => {
+    const initialItems = Array.from(
+      { length: 64 },
+      (_, index): Item => ({ id: `row-${index}`, label: `Row ${index}` }),
+    );
+    const harness = createWindowHarness(initialItems);
+    let queueReact: (
+      firstPosition: number,
+      first: readonly Item[],
+      secondPosition: number,
+      second: readonly Item[],
+    ) => void = () => undefined;
+    function NormalTable() {
+      const [items, setItems] = useState(initialItems);
+      queueReact = (firstPosition, first, secondPosition, second) => {
+        setItems((previous) =>
+          (previous as WindowArray).toSpliced(firstPosition, first.length, ...first),
+        );
+        setItems((previous) =>
+          (previous as WindowArray).toSpliced(secondPosition, second.length, ...second),
+        );
+      };
+      return (
+        <ol>
+          {items.map((item) => (
+            <li key={item.id}>{item.label}</li>
+          ))}
+        </ol>
+      );
+    }
+    const compiledContainer = document.createElement("div");
+    const reactContainer = document.createElement("div");
+    document.body.append(compiledContainer, reactContainer);
+    const compiledRoot = createRoot(compiledContainer);
+    const reactRoot = createRoot(reactContainer);
+    roots.push(compiledRoot, reactRoot);
+    await act(async () => {
+      compiledRoot.render(<harness.Table />);
+      reactRoot.render(<NormalTable />);
+    });
+    const retainedRows = [...compiledContainer.querySelectorAll("li")];
+    harness.counters.descriptors = 0;
+    let expected = initialItems;
+    let random = 0x52f1_4a8d;
+    const nextRandom = () => {
+      random = (Math.imul(random, 1_664_525) + 1_013_904_223) >>> 0;
+      return random;
+    };
+
+    for (let step = 0; step < 500; step += 1) {
+      const firstCount = (nextRandom() % 8) + 1;
+      const firstPosition = nextRandom() % (expected.length - firstCount + 1);
+      const first = expected
+        .slice(firstPosition, firstPosition + firstCount)
+        .map((item, offset) => ({
+          ...item,
+          label: `First ${step}.${offset}`,
+        }));
+      const afterFirst = (expected as WindowArray).toSpliced(firstPosition, firstCount, ...first);
+      const secondCount = (nextRandom() % 8) + 1;
+      const secondPosition = nextRandom() % (afterFirst.length - secondCount + 1);
+      const second = afterFirst
+        .slice(secondPosition, secondPosition + secondCount)
+        .map((item, offset) => ({ ...item, label: `Second ${step}.${offset}` }));
+      expected = (afterFirst as WindowArray).toSpliced(secondPosition, secondCount, ...second);
+
+      await act(async () => {
+        harness.queueRefreshes(firstPosition, first, secondPosition, second);
+        queueReact(firstPosition, first, secondPosition, second);
+        await flushCompilerUpdates();
+      });
+      expect(compiledContainer.querySelector("ul")?.textContent).toBe(
+        reactContainer.querySelector("ol")?.textContent,
+      );
+    }
+
+    const finalRows = [...compiledContainer.querySelectorAll("li")];
+    expect(finalRows).toHaveLength(retainedRows.length);
+    finalRows.forEach((row, index) => expect(row).toBe(retainedRows[index]));
+    expect(harness.counters.descriptors).toBe(0);
+    expect(harness.counters.executions).toBe(1);
+    expect(harness.counters.renders).toBe(1);
+  }, 15_000);
+
   it("hydrates in StrictMode and drops a queued replacement after unmount", async () => {
     const harness = createWindowHarness([
       { id: "a", label: "Alpha" },
@@ -690,8 +1008,7 @@ describe("compiled keyed-array window replacement hints", () => {
     const gamma = container.querySelector('[data-key="c"]');
 
     await act(async () => {
-      harness.replace(1, 2, [
-        { id: "b", label: "Beta hydrated" },
+      harness.queueRefreshes(1, [{ id: "b", label: "Beta hydrated" }], 2, [
         { id: "c", label: "Gamma hydrated" },
       ]);
       await flushCompilerUpdates();

--- a/packages/farm-react/src/compiler-runtime.tsx
+++ b/packages/farm-react/src/compiler-runtime.tsx
@@ -67,6 +67,7 @@ interface CompilerKeyedArrayWindowReplaceHint {
   readonly position: number;
   readonly removedCount: number;
   readonly insertedCount: number;
+  readonly previous?: CompilerKeyedArrayWindowReplaceHint;
 }
 
 interface CompilerKeyedArrayReorderHint {
@@ -386,29 +387,42 @@ function compilerKeyedArrayBatchInsert(
   return update;
 }
 
-function compilerKeyedArrayWindowReplace(
+function compilerKeyedArrayWindowReplacements(
   value: unknown,
   sourceToken: object | undefined,
   expectedLength: number,
-): CompilerKeyedArrayWindowReplaceHint | undefined {
+): readonly CompilerKeyedArrayWindowReplaceHint[] | undefined {
   const target = compilerObject(value);
   if (!target || !sourceToken || !Array.isArray(value)) return undefined;
   const update = COMPILER_KEYED_ARRAY_WINDOW_REPLACEMENTS.get(target);
-  if (
-    !update ||
-    update.sourceToken !== sourceToken ||
-    update.sourceLength !== expectedLength ||
-    update.resultLength !== value.length ||
-    update.position < 0 ||
-    update.position >= expectedLength ||
-    update.removedCount < 1 ||
-    update.position + update.removedCount > expectedLength ||
-    update.insertedCount < 0 ||
-    update.resultLength !== expectedLength - update.removedCount + update.insertedCount
+  if (!update || update.sourceToken !== sourceToken) return undefined;
+  const updates: CompilerKeyedArrayWindowReplaceHint[] = [];
+  for (
+    let current: CompilerKeyedArrayWindowReplaceHint | undefined = update;
+    current;
+    current = current.previous
   ) {
-    return undefined;
+    if (current.sourceToken !== sourceToken) return undefined;
+    updates.push(current);
   }
-  return update;
+  updates.reverse();
+
+  let length = expectedLength;
+  for (const current of updates) {
+    if (
+      current.sourceLength !== length ||
+      current.position < 0 ||
+      current.position >= current.sourceLength ||
+      current.removedCount < 1 ||
+      current.position + current.removedCount > current.sourceLength ||
+      current.insertedCount < 0 ||
+      current.resultLength !== current.sourceLength - current.removedCount + current.insertedCount
+    ) {
+      return undefined;
+    }
+    length = current.resultLength;
+  }
+  return length === value.length ? updates : undefined;
 }
 
 function compilerKeyedArrayReorder(
@@ -892,7 +906,6 @@ export function createCompilerKeyedArrayWindowReplace(
     if (
       !previousTarget ||
       !valueTarget ||
-      !COMPILER_KEYED_COMMITTED_COLLECTIONS.has(previousTarget) ||
       !Array.isArray(previous) ||
       !Array.isArray(value) ||
       Object.getPrototypeOf(previous) !== NATIVE_ARRAY_PROTOTYPE ||
@@ -913,7 +926,12 @@ export function createCompilerKeyedArrayWindowReplace(
     if (removedCount < 1 || value.length !== previous.length - removedCount + items.length) {
       return value;
     }
-    const sourceToken = compilerKeyedCollectionToken(previousTarget);
+    const committedSource = COMPILER_KEYED_COMMITTED_COLLECTIONS.has(previousTarget);
+    const previousUpdate = committedSource
+      ? undefined
+      : COMPILER_KEYED_ARRAY_WINDOW_REPLACEMENTS.get(previousTarget);
+    if (!committedSource && !previousUpdate) return value;
+    const sourceToken = previousUpdate?.sourceToken || compilerKeyedCollectionToken(previousTarget);
     if (!sourceToken) return value;
     COMPILER_KEYED_ARRAY_WINDOW_REPLACEMENTS.set(valueTarget, {
       sourceToken,
@@ -922,6 +940,7 @@ export function createCompilerKeyedArrayWindowReplace(
       position: normalizedPosition,
       removedCount,
       insertedCount: items.length,
+      ...(previousUpdate ? { previous: previousUpdate } : {}),
     });
   } catch {
     // Metadata must never change the result of a successful native update.
@@ -4768,9 +4787,59 @@ function reconcileCompilerKeyedArrayWindowReplace(
   }
 
   const finalValue = props.items();
-  const update = compilerKeyedArrayWindowReplace(finalValue, collectionToken, instances.size);
-  if (!update || !Array.isArray(finalValue)) return undefined;
+  const updates = compilerKeyedArrayWindowReplacements(finalValue, collectionToken, instances.size);
+  if (!updates || !Array.isArray(finalValue)) return undefined;
   const previousInstances = [...instances.values()];
+  if (updates.length > 1) {
+    const touchedIndices = new Set<number>();
+    for (const update of updates) {
+      if (update.insertedCount !== update.removedCount) return undefined;
+      for (let index = update.position; index < update.position + update.removedCount; index += 1) {
+        touchedIndices.add(index);
+      }
+    }
+
+    for (let index = 0; index < previousInstances.length; index += 1) {
+      const instance = previousInstances[index];
+      const touched = touchedIndices.has(index);
+      if (
+        !instance ||
+        instance.index !== index ||
+        (touched
+          ? instance.element.parentNode !== root
+          : !Object.is(instance.item, finalValue[index]))
+      ) {
+        return undefined;
+      }
+    }
+
+    const prepared: Array<
+      readonly [
+        instance: CompilerKeyedRowInstance,
+        item: unknown,
+        updates: readonly CompilerPreparedKeyedRowBindingUpdate[],
+      ]
+    > = [];
+    try {
+      for (const index of [...touchedIndices].sort((left, right) => left - right)) {
+        const instance = previousInstances[index];
+        const item = finalValue[index];
+        if (keyedRowIdentity(props.rowKey(item, index)) !== instance.key) return undefined;
+        const bindingUpdates = prepareKeyedRowBindingUpdates(props, instance, item, index);
+        if (!bindingUpdates) return undefined;
+        prepared.push([instance, item, bindingUpdates]);
+      }
+    } catch {
+      return undefined;
+    }
+    for (const [instance, item, bindingUpdates] of prepared) {
+      applyPreparedKeyedRowBindingUpdates(props, instance, bindingUpdates);
+      instance.item = item;
+    }
+    return instances;
+  }
+
+  const update = updates[0];
   const removedEnd = update.position + update.removedCount;
   for (let sourceIndex = 0; sourceIndex < update.sourceLength; sourceIndex += 1) {
     const instance = previousInstances[sourceIndex];


### PR DESCRIPTION
## Problem

Two concise same-key exact-window setters can run in one event before the compiler flushes:

```tsx
setRows((current) => current.toSpliced(firstIndex, first.length, ...first));
setRows((current) => current.toSpliced(secondIndex, second.length, ...second));
```

The first result carries an exact-window hint, but the second setter receives an uncommitted array. The runtime previously discarded the second hint and used complete keyed reconciliation, even when both windows were length-preserving and retained the same keys.

## Root cause

Exact-window metadata represented only one update and accepted only a committed collection as its source. It could not prove that an uncommitted source was the validated result of an earlier hinted update from the same committed collection.

## Change

- Chain exact-window metadata through consecutive native `toSpliced()` results that share one committed source token.
- Compose multiple length-preserving same-key windows into one touched-index set.
- Support disjoint and overlapping windows; the final queued value wins at an overlap.
- Prepare every touched key, binding snapshot, and DOM target before the first write, then patch the existing row instances in place.
- Add an isolated 10,000-row production-browser workload and a block-bodied compiled control.
- Document the supported shape, validation model, fallback boundaries, measured performance, and runtime-size effect.

## Safety and compatibility

The composed path runs only after the complete chain proves source/result lengths, valid native-array operations, stable row positions, connected compiler-owned DOM, and the same final key at every touched index. Untouched items must remain referentially identical.

Structural or key-changing windows, reordered/duplicate keys, an unhinted intermediate update, custom/sparse/subclassed arrays, unsupported row structures, failed binding or target preparation, and ambiguous ownership all use complete existing reconciliation before any fast-path DOM mutation. The existing single-window path and public configuration API are unchanged. No new runtime/report counter or syntax is introduced.

Coverage includes disjoint and overlapping windows, last-update-wins behavior, atomic preparation failure, structural/key-changing/unhinted fallback, controlled input focus and selection, latest delegated event data, Strict Mode hydration, recoverable hydration errors, unmount cleanup, React 18.3.1, React 19.2.8, and 1,000 deterministic queued differential updates against normal React.

## Verification

- `pnpm --filter @farm.js/react test` — 68 files, 595 tests passed
- `pnpm --filter @farm.js/react type-check`
- `pnpm --filter @farm.js/react test:compat` — React 18.3.1 and 19.2.8 passed from the packed package
- `pnpm --filter @farm.js/react test:runtime-size`
- `pnpm --filter farm-react-compiler-dashboard-example benchmark` — PASS; every existing correctness, performance, persistence, and scalability gate remained green without lowering a threshold
- `pnpm docs:check-navigation` — 74 visible pages covered
- `pnpm docs:build`
- focused `oxfmt`, `oxlint`, and `git diff --check`

Final queued-window browser result on Chrome 145.0.7632.6, Node.js 23.11.0, Apple M1 macOS arm64:

| Mode | React median | Queued refresh | Compiled control | vs React | vs control |
| --- | ---: | ---: | ---: | ---: | ---: |
| Static | 60.70 ms | 14.00 ms | 28.30 ms | 4.34x | 2.02x |
| Hybrid | 60.70 ms | 9.20 ms | 18.30 ms | 6.60x | 1.99x |

The isolated exact-window fixture premium is 13,358 B gzip, 254 B over the previous result and within the unchanged 256 B allowance. Direct, core-only, and unrelated hint fixtures remain unchanged.

## Documentation and release

Updated the React renderer guide, package README, dashboard benchmark guide, recorded browser results, and checked runtime-size results. No version, template, generated route, or release-flow change.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Composes multiple queued same-key exact-window refreshes into one atomic targeted update, replacing full keyed reconciliation when the chain proves safe.

- Chains exact-window metadata across consecutive native `toSpliced()` results that share one committed source token.
- Compose disjoint and overlapping length-preserving same-key windows; overlapping positions use the last queued value.
- Prepares every touched key, binding snapshot, and DOM target before any write, then patches existing rows in place.
- Falls back to complete reconciliation for structural windows, unhinted intermediate updates, reordered/duplicate keys, custom arrays, or failed preparation.
- Adds a 10,000-row production-browser benchmark and 1,000 deterministic differential tests against React.
- Keeps the existing single-window path and public API unchanged.

<sup>Written for commit 9874049d0c058627c9010cf9eebd972693708d50. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/635?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

