### PR TITLE
fix(query): compose throttled URL updates

### DIFF
--- a/docs/src/app/docs/query/page.md
+++ b/docs/src/app/docs/query/page.md
@@ -36,10 +36,15 @@ export default async function SearchPage({ searchParams }: PagePropsSafe) {
 import { asString, useQueryState } from "@farm.js/core/query/client";
 
 export function SearchControls() {
-  const [q, setQ] = useQueryState("q", asString.withDefault!(""));
+  const [q, setQ] = useQueryState("q", asString.withDefault!(""), {
+    throttleMs: 150,
+  });
   return <input value={q} onChange={(event) => setQ(event.target.value)} />;
 }
 ```
+
+`throttleMs` coalesces rapid writes to the same query key. Updates to different keys are
+composed against the latest URL, and returning a value to the current URL cancels its queued write.
 
 ## Multiple query values
 

--- a/packages/farm/src/__tests__/query-client-shallow.test.tsx
+++ b/packages/farm/src/__tests__/query-client-shallow.test.tsx
@@ -251,6 +251,60 @@ describe("useQueryState shallow routing", () => {
     expect(historyChange).toHaveBeenCalledTimes(1);
   });
 
+  it("composes throttled updates for different query keys", () => {
+    vi.useFakeTimers();
+
+    let setQuery!: (value: string | null) => void;
+    let setPage!: (value: string | null) => void;
+
+    function App() {
+      const [, updateQuery] = useQueryState("q", asString, { throttleMs: 50 });
+      const [, updatePage] = useQueryState("page", asString, { throttleMs: 50 });
+      setQuery = updateQuery;
+      setPage = updatePage;
+      return null;
+    }
+
+    root = createRoot(container);
+    act(() => {
+      root?.render(createElement(App));
+    });
+
+    act(() => {
+      setQuery("farm");
+      setPage("2");
+      vi.runAllTimers();
+    });
+
+    expect(window.location.search).toBe("?q=farm&page=2");
+  });
+
+  it("cancels a throttled update when the value returns to the current URL", () => {
+    vi.useFakeTimers();
+    window.history.replaceState(null, "", "/?q=old");
+
+    let setQuery!: (value: string | null) => void;
+
+    function App() {
+      const [, updateQuery] = useQueryState("q", asString, { throttleMs: 50 });
+      setQuery = updateQuery;
+      return null;
+    }
+
+    root = createRoot(container);
+    act(() => {
+      root?.render(createElement(App));
+    });
+
+    act(() => {
+      setQuery("new");
+      setQuery("old");
+      vi.runAllTimers();
+    });
+
+    expect(window.location.search).toBe("?q=old");
+  });
+
   it("preserves Farm page history state when updating query params", async () => {
     vi.useFakeTimers();
     spaRouter = new SPARouter({ scrollRestoration: false });

--- a/packages/farm/src/query/client.ts
+++ b/packages/farm/src/query/client.ts
@@ -73,6 +73,47 @@ const applyChange = (
   return newParams;
 };
 
+const commitURLUpdate = (
+  updates: Record<string, string | null>,
+  options: Options,
+  emitUpdate: boolean,
+) => {
+  const { history = "pushState", shallow = true, scroll = false } = options;
+  const url = new URL(window.location.href);
+  const newSearchParams = applyChange(url.searchParams, updates);
+  const newSearch = newSearchParams.toString();
+  const newUrl = url.pathname + (newSearch ? `?${newSearch}` : "") + url.hash;
+  const currentUrl = url.pathname + url.search + url.hash;
+
+  if (newUrl === currentUrl) return;
+
+  // Preserve Farm's history state (page state, interception markers) and
+  // keep its recorded path in sync with the new query string so pops
+  // report the entry's real location.
+  const historyState = window.history.state;
+  const nextHistoryState =
+    historyState && typeof historyState === "object" && "path" in historyState
+      ? { ...historyState, path: newUrl }
+      : historyState;
+
+  if (history === "replaceState") {
+    window.history.replaceState(nextHistoryState, "", newUrl);
+  } else {
+    window.history.pushState(nextHistoryState, "", newUrl);
+  }
+
+  if (emitUpdate) {
+    const actualSearchParams = new URLSearchParams(window.location.search);
+    emitter.emitUpdate(actualSearchParams);
+  }
+
+  if (shallow) notifyHistoryChange("url-search");
+
+  if (scroll) {
+    window.scrollTo(0, 0);
+  }
+};
+
 const updateURL = (
   updates: Record<string, string | null>,
   options: Options = {},
@@ -80,62 +121,31 @@ const updateURL = (
 ) => {
   if (typeof window === "undefined") return;
 
-  const { history = "pushState", shallow = true, scroll = false, throttleMs } = options;
-  const url = new URL(window.location.href);
-
-  const newSearchParams = applyChange(new URLSearchParams(url.search), updates);
-  const newSearch = newSearchParams.toString();
-  const newUrl = url.pathname + (newSearch ? `?${newSearch}` : "") + url.hash;
-  const currentUrl =
-    window.location.pathname + (window.location.search || "") + window.location.hash;
-
-  if (newUrl !== currentUrl) {
-    const update = () => {
-      // Preserve Farm's history state (page state, interception markers) and
-      // keep its recorded path in sync with the new query string so pops
-      // report the entry's real location.
-      const historyState = window.history.state;
-      const nextHistoryState =
-        historyState && typeof historyState === "object" && "path" in historyState
-          ? { ...historyState, path: newUrl }
-          : historyState;
-
-      if (history === "replaceState") {
-        window.history.replaceState(nextHistoryState, "", newUrl);
-      } else {
-        window.history.pushState(nextHistoryState, "", newUrl);
-      }
-
-      if (emitUpdate) {
-        const actualSearchParams = new URLSearchParams(window.location.search);
-        emitter.emitUpdate(actualSearchParams);
-      }
-
-      if (shallow) notifyHistoryChange("url-search");
-
-      if (scroll) {
-        window.scrollTo(0, 0);
-      }
-    };
-
-    if (throttleMs && throttleMs > 0) {
-      const throttleKey = Object.keys(updates).sort().join(",");
-
-      const existingTimeout = throttleTimers.get(throttleKey);
-      if (existingTimeout) {
-        clearTimeout(existingTimeout);
-      }
-
-      const timeout = setTimeout(() => {
-        update();
-        throttleTimers.delete(throttleKey);
-      }, throttleMs);
-
-      throttleTimers.set(throttleKey, timeout);
-    } else {
-      update();
-    }
+  const { throttleMs } = options;
+  if (!throttleMs || throttleMs <= 0) {
+    commitURLUpdate(updates, options, emitUpdate);
+    return;
   }
+
+  const throttleKey = Object.keys(updates).sort().join(",");
+  const existingTimeout = throttleTimers.get(throttleKey);
+  if (existingTimeout) {
+    clearTimeout(existingTimeout);
+    throttleTimers.delete(throttleKey);
+  }
+
+  const currentUrl = new URL(window.location.href);
+  const nextSearch = applyChange(currentUrl.searchParams, updates).toString();
+  if (nextSearch === currentUrl.searchParams.toString()) return;
+
+  const timeout = setTimeout(() => {
+    if (throttleTimers.get(throttleKey) === timeout) {
+      throttleTimers.delete(throttleKey);
+    }
+    commitURLUpdate(updates, options, emitUpdate);
+  }, throttleMs);
+
+  throttleTimers.set(throttleKey, timeout);
 };
 
 export function useQueryState<TParser extends Parser<any>>(


### PR DESCRIPTION
## Problem

Throttled query-state writes captured the URL when they were scheduled. Updates to different keys could overwrite one another, and setting a key back to its current URL value did not cancel an older queued write.

## Root cause

Each timer committed a stale, precomputed URL. The no-op check also ran before the existing timer for that key was cancelled.

## Change

Recompute the URL when a throttled write commits, cancel same-key work before checking for a no-op, and add regressions for cross-key composition and reverted values. Document the throttling behavior.

## Safety and compatibility

Unthrottled behavior and the public API are unchanged. History state, shallow notifications, scroll handling, and emitter updates still use the existing path.

## Verification

- `pnpm --filter @farm.js/core test -- query-client-shallow.test.tsx --reporter=dot` (10 tests)
- `pnpm --filter @farm.js/core type-check`
- `pnpm exec oxlint packages/farm/src/query/client.ts packages/farm/src/__tests__/query-client-shallow.test.tsx` (one pre-existing unused-parameter warning)
- `git diff --check`

The two new regression tests fail on `main`: one loses the first query key and the other reapplies the reverted value.

## Documentation and release

Updated the Query and Params guide with `throttleMs` composition and cancellation semantics.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes throttled query-state writes so updates to different keys compose against the latest URL and reverting a key to its current URL cancels its queued write. Previously each timer committed a stale, precomputed URL, so concurrent writes could overwrite one another.

- Recomputes the URL when a throttled write commits and cancels same-key work before checking for a no-op.
- Adds regression tests for cross-key composition and reverted values.
- Documents `throttleMs` composition and cancellation semantics in the Query and Params guide.
- Unthrottled behavior and the public API are unchanged.

<sup>Written for commit 9d10fd6f1664a0f1c04f4d738be31386aae42e80. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/637?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

