### PR TITLE
fix(i18n): match config routes without locale prefixes

### DIFF
--- a/docs/src/app/docs/internationalization/page.md
+++ b/docs/src/app/docs/internationalization/page.md
@@ -169,6 +169,10 @@ export function ProductLinks() {
 
 Farm also strips the locale before route and middleware matching, keeps it in SPA page-data snapshots, and localizes internal `redirect()` destinations. Existing page, layout, loading, error, metadata image, and middleware files do not need locale wrappers.
 
+Configuration `redirects()`, `rewrites()`, and `headers()` use the same internal, unprefixed source
+paths. A request such as `/fr/legacy` can match a `/legacy` rule; an internal redirect or rewrite
+destination keeps the active `fr` prefix. Development and production apply this behavior equally.
+
 ## Request signals
 
 For a request without an explicit locale prefix, Farm resolves the locale in this order:

--- a/packages/farm/src/__tests__/config-route-plugins.test.ts
+++ b/packages/farm/src/__tests__/config-route-plugins.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import { createHeadersPlugin } from "../plugins/headers";
 import { createRedirectsPlugin } from "../plugins/redirects";
 import { createRewritesPlugin } from "../plugins/rewrites";
+import { resolveFarmI18nConfig } from "../i18n/config";
 
 function createRequest(url: string): IncomingMessage {
   return {
@@ -32,6 +33,15 @@ async function runBeforeRequest(
 }
 
 describe("config route plugins", () => {
+  const i18n = resolveFarmI18nConfig(
+    {
+      locales: ["en", "fr"],
+      defaultLocale: "en",
+      routing: "prefix-except-default",
+    },
+    { root: "/tmp/farm-config-route-i18n", mode: "development" },
+  );
+
   it("keeps named and plain redirect captures in source order", async () => {
     const plugin = createRedirectsPlugin([
       {
@@ -133,5 +143,36 @@ describe("config route plugins", () => {
     await runBeforeRequest(plugin, req, createResponse());
 
     expect(req.url).toBe("/current?view=compact");
+  });
+
+  it("matches locale-prefixed config routes and localizes their destinations", async () => {
+    const redirect = createRedirectsPlugin(
+      [{ source: "/docs/:path*", destination: "/learn/:path*" }],
+      { i18n },
+    );
+    const redirectRequest = createRequest("/fr/docs/start");
+    const redirectResponse = createResponse();
+
+    await runBeforeRequest(redirect, redirectRequest, redirectResponse);
+
+    expect(redirectResponse.writeHead).toHaveBeenCalledWith(307, {
+      Location: "/fr/learn/start",
+    });
+
+    const rewrite = createRewritesPlugin(
+      [{ source: "/legacy/:path*", destination: "/current/:path*" }],
+      { i18n },
+    );
+    const rewriteRequest = createRequest("/fr/legacy/guide?view=full");
+    await runBeforeRequest(rewrite, rewriteRequest, createResponse());
+    expect(rewriteRequest.url).toBe("/fr/current/guide?view=full");
+
+    const headers = createHeadersPlugin(
+      [{ source: "/docs/:path*", headers: [{ key: "x-docs", value: "yes" }] }],
+      { i18n },
+    );
+    const headerResponse = createResponse();
+    await runBeforeRequest(headers, createRequest("/fr/docs/start"), headerResponse);
+    expect(headerResponse.getHeader("x-docs")).toBe("yes");
   });
 });

--- a/packages/farm/src/plugins/headers.ts
+++ b/packages/farm/src/plugins/headers.ts
@@ -1,7 +1,8 @@
 import type { FarmPlugin, FarmPluginContext } from "../plugin";
 import type { HeaderConfig } from "../config";
 import type { FarmRequest, FarmResponse } from "../types";
-import { compileConfigRoutePattern } from "./route-pattern";
+import type { ResolvedFarmI18nConfig } from "../i18n/types";
+import { compileConfigRoutePattern, resolveConfigRoutePathname } from "./route-pattern";
 
 const FARM_CONFIG_HEADERS_FINALIZER = Symbol.for("farm.configHeadersFinalizer");
 
@@ -52,6 +53,7 @@ export function createHeadersPlugin(
   {
     beforeRequest: overrideBeforeRequest,
     afterResponse: overrideAfterResponse,
+    i18n,
   }: {
     beforeRequest?: (
       req: FarmRequest,
@@ -63,6 +65,7 @@ export function createHeadersPlugin(
       res: FarmResponse,
       context: FarmPluginContext,
     ) => void | Promise<void>;
+    i18n?: ResolvedFarmI18nConfig;
   } = {},
 ): FarmPlugin {
   const compiledHeaders = headers.map((config) => ({
@@ -79,7 +82,7 @@ export function createHeadersPlugin(
         await overrideBeforeRequest(req, res, context);
       }
       const url = new URL(req.url || "/", `http://${req.headers.host}`);
-      const pathname = url.pathname;
+      const pathname = resolveConfigRoutePathname(url.pathname, i18n).pathname;
       const matchedHeaders = compiledHeaders
         .filter(({ pattern }) => pattern.regex.test(pathname))
         .map(({ config }) => config.headers);

--- a/packages/farm/src/plugins/redirects.ts
+++ b/packages/farm/src/plugins/redirects.ts
@@ -1,13 +1,20 @@
 import type { FarmPlugin, FarmPluginContext } from "../plugin";
 import type { RedirectConfig } from "../config";
 import type { FarmRequest, FarmResponse } from "../types";
-import { compileConfigRoutePattern, interpolateConfigRouteDestination } from "./route-pattern";
+import type { ResolvedFarmI18nConfig } from "../i18n/types";
+import {
+  compileConfigRoutePattern,
+  interpolateConfigRouteDestination,
+  localizeConfigRouteDestination,
+  resolveConfigRoutePathname,
+} from "./route-pattern";
 
 export function createRedirectsPlugin(
   redirects: RedirectConfig[],
   {
     beforeRequest: overrideBeforeRequest,
     afterResponse: overrideAfterResponse,
+    i18n,
   }: {
     beforeRequest?: (
       req: FarmRequest,
@@ -19,6 +26,7 @@ export function createRedirectsPlugin(
       res: FarmResponse,
       context: FarmPluginContext,
     ) => void | Promise<void>;
+    i18n?: ResolvedFarmI18nConfig;
   } = {},
 ): FarmPlugin {
   const compiledRedirects = redirects.map((redirect) => ({
@@ -34,15 +42,16 @@ export function createRedirectsPlugin(
         await overrideBeforeRequest(req, res, context);
       }
       const url = new URL(req.url || "/", `http://${req.headers.host}`);
-      const pathname = url.pathname;
+      const routePath = resolveConfigRoutePathname(url.pathname, i18n);
+      const pathname = routePath.pathname;
 
       for (const { redirect, pattern } of compiledRedirects) {
         const match = pathname.match(pattern.regex);
         if (match) {
-          const destination = interpolateConfigRouteDestination(
-            redirect.destination,
-            match,
-            pattern.tokens,
+          const destination = localizeConfigRouteDestination(
+            interpolateConfigRouteDestination(redirect.destination, match, pattern.tokens),
+            routePath.locale,
+            i18n,
           );
 
           const statusCode = redirect.statusCode || (redirect.permanent ? 308 : 307);

--- a/packages/farm/src/plugins/rewrites.ts
+++ b/packages/farm/src/plugins/rewrites.ts
@@ -1,7 +1,13 @@
 import type { FarmPlugin, FarmPluginContext } from "../plugin";
 import type { RewriteConfig } from "../config";
 import type { FarmRequest, FarmResponse } from "../types";
-import { compileConfigRoutePattern, interpolateConfigRouteDestination } from "./route-pattern";
+import type { ResolvedFarmI18nConfig } from "../i18n/types";
+import {
+  compileConfigRoutePattern,
+  interpolateConfigRouteDestination,
+  localizeConfigRouteDestination,
+  resolveConfigRoutePathname,
+} from "./route-pattern";
 
 export const FARM_CONFIG_REWRITES_PLUGIN_NAME = "farm:rewrites";
 
@@ -10,6 +16,7 @@ export function createRewritesPlugin(
   {
     beforeRequest: overrideBeforeRequest,
     afterResponse: overrideAfterResponse,
+    i18n,
   }: {
     beforeRequest?: (
       req: FarmRequest,
@@ -21,6 +28,7 @@ export function createRewritesPlugin(
       res: FarmResponse,
       context: FarmPluginContext,
     ) => void | Promise<void>;
+    i18n?: ResolvedFarmI18nConfig;
   } = {},
 ): FarmPlugin {
   const compiledRewrites = rewrites.map((rewrite) => ({
@@ -37,15 +45,16 @@ export function createRewritesPlugin(
         await overrideBeforeRequest(req, res, context);
       }
       const url = new URL(req.url || "/", `http://${req.headers.host}`);
-      const pathname = url.pathname;
+      const routePath = resolveConfigRoutePathname(url.pathname, i18n);
+      const pathname = routePath.pathname;
 
       for (const { rewrite, pattern } of compiledRewrites) {
         const match = pathname.match(pattern.regex);
         if (match) {
-          const newPath = interpolateConfigRouteDestination(
-            rewrite.destination,
-            match,
-            pattern.tokens,
+          const newPath = localizeConfigRouteDestination(
+            interpolateConfigRouteDestination(rewrite.destination, match, pattern.tokens),
+            routePath.locale,
+            i18n,
           );
           const destinationUrl = new URL(newPath, url);
           if (!destinationUrl.search && url.search) {

--- a/packages/farm/src/plugins/route-pattern.ts
+++ b/packages/farm/src/plugins/route-pattern.ts
@@ -1,3 +1,6 @@
+import { localizeFarmHref, resolveFarmLocalePath } from "../i18n/routing";
+import type { ResolvedFarmI18nConfig } from "../i18n/types";
+
 type ConfigRoutePatternToken =
   | { kind: "param"; name: string; captureIndex: number }
   | { kind: "wildcard"; captureIndex: number };
@@ -5,6 +8,23 @@ type ConfigRoutePatternToken =
 export interface CompiledConfigRoutePattern {
   regex: RegExp;
   tokens: ConfigRoutePatternToken[];
+}
+
+export function resolveConfigRoutePathname(
+  pathname: string,
+  i18n?: ResolvedFarmI18nConfig,
+): { pathname: string; locale?: string } {
+  if (!i18n?.enabled) return { pathname };
+  const match = resolveFarmLocalePath(pathname, i18n);
+  return { pathname: match.pathname, locale: match.locale };
+}
+
+export function localizeConfigRouteDestination(
+  destination: string,
+  locale: string | undefined,
+  i18n?: ResolvedFarmI18nConfig,
+): string {
+  return locale && i18n?.enabled ? localizeFarmHref(destination, locale, i18n) : destination;
 }
 
 function escapeRegexCharacter(character: string): string {

--- a/packages/farm/src/server/create-server.ts
+++ b/packages/farm/src/server/create-server.ts
@@ -163,15 +163,15 @@ export async function createServer(config: FarmConfig = {}) {
       const rewrites = await resolvedConfig.rewrites();
 
       if (redirects.length > 0) {
-        pluginManager.addPlugin(createRedirectsPlugin(redirects));
+        pluginManager.addPlugin(createRedirectsPlugin(redirects, { i18n: resolvedConfig.i18n }));
       }
 
       if (headers.length > 0) {
-        pluginManager.addPlugin(createHeadersPlugin(headers));
+        pluginManager.addPlugin(createHeadersPlugin(headers, { i18n: resolvedConfig.i18n }));
       }
 
       if (rewrites.length > 0) {
-        pluginManager.addPlugin(createRewritesPlugin(rewrites));
+        pluginManager.addPlugin(createRewritesPlugin(rewrites, { i18n: resolvedConfig.i18n }));
       }
 
       // Compression is applied by production adapters. Its hook is a no-op in


### PR DESCRIPTION
## Problem

Locale-prefixed requests did not match `redirects()`, `rewrites()`, or `headers()` sources in development. Production strips the locale before matching and restores it on internal destinations.

## Root cause

The Node config-route plugins matched the public pathname directly and were not given resolved i18n configuration.

## Change

Share locale-aware config-route helpers, pass resolved i18n config to all three built-in plugins, match their unprefixed source paths, and localize internal redirect/rewrite destinations back to the active locale.

## Safety and compatibility

Apps without i18n are unchanged. External and protocol-relative destinations are never localized. Query strings, captures, header precedence, and default-locale clean URLs retain their existing behavior.

## Verification

- `pnpm --filter @farm.js/core test -- config-route-plugins.test.ts i18n.test.ts --reporter=dot` (25 tests)
- `pnpm --filter @farm.js/core type-check`
- focused oxlint on the six changed TypeScript files
- `git diff --check`

The locale-prefixed redirect, rewrite, and header assertions fail on `main`.

## Documentation and release

Documented locale-neutral config sources, localized internal destinations, and dev/production parity.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes config route matching for locale-prefixed requests in development so `redirects()`, `rewrites()`, and `headers()` behave like production, which strips the locale before matching.

- Passes resolved i18n config to all three built-in config-route plugins.
- Matches unprefixed source paths and localizes internal redirect/rewrite destinations back to the active locale.
- Apps without i18n, external/protocol-relative destinations, query strings, captures, and header precedence are unchanged.
- Adds tests for locale-prefixed redirect, rewrite, and header cases and documents the behavior.

<sup>Written for commit c2db61b92ce62f1413d8ad71456b8f036ca80555. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/646?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

