### PR TITLE
fix(server): stop stalled streams after disconnect

### DIFF
--- a/packages/farm/src/__tests__/send-web-response.test.ts
+++ b/packages/farm/src/__tests__/send-web-response.test.ts
@@ -41,6 +41,44 @@ async function listen(server: Server): Promise<number> {
 }
 
 describe("sendWebResponse", () => {
+  it("settles when the client disconnects while the body is waiting for data", async () => {
+    let bodyCancelled = false;
+    let settleHandler!: (result: "returned" | "threw") => void;
+    const handlerSettled = new Promise<"returned" | "threw">((resolve) => {
+      settleHandler = resolve;
+    });
+    const server = createServer((_req, res) => {
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode("ready"));
+        },
+        cancel() {
+          bodyCancelled = true;
+        },
+      });
+
+      void sendWebResponse(res, new Response(stream)).then(
+        () => settleHandler("returned"),
+        () => settleHandler("threw"),
+      );
+    });
+    const port = await listen(server);
+
+    await new Promise<void>((resolve, reject) => {
+      const socket = connect(port, "127.0.0.1", () => {
+        socket.write("GET / HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: keep-alive\r\n\r\n");
+      });
+      socket.once("data", () => {
+        socket.destroy();
+        resolve();
+      });
+      socket.once("error", reject);
+    });
+
+    await expect(handlerSettled).resolves.toBe("returned");
+    expect(bodyCancelled).toBe(true);
+  });
+
   it("settles when the client disconnects mid-stream under backpressure", async () => {
     let handlerSettled: "pending" | "returned" | "threw" = "pending";
     const server = createServer((_req, res) => {

--- a/packages/farm/src/server/response.ts
+++ b/packages/farm/src/server/response.ts
@@ -56,6 +56,11 @@ export async function sendWebResponse(res: ServerResponse, response: Response): 
   }
 
   const reader = response.body.getReader();
+  const disconnectAbort = new AbortController();
+  const disconnected = once(res, "close", { signal: disconnectAbort.signal }).then(
+    () => true,
+    (error) => error?.name !== "AbortError",
+  );
 
   try {
     while (true) {
@@ -66,7 +71,19 @@ export async function sendWebResponse(res: ServerResponse, response: Response): 
         return;
       }
 
-      const { done, value } = await reader.read();
+      const next = await Promise.race([
+        reader.read().then((result) => ({ type: "read" as const, result })),
+        disconnected.then((closed) => ({ type: "disconnect" as const, closed })),
+      ]);
+      if (next.type === "disconnect" && next.closed) {
+        void reader.cancel().catch(() => {});
+        return;
+      }
+      if (next.type !== "read") {
+        continue;
+      }
+
+      const { done, value } = next.result;
       if (done) {
         break;
       }
@@ -95,6 +112,13 @@ export async function sendWebResponse(res: ServerResponse, response: Response): 
     }
     throw error;
   } finally {
-    reader.releaseLock();
+    disconnectAbort.abort();
+    try {
+      reader.releaseLock();
+    } catch {
+      // A disconnect can win the race with a pending read. Cancelling the
+      // reader settles it asynchronously, so there may be no lock to release
+      // synchronously here.
+    }
   }
 }


### PR DESCRIPTION
## Problem

`sendWebResponse` could remain pending forever when a client disconnected while the response body was waiting for its next chunk. Existing disconnect handling only covered backpressure and checks between reads.

## Root cause

The server awaited `reader.read()` without racing it against the Node response close/error lifecycle. A stalled stream therefore never returned control to observe `res.destroyed`.

## Change

Race each body read with a request-scoped disconnect signal, cancel the body when the socket closes, and clean up the close listener and reader lock. Add a real TCP regression with a body that deliberately stalls after its first chunk.

## Safety and compatibility

Normal streaming and backpressure behavior are unchanged. Disconnects now release the handler and ask the Web stream producer to cancel; no response bytes or public API change for connected clients.

## Verification

- `pnpm --filter @farm.js/core test -- send-web-response.test.ts server-response.test.ts --reporter=dot` (4 tests)
- `pnpm --filter @farm.js/core type-check`
- `pnpm exec oxlint packages/farm/src/server/response.ts packages/farm/src/__tests__/send-web-response.test.ts`
- `git diff --check`

The new TCP regression times out on `main` because the second `reader.read()` never settles.

## Documentation and release

None. This corrects internal response lifecycle behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `sendWebResponse` so it settles when the client disconnects while the response body is waiting for its next chunk. Previously the handler could stay pending forever; now each read races a disconnect signal, and the body is canceled when the socket closes. Adds a regression test with a body that deliberately stalls after the first chunk.

<sup>Written for commit 54be20ec3650aad28c958e158f8c5a76d464bd6a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/639?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

