### PR TITLE
fix(api): match encoded Unicode route segments

### DIFF
--- a/docs/src/app/docs/api-routes/page.md
+++ b/docs/src/app/docs/api-routes/page.md
@@ -60,6 +60,9 @@ src/app/api/users/[id]/route.ts     -> /api/users/:id
 src/app/api/files/[...path]/route.ts -> /api/files/*
 ```
 
+Static route directory names may contain Unicode. Browsers percent-encode those path segments;
+Farm decodes both the discovered route and request segment before matching them.
+
 Use `createEndpoint` when you want input validation and typed client generation. Use plain `GET`, `POST`, `PATCH`, and friends when you want to handle the raw `Request`.
 Plain handlers always receive that `Request`; parameter names such as `request`, `context`, or `ctx`
 do not change the calling convention. Use `createEndpoint` for the parsed `{ body, query, headers }`

--- a/packages/farm/src/__tests__/api-route-manager.test.ts
+++ b/packages/farm/src/__tests__/api-route-manager.test.ts
@@ -87,6 +87,23 @@ describe("APIRouteManager", () => {
     expect(manager.matchRoute("/api/shop/settings")?.route.path).toBe("/api/shop/[item]");
   });
 
+  it("matches URL-encoded Unicode static route segments", async () => {
+    const manager = new APIRouteManager("/tmp/farm-api-unicode-test");
+    manager.getRoutes().set("/api/café", {
+      path: "/api/café",
+      filePath: "/tmp/farm-api-unicode-test/café/route.ts",
+      methods: ["GET"],
+      endpoints: { GET: async () => Response.json({ route: "café" }) },
+    });
+
+    const pathname = new URL("http://example.com/api/caf%C3%A9").pathname;
+    expect(manager.matchRoute(pathname)?.route.path).toBe("/api/café");
+
+    const response = await manager.getHandler()!(new Request("http://example.com/api/caf%C3%A9"));
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ route: "café" });
+  });
+
   it("uses GET for HEAD requests and strips the response body", async () => {
     const manager = new APIRouteManager("/tmp/farm-api-head-test");
     const getHandler = async () =>

--- a/packages/farm/src/api/runtime.ts
+++ b/packages/farm/src/api/runtime.ts
@@ -431,7 +431,7 @@ function matchRoutePath(routePath: string, pathname: string): APIRouteParams | n
       continue;
     }
 
-    if (routeSegment !== pathnameSegment) {
+    if (decodePathSegment(routeSegment) !== decodePathSegment(pathnameSegment)) {
       return null;
     }
 


### PR DESCRIPTION
## Problem

A static API directory containing Unicode, such as `api/café/route.ts`, did not match the ordinary browser request path `/api/caf%C3%A9`. Dynamic parameters already decoded correctly.

## Root cause

Static segments were compared as raw strings, so the discovered Unicode route and percent-encoded URL pathname differed.

## Change

Decode both static route and request segments for comparison and add a handler-level regression for an encoded Unicode URL.

## Safety and compatibility

ASCII routes, dynamic/catch-all params, trailing slashes, and route specificity are unchanged. Malformed percent escapes retain the existing raw fallback.

## Verification

- `pnpm --filter @farm.js/core test -- api-route-manager.test.ts --reporter=dot` (20 tests)
- `pnpm --filter @farm.js/core type-check`
- `pnpm exec oxlint packages/farm/src/api/runtime.ts packages/farm/src/__tests__/api-route-manager.test.ts`
- `git diff --check`

The new regression returns no route on `main`.

## Documentation and release

Documented Unicode static API-directory matching.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes static API route matching so Unicode route segments like `café` match the browser's percent-encoded request path `/api/caf%C3%A9`.

- Decodes both route and request segments before comparison; dynamic parameters were already decoded.
- Adds a handler-level regression test and documents the behavior.
- ASCII routes, dynamic/catch-all params, trailing slashes, and route specificity are unchanged, and malformed percent escapes keep the raw fallback.

<sup>Written for commit 95d46249bd891dc883cb6502474633125db61aef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/644?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

