### PR TITLE
fix(compression): encode negotiated response bodies

### DIFF
--- a/docs/src/app/docs/plugins/page.md
+++ b/docs/src/app/docs/plugins/page.md
@@ -342,6 +342,11 @@ Each plugin owns its private `state`. At runtime, `ctx` is the read-only aggrega
 
 Farm includes plugins for logging, compression, redirects, rewrites, headers, and environment helpers. Register them from `@farm.js/core/plugin/server`.
 
+The production compression plugin negotiates Brotli or gzip from `Accept-Encoding`, streams the
+encoded response body, adds `Vary: Accept-Encoding`, and removes the identity `Content-Length`.
+Responses that are already encoded, partial, marked `no-transform`, or sent as server-sent events
+are left unchanged.
+
 ## Legacy hooks
 
 Existing flat hooks such as `beforeRequest`, `afterResponse`, `beforeApiHandler`, `afterRender`, `beforeBundle`, and `shutdown` remain supported. They are deprecated where a structured equivalent exists. New plugins should use the grouped interface; do not define both versions of the same phase in one plugin because Farm will run both.

--- a/packages/farm/src/__tests__/compression.test.ts
+++ b/packages/farm/src/__tests__/compression.test.ts
@@ -1,0 +1,75 @@
+import { brotliDecompressSync, gunzipSync } from "node:zlib";
+import { describe, expect, it } from "vitest";
+import { PluginManager } from "../plugin";
+import { createCompressionPlugin } from "../plugins/compression";
+
+function createManager() {
+  const manager = new PluginManager({
+    config: {},
+    isDev: false,
+    isProd: true,
+  });
+  manager.addPlugin(createCompressionPlugin());
+  return manager;
+}
+
+describe("compression plugin", () => {
+  it("compresses response bytes and removes the identity content length", async () => {
+    const body = "farm-response-".repeat(128);
+    const manager = createManager();
+    const response = await manager.runRuntimeRequest(
+      new Request("https://farm.test/", { headers: { "accept-encoding": "gzip" } }),
+      () =>
+        new Response(body, {
+          headers: {
+            "content-type": "text/plain",
+            "content-length": String(Buffer.byteLength(body)),
+            etag: '"identity"',
+          },
+        }),
+    );
+
+    expect(response.headers.get("content-encoding")).toBe("gzip");
+    expect(response.headers.get("content-length")).toBeNull();
+    expect(response.headers.get("vary")).toBe("Accept-Encoding");
+    expect(response.headers.get("etag")).toBe('W/"identity"');
+    expect(gunzipSync(Buffer.from(await response.arrayBuffer())).toString()).toBe(body);
+  });
+
+  it("honors encoding quality values and never selects a disabled encoding", async () => {
+    const body = "quality-negotiation".repeat(64);
+    const manager = createManager();
+    const response = await manager.runRuntimeRequest(
+      new Request("https://farm.test/", {
+        headers: { "accept-encoding": "gzip;q=0, br;q=0.8" },
+      }),
+      () => new Response(body),
+    );
+
+    expect(response.headers.get("content-encoding")).toBe("br");
+    expect(brotliDecompressSync(Buffer.from(await response.arrayBuffer())).toString()).toBe(body);
+  });
+
+  it("leaves existing encodings and streaming event responses untouched", async () => {
+    const manager = createManager();
+    const encoded = await manager.runRuntimeRequest(
+      new Request("https://farm.test/", { headers: { "accept-encoding": "br, gzip" } }),
+      () =>
+        new Response("already encoded", {
+          headers: { "content-encoding": "custom" },
+        }),
+    );
+    const eventStream = await manager.runRuntimeRequest(
+      new Request("https://farm.test/events", { headers: { "accept-encoding": "gzip" } }),
+      () =>
+        new Response("data: ready\n\n", {
+          headers: { "content-type": "text/event-stream" },
+        }),
+    );
+
+    expect(encoded.headers.get("content-encoding")).toBe("custom");
+    expect(await encoded.text()).toBe("already encoded");
+    expect(eventStream.headers.get("content-encoding")).toBeNull();
+    expect(await eventStream.text()).toBe("data: ready\n\n");
+  });
+});

--- a/packages/farm/src/plugins/compression.ts
+++ b/packages/farm/src/plugins/compression.ts
@@ -1,6 +1,101 @@
 import type { FarmPlugin, FarmPluginContext } from "../plugin";
 import type { FarmRequest, FarmResponse } from "../types";
-import * as zlib from "zlib";
+import { Readable } from "node:stream";
+import { constants, createBrotliCompress, createGzip } from "node:zlib";
+
+type SupportedEncoding = "br" | "gzip";
+
+const Q_VALUE = /^(?:0(?:\.\d{0,3})?|1(?:\.0{0,3})?)$/;
+
+function parseEncodingQuality(header: string): Map<string, number> {
+  const qualities = new Map<string, number>();
+
+  for (const item of header.split(",")) {
+    const [rawEncoding, ...parameters] = item.trim().split(";");
+    const encoding = rawEncoding?.trim().toLowerCase();
+    if (!encoding) continue;
+
+    let quality = 1;
+    for (const parameter of parameters) {
+      const [rawName, rawValue] = parameter.split("=", 2);
+      if (rawName?.trim().toLowerCase() !== "q") continue;
+      const value = rawValue?.trim() ?? "";
+      quality = Q_VALUE.test(value) ? Number(value) : 0;
+    }
+
+    qualities.set(encoding, Math.max(qualities.get(encoding) ?? 0, quality));
+  }
+
+  return qualities;
+}
+
+function selectEncoding(header: string): SupportedEncoding | undefined {
+  if (!header.trim()) return undefined;
+
+  const qualities = parseEncodingQuality(header);
+  const wildcard = qualities.get("*") ?? 0;
+  const quality = (encoding: SupportedEncoding) => qualities.get(encoding) ?? wildcard;
+  const brotli = quality("br");
+  const gzip = quality("gzip");
+
+  if (brotli <= 0 && gzip <= 0) return undefined;
+  return brotli >= gzip ? "br" : "gzip";
+}
+
+function canCompress(request: Request, response: Response): boolean {
+  if (
+    request.method === "HEAD" ||
+    !response.body ||
+    response.status === 204 ||
+    response.status === 205 ||
+    response.status === 304 ||
+    response.headers.has("content-encoding") ||
+    response.headers.has("content-range") ||
+    response.headers.get("cache-control")?.toLowerCase().includes("no-transform")
+  ) {
+    return false;
+  }
+
+  const contentType = response.headers.get("content-type")?.toLowerCase() ?? "";
+  return contentType !== "text/event-stream";
+}
+
+function appendVary(headers: Headers, value: string): void {
+  const current = headers.get("vary");
+  const values = current
+    ? current
+        .split(",")
+        .map((item) => item.trim())
+        .filter(Boolean)
+    : [];
+  if (!values.some((item) => item.toLowerCase() === value.toLowerCase())) {
+    values.push(value);
+  }
+  headers.set("vary", values.join(", "));
+}
+
+function compressResponse(response: Response, encoding: SupportedEncoding): Response {
+  const compressor =
+    encoding === "br" ? createBrotliCompress() : createGzip({ flush: constants.Z_SYNC_FLUSH });
+  const input = Readable.fromWeb(response.body as any);
+  const output = input.pipe(compressor);
+  const headers = new Headers(response.headers);
+
+  headers.set("content-encoding", encoding);
+  headers.delete("content-length");
+  appendVary(headers, "Accept-Encoding");
+
+  const etag = headers.get("etag");
+  if (etag && !etag.startsWith("W/")) {
+    headers.set("etag", `W/${etag}`);
+  }
+
+  return new Response(Readable.toWeb(output) as ReadableStream<Uint8Array>, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
 
 export function createCompressionPlugin({
   beforeRequest: overrideBeforeRequest,
@@ -21,6 +116,16 @@ export function createCompressionPlugin({
     name: "farm:compression",
     enforce: "post",
 
+    runtime: {
+      after({ request, response, isProd }) {
+        if (!isProd || !canCompress(request, response)) return;
+
+        const encoding = selectEncoding(request.headers.get("accept-encoding") ?? "");
+        if (!encoding) return;
+        return compressResponse(response, encoding);
+      },
+    },
+
     async beforeRequest(req, res, context) {
       if (overrideBeforeRequest) {
         await overrideBeforeRequest(req, res, context);
@@ -30,15 +135,6 @@ export function createCompressionPlugin({
     async afterResponse(req, res, context) {
       if (overrideAfterResponse) {
         await overrideAfterResponse(req, res, context);
-      }
-      if (!context.isProd) return;
-
-      const acceptEncoding = req.headers["accept-encoding"] || "";
-
-      if (acceptEncoding.includes("gzip")) {
-        res.setHeader("Content-Encoding", "gzip");
-      } else if (acceptEncoding.includes("br")) {
-        res.setHeader("Content-Encoding", "br");
       }
     },
   };


### PR DESCRIPTION
## Problem

The built-in compression plugin could advertise `Content-Encoding: gzip` or `br` without transforming the response bytes. It also selected encodings through substring checks, so an encoding with `q=0` could be chosen.

## Root cause

Compression ran in the legacy Node `afterResponse` hook after the body had already been written, and it did not parse `Accept-Encoding` quality values.

## Change

Move compression to `runtime.after`, negotiate Brotli/gzip quality values, and stream the actual response through Node zlib. The transformed response removes `Content-Length`, varies on `Accept-Encoding`, weakens identity ETags, and skips responses that must not be transformed.

## Safety and compatibility

Compression remains production-only. Already encoded, partial, no-transform, bodyless, HEAD, and server-sent-event responses are unchanged. Legacy override callbacks remain supported, but the old incorrect header mutation is removed.

## Verification

- `pnpm --filter @farm.js/core test -- compression.test.ts --reporter=dot` (3 tests)
- `pnpm --filter @farm.js/core type-check`
- `pnpm exec oxlint packages/farm/src/plugins/compression.ts packages/farm/src/__tests__/compression.test.ts`
- `git diff --check`

The byte-level gzip and quality-negotiation regressions fail on `main`: bytes remain uncompressed and `gzip;q=0` is selected.

## Documentation and release

Updated the built-in plugin documentation with negotiation, streaming, header, and exclusion behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the compression plugin so negotiated responses are actually compressed instead of just labeling the body with a `Content-Encoding` header.

- Negotiates Brotli/gzip using `Accept-Encoding` quality values, so disabled encodings (`q=0`) are never selected.
- Streams response bodies through Node zlib and removes the identity `Content-Length`.
- Adds `Vary: Accept-Encoding` and weakens identity ETags on compressed responses.
- Skips responses that are already encoded, partial, `no-transform`, bodyless, HEAD, or server-sent events.
- Legacy `afterResponse` header mutation is removed; override callbacks remain supported.

**Migration**
- Compression is production-only and unchanged for excluded response types, but the old behavior of setting `Content-Encoding` without transforming bytes is gone.

<sup>Written for commit 7750ebf93e76de10c6983ff228dc3891ba59eac4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/640?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

