### PR TITLE
fix(cache): keep clear authoritative over in-flight fills

### DIFF
--- a/docs/src/app/docs/cache-ppr/page.md
+++ b/docs/src/app/docs/cache-ppr/page.md
@@ -55,6 +55,9 @@ const products = await cache.getOrSet(key, () => fetchProducts(), {
 });
 ```
 
+`clear()` invalidates entries and any fills already in progress. Existing callers still receive
+their result, but an older fill cannot repopulate the cache after it has been cleared.
+
 ## Revalidate
 
 **server action or route handler**

--- a/packages/farm/src/__tests__/cache.test.ts
+++ b/packages/farm/src/__tests__/cache.test.ts
@@ -346,6 +346,48 @@ describe("server cache primitives", () => {
     expect(calls).toBe(1);
   });
 
+  it("does not restore an in-flight cache fill after clear", async () => {
+    const cache = new FarmDataCache();
+    let finishFirstFill!: () => void;
+    let finishSecondFill!: () => void;
+    const firstFillGate = new Promise<void>((resolve) => {
+      finishFirstFill = resolve;
+    });
+    const secondFillGate = new Promise<void>((resolve) => {
+      finishSecondFill = resolve;
+    });
+    let calls = 0;
+
+    const firstFill = cache.getOrSet("products", async () => {
+      const value = ++calls;
+      await firstFillGate;
+      return { calls: value };
+    });
+
+    await vi.waitFor(() => expect(calls).toBe(1));
+    cache.clear();
+
+    const secondFill = cache.getOrSet("products", async () => {
+      const value = ++calls;
+      await secondFillGate;
+      return { calls: value };
+    });
+    await vi.waitFor(() => expect(calls).toBe(2));
+
+    finishFirstFill();
+    await expect(firstFill).resolves.toEqual({ calls: 1 });
+    expect(cache.get("products")).toBeUndefined();
+
+    const dedupedFill = cache.getOrSet("products", async () => ({ calls: ++calls }));
+    finishSecondFill();
+    await expect(Promise.all([secondFill, dedupedFill])).resolves.toEqual([
+      { calls: 2 },
+      { calls: 2 },
+    ]);
+    expect(calls).toBe(2);
+    expect(cache.get("products")).toEqual({ calls: 2 });
+  });
+
   it("does not make a local value fresh when its tag is invalidated during generation", async () => {
     const cache = new FarmDataCache();
     let finishGeneration!: () => void;

--- a/packages/farm/src/cache.ts
+++ b/packages/farm/src/cache.ts
@@ -233,6 +233,7 @@ export class FarmDataCache {
   private inflight = new Map<string, Promise<unknown>>();
   private invalidatedTagVersions = new Map<string, number>();
   private version = 0;
+  private generation = 0;
   private adapter?: FarmCacheAdapter;
   private namespace = "farm";
   private local = true;
@@ -467,6 +468,7 @@ export class FarmDataCache {
 
   clear(): void {
     const count = this.entries.size;
+    this.generation++;
     this.entries.clear();
     this.inflight.clear();
     this.invalidatedTagVersions.clear();
@@ -594,13 +596,16 @@ export class FarmDataCache {
     }
 
     const tags = Array.from(normalizeCacheOptionsTags(options));
-    const promise = this.fillCacheEntry(key, producer, options, tags)
+    const generation = this.generation;
+    const promise = this.fillCacheEntry(key, producer, options, tags, generation)
       .catch((error) => {
         emitFarmEvent({ type: "cache.error", key, operation: "set", error });
         throw error;
       })
       .finally(() => {
-        this.inflight.delete(key);
+        if (this.inflight.get(key) === promise) {
+          this.inflight.delete(key);
+        }
       });
 
     this.inflight.set(key, promise);
@@ -612,6 +617,7 @@ export class FarmDataCache {
     producer: () => Promise<T> | T,
     options: FarmCacheOptions,
     tags: readonly string[],
+    generation: number,
   ): Promise<T> {
     const leaseKey = `${this.namespace}:lease:${key}`;
     let leaseToken: string | null | undefined;
@@ -632,7 +638,9 @@ export class FarmDataCache {
       const initialCreatedVersion = this.version;
       const initialTagVersions = await this.getAdapterTagVersions(tags);
       const value = await producer();
-      await this.writeAsync(key, value, options, initialTagVersions, initialCreatedVersion);
+      if (generation === this.generation) {
+        await this.writeAsync(key, value, options, initialTagVersions, initialCreatedVersion);
+      }
       return value;
     } finally {
       if (leaseToken && this.adapter?.releaseLease) {


### PR DESCRIPTION
## Problem

Calling `FarmDataCache.clear()` while a producer was running allowed that older producer to repopulate the cache after the clear. Its cleanup could also remove a newer in-flight producer for the same key.

## Root cause

Cache fills had no generation ownership, and every fill unconditionally deleted the key from the in-flight map when it settled.

## Change

Capture the cache generation for each fill, advance it on clear, skip writes from older generations, and only remove an in-flight entry when the settling promise still owns it. Add a regression covering both stale repopulation and newer-fill deduplication.

## Safety and compatibility

Existing callers still receive the value produced before a clear; that value is simply not cached. Normal fills, tag invalidation, adapters, and cache keys keep their existing API.

## Verification

- `pnpm --filter @farm.js/core test -- cache.test.ts --reporter=dot` (28 tests)
- `pnpm --filter @farm.js/core type-check`
- `pnpm exec oxlint packages/farm/src/cache.ts packages/farm/src/__tests__/cache.test.ts`
- `git diff --check`

The new regression fails on `main` because the old fill overwrites the value and removes ownership of the newer fill.

## Documentation and release

Updated the Cache and PPR guide with clear/in-flight semantics.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `FarmDataCache.clear()` so in-flight fills cannot repopulate the cache after clearing. Previously, a fill that started before a clear could write its value back after the clear, and its cleanup could evict a newer fill for the same key. Now fills capture a generation and only write if the cache hasn't been cleared, and in-flight cleanup only removes the entry if it still owns it.

Adds a regression test for both stale repopulation and newer-fill deduplication, and updates the cache-PPR docs.

<sup>Written for commit a73ed0c5592e5b079ee2be46137520e386de68e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/638?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

