### PR TITLE
fix(query): bound pagination metadata

### DIFF
--- a/docs/src/app/docs/query/page.md
+++ b/docs/src/app/docs/query/page.md
@@ -105,6 +105,13 @@ export default async function UserPage({ params }: PageProps) {
 }
 ```
 
+## Pagination metadata
+
+`createPaginationMeta(searchParams, { totalItems, itemsPerPage })` returns a safe page, offset,
+limit, and next/previous flags for server-rendered lists. Missing, malformed, zero, negative, or
+unsafe `page` values fall back to page 1. `totalItems` must be a non-negative safe integer and
+`itemsPerPage` must be a positive safe integer; invalid configuration throws a `RangeError`.
+
 ## Parser reference
 
 | Parser              | Reads                                                    |

--- a/packages/farm/src/__tests__/load-search-params.test.ts
+++ b/packages/farm/src/__tests__/load-search-params.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { asArrayOf, asInteger, asString } from "../query/parsers";
-import { loadSearchParams } from "../query/server";
+import { createPaginationMeta, loadSearchParams } from "../query/server";
 
 describe("loadSearchParams", () => {
   it("keeps every value of an array-shaped prop", async () => {
@@ -66,5 +66,42 @@ describe("loadSearchParams", () => {
 
     expect(query.tag).toBeNull();
     expect(query.name).toBeNull();
+  });
+
+  it("keeps pagination metadata finite and non-negative", async () => {
+    await expect(
+      createPaginationMeta(Promise.resolve(new URLSearchParams("page=-3")), {
+        totalItems: 42,
+        itemsPerPage: 10,
+      }),
+    ).resolves.toMatchObject({
+      currentPage: 1,
+      totalPages: 5,
+      offset: 0,
+      limit: 10,
+      hasPreviousPage: false,
+      hasNextPage: true,
+    });
+
+    await expect(
+      createPaginationMeta(Promise.resolve(new URLSearchParams("page=not-a-number")), {
+        totalItems: 0,
+      }),
+    ).resolves.toMatchObject({
+      currentPage: 1,
+      totalPages: 0,
+      offset: 0,
+      hasPreviousPage: false,
+      hasNextPage: false,
+    });
+  });
+
+  it("rejects invalid pagination configuration", async () => {
+    await expect(createPaginationMeta(Promise.resolve({}), { totalItems: -1 })).rejects.toThrow(
+      "Pagination totalItems",
+    );
+    await expect(
+      createPaginationMeta(Promise.resolve({}), { totalItems: 10, itemsPerPage: 0 }),
+    ).rejects.toThrow("Pagination itemsPerPage");
   });
 });

--- a/packages/farm/src/query/server.ts
+++ b/packages/farm/src/query/server.ts
@@ -122,8 +122,15 @@ export async function createPaginationMeta(
   }
 
   const pageParam = options.pageParam || "page";
-  const itemsPerPage = options.itemsPerPage || 10;
-  const currentPage = Number.parseInt(urlParams.get(pageParam) || "1", 10);
+  const itemsPerPage = options.itemsPerPage ?? 10;
+  assertPaginationInteger(options.totalItems, "totalItems", true);
+  assertPaginationInteger(itemsPerPage, "itemsPerPage", false);
+
+  const requestedPage = parsePositivePaginationInteger(urlParams.get(pageParam));
+  const currentPage =
+    requestedPage !== null && Number.isSafeInteger((requestedPage - 1) * itemsPerPage)
+      ? requestedPage
+      : 1;
 
   const totalPages = Math.ceil(options.totalItems / itemsPerPage);
   const offset = (currentPage - 1) * itemsPerPage;
@@ -139,4 +146,19 @@ export async function createPaginationMeta(
     hasNextPage: currentPage < totalPages,
     hasPreviousPage: currentPage > 1,
   };
+}
+
+function parsePositivePaginationInteger(value: string | null): number | null {
+  if (!value || !/^[+]?[0-9]+$/.test(value)) return null;
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed >= 1 ? parsed : null;
+}
+
+function assertPaginationInteger(value: number, name: string, allowZero: boolean): void {
+  const minimum = allowZero ? 0 : 1;
+  if (!Number.isSafeInteger(value) || value < minimum) {
+    throw new RangeError(
+      `Pagination ${name} must be a safe integer greater than or equal to ${minimum}.`,
+    );
+  }
 }


### PR DESCRIPTION
## Problem

`createPaginationMeta` could emit `NaN`, negative offsets/pages, or nonsensical totals for malformed query input and invalid pagination configuration.

## Root cause

The helper used permissive `parseInt`, accepted negative values, and did not validate `totalItems` or `itemsPerPage`.

## Change

Accept only complete positive safe page integers, fall invalid requests back to page 1, guard offset arithmetic, and require safe non-negative totals plus positive page sizes. Add malformed, negative, empty-total, and invalid-config regressions.

## Safety and compatibility

Valid pagination output is unchanged. Query input remains untrusted and falls back safely; invalid developer configuration now fails early with an actionable `RangeError`. Pages beyond the available total remain representable for empty-result responses.

## Verification

- `pnpm --filter @farm.js/core test -- load-search-params.test.ts --reporter=dot` (10 tests)
- `pnpm --filter @farm.js/core type-check`
- `pnpm exec oxlint packages/farm/src/query/server.ts packages/farm/src/__tests__/load-search-params.test.ts`
- `git diff --check`

The malformed/negative assertions fail on `main` with NaN or negative metadata.

## Documentation and release

Documented pagination fallbacks, returned fields, and configuration constraints.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents `createPaginationMeta` from emitting `NaN`, negative offsets/pages, or nonsensical totals for malformed query input or invalid pagination configuration. Invalid `page` values now fall back to page 1; invalid configuration now throws a `RangeError`; valid output is unchanged.

**Details**
- Accepts only complete positive safe integers for `page`.
- Requires a non-negative safe `totalItems` and a positive safe `itemsPerPage`.
- Pages beyond the total remain representable for empty-result responses.
- Adds regression tests for malformed, negative, empty-total, and invalid-config cases and documents the fallback and constraints.

<sup>Written for commit 03f4390c11c9452719191dcdd48cee89aefc06b6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/649?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

