### PR TITLE
fix(query): reject partial numeric values

### DIFF
--- a/docs/src/app/docs/query/page.md
+++ b/docs/src/app/docs/query/page.md
@@ -107,16 +107,16 @@ export default async function UserPage({ params }: PageProps) {
 
 ## Parser reference
 
-| Parser              | Reads                                              |
-| ------------------- | -------------------------------------------------- |
-| `asString`          | Plain strings.                                     |
-| `asInteger`         | Integer values for pagination and limits.          |
-| `asFloat`           | Decimal numbers.                                   |
-| `asBoolean`         | Boolean flags.                                     |
-| `asArrayOf(parser)` | Repeated values serialized through another parser. |
-| `asJson`            | Structured JSON encoded in the URL.                |
-| `asIsoDate`         | Date strings.                                      |
-| `asIsoDateTime`     | Date-time strings.                                 |
+| Parser              | Reads                                                    |
+| ------------------- | -------------------------------------------------------- |
+| `asString`          | Plain strings.                                           |
+| `asInteger`         | Complete, safe integer values for pagination and limits. |
+| `asFloat`           | Complete finite decimal or exponent values.              |
+| `asBoolean`         | Boolean flags.                                           |
+| `asArrayOf(parser)` | Repeated values serialized through another parser.       |
+| `asJson`            | Structured JSON encoded in the URL.                      |
+| `asIsoDate`         | Date strings.                                            |
+| `asIsoDateTime`     | Date-time strings.                                       |
 
 ## Production notes
 

--- a/packages/farm/src/__tests__/query-params.test.ts
+++ b/packages/farm/src/__tests__/query-params.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { asInteger, asString } from "../query/parsers";
+import { asFloat, asInteger, asString } from "../query/parsers";
 import { loadRouteParams, parseRouteParams } from "../query/params";
 
 describe("query route params parsing", () => {
@@ -36,5 +36,19 @@ describe("query route params parsing", () => {
         { strict: true },
       ),
     ).toThrow('Failed to parse route param "id"');
+  });
+
+  it("rejects partial and non-finite numeric values", () => {
+    expect(asInteger.parse("42")).toBe(42);
+    expect(asInteger.parse("42px")).toBeNull();
+    expect(asInteger.parse("1.5")).toBeNull();
+    expect(asInteger.parse("9007199254740992")).toBeNull();
+    expect(asInteger.withDefault!(7).parse("12items")).toBe(7);
+
+    expect(asFloat.parse("-1.25e2")).toBe(-125);
+    expect(asFloat.parse("1.5rem")).toBeNull();
+    expect(asFloat.parse("Infinity")).toBeNull();
+    expect(asFloat.parse(" 1.5 ")).toBeNull();
+    expect(asFloat.withDefault!(0.5).parse("4.2px")).toBe(0.5);
   });
 });

--- a/packages/farm/src/query/parsers.ts
+++ b/packages/farm/src/query/parsers.ts
@@ -10,6 +10,21 @@ export interface Parser<T> {
   withDefault?: (defaultValue: T) => Parser<T>;
 }
 
+const INTEGER_PATTERN = /^[+-]?\d+$/;
+const FLOAT_PATTERN = /^[+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?$/;
+
+function parseInteger(value: string): number | null {
+  if (!INTEGER_PATTERN.test(value)) return null;
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) ? parsed : null;
+}
+
+function parseFloatValue(value: string): number | null {
+  if (!FLOAT_PATTERN.test(value)) return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
 // String parser
 export const asString: Parser<string> = {
   parse: (value: string) => (value && value.trim()) || null,
@@ -22,32 +37,20 @@ export const asString: Parser<string> = {
 
 // Integer parser
 export const asInteger: Parser<number> = {
-  parse: (value: string) => {
-    const parsed = Number.parseInt(value, 10);
-    return isNaN(parsed) ? null : parsed;
-  },
+  parse: parseInteger,
   serialize: (value: number) => value.toString(),
   withDefault: (defaultValue: number) => ({
-    parse: (value: string) => {
-      const parsed = Number.parseInt(value, 10);
-      return isNaN(parsed) ? defaultValue : parsed;
-    },
+    parse: (value: string) => parseInteger(value) ?? defaultValue,
     serialize: (value: number) => value.toString(),
   }),
 };
 
 // Float parser
 export const asFloat: Parser<number> = {
-  parse: (value: string) => {
-    const parsed = Number.parseFloat(value);
-    return isNaN(parsed) ? null : parsed;
-  },
+  parse: parseFloatValue,
   serialize: (value: number) => value.toString(),
   withDefault: (defaultValue: number) => ({
-    parse: (value: string) => {
-      const parsed = Number.parseFloat(value);
-      return isNaN(parsed) ? defaultValue : parsed;
-    },
+    parse: (value: string) => parseFloatValue(value) ?? defaultValue,
     serialize: (value: number) => value.toString(),
   }),
 };


### PR DESCRIPTION
## Problem

`asInteger` and `asFloat` accepted a valid numeric prefix and ignored trailing input, so values such as `42px` or `1.5rem` silently became numbers. Non-finite and unsafe values could also pass.

## Root cause

The parsers delegated directly to `parseInt` and `parseFloat`, which intentionally allow partial strings.

## Change

Validate the complete numeric grammar first, require safe integers and finite floats, and route defaulted parsers through the same validation. Add coverage for suffixes, decimals-as-integers, unsafe integers, exponents, Infinity, whitespace, and defaults.

## Safety and compatibility

Valid signed integers and finite decimal/exponent values continue to parse. Invalid values now return `null` or the configured default instead of being truncated. Serialization and parser types are unchanged.

## Verification

- `pnpm --filter @farm.js/core test -- query-params.test.ts load-search-params.test.ts --reporter=dot` (18 tests)
- `pnpm --filter @farm.js/core type-check`
- `pnpm exec oxlint packages/farm/src/query/parsers.ts packages/farm/src/__tests__/query-params.test.ts`
- `git diff --check`

The partial-value assertions fail on `main` because prefixes are accepted.

## Documentation and release

Clarified complete safe-integer and finite float grammar in the parser reference.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `asInteger` and `asFloat` so they reject partial numeric values like `42px` or `1.5rem` instead of silently truncating them. Invalid and unsafe values now return `null` or the configured default, and the parser reference docs reflect the stricter grammar.

<sup>Written for commit dd8a8bd8964018143261b0f523384c8b7b051aa4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/648?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

