### PR TITLE
fix(api): always pass Request to plain handlers

### DIFF
--- a/docs/src/app/docs/api-routes/page.md
+++ b/docs/src/app/docs/api-routes/page.md
@@ -61,6 +61,9 @@ src/app/api/files/[...path]/route.ts -> /api/files/*
 ```
 
 Use `createEndpoint` when you want input validation and typed client generation. Use plain `GET`, `POST`, `PATCH`, and friends when you want to handle the raw `Request`.
+Plain handlers always receive that `Request`; parameter names such as `request`, `context`, or `ctx`
+do not change the calling convention. Use `createEndpoint` for the parsed `{ body, query, headers }`
+context.
 
 `HEAD` follows normal HTTP semantics. A route can export a dedicated `HEAD` handler, otherwise Farm
 uses its `GET` handler and returns the same status and headers without a response body.

--- a/packages/farm/src/__tests__/api-route-manager.test.ts
+++ b/packages/farm/src/__tests__/api-route-manager.test.ts
@@ -608,14 +608,14 @@ describe("APIRouteManager", () => {
       ssrLoadModule: async (filePath: string) => {
         expect(filePath).toBe(routeFile);
         return {
-          DELETE: async (ctx: { body: unknown }) => ({
+          DELETE: createEndpoint({ method: "DELETE" }, async (ctx) => ({
             method: "DELETE",
             body: ctx.body ?? null,
-          }),
-          POST: async (ctx: { body: unknown }) => ({
+          })),
+          POST: createEndpoint({ method: "POST" }, async (ctx) => ({
             method: "POST",
             body: ctx.body ?? null,
-          }),
+          })),
         };
       },
     } as any);
@@ -650,6 +650,35 @@ describe("APIRouteManager", () => {
     await expect(postResponse.json()).resolves.toEqual({
       method: "POST",
       body: { backend: "local", value: "hello" },
+    });
+  });
+
+  it("passes a Request to plain handlers regardless of the parameter name", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "farm-api-route-"));
+    tempDirs.push(root);
+
+    const routeDir = path.join(root, "api", "native");
+    fs.mkdirSync(routeDir, { recursive: true });
+    const routeFile = path.join(routeDir, "route.js");
+    fs.writeFileSync(routeFile, "export {};\n");
+
+    const manager = new APIRouteManager(root, {
+      ssrLoadModule: async () => ({
+        GET: async (context: Request) =>
+          Response.json({
+            isRequest: context instanceof Request,
+            url: context.url,
+          }),
+      }),
+    } as any);
+    await manager.discoverRoutes();
+
+    const response = await manager.getHandler()!(
+      new Request("http://example.com/api/native?source=test"),
+    );
+    await expect(response.json()).resolves.toEqual({
+      isRequest: true,
+      url: "http://example.com/api/native?source=test",
     });
   });
 });

--- a/packages/farm/src/api/runtime.ts
+++ b/packages/farm/src/api/runtime.ts
@@ -142,7 +142,11 @@ async function invokeAPIRouteEndpointInContext(
     return queryContentTypeError;
   }
 
-  const farmHandler = endpoint.__handler || (isFarmContextHandler(endpoint) ? endpoint : null);
+  // `createEndpoint` brands its parsed-context handler explicitly. Plain route
+  // exports always receive the Web Request regardless of their parameter name;
+  // inferring a calling convention from `Function#toString()` misclassified
+  // valid handlers named `context`, `ctx`, or using destructuring.
+  const farmHandler = endpoint.__handler || null;
 
   if (!farmHandler) {
     const result = await endpoint(request, {
@@ -297,21 +301,6 @@ export function createEndpointFailureResponse(failure: EndpointFailure<string, u
       },
     },
   );
-}
-
-function isFarmContextHandler(endpoint: unknown): boolean {
-  if (typeof endpoint !== "function") {
-    return false;
-  }
-
-  const source = Function.prototype.toString.call(endpoint).trim();
-  const arrowMatch = source.match(/^(?:async\s*)?(?:\(([^)]*)\)|([A-Za-z_$][\w$]*))\s*=>/);
-  const functionMatch = source.match(/^(?:async\s*)?function[^(]*\(([^)]*)\)/);
-  const firstParameter = (arrowMatch?.[1] || arrowMatch?.[2] || functionMatch?.[1] || "")
-    .split(",")[0]
-    .trim();
-
-  return firstParameter === "ctx" || firstParameter === "context" || firstParameter.startsWith("{");
 }
 
 interface RequestBodyParseResult {


### PR DESCRIPTION
## Problem

A valid plain route handler was called with Farm parsed context instead of the Web `Request` when its first parameter happened to be named `context`, `ctx`, or used destructuring.

## Root cause

The runtime inferred the handler contract from `Function.prototype.toString()` and the spelling of the first parameter. Parameter names are not an API contract and transforms or minification can change them.

## Change

Treat only explicitly branded `createEndpoint` handlers as parsed-context handlers. Plain HTTP method exports now always receive the Web `Request`. Update the body-parsing test to use `createEndpoint` and document the boundary.

## Safety and compatibility

Plain Fetch-style handlers now follow the documented behavior in development and production. Context-shaped handlers should use `createEndpoint`, which is the typed public API for parsed body, query, and headers.

## Verification

- `pnpm --filter @farm.js/core test -- api-route-manager.test.ts --reporter=dot` (19 tests)
- `pnpm --filter @farm.js/core type-check`
- `pnpm exec oxlint packages/farm/src/api/runtime.ts packages/farm/src/__tests__/api-route-manager.test.ts`
- `git diff --check`

The new regression returns `isRequest: false` before this change.

## Documentation and release

Updated the API route guide to make the plain-handler calling convention explicit.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes API route handling so plain handlers (exported HTTP method functions) always receive the Web `Request` instead of a parsed context. Previously, the runtime inferred the calling convention from the first parameter's name, which misclassified valid handlers named `context`, `ctx`, or using destructuring. Now only `createEndpoint` handlers get the parsed `{ body, query, headers }` context. Updated the API route guide to make this explicit and added a regression test.

<sup>Written for commit f1303a6e68e0970ad1d9a912c5cbb1248b9b744c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/636?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

