### PR TITLE
perf(react): compose queued fresh-key window replacements

### DIFF
--- a/docs/src/app/docs/renderers/react/page.md
+++ b/docs/src/app/docs/renderers/react/page.md
@@ -1072,7 +1072,10 @@ created, and every row keeps its identity, focus, and text selection. Multiple l
 same-key windows queued before one compiler flush compose into one atomic refresh. Disjoint and
 overlapping windows are supported; an overlapping position uses the last queued value. Farm
 validates the complete chain and prepares every touched key, binding value, and DOM target before
-applying any write. Reordered, partially reused, mixed, or duplicate keys take complete
+applying any write. Disjoint fixed-length queued windows may also mix same-key rows with globally
+new keys. Farm prepares every new descriptor, binding snapshot, and disconnected DOM row before
+the first write, then patches the same-key positions and swaps only the fresh-key positions.
+Untouched rows retain their identity. Reordered, partially reused, or duplicate keys take complete
 reconciliation before fast-path mutation. A single insertion
 creates one row at that position. A removal cleans up and removes only the known row or contiguous
 range while preserving every
@@ -1084,9 +1087,10 @@ The proof requires compiler-owned host rows whose render and key do not observe 
 Effectful position expressions, runtime values that are fractional or otherwise not safe integers,
 dynamic, zero, negative, or fractional removal counts, other `toSpliced()` shapes, block-bodied
 updaters, unsafe incoming expressions, custom methods, queued chains containing a structural
-window or unhinted intermediate update, duplicate, reordered, mixed, or partially reused incoming
-keys, collection-reading bindings, React-owned rows, nested host blocks, row conditionals,
-unrelated dirty dependencies, and failed runtime checks keep complete keyed reconciliation.
+window or unhinted intermediate update, an overlapping window whose final key changes, an existing
+key moved from another position, duplicate or partially reused incoming keys, collection-reading
+bindings, React-owned rows, nested host blocks, row conditionals, unrelated dirty dependencies, and
+failed runtime checks keep complete keyed reconciliation.
 Negative safe-integer positions and counts larger than the remaining suffix use the native
 method's normal clamping rules. No new option or component is required. Reports expose emitted
 sites as `keyedArrayPositionHints`. Batch insertion and exact-window replacement select
@@ -1977,7 +1981,10 @@ The package and example test suites verify more than generated code:
   atomic binding preparation, empty spreads, reordered and duplicate key fallback, latest delegated
   event data, focus, selection, hydration, Strict Mode, and queued structural fallback; another
   1,000 deterministic queued same-key window refreshes match normal React while disjoint and
-  overlapping targeted tests preserve row identity and perform no descriptor work;
+  overlapping targeted tests preserve row identity and perform no descriptor work; 1,000 queued
+  mixed fresh-key and same-key replacements also match React while targeted tests require only the
+  64 incoming descriptors, preserve every untouched row, prepare all new rows before mutation, and
+  cover overlapping-key-change and existing-key-move fallback;
 - 2,000 deterministic randomized reversals match normal React; a 4,096-row targeted test requires
   exactly `n - 1` connected DOM moves and zero key, descriptor, or binding reads, while fallback
   tests cover custom methods, queued updates, collection-reading rows, StrictMode hydration, and

--- a/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
+++ b/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
@@ -2,6 +2,31 @@
 
 Date: 2026-08-29
 
+## Queued fresh-key exact-window replacement follow-up — 2026-09-01
+
+The full bracketed production-browser run added a separate 10,000-row workload that queues two
+disjoint 32-row fresh-key replacements before one compiler flush. Both compiler builds emitted all
+11 expected `keyedArrayPositionHints` sites, preserved the four surrounding anchor rows,
+disconnected all 64 replaced rows, mounted 64 rows with new keys, produced zero owner executions,
+and passed every existing correctness, performance, persistence, and scalability gate without
+lowering a threshold.
+
+| Mode   | React median | Queued replacement | Compiled control | vs React | vs control |
+| ------ | -----------: | -----------------: | ---------------: | -------: | ---------: |
+| Static |     68.15 ms |           10.00 ms |         21.10 ms |    6.81x |      2.11x |
+| Hybrid |     68.15 ms |            9.80 ms |         21.10 ms |    6.95x |      2.15x |
+
+The independent gate requires at least 4x versus React and 1.5x versus the block-bodied compiled
+control in both modes. Package tests separately prove exact 64-row preparation work across 4,096
+rows, mixed same-key patches and fresh-key replacements, complete preparation before the first DOM
+replacement, existing-key, duplicate-key, overlapping-window, and failed-validation fallback,
+1,000 deterministic differential updates, controlled-input focus and selection, delegated events,
+hydration, Strict Mode, React 18/19 compatibility, and unmount cleanup. The isolated exact-window
+fixture has a 13,525 B gzip compiler premium, 167 B above the previous result and inside its
+unchanged 256 B allowance. Every unrelated runtime-size fixture remains byte-for-byte unchanged;
+the isolated full-runtime bundle still removes 81.8% when the compiler is disabled. The measured
+environment was Chrome 145.0.7632.6, Node.js 23.11.0, and Apple M1 macOS arm64.
+
 ## Queued same-key exact-window refresh follow-up — 2026-08-31
 
 The full bracketed production-browser run added a separate 10,000-row workload that queues two

--- a/examples/react-compiler-dashboard/README.md
+++ b/examples/react-compiler-dashboard/README.md
@@ -133,10 +133,19 @@ Queued same-key exact-window refresh has its own 10,000-row gate. One event queu
 32-row refreshes before the compiler flushes, and the benchmark requires all 64 DOM rows to retain
 identity while both changed labels and amounts reach the DOM. Static and hybrid modes must remain
 at least 4x faster than React and 1.5x faster than the equivalent block-bodied compiled control.
-Together with the existing position workloads, the compiler report must contain all nine dashboard
-`keyedArrayPositionHints`. Package tests compare 1,000 deterministic queued updates with React and
-cover disjoint windows, overlap with last-update-wins semantics, atomic preparation, structural and
-key-changing fallback, controlled-input selection, events, Strict Mode hydration, and cleanup.
+That workload contributes two of the dashboard `keyedArrayPositionHints`. Package tests compare
+1,000 deterministic queued updates with React and cover disjoint windows, overlap with
+last-update-wins semantics, atomic preparation, structural fallback, controlled-input selection,
+events, Strict Mode hydration, and cleanup.
+
+Queued fresh-key exact-window replacement has a separate 10,000-row gate. One event replaces two
+disjoint 32-row windows with globally new keys. The benchmark requires the 64 old rows to disconnect,
+all four surrounding anchors to retain identity, both new labels to reach the DOM, and zero compiled
+owner executions. Static and hybrid modes must remain at least 4x faster than React and 1.5x faster
+than the equivalent block-bodied compiled control. Together with the existing position workloads,
+the compiler report must contain all eleven dashboard `keyedArrayPositionHints`. Package tests also
+cover mixed same-key/fresh-key commits, atomic preparation, overlap and existing-key-move fallback,
+events, controlled-input selection, Strict Mode hydration, cleanup, and 1,000 differential updates.
 
 Native keyed-array reversal has a separate 10,000-row comparison. Concise `toReversed()` is
 measured against bracketed React and an equivalent block-bodied compiled control. Both compiler
@@ -215,6 +224,9 @@ The default JSON report is `/tmp/farm-react-dashboard-benchmark.json`; change it
 - The queued same-key control issues two concise native window replacements before one flush. Its
   block-bodied pair performs the same array and DOM-visible work through complete reconciliation,
   isolating the benefit of combining both validated windows into one targeted refresh.
+- The queued fresh-key control replaces two distant windows before one flush. Its block-bodied pair
+  creates the same 64 rows through complete reconciliation, isolating the saved untouched key,
+  descriptor, binding, and generic keyed-diff work.
 - The reverse control compares concise native `toReversed()` with an equivalent block-bodied
   compiled update. Both paths move the same keyed DOM rows; the hint isolates the saved key,
   descriptor, binding, and generic LIS work.

--- a/examples/react-compiler-dashboard/scripts/benchmark.mjs
+++ b/examples/react-compiler-dashboard/scripts/benchmark.mjs
@@ -143,7 +143,7 @@ async function inspectBuild(compilerMode) {
       "The compiler build did not emit a keyed-array prepend hint.",
     );
     assert(
-      compilerReport.summary.keyedArrayPositionHints >= 9,
+      compilerReport.summary.keyedArrayPositionHints >= 11,
       "The compiler build did not emit the keyed-array exact-position hints.",
     );
     assert(
@@ -764,6 +764,54 @@ async function measureTrial(browser, trial, compilerMode, port) {
             ),
         );
 
+        const measureQueuedWindowReplacement = async (action) => {
+          const rows = table.querySelectorAll("tbody tr");
+          const firstRemoved = [...rows].slice(2_500, 2_532);
+          const secondRemoved = [...rows].slice(7_500, 7_532);
+          const beforeFirst = rows[2_499];
+          const afterFirst = rows[2_532];
+          const beforeSecond = rows[7_499];
+          const afterSecond = rows[7_532];
+          const firstOldKey = firstRemoved[16]?.getAttribute("data-row-id");
+          const secondOldKey = secondRemoved[16]?.getAttribute("data-row-id");
+          await runTableAction(action, () => {
+            const nextRows = table.querySelectorAll("tbody tr");
+            return (
+              rowCount() === 10_000 &&
+              nextRows[2_499] === beforeFirst &&
+              nextRows[2_532] === afterFirst &&
+              nextRows[7_499] === beforeSecond &&
+              nextRows[7_532] === afterSecond &&
+              firstRemoved.every((row, offset) =>
+                Boolean(!row.isConnected && nextRows[2_500 + offset] !== row),
+              ) &&
+              secondRemoved.every((row, offset) =>
+                Boolean(!row.isConnected && nextRows[7_500 + offset] !== row),
+              ) &&
+              nextRows[2_516]?.getAttribute("data-row-id") !== firstOldKey &&
+              nextRows[7_516]?.getAttribute("data-row-id") !== secondOldKey &&
+              nextRows[2_516]?.children[1]?.textContent?.endsWith(" queued replacement") &&
+              nextRows[7_516]?.children[1]?.textContent?.endsWith(" queued replacement")
+            );
+          });
+        };
+
+        const tablePositionWindowReplaceQueued = await measureTable(
+          async () => ensure10000(),
+          async () =>
+            measureQueuedWindowReplacement(() =>
+              tableButton("table-position-window-replace-queued").click(),
+            ),
+        );
+
+        const tablePositionWindowReplaceQueuedSnapshot = await measureTable(
+          async () => ensure10000(),
+          async () =>
+            measureQueuedWindowReplacement(() =>
+              tableButton("table-position-window-replace-queued-snapshot").click(),
+            ),
+        );
+
         const tablePositionRemove = await measureTable(
           async () => ensure10000(),
           async () => {
@@ -1299,6 +1347,8 @@ async function measureTrial(browser, trial, compilerMode, port) {
             positionBatchInsert: tablePositionBatchInsert,
             positionBatchInsertSnapshot: tablePositionBatchInsertSnapshot,
             positionWindowReplace: tablePositionWindowReplace,
+            positionWindowReplaceQueued: tablePositionWindowReplaceQueued,
+            positionWindowReplaceQueuedSnapshot: tablePositionWindowReplaceQueuedSnapshot,
             positionWindowReplaceSnapshot: tablePositionWindowReplaceSnapshot,
             positionWindowRefresh: tablePositionWindowRefresh,
             positionWindowRefreshQueued: tablePositionWindowRefreshQueued,
@@ -1405,6 +1455,10 @@ async function measureTrial(browser, trial, compilerMode, port) {
         positionBatchInsert: timingSummary(result.table.positionBatchInsert),
         positionBatchInsertSnapshot: timingSummary(result.table.positionBatchInsertSnapshot),
         positionWindowReplace: timingSummary(result.table.positionWindowReplace),
+        positionWindowReplaceQueued: timingSummary(result.table.positionWindowReplaceQueued),
+        positionWindowReplaceQueuedSnapshot: timingSummary(
+          result.table.positionWindowReplaceQueuedSnapshot,
+        ),
         positionWindowReplaceSnapshot: timingSummary(
           result.table.positionWindowReplaceSnapshot,
         ),
@@ -1513,6 +1567,8 @@ const tableMetrics = [
   "positionBatchInsert",
   "positionBatchInsertSnapshot",
   "positionWindowReplace",
+  "positionWindowReplaceQueued",
+  "positionWindowReplaceQueuedSnapshot",
   "positionWindowReplaceSnapshot",
   "positionWindowRefresh",
   "positionWindowRefreshQueued",
@@ -1859,6 +1915,30 @@ const keyedQueuedWindowRefreshRegressions = keyedQueuedWindowRefreshResults.filt
     !Number.isFinite(snapshotSpeedup) ||
     snapshotSpeedup < keyedQueuedWindowRefreshMinimumSnapshotSpeedup,
 );
+// Two disjoint fixed-length fresh-key windows should create and swap only their incoming rows.
+// Protect the queued replacement path separately from both the single-window replacement and the
+// queued same-key refresh so neither can hide a regression to complete reconciliation.
+const keyedQueuedWindowReplaceMinimumSpeedup = 4;
+const keyedQueuedWindowReplaceMinimumSnapshotSpeedup = 1.5;
+const keyedQueuedWindowReplaceResults = ["static", "hybrid"].map((mode) => {
+  const replaceMedianMs = comparisons.table.positionWindowReplaceQueued[mode].medianMs;
+  const snapshotMedianMs =
+    comparisons.table.positionWindowReplaceQueuedSnapshot[mode].medianMs;
+  return {
+    mode,
+    replaceMedianMs,
+    snapshotMedianMs,
+    snapshotSpeedup: snapshotMedianMs / replaceMedianMs,
+    speedup: comparisons.table.positionWindowReplaceQueued[`${mode}VsBaseline`].speedup,
+  };
+});
+const keyedQueuedWindowReplaceRegressions = keyedQueuedWindowReplaceResults.filter(
+  ({ snapshotSpeedup, speedup }) =>
+    !Number.isFinite(speedup) ||
+    speedup < keyedQueuedWindowReplaceMinimumSpeedup ||
+    !Number.isFinite(snapshotSpeedup) ||
+    snapshotSpeedup < keyedQueuedWindowReplaceMinimumSnapshotSpeedup,
+);
 // Native toSpliced()/with() calls with event-local runtime positions expose one exact insertion,
 // removal, or replacement position. The hinted runtime should beat both React and an equivalent
 // block-bodied compiled control while preserving the same row identities around the changed position.
@@ -2135,6 +2215,7 @@ const passed =
   keyedWindowReplaceRegressions.length === 0 &&
   keyedWindowRefreshRegressions.length === 0 &&
   keyedQueuedWindowRefreshRegressions.length === 0 &&
+  keyedQueuedWindowReplaceRegressions.length === 0 &&
   keyedPositionRegressions.length === 0 &&
   keyedRangeRemovalRegressions.length === 0 &&
   keyedReorderRegressions.length === 0 &&
@@ -2215,6 +2296,13 @@ const report = {
     regressions: keyedQueuedWindowRefreshRegressions,
     results: keyedQueuedWindowRefreshResults,
     status: keyedQueuedWindowRefreshRegressions.length === 0 ? "PASS" : "FAIL",
+  },
+  keyedQueuedWindowReplaceHintGate: {
+    minimumSnapshotSpeedup: keyedQueuedWindowReplaceMinimumSnapshotSpeedup,
+    minimumSpeedup: keyedQueuedWindowReplaceMinimumSpeedup,
+    regressions: keyedQueuedWindowReplaceRegressions,
+    results: keyedQueuedWindowReplaceResults,
+    status: keyedQueuedWindowReplaceRegressions.length === 0 ? "PASS" : "FAIL",
   },
   keyedPositionHintGate: {
     insertMinimumSnapshotSpeedup: keyedPositionInsertMinimumSnapshotSpeedup,

--- a/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
+++ b/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
@@ -437,6 +437,56 @@ export function StandardTableBenchmark() {
           Refresh two queued same-key windows (snapshot control)
         </button>
         <button
+          data-action="table-position-window-replace-queued"
+          type="button"
+          onClick={() => {
+            const firstPosition = 2_500;
+            const secondPosition = 7_500;
+            const firstSeed = seed + 1;
+            const secondSeed = seed + 2;
+            const first = buildRows(32, firstSeed).map((row, offset) =>
+              offset === 16 ? { ...row, label: `${row.label} queued replacement` } : row,
+            );
+            const second = buildRows(32, secondSeed).map((row, offset) =>
+              offset === 16 ? { ...row, label: `${row.label} queued replacement` } : row,
+            );
+            setSeed(secondSeed);
+            setRows((current) => current.toSpliced(firstPosition, 32, ...first));
+            setRows((current) => current.toSpliced(secondPosition, 32, ...second));
+            setOperation("replace two queued fresh-key windows");
+            setRevision((value) => value + 1);
+          }}
+        >
+          Replace two queued fresh-key windows
+        </button>
+        <button
+          data-action="table-position-window-replace-queued-snapshot"
+          type="button"
+          onClick={() => {
+            const firstPosition = 2_500;
+            const secondPosition = 7_500;
+            const firstSeed = seed + 1;
+            const secondSeed = seed + 2;
+            const first = buildRows(32, firstSeed).map((row, offset) =>
+              offset === 16 ? { ...row, label: `${row.label} queued replacement` } : row,
+            );
+            const second = buildRows(32, secondSeed).map((row, offset) =>
+              offset === 16 ? { ...row, label: `${row.label} queued replacement` } : row,
+            );
+            setSeed(secondSeed);
+            setRows((current) => {
+              return current.toSpliced(firstPosition, 32, ...first);
+            });
+            setRows((current) => {
+              return current.toSpliced(secondPosition, 32, ...second);
+            });
+            setOperation("replace two queued fresh-key windows (snapshot control)");
+            setRevision((value) => value + 1);
+          }}
+        >
+          Replace two queued fresh-key windows (snapshot control)
+        </button>
+        <button
           data-action="table-position-remove"
           type="button"
           onClick={() => {

--- a/packages/farm-react/README.md
+++ b/packages/farm-react/README.md
@@ -333,16 +333,20 @@ updates the stored row objects used by later events. That path creates no descri
 and preserves row identity, focus, and selection. Multiple length-preserving same-key windows
 queued before one compiler flush compose into one atomic refresh. Disjoint and overlapping windows
 are both supported; overlapping positions use the last queued value. Farm validates the complete
-chain and prepares every touched key, binding value, and DOM target before applying any write. The
-runtime otherwise creates one inserted row,
+chain and prepares every touched key, binding value, and DOM target before applying any write.
+Disjoint fixed-length queued windows may also mix same-key refreshes with globally new keys. Farm
+prepares every new descriptor, binding snapshot, and disconnected DOM row first, then patches the
+same-key positions and swaps only the fresh-key positions. Untouched rows keep their identity and
+are not recreated. The runtime otherwise creates one inserted row,
 removes only the known row or range, or patches/replaces one row at that position without rereading
 every existing key, descriptor, and binding. Surviving rows keep their DOM identity. Index-aware or
 collection-reading rows, custom methods, position expressions with user calls or mutations,
 runtime positions that are not safe integers, dynamic, zero, negative, or fractional removal
 counts, other `toSpliced()` forms, block-bodied updaters, unsafe incoming expressions, queued
-chains containing a structural window or unhinted intermediate update, reordered or partially
-reused windows, duplicate keys, nested or React-owned rows, and failed checks use complete keyed
-reconciliation before the fast path mutates the DOM.
+chains containing a structural window or unhinted intermediate update, an overlapping window whose
+final key changes, existing keys moved from another position, partially reused windows, duplicate
+keys, nested or React-owned rows, and failed checks use complete keyed reconciliation before the
+fast path mutates the DOM.
 Reports expose the site count as `keyedArrayPositionHints`. Batch insertion and exact-window
 replacement use progressively separate optional runtime capabilities, so existing single-position
 and batch-only bundles do not retain window validation or replacement code.

--- a/packages/farm-react/RUNTIME_SIZE_RESULTS.json
+++ b/packages/farm-react/RUNTIME_SIZE_RESULTS.json
@@ -123,19 +123,19 @@
     },
     "keyedWindowPosition": {
       "compilerOff": {
-        "raw": 193010,
-        "gzip": 60119,
-        "brotli": 51744
+        "raw": 192991,
+        "gzip": 60124,
+        "brotli": 51793
       },
       "compilerOn": {
-        "raw": 241158,
-        "gzip": 73477,
-        "brotli": 63060
+        "raw": 241569,
+        "gzip": 73649,
+        "brotli": 63137
       },
       "compilerPremium": {
-        "raw": 48148,
-        "gzip": 13358,
-        "brotli": 11316
+        "raw": 48578,
+        "gzip": 13525,
+        "brotli": 11344
       }
     },
     "keyedReorder": {
@@ -213,18 +213,18 @@
         "brotli": 51666
       },
       "full": {
-        "raw": 284720,
-        "gzip": 80470,
-        "brotli": 68747
+        "raw": 285152,
+        "gzip": 80596,
+        "brotli": 68885
       },
       "coreOnly": {
         "raw": 204922,
         "gzip": 63685,
         "brotli": 54902
       },
-      "fullRuntimePremiumGzip": 20551,
+      "fullRuntimePremiumGzip": 20677,
       "coreRuntimePremiumGzip": 3766,
-      "gzipReductionPercent": 81.7
+      "gzipReductionPercent": 81.8
     }
   }
 }

--- a/packages/farm-react/RUNTIME_SIZE_RESULTS.md
+++ b/packages/farm-react/RUNTIME_SIZE_RESULTS.md
@@ -31,13 +31,13 @@ is enforced on every pull request instead of serving only as a manually recorded
 | Keyed rows with slice hints                       |          60,075 B |         72,335 B |         12,260 B |
 | Keyed rows with known-position hints              |          60,076 B |         72,361 B |         12,285 B |
 | Keyed rows with batch-position hints              |          60,091 B |         72,561 B |         12,470 B |
-| Keyed rows with exact-window hints                |          60,119 B |         73,477 B |         13,358 B |
+| Keyed rows with exact-window hints                |          60,124 B |         73,649 B |         13,525 B |
 | Keyed rows with reverse hints                     |          60,058 B |         72,164 B |         12,106 B |
 | Keyed rows with sort hints                        |          60,077 B |         72,219 B |         12,142 B |
 | Keyed rows with rolling-window hints              |          60,098 B |         73,082 B |         12,984 B |
 
-The isolated compatibility runtime contributes 20,551 B gzip over the React control. The
-compiler-selected core contributes 3,766 B, an **81.7% reduction**. This comparison uses the same
+The isolated compatibility runtime contributes 20,677 B gzip over the React control. The
+compiler-selected core contributes 3,766 B, an **81.8% reduction**. This comparison uses the same
 hand-authored compiled definition and changes only the runtime entry used to create it.
 
 The keyed fixture retains `FarmCompiledKeyedRows` plus compiler-emitted `identityTarget`,
@@ -48,11 +48,11 @@ reuses the filter removal capability. Position-only, batch-position, exact-windo
 rolling-window modules select separate hint runtimes only when the compiler emits those update
 shapes. Reverse and sort share the optional reorder capability; the direct and isolated core
 results remain byte-for-byte unchanged. Over the ordinary keyed fixture, position pays 1,092 B
-gzip, batch-position pays 1,277 B, exact-window pays 2,155 B, reverse pays 913 B, sort pays 949 B,
+gzip, batch-position pays 1,277 B, exact-window pays 2,332 B, reverse pays 913 B, sort pays 949 B,
 slice pays 1,067 B, and rolling-window pays 1,791 B. The exact-window figure includes fresh-key
-replacement, atomic same-key binding refresh, and queued same-key window composition. Unrelated
-bundles reject the optional position and reorder runtime markers, and the direct fixture rejects
-every structural runtime marker. The checked machine-readable result is
+replacement, atomic same-key binding refresh, queued same-key window composition, and disjoint
+queued fresh-key replacement. Unrelated bundles reject the optional position and reorder runtime
+markers, and the direct fixture rejects every structural runtime marker. The checked machine-readable result is
 [`RUNTIME_SIZE_RESULTS.json`](./RUNTIME_SIZE_RESULTS.json).
 
 ## Existing production benchmark audit

--- a/packages/farm-react/fixtures/runtime-size/keyed-window-position.tsx
+++ b/packages/farm-react/fixtures/runtime-size/keyed-window-position.tsx
@@ -43,8 +43,5 @@ export function WindowPositionTable({ first, second }: WindowPositionTableProps)
 }
 
 createRoot(document.body).render(
-  <WindowPositionTable
-    first={[{ id: 2, label: "Beta refreshed" }]}
-    second={[{ id: 3, label: "Gamma refreshed" }]}
-  />,
+  <WindowPositionTable first={[{ id: 5, label: "Epsilon" }]} second={[{ id: 6, label: "Phi" }]} />,
 );

--- a/packages/farm-react/scripts/test-react-version.mjs
+++ b/packages/farm-react/scripts/test-react-version.mjs
@@ -95,6 +95,7 @@ const testSource = String.raw`
   let removeCompatibilityRow = () => undefined;
   let replaceCompatibilityRows = () => undefined;
   let refreshCompatibilityRows = () => undefined;
+  let replaceQueuedCompatibilityRows = () => undefined;
   let sortCompatibilityRows = () => undefined;
   let reorderExecutions = 0;
   const ReorderRows = createCompiledComponent({
@@ -159,6 +160,26 @@ const testSource = String.raw`
             2,
             1,
             { id: "g", label: "Gamma refreshed", rank: 9 },
+          ),
+        );
+      };
+      replaceQueuedCompatibilityRows = () => {
+        state[0].set((previous) =>
+          createCompilerKeyedArrayWindowReplace(
+            previous,
+            previous.toSpliced,
+            1,
+            1,
+            { id: "h", label: "Eta", rank: 10 },
+          ),
+        );
+        state[0].set((previous) =>
+          createCompilerKeyedArrayWindowReplace(
+            previous,
+            previous.toSpliced,
+            2,
+            1,
+            { id: "i", label: "Iota", rank: 11 },
           ),
         );
       };
@@ -256,6 +277,14 @@ const testSource = String.raw`
   assert.equal(reorderContainer.querySelectorAll("li")[2], compatibilityGamma);
   assert.equal(reorderContainer.querySelectorAll("li")[1].textContent, "Phi refreshed");
   assert.equal(reorderContainer.querySelectorAll("li")[2].textContent, "Gamma refreshed");
+  assert.equal(reorderExecutions, 1);
+  replaceQueuedCompatibilityRows();
+  await Promise.resolve();
+  await Promise.resolve();
+  assert.equal(compatibilityPhi.isConnected, false);
+  assert.equal(compatibilityGamma.isConnected, false);
+  assert.equal(reorderContainer.querySelectorAll("li")[1].textContent, "Eta");
+  assert.equal(reorderContainer.querySelectorAll("li")[2].textContent, "Iota");
   assert.equal(reorderExecutions, 1);
   flushSync(() => reorderRoot.unmount());
 

--- a/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-window-replace-hints.test.tsx
+++ b/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-window-replace-hints.test.tsx
@@ -71,6 +71,7 @@ function rowDescriptor(item: Item): CompilerKeyedRowElement {
 function createWindowHarness(initialItems: Item[]) {
   const counters = { executions: 0, renders: 0, keys: 0, descriptors: 0, bindings: 0 };
   let bindingFailure: string | undefined;
+  let descriptorFailure: string | undefined;
   let bindingTrace: string[] | undefined;
   let replace: (position: number, deleteCount: number, items: readonly Item[]) => void = () =>
     undefined;
@@ -150,6 +151,12 @@ function createWindowHarness(initialItems: Item[]) {
               }}
               create={(item) => {
                 counters.descriptors += 1;
+                const row = item as Item;
+                bindingTrace?.push(`create:${row.id}`);
+                if (descriptorFailure === row.id) {
+                  descriptorFailure = undefined;
+                  throw new Error(`descriptor failure for ${row.id}`);
+                }
                 return rowDescriptor(item as Item);
               }}
               bindings={[
@@ -182,6 +189,9 @@ function createWindowHarness(initialItems: Item[]) {
     customReplace: (items: readonly Item[]) => customReplace(items),
     failNextBindingFor: (key: string) => {
       bindingFailure = key;
+    },
+    failNextDescriptorFor: (key: string) => {
+      descriptorFailure = key;
     },
     queueTwo: (first: readonly Item[], second: readonly Item[]) => queueTwo(first, second),
     queueRefreshes: (
@@ -505,6 +515,42 @@ describe("compiled keyed-array window replacement hints", () => {
     expect(container.textContent).toBe("Alpha queuedBeta queuedGamma queuedDelta queued");
   });
 
+  it("prepares every queued fresh row before replacing the first DOM row", async () => {
+    const harness = createWindowHarness([
+      { id: "a", label: "Alpha" },
+      { id: "b", label: "Beta" },
+      { id: "c", label: "Gamma" },
+      { id: "d", label: "Delta" },
+    ]);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Table />));
+    const trace: string[] = [];
+    const replaceWith = Element.prototype.replaceWith;
+    vi.spyOn(Element.prototype, "replaceWith").mockImplementation(function (
+      this: Element,
+      ...nodes: (Node | string)[]
+    ) {
+      trace.push(`replace:${this.getAttribute("data-key")}`);
+      replaceWith.call(this, ...nodes);
+    });
+    harness.traceBindings(trace);
+    harness.failNextDescriptorFor("f");
+
+    await act(async () => {
+      harness.queueRefreshes(0, [{ id: "e", label: "Epsilon" }], 2, [{ id: "f", label: "Phi" }]);
+      await flushCompilerUpdates();
+    });
+
+    const failedCreate = trace.indexOf("create:f");
+    const firstReplace = trace.findIndex((entry) => entry.startsWith("replace:"));
+    expect(failedCreate).toBeGreaterThanOrEqual(0);
+    expect(firstReplace === -1 || firstReplace > failedCreate).toBe(true);
+    expect(container.textContent).toBe("EpsilonBetaPhiDelta");
+  });
+
   it("supports empty incoming spreads, negative positions, and clamped delete counts", async () => {
     const harness = createWindowHarness([
       { id: "a", label: "Alpha" },
@@ -615,7 +661,60 @@ describe("compiled keyed-array window replacement hints", () => {
     expect(container.textContent).toBe("DeltaGamma twoIotaJotaAlpha");
   });
 
-  it("falls back atomically when any queued window changes row identity", async () => {
+  it("replaces disjoint queued fresh-key windows without scanning untouched rows", async () => {
+    const initialItems = Array.from(
+      { length: 4_096 },
+      (_, index): Item => ({ id: `row-${index}`, label: `Row ${index}` }),
+    );
+    const harness = createWindowHarness(initialItems);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Table />));
+    const rows = [...container.querySelectorAll("li")];
+    harness.counters.keys = 0;
+    harness.counters.descriptors = 0;
+    harness.counters.bindings = 0;
+
+    await act(async () => {
+      harness.queueRefreshes(
+        1_024,
+        Array.from(
+          { length: 32 },
+          (_, offset): Item => ({ id: `first-${offset}`, label: `First ${offset}` }),
+        ),
+        3_072,
+        Array.from(
+          { length: 32 },
+          (_, offset): Item => ({ id: `second-${offset}`, label: `Second ${offset}` }),
+        ),
+      );
+      await flushCompilerUpdates();
+    });
+
+    const nextRows = [...container.querySelectorAll("li")];
+    expect(nextRows).toHaveLength(4_096);
+    for (let index = 0; index < nextRows.length; index += 1) {
+      if ((index >= 1_024 && index < 1_056) || (index >= 3_072 && index < 3_104)) {
+        expect(nextRows[index]).not.toBe(rows[index]);
+        expect(rows[index]?.isConnected).toBe(false);
+      } else {
+        expect(nextRows[index]).toBe(rows[index]);
+      }
+    }
+    expect(nextRows[1_024]?.getAttribute("data-key")).toBe("first-0");
+    expect(nextRows[3_103]?.textContent).toBe("Second 31");
+    expect(harness.counters).toEqual({
+      executions: 1,
+      renders: 1,
+      keys: 64,
+      descriptors: 64,
+      bindings: 64,
+    });
+  });
+
+  it("patches and replaces disjoint rows in one queued commit", async () => {
     const harness = createWindowHarness([
       { id: "a", label: "Alpha" },
       { id: "b", label: "Beta" },
@@ -627,19 +726,75 @@ describe("compiled keyed-array window replacement hints", () => {
     const root = createRoot(container);
     roots.push(root);
     await act(async () => root.render(<harness.Table />));
+    const alpha = container.querySelector('[data-key="a"]');
     const beta = container.querySelector('[data-key="b"]');
+    const gamma = container.querySelector('[data-key="c"]');
     const delta = container.querySelector('[data-key="d"]');
     harness.counters.keys = 0;
+    harness.counters.descriptors = 0;
+    harness.counters.bindings = 0;
 
     await act(async () => {
-      harness.queueRefreshes(0, [{ id: "e", label: "Epsilon" }], 2, [{ id: "f", label: "Phi" }]);
+      harness.queueRefreshes(0, [{ id: "a", label: "Alpha refreshed" }], 2, [
+        { id: "f", label: "Phi" },
+      ]);
       await flushCompilerUpdates();
     });
 
-    expect(container.textContent).toBe("EpsilonBetaPhiDelta");
+    expect(container.textContent).toBe("Alpha refreshedBetaPhiDelta");
+    expect(container.querySelector('[data-key="a"]')).toBe(alpha);
     expect(container.querySelector('[data-key="b"]')).toBe(beta);
+    expect(container.querySelector('[data-key="c"]')).not.toBe(gamma);
+    expect(gamma?.isConnected).toBe(false);
     expect(container.querySelector('[data-key="d"]')).toBe(delta);
-    expect(harness.counters.keys).toBeGreaterThan(2);
+    expect(harness.counters).toEqual({
+      executions: 1,
+      renders: 1,
+      keys: 2,
+      descriptors: 1,
+      bindings: 2,
+    });
+  });
+
+  it("falls back for overlapping fresh keys and existing-key moves", async () => {
+    const initialItems = [
+      { id: "a", label: "Alpha" },
+      { id: "b", label: "Beta" },
+      { id: "c", label: "Gamma" },
+      { id: "d", label: "Delta" },
+    ];
+    for (const operation of ["overlap", "move"] as const) {
+      const harness = createWindowHarness(initialItems);
+      const container = document.createElement("div");
+      document.body.append(container);
+      const root = createRoot(container);
+      roots.push(root);
+      await act(async () => root.render(<harness.Table />));
+      harness.counters.keys = 0;
+      harness.counters.descriptors = 0;
+
+      await act(async () => {
+        if (operation === "overlap") {
+          harness.queueRefreshes(
+            0,
+            [
+              { id: "e", label: "Epsilon" },
+              { id: "f", label: "Phi" },
+            ],
+            1,
+            [{ id: "g", label: "Gamma replacement" }],
+          );
+        } else {
+          harness.queueRefreshes(0, [initialItems[2]], 2, [initialItems[0]]);
+        }
+        await flushCompilerUpdates();
+      });
+
+      expect(container.textContent).toBe(
+        operation === "overlap" ? "EpsilonGamma replacementGammaDelta" : "GammaBetaAlphaDelta",
+      );
+      expect(harness.counters.keys).toBeGreaterThan(operation === "overlap" ? 3 : 2);
+    }
   });
 
   it("falls back when an unhinted update breaks the queued chain", async () => {
@@ -692,9 +847,7 @@ describe("compiled keyed-array window replacement hints", () => {
             );
           refresh = () => {
             state[0].set((previous) =>
-              hintedWindowReplace(previous as Item[], 1, 1, [
-                { id: "e", label: "Epsilon refreshed" },
-              ]),
+              hintedWindowReplace(previous as Item[], 1, 1, [{ id: "f", label: "Phi refreshed" }]),
             );
             state[0].set((previous) =>
               hintedWindowReplace(previous as Item[], 2, 1, [
@@ -806,21 +959,22 @@ describe("compiled keyed-array window replacement hints", () => {
       refresh();
       await flushCompilerUpdates();
     });
-    expect(container.querySelector('[data-key="e"]')).toBe(epsilonRow);
+    expect(epsilonRow?.isConnected).toBe(false);
+    expect(container.querySelector('[data-key="f"]')).not.toBe(epsilonRow);
     expect(container.querySelector('[data-key="d"]')).toBe(deltaRow);
     expect(container.querySelector('[aria-label="Edit d"]')).toBe(input);
     expect(input.value).toBe("Delta refreshed");
-    expect(container.querySelector('[data-row-button="e"]')?.textContent).toBe(
-      "Select Epsilon refreshed",
+    expect(container.querySelector('[data-row-button="f"]')?.textContent).toBe(
+      "Select Phi refreshed",
     );
     expect(document.activeElement).toBe(input);
     expect([input.selectionStart, input.selectionEnd]).toEqual([1, 3]);
 
     await act(async () => {
-      (container.querySelector('[data-row-button="e"]') as HTMLButtonElement).click();
+      (container.querySelector('[data-row-button="f"]') as HTMLButtonElement).click();
       (container.querySelector('[data-row-button="d"]') as HTMLButtonElement).click();
     });
-    expect(calls).toEqual(["e:Epsilon refreshed:1", "d:Delta refreshed:2"]);
+    expect(calls).toEqual(["f:Phi refreshed:1", "d:Delta refreshed:2"]);
   });
 
   it("matches normal React through 1,000 deterministic bounded replacements", async () => {
@@ -979,6 +1133,96 @@ describe("compiled keyed-array window replacement hints", () => {
     expect(harness.counters.renders).toBe(1);
   }, 15_000);
 
+  it("matches React through 1,000 queued mixed fresh-key and same-key replacements", async () => {
+    const initialItems = Array.from(
+      { length: 64 },
+      (_, index): Item => ({ id: `row-${index}`, label: `Row ${index}` }),
+    );
+    const harness = createWindowHarness(initialItems);
+    let queueReact: (
+      firstPosition: number,
+      first: readonly Item[],
+      secondPosition: number,
+      second: readonly Item[],
+    ) => void = () => undefined;
+    function NormalTable() {
+      const [items, setItems] = useState(initialItems);
+      queueReact = (firstPosition, first, secondPosition, second) => {
+        setItems((previous) =>
+          (previous as WindowArray).toSpliced(firstPosition, first.length, ...first),
+        );
+        setItems((previous) =>
+          (previous as WindowArray).toSpliced(secondPosition, second.length, ...second),
+        );
+      };
+      return (
+        <ol>
+          {items.map((item) => (
+            <li data-key={item.id} key={item.id}>
+              {item.label}
+            </li>
+          ))}
+        </ol>
+      );
+    }
+    const compiledContainer = document.createElement("div");
+    const reactContainer = document.createElement("div");
+    document.body.append(compiledContainer, reactContainer);
+    const compiledRoot = createRoot(compiledContainer);
+    const reactRoot = createRoot(reactContainer);
+    roots.push(compiledRoot, reactRoot);
+    await act(async () => {
+      compiledRoot.render(<harness.Table />);
+      reactRoot.render(<NormalTable />);
+    });
+    harness.counters.keys = 0;
+    harness.counters.descriptors = 0;
+    harness.counters.bindings = 0;
+    let expected = initialItems;
+    let random = 0xa17e_39b5;
+    const nextRandom = () => {
+      random = (Math.imul(random, 1_103_515_245) + 12_345) >>> 0;
+      return random;
+    };
+
+    for (let step = 0; step < 500; step += 1) {
+      const firstPosition = nextRandom() % expected.length;
+      let secondPosition = nextRandom() % expected.length;
+      if (secondPosition === firstPosition) secondPosition = (secondPosition + 1) % expected.length;
+      const firstPrevious = expected[firstPosition];
+      const secondPrevious = expected[secondPosition];
+      const firstElement = compiledContainer.querySelector(`[data-key="${firstPrevious.id}"]`);
+      const secondElement = compiledContainer.querySelector(`[data-key="${secondPrevious.id}"]`);
+      const first: Item[] = [{ id: `fresh-${step}`, label: `Fresh ${step}` }];
+      const second: Item[] = [{ ...secondPrevious, label: `Refresh ${step}` }];
+      const afterFirst = (expected as WindowArray).toSpliced(firstPosition, 1, ...first);
+      expected = (afterFirst as WindowArray).toSpliced(secondPosition, 1, ...second);
+
+      await act(async () => {
+        harness.queueRefreshes(firstPosition, first, secondPosition, second);
+        queueReact(firstPosition, first, secondPosition, second);
+        await flushCompilerUpdates();
+      });
+
+      expect(compiledContainer.querySelector("ul")?.textContent).toBe(
+        reactContainer.querySelector("ol")?.textContent,
+      );
+      expect(firstElement?.isConnected).toBe(false);
+      expect(compiledContainer.querySelector(`[data-key="fresh-${step}"]`)).not.toBe(firstElement);
+      expect(compiledContainer.querySelector(`[data-key="${secondPrevious.id}"]`)).toBe(
+        secondElement,
+      );
+    }
+
+    expect(harness.counters).toEqual({
+      executions: 1,
+      renders: 1,
+      keys: 1_000,
+      descriptors: 500,
+      bindings: 1_000,
+    });
+  }, 15_000);
+
   it("hydrates in StrictMode and drops a queued replacement after unmount", async () => {
     const harness = createWindowHarness([
       { id: "a", label: "Alpha" },
@@ -1016,6 +1260,17 @@ describe("compiled keyed-array window replacement hints", () => {
     expect(container.textContent).toBe("AlphaBeta hydratedGamma hydrated");
     expect(container.querySelector('[data-key="b"]')).toBe(beta);
     expect(container.querySelector('[data-key="c"]')).toBe(gamma);
+    expect(recoverable).toEqual([]);
+
+    await act(async () => {
+      harness.queueRefreshes(1, [{ id: "e", label: "Epsilon hydrated" }], 2, [
+        { id: "f", label: "Phi hydrated" },
+      ]);
+      await flushCompilerUpdates();
+    });
+    expect(container.textContent).toBe("AlphaEpsilon hydratedPhi hydrated");
+    expect(beta?.isConnected).toBe(false);
+    expect(gamma?.isConnected).toBe(false);
     expect(recoverable).toEqual([]);
 
     roots.pop();

--- a/packages/farm-react/src/compiler-runtime.tsx
+++ b/packages/farm-react/src/compiler-runtime.tsx
@@ -4792,9 +4792,11 @@ function reconcileCompilerKeyedArrayWindowReplace(
   const previousInstances = [...instances.values()];
   if (updates.length > 1) {
     const touchedIndices = new Set<number>();
+    let overlaps = false;
     for (const update of updates) {
       if (update.insertedCount !== update.removedCount) return undefined;
       for (let index = update.position; index < update.position + update.removedCount; index += 1) {
+        overlaps ||= touchedIndices.has(index);
         touchedIndices.add(index);
       }
     }
@@ -4813,30 +4815,67 @@ function reconcileCompilerKeyedArrayWindowReplace(
       }
     }
 
+    const knownKeys = new Set(instances.keys());
+    const incomingKeys = new Set<string>();
+    let replacesRows = false;
     const prepared: Array<
       readonly [
+        index: number,
         instance: CompilerKeyedRowInstance,
         item: unknown,
-        updates: readonly CompilerPreparedKeyedRowBindingUpdate[],
+        updates: readonly CompilerPreparedKeyedRowBindingUpdate[] | undefined,
+        replacement: CompilerKeyedRowInstance | undefined,
       ]
     > = [];
     try {
       for (const index of [...touchedIndices].sort((left, right) => left - right)) {
         const instance = previousInstances[index];
         const item = finalValue[index];
-        if (keyedRowIdentity(props.rowKey(item, index)) !== instance.key) return undefined;
+        const key = keyedRowIdentity(props.rowKey(item, index));
+        if (key !== instance.key) {
+          // Overlapping fresh-key windows can introduce and then remove an
+          // intermediate identity. Keep that edit history on complete keyed
+          // reconciliation until it has a separate proof.
+          if (overlaps || knownKeys.has(key) || incomingKeys.has(key)) return undefined;
+          incomingKeys.add(key);
+          replacesRows = true;
+          const descriptor = props.create(item, index);
+          prepared.push([
+            index,
+            instance,
+            item,
+            undefined,
+            {
+              key,
+              element: createCompilerHostElement(root.ownerDocument, descriptor),
+              values: readKeyedRowBindingValues(props, item, index),
+              item,
+              index,
+              conditionalValues: EMPTY_KEYED_ROW_CONDITIONAL_VALUES,
+            },
+          ]);
+          continue;
+        }
         const bindingUpdates = prepareKeyedRowBindingUpdates(props, instance, item, index);
         if (!bindingUpdates) return undefined;
-        prepared.push([instance, item, bindingUpdates]);
+        prepared.push([index, instance, item, bindingUpdates, undefined]);
       }
     } catch {
       return undefined;
     }
-    for (const [instance, item, bindingUpdates] of prepared) {
-      applyPreparedKeyedRowBindingUpdates(props, instance, bindingUpdates);
-      instance.item = item;
+    for (const [index, instance, item, bindingUpdates, replacement] of prepared) {
+      if (replacement) {
+        instance.scope?.cleanup();
+        instance.element.replaceWith(replacement.element);
+        previousInstances[index] = replacement;
+      } else {
+        applyPreparedKeyedRowBindingUpdates(props, instance, bindingUpdates!);
+        instance.item = item;
+      }
     }
-    return instances;
+    return replacesRows
+      ? new Map(previousInstances.map((instance) => [instance.key, instance]))
+      : instances;
   }
 
   const update = updates[0];


### PR DESCRIPTION
## Problem

Two concise, length-preserving `toSpliced()` window replacements queued before one compiler flush already carry exact compiler metadata. The runtime fast path could compose the updates only when every touched row kept the same key. A globally new key in either disjoint window forced complete keyed reconciliation, rereading the whole collection and rebuilding generic reconciliation state even though only the known windows could change.

## Root cause

The multi-window branch required each final touched key to equal the existing row key and prepared only in-place binding updates. It had no proof or preparation phase for fresh keyed rows, so it could not safely replace them without falling back.

## Change

- Validate the complete queued chain and require every operation to preserve length.
- Prove untouched item identity and connected touched DOM before mutation.
- Patch same-key rows in place and prepare globally new keyed rows while disconnected.
- Replace only the proven fresh-key positions after every key, descriptor, binding snapshot, and target has been prepared.
- Add a 10,000-row production-browser workload for two disjoint 32-row fresh-key windows, plus a separate block-bodied compiled control.
- Document supported behavior, fallback boundaries, correctness coverage, benchmark results, and runtime-size impact.

## Safety and compatibility

The fast path remains limited to compiler-owned, index-independent host rows and disjoint fixed-length windows. Overlapping windows whose final key changes, existing-key moves, duplicate or partially reused keys, structural or unhinted queued updates, collection-reading bindings, nested blocks, React-owned rows, sparse or subclassed collections, custom methods, and failed validation use complete React-compatible keyed reconciliation before any fast-path DOM mutation.

All incoming rows are created off-DOM before the first write. Untouched rows preserve DOM identity. Same-key rows preserve focus and selection, delegated handlers observe the latest item, hydration and Strict Mode retain their existing behavior, and unmount cleanup remains intact. There is no public API or configuration change. The optional exact-window runtime remains compiler-selected and tree-shakeable.

## Verification

- `pnpm exec oxlint <changed JS/TS files>`
- `pnpm --filter @farm.js/react test -- --maxWorkers=2` — 68 files and 599 tests passed
- The two unchanged heavy suites that timed out under the initial high-concurrency local run passed in isolation without changing timeouts
- `pnpm --filter @farm.js/react test:compat` — React 18.3.1 and 19.2.8 passed from the packed package
- `pnpm --filter @farm.js/react test:runtime-size`
- `pnpm --filter @farm.js/react type-check`
- `pnpm --filter @farm.js/core build`
- `pnpm --filter farm-react-compiler-dashboard-example run type-check`
- `pnpm --filter farm-react-compiler-dashboard-example benchmark`
- `pnpm --dir docs exec farm generate --check`
- `pnpm docs:check-navigation`
- `pnpm docs:build`

The bracketed production benchmark passed every existing correctness, persistence, performance, and scalability gate. For two disjoint 32-row replacements in 10,000 rows:

| Mode | React median | Queued replacement | Compiled control | vs React | vs control |
| --- | ---: | ---: | ---: | ---: | ---: |
| Static | 68.15 ms | 10.00 ms | 21.10 ms | 6.81x | 2.11x |
| Hybrid | 68.15 ms | 9.80 ms | 21.10 ms | 6.95x | 2.15x |

Both compiler modes produced zero owner executions. The exact-window fixture premium is 13,525 B gzip, up 167 B and within the unchanged 256 B allowance. Unrelated fixtures are byte-for-byte unchanged, and disabling the compiler still removes 81.8% of the isolated full runtime. Benchmark environment: Chrome 145.0.7632.6, Node.js 23.11.0, Apple M1, macOS arm64.

## Documentation and release

Updated the React renderer docs, package README, benchmark README, checked benchmark results, runtime-size results, and the maintained compiler dashboard example. No template, version, release-flow, or configuration changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Composes queued disjoint window replacements that contain globally new keys, so the compiler runtime no longer falls back to full keyed reconciliation when a fresh key appears in either window.

**Behavior**
- Prepares every new descriptor, binding snapshot, and disconnected DOM row before the first write, then patches same-key rows in place and swaps only the fresh-key positions.
- Overlapping fresh-key windows, existing-key moves, and duplicate or partially reused keys still fall back to complete reconciliation atomically.
- No public API or configuration change; hydration, Strict Mode, focus, and selection behavior are unchanged.

**Benchmarks**
- A new 10,000-row gate with two disjoint 32-row fresh-key windows measures 6.81x (static) and 6.95x (hybrid) faster than React and 2.11x / 2.15x faster than the block-bodied compiled control.
- The exact-window gzip premium is now 13,525 B, up 167 B and within the unchanged 256 B allowance.
- Added 1,000 deterministic differential tests and a dashboard workload; the React 18 and 19 compat suites pass.

<sup>Written for commit cc7c2330f3066d3670830ac9e8049ba7a1f3f21f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/647?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

