### PR TITLE
fix(rewrites): preserve destination query strings

### DIFF
--- a/docs/src/app/docs/configuration/page.md
+++ b/docs/src/app/docs/configuration/page.md
@@ -565,6 +565,8 @@ Farm's `redirects()`, `rewrites()`, and `headers()` config functions use the sam
 syntax. `:name` captures one path segment, while `:name*` and plain `*` capture the remaining
 characters. Redirect and rewrite destinations can reuse named captures or use numbered captures
 such as `$1`. All other source characters are matched literally.
+For rewrites, the incoming query string is preserved when the destination has no query. A query
+written in the destination replaces the incoming query string.
 
 ```ts
 export default defineConfig({

--- a/packages/farm/src/__tests__/config-route-plugins.test.ts
+++ b/packages/farm/src/__tests__/config-route-plugins.test.ts
@@ -90,4 +90,18 @@ describe("config route plugins", () => {
 
     expect(numberedRequest.url).toBe("/current/guide");
   });
+
+  it("uses a rewrite destination query instead of appending the source query", async () => {
+    const plugin = createRewritesPlugin([
+      {
+        source: "/legacy",
+        destination: "/current?view=compact",
+      },
+    ]);
+    const req = createRequest("/legacy?view=full&page=2");
+
+    await runBeforeRequest(plugin, req, createResponse());
+
+    expect(req.url).toBe("/current?view=compact");
+  });
 });

--- a/packages/farm/src/plugins/rewrites.ts
+++ b/packages/farm/src/plugins/rewrites.ts
@@ -45,7 +45,14 @@ export function createRewritesPlugin(
             match,
             pattern.tokens,
           );
-          req.url = newPath + url.search;
+          const destinationUrl = new URL(newPath, url);
+          if (!destinationUrl.search && url.search) {
+            destinationUrl.search = url.search;
+          }
+          req.url =
+            destinationUrl.origin === url.origin
+              ? destinationUrl.pathname + destinationUrl.search
+              : destinationUrl.href;
           break;
         }
       }


### PR DESCRIPTION
## Problem

In development, rewriting `/old?source=1` to `/new?fixed=1` produced `/new?fixed=1?source=1`. Production correctly kept the destination query.

## Root cause

The Node rewrite plugin concatenated the source query onto the interpolated destination as plain text instead of resolving both as URLs.

## Change

Resolve the destination with the URL API, preserve the source query only when the destination has none, and add a parity regression.

## Safety and compatibility

Capture interpolation and query preservation for destinations without a query remain unchanged. Destination queries now have the same precedence in development and production.

## Verification

- `pnpm --filter @farm.js/core test -- config-route-plugins.test.ts --reporter=dot` (5 tests)
- `pnpm --filter @farm.js/core type-check`
- `pnpm exec oxlint packages/farm/src/plugins/rewrites.ts packages/farm/src/__tests__/config-route-plugins.test.ts`
- `git diff --check`

The new regression fails on `main` with a second question mark in the rewritten request target.

## Documentation and release

Documented source-query preservation and destination-query precedence in Configuration.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes rewrite destination query handling in `@farm.js/core` so development matches production. Previously, rewriting `/old?source=1` to `/new?fixed=1` produced a malformed `/new?fixed=1?source=1`; now the destination query takes precedence and the source query is preserved only when the destination has none.

- Resolves the rewritten destination with the URL API instead of string concatenation.
- Adds a regression test and documents query precedence in the configuration docs.

<sup>Written for commit f5b2897271c948102f212d3b43d78b03109cd010. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/641?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

