### PR TITLE
fix(rewrites): keep local routes ahead in development

### DIFF
--- a/docs/src/app/docs/configuration/page.md
+++ b/docs/src/app/docs/configuration/page.md
@@ -567,6 +567,8 @@ characters. Redirect and rewrite destinations can reuse named captures or use nu
 such as `$1`. All other source characters are matched literally.
 For rewrites, the incoming query string is preserved when the destination has no query. A query
 written in the destination replaces the incoming query string.
+Rewrites use after-files semantics in development and production: an existing Farm page, API,
+integration, docs, image, or metadata route wins, and the rewrite is considered only as a fallback.
 
 ```ts
 export default defineConfig({

--- a/packages/farm/src/__tests__/development-rewrites.test.ts
+++ b/packages/farm/src/__tests__/development-rewrites.test.ts
@@ -1,0 +1,104 @@
+// @vitest-environment node
+
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+import type { ViteDevServer } from "vite";
+import { createServer } from "../server/create-server";
+
+const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const temporaryRoots = new Set<string>();
+const servers = new Set<ViteDevServer>();
+
+afterEach(async () => {
+  await Promise.all([...servers].map((server) => server.close()));
+  servers.clear();
+  await Promise.all(
+    [...temporaryRoots].map((root) => fs.rm(root, { recursive: true, force: true })),
+  );
+  temporaryRoots.clear();
+});
+
+async function writeModule(root: string, relativePath: string, source: string): Promise<void> {
+  const filePath = path.join(root, relativePath);
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, source);
+}
+
+describe("development config rewrites", () => {
+  it("uses rewrites after local page and API routes", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "farm-development-rewrites-"));
+    temporaryRoots.add(root);
+
+    await fs.mkdir(path.join(root, "node_modules"), { recursive: true });
+    await fs.symlink(
+      await fs.realpath(path.join(packageRoot, "node_modules", "react")),
+      path.join(root, "node_modules", "react"),
+      "junction",
+    );
+    await fs.symlink(
+      await fs.realpath(path.join(packageRoot, "node_modules", "react-dom")),
+      path.join(root, "node_modules", "react-dom"),
+      "junction",
+    );
+    await fs.writeFile(path.join(root, "package.json"), '{"private":true,"type":"module"}');
+    await fs.writeFile(
+      path.join(root, "farm.config.ts"),
+      `export default {
+  rewrites: async () => [
+    { source: "/local", destination: "/fallback" },
+    { source: "/api/local", destination: "/api/fallback" },
+    { source: "/legacy", destination: "/fallback" },
+  ],
+};`,
+    );
+    await writeModule(
+      root,
+      "src/app/layout.tsx",
+      `import React from "react";
+export default function Layout({ children }) {
+  return <>{children}</>;
+}`,
+    );
+    await writeModule(
+      root,
+      "src/app/local/page.tsx",
+      `import React from "react";
+export default function Page() { return <main>local page</main>; }`,
+    );
+    await writeModule(
+      root,
+      "src/app/fallback/page.tsx",
+      `import React from "react";
+export default function Page() { return <main>fallback page</main>; }`,
+    );
+    await writeModule(
+      root,
+      "src/app/api/local/route.ts",
+      `export function GET() { return Response.json({ source: "local" }); }`,
+    );
+    await writeModule(
+      root,
+      "src/app/api/fallback/route.ts",
+      `export function GET() { return Response.json({ source: "fallback" }); }`,
+    );
+
+    const server = await createServer({ root, images: { provider: "none" } });
+    servers.add(server);
+    await server.listen(0);
+    const address = server.httpServer?.address();
+    if (!address || typeof address === "string") throw new Error("Missing dev server address");
+    const origin = `http://localhost:${address.port}`;
+
+    const localPage = await fetch(`${origin}/local`).then((response) => response.text());
+    const fallbackPage = await fetch(`${origin}/legacy`).then((response) => response.text());
+    const localApi = await fetch(`${origin}/api/local`).then((response) => response.json());
+
+    expect(localPage).toContain("local page");
+    expect(localPage).not.toContain("fallback page");
+    expect(fallbackPage).toContain("fallback page");
+    expect(localApi).toEqual({ source: "local" });
+  }, 30_000);
+});

--- a/packages/farm/src/plugins/rewrites.ts
+++ b/packages/farm/src/plugins/rewrites.ts
@@ -3,6 +3,8 @@ import type { RewriteConfig } from "../config";
 import type { FarmRequest, FarmResponse } from "../types";
 import { compileConfigRoutePattern, interpolateConfigRouteDestination } from "./route-pattern";
 
+export const FARM_CONFIG_REWRITES_PLUGIN_NAME = "farm:rewrites";
+
 export function createRewritesPlugin(
   rewrites: RewriteConfig[],
   {
@@ -27,7 +29,7 @@ export function createRewritesPlugin(
   }));
 
   return {
-    name: "farm:rewrites",
+    name: FARM_CONFIG_REWRITES_PLUGIN_NAME,
     enforce: "pre",
 
     async beforeRequest(req, res, context) {

--- a/packages/farm/src/vite.ts
+++ b/packages/farm/src/vite.ts
@@ -98,6 +98,7 @@ import {
   parseFarmLayoutChainHeader,
 } from "./navigation/render-plan";
 import { resolveFarmPageDataFailure } from "./navigation/page-data-error";
+import { FARM_CONFIG_REWRITES_PLUGIN_NAME } from "./plugins/rewrites";
 
 interface FarmVitePluginOptions extends FarmConfig {
   openapi?: FarmUserConfig["openapi"];
@@ -1530,7 +1531,10 @@ window.__FARM_MANIFEST__ = ${inlineValue({
                   "beforeRequest",
                   (plugin) => {
                     const owner = getFarmIntegrationPluginOwner(plugin);
-                    return owner?.source !== "lifecycle" || owner.key !== matchedRoute.key;
+                    return (
+                      plugin.name !== FARM_CONFIG_REWRITES_PLUGIN_NAME &&
+                      (owner?.source !== "lifecycle" || owner.key !== matchedRoute.key)
+                    );
                   },
                   req,
                   res,
@@ -1643,7 +1647,16 @@ window.__FARM_MANIFEST__ = ${inlineValue({
 
             try {
               if (pm) {
-                await pm.runHookParallel("beforeRequest", req, res);
+                if (hasMatchedApiRoute) {
+                  await pm.runHookParallelFiltered(
+                    "beforeRequest",
+                    (plugin) => plugin.name !== FARM_CONFIG_REWRITES_PLUGIN_NAME,
+                    req,
+                    res,
+                  );
+                } else {
+                  await pm.runHookParallel("beforeRequest", req, res);
+                }
               }
 
               if (res.writableEnded) {
@@ -2313,7 +2326,17 @@ window.__FARM_MANIFEST__ = ${inlineValue({
 
             // Run beforeRequest hooks
             if (pm && hasBeforeRequestHook) {
-              await pm.runHookParallel("beforeRequest", req, res);
+              const currentPathname = new URL(
+                req.url || "/",
+                `http://${req.headers.host || "localhost:3000"}`,
+              ).pathname;
+              const hasLocalPageRoute = Boolean(routeManager.matchRoute(currentPathname)?.route);
+              await pm.runHookParallelFiltered(
+                "beforeRequest",
+                (plugin) => !hasLocalPageRoute || plugin.name !== FARM_CONFIG_REWRITES_PLUGIN_NAME,
+                req,
+                res,
+              );
             }
 
             if (res.writableEnded) {


### PR DESCRIPTION
## Problem

Configured rewrites ran before existing Farm routes in development, while production uses after-files semantics. A rewrite could therefore hide a local page, API route, or integration only during development.

## Root cause

The built-in rewrite plugin participated in every legacy `beforeRequest` pass without knowing that the dev dispatcher had already matched a local route.

## Change

Identify the built-in config rewrite plugin and exclude it from request hooks after a local integration, API, or page match. Keep it enabled for unmatched paths. Add a real Vite development-server regression covering local pages, local APIs, and a fallback rewrite.

## Safety and compatibility

Redirect precedence and user plugins are unchanged. Rewrites still run for unmatched paths and now follow the same after-files rule in development and production.

## Verification

- `pnpm --filter @farm.js/core test -- development-rewrites.test.ts config-route-plugins.test.ts --reporter=dot` (6 tests)
- `pnpm --filter @farm.js/core type-check`
- `pnpm exec oxlint packages/farm/src/vite.ts packages/farm/src/plugins/rewrites.ts packages/farm/src/__tests__/development-rewrites.test.ts`
- `git diff --check`

The development regression fails on `main` because `/local` and `/api/local` are rewritten to their fallback routes.

## Documentation and release

Documented after-files semantics for development and production route rules.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes dev-only rewrites that could hide local pages, APIs, or integrations. Rewrites now run as a fallback after a local route is matched, so development follows the same after-files semantics as production.

- Excludes the built-in config rewrite plugin from request hooks once a local page, API, or integration matches; unmatched paths still use rewrites.
- Keeps redirect precedence and user plugins unchanged.
- Adds a Vite dev-server regression test covering a local page, a local API, and a fallback rewrite.

<sup>Written for commit 87b0da5df5bd9abb1ec9a5cfba9186cb01f8f286. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/642?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

