### PR TITLE
fix(metadata): apply parent title templates

### DIFF
--- a/docs/src/app/docs/routing/page.md
+++ b/docs/src/app/docs/routing/page.md
@@ -667,6 +667,18 @@ from the rendered React page automatically.
 
 Export `metadata` for static head tags or `generateMetadata` when the values depend on route params, search params, middleware data, or route data. Farm merges layout metadata from root to leaf, then applies the page metadata last.
 
+A layout can define a default title and a `%s` template for child segments. The layout itself uses
+the default; a child string title is substituted into the nearest parent template:
+
+```tsx
+export const metadata = {
+  title: {
+    default: "Acme",
+    template: "%s | Acme",
+  },
+};
+```
+
 **src/app/products/[id]/page.tsx**
 
 ```tsx

--- a/packages/farm/src/__tests__/metadata.test.ts
+++ b/packages/farm/src/__tests__/metadata.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { renderMetadataHead } from "../metadata";
+import { mergeMetadata, renderMetadataHead } from "../metadata";
 
 describe("metadata head rendering", () => {
   it("reports when favicon metadata emits a browser icon", () => {
@@ -29,6 +29,20 @@ describe("metadata head rendering", () => {
     expect(renderMetadataHead(undefined)).toMatchObject({
       hasExplicitTitle: false,
     });
+  });
+
+  it("applies parent title templates to child metadata", () => {
+    const root = mergeMetadata(undefined, {
+      title: { default: "Acme", template: "%s | Acme" },
+    });
+    const section = mergeMetadata(root, {
+      title: { default: "Docs", template: "%s — Docs" },
+    });
+    const page = mergeMetadata(section, { title: "Getting started" });
+
+    expect(renderMetadataHead(root).title).toBe("Acme");
+    expect(renderMetadataHead(section).title).toBe("Docs | Acme");
+    expect(renderMetadataHead(page).title).toBe("Getting started — Docs");
   });
 
   it("keeps the fallback available when only an Apple touch icon is configured", () => {

--- a/packages/farm/src/metadata.ts
+++ b/packages/farm/src/metadata.ts
@@ -31,11 +31,36 @@ export function mergeMetadata(
   return {
     ...base,
     ...next,
+    title: mergeMetadataTitle(base.title, next.title),
     openGraph: mergeNestedMetadata(base.openGraph, next.openGraph),
     twitter: mergeNestedMetadata(base.twitter, next.twitter),
     alternates: mergeNestedMetadata((base as any).alternates, (next as any).alternates),
     icons: mergeNestedMetadata((base as any).icons, (next as any).icons),
   };
+}
+
+function mergeMetadataTitle(base: Metadata["title"], next: Metadata["title"]): Metadata["title"] {
+  if (next === undefined) return base;
+
+  const parentTemplate = isRecord(base) ? normalizeContent(base.template) : undefined;
+  if (typeof next === "string") {
+    return parentTemplate ? applyTitleTemplate(parentTemplate, next) : next;
+  }
+
+  if (!isRecord(next)) return next;
+
+  const defaultTitle = normalizeContent(next.default) ?? resolveMetadataTitle(base);
+  return {
+    ...next,
+    default:
+      defaultTitle && parentTemplate
+        ? applyTitleTemplate(parentTemplate, defaultTitle)
+        : defaultTitle,
+  };
+}
+
+function applyTitleTemplate(template: string, title: string): string {
+  return template.split("%s").join(title);
 }
 
 export function addMetadataImageReference(


### PR DESCRIPTION
## Problem

Layout `title.template` metadata was dropped during root-to-leaf merging. Child pages rendered their raw title instead of substituting it into the nearest layout template.

## Root cause

`mergeMetadata` used a shallow title replacement and `renderMetadataHead` only read a string or object default; no merge step applied the parent template.

## Change

Merge title metadata explicitly: apply a parent `%s` template to a child string/default, retain a nested layout template for its descendants, and preserve the layout default for its own route. Add root, nested-layout, and page assertions.

## Safety and compatibility

Plain string titles and metadata without a template are unchanged. Open Graph and Twitter titles remain independently controlled. The nearest child layout template replaces the parent template for deeper descendants, matching nested metadata semantics.

## Verification

- `pnpm --filter @farm.js/core test -- metadata.test.ts --reporter=dot` (4 tests)
- `pnpm --filter @farm.js/core type-check`
- `pnpm exec oxlint packages/farm/src/metadata.ts packages/farm/src/__tests__/metadata.test.ts`
- `git diff --check`

The nested title regression fails on `main` because both child titles render without their parent template.

## Documentation and release

Added a layout title-template example and documented nearest-parent substitution.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes layout title templates being dropped during metadata merging, so child pages now render with the nearest parent template applied.

- Merges title metadata explicitly, applying a parent `%s` template to child string or object defaults.
- Retains the nested layout template for deeper descendants and preserves the layout's own default title.
- Adds tests covering root, nested layout, and page title rendering.
- Documents layout title templates and nearest-parent substitution in `docs/src/app/docs/routing/page.md`.

<sup>Written for commit c644abf7f4ac99f9d2d2fdd42e2064648687d413. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/645?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

