### PR TITLE
fix(headers): finalize configured response values

### DIFF
--- a/docs/src/app/docs/configuration/page.md
+++ b/docs/src/app/docs/configuration/page.md
@@ -569,6 +569,9 @@ For rewrites, the incoming query string is preserved when the destination has no
 written in the destination replaces the incoming query string.
 Rewrites use after-files semantics in development and production: an existing Farm page, API,
 integration, docs, image, or metadata route wins, and the rewrite is considered only as a fallback.
+Configured response headers are applied after route handlers in both modes, so they win when the
+same header is returned by a handler. `Link` is additive: handler and configured link values are
+merged instead of replacing one another.
 
 ```ts
 export default defineConfig({

--- a/packages/farm/src/__tests__/config-route-plugins.test.ts
+++ b/packages/farm/src/__tests__/config-route-plugins.test.ts
@@ -12,8 +12,12 @@ function createRequest(url: string): IncomingMessage {
 }
 
 function createResponse(): ServerResponse {
+  const headers = new Map<string, number | string | string[]>();
   return {
-    setHeader: vi.fn(),
+    setHeader: vi.fn((key: string, value: number | string | readonly string[]) => {
+      headers.set(key.toLowerCase(), Array.isArray(value) ? [...value] : value);
+    }),
+    getHeader: vi.fn((key: string) => headers.get(key.toLowerCase())),
     writeHead: vi.fn(),
     end: vi.fn(),
   } as unknown as ServerResponse;
@@ -68,6 +72,32 @@ describe("config route plugins", () => {
     await runBeforeRequest(plugin, req, res);
 
     expect(res.setHeader).toHaveBeenCalledWith("x-docs", "yes");
+  });
+
+  it("finalizes configured headers after handler headers like production", async () => {
+    const plugin = createHeadersPlugin([
+      {
+        source: "/docs/:path*",
+        headers: [
+          { key: "cache-control", value: "public, max-age=60" },
+          { key: "Link", value: "</configured.css>; rel=preload; as=style" },
+        ],
+      },
+    ]);
+    const req = createRequest("/docs/start");
+    const res = createResponse();
+
+    await runBeforeRequest(plugin, req, res);
+    res.setHeader("cache-control", "private");
+    res.writeHead(200, {
+      "cache-control": "no-store",
+      Link: "</handler.js>; rel=preload; as=script",
+    });
+
+    expect(res.getHeader("cache-control")).toBe("public, max-age=60");
+    expect(res.getHeader("Link")).toBe(
+      "</handler.js>; rel=preload; as=script, </configured.css>; rel=preload; as=style",
+    );
   });
 
   it("interpolates named and numbered rewrite captures", async () => {

--- a/packages/farm/src/plugins/headers.ts
+++ b/packages/farm/src/plugins/headers.ts
@@ -3,6 +3,50 @@ import type { HeaderConfig } from "../config";
 import type { FarmRequest, FarmResponse } from "../types";
 import { compileConfigRoutePattern } from "./route-pattern";
 
+const FARM_CONFIG_HEADERS_FINALIZER = Symbol.for("farm.configHeadersFinalizer");
+
+function appendConfiguredLinkHeader(res: FarmResponse, value: string): void {
+  const current = res.getHeader("Link");
+  if (current === undefined) {
+    res.setHeader("Link", value);
+    return;
+  }
+
+  const currentValue = Array.isArray(current) ? current.join(", ") : String(current);
+  if (currentValue !== value && !currentValue.endsWith(`, ${value}`)) {
+    res.setHeader("Link", `${currentValue}, ${value}`);
+  }
+}
+
+function applyResponseHeaders(
+  res: FarmResponse,
+  matchedHeaders: readonly HeaderConfig["headers"][],
+): void {
+  for (const headers of matchedHeaders) {
+    for (const header of headers) {
+      if (header.key.toLowerCase() === "link") {
+        appendConfiguredLinkHeader(res, header.value);
+      } else {
+        res.setHeader(header.key, header.value);
+      }
+    }
+  }
+}
+
+function applyWriteHeadHeaders(res: FarmResponse, headers: unknown): void {
+  if (Array.isArray(headers)) {
+    for (let index = 0; index + 1 < headers.length; index += 2) {
+      res.setHeader(String(headers[index]), headers[index + 1]);
+    }
+    return;
+  }
+
+  if (!headers || typeof headers !== "object") return;
+  for (const [key, value] of Object.entries(headers)) {
+    if (value !== undefined) res.setHeader(key, value);
+  }
+}
+
 export function createHeadersPlugin(
   headers: HeaderConfig[],
   {
@@ -36,14 +80,29 @@ export function createHeadersPlugin(
       }
       const url = new URL(req.url || "/", `http://${req.headers.host}`);
       const pathname = url.pathname;
+      const matchedHeaders = compiledHeaders
+        .filter(({ pattern }) => pattern.regex.test(pathname))
+        .map(({ config }) => config.headers);
 
-      for (const { config, pattern } of compiledHeaders) {
-        if (pattern.regex.test(pathname)) {
-          for (const header of config.headers) {
-            res.setHeader(header.key, header.value);
-          }
-        }
+      applyResponseHeaders(res, matchedHeaders);
+
+      const responseWithFinalizer = res as FarmResponse & {
+        [FARM_CONFIG_HEADERS_FINALIZER]?: boolean;
+      };
+      if (matchedHeaders.length === 0 || responseWithFinalizer[FARM_CONFIG_HEADERS_FINALIZER]) {
+        return;
       }
+
+      responseWithFinalizer[FARM_CONFIG_HEADERS_FINALIZER] = true;
+      const writeHead = res.writeHead;
+      res.writeHead = ((statusCode: number, ...args: unknown[]) => {
+        const statusMessage = typeof args[0] === "string" ? (args.shift() as string) : undefined;
+        applyWriteHeadHeaders(res, args[0]);
+        applyResponseHeaders(res, matchedHeaders);
+        return statusMessage === undefined
+          ? (writeHead as any).call(res, statusCode)
+          : (writeHead as any).call(res, statusCode, statusMessage);
+      }) as FarmResponse["writeHead"];
     },
 
     async afterResponse(req, res, context) {


### PR DESCRIPTION
## Problem

Configured headers were written before development handlers, so a handler could replace them. Production applies configured headers after the response. Development also replaced `Link` instead of preserving handler preload links.

## Root cause

The Node header plugin only used `beforeRequest` and had no finalization step before `writeHead`.

## Change

Keep the early header visibility, then finalize matching config headers immediately before Node commits the response. Non-Link config values win; `Link` values append with the same ordering and deduplication behavior as production. Explicit `writeHead` header objects are included in finalization.

## Safety and compatibility

Header matching and the plugin API are unchanged. Handler-only headers are preserved, configured non-Link precedence now matches production, and Link remains additive.

## Verification

- `pnpm --filter @farm.js/core test -- config-route-plugins.test.ts --reporter=dot` (6 tests)
- `pnpm --filter @farm.js/core type-check`
- `pnpm exec oxlint packages/farm/src/plugins/headers.ts packages/farm/src/__tests__/config-route-plugins.test.ts`
- `git diff --check`

The new regression fails on `main`: handler `cache-control` replaces config and handler `Link` replaces the configured preload.

## Documentation and release

Documented configured-header precedence and additive Link behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes dev-mode header precedence so configured response headers behave like production.

- Configured headers are now finalized after route handlers and `writeHead`, so they override handler values for non-`Link` headers.
- `Link` headers are appended instead of replaced, matching production's deduplication.
- Explicit `writeHead` header objects are included in finalization.
- Documentation now clarifies configured-header precedence.

<sup>Written for commit feb6f8da6984f81481d5f76c8cad9d4b37b81a0a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/643?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

