### PR TITLE
fix(query): validate ISO date parser formats

### DIFF
--- a/docs/src/app/docs/query/page.md
+++ b/docs/src/app/docs/query/page.md
@@ -114,16 +114,16 @@ unsafe `page` values fall back to page 1. `totalItems` must be a non-negative sa
 
 ## Parser reference
 
-| Parser              | Reads                                                    |
-| ------------------- | -------------------------------------------------------- |
-| `asString`          | Plain strings.                                           |
-| `asInteger`         | Complete, safe integer values for pagination and limits. |
-| `asFloat`           | Complete finite decimal or exponent values.              |
-| `asBoolean`         | Boolean flags.                                           |
-| `asArrayOf(parser)` | Repeated values serialized through another parser.       |
-| `asJson`            | Structured JSON encoded in the URL.                      |
-| `asIsoDate`         | Date strings.                                            |
-| `asIsoDateTime`     | Date-time strings.                                       |
+| Parser              | Reads                                                     |
+| ------------------- | --------------------------------------------------------- |
+| `asString`          | Plain strings.                                            |
+| `asInteger`         | Complete, safe integer values for pagination and limits.  |
+| `asFloat`           | Complete finite decimal or exponent values.               |
+| `asBoolean`         | Boolean flags.                                            |
+| `asArrayOf(parser)` | Repeated values serialized through another parser.        |
+| `asJson`            | Structured JSON encoded in the URL.                       |
+| `asIsoDate`         | Calendar-valid `YYYY-MM-DD` values.                       |
+| `asIsoDateTime`     | Calendar-valid ISO date-times with `Z` or numeric offset. |
 
 ## Production notes
 

--- a/packages/farm/src/__tests__/query-params.test.ts
+++ b/packages/farm/src/__tests__/query-params.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { asFloat, asInteger, asString } from "../query/parsers";
+import { asFloat, asInteger, asIsoDate, asIsoDateTime, asString } from "../query/parsers";
 import { loadRouteParams, parseRouteParams } from "../query/params";
 
 describe("query route params parsing", () => {
@@ -50,5 +50,24 @@ describe("query route params parsing", () => {
     expect(asFloat.parse("Infinity")).toBeNull();
     expect(asFloat.parse(" 1.5 ")).toBeNull();
     expect(asFloat.withDefault!(0.5).parse("4.2px")).toBe(0.5);
+  });
+
+  it("keeps ISO dates and date-times distinct and calendar-valid", () => {
+    expect(asIsoDate.parse("2024-02-29")?.toISOString()).toBe("2024-02-29T00:00:00.000Z");
+    expect(asIsoDate.serialize(new Date("2024-02-29T18:00:00.000Z"))).toBe("2024-02-29");
+    expect(asIsoDate.parse("2023-02-29")).toBeNull();
+    expect(asIsoDate.parse("2024-02-29T00:00:00Z")).toBeNull();
+    expect(asIsoDate.parse("February 29, 2024")).toBeNull();
+
+    expect(asIsoDateTime.parse("2024-02-29T23:30:00+02:00")?.toISOString()).toBe(
+      "2024-02-29T21:30:00.000Z",
+    );
+    expect(asIsoDateTime.parse("2024-02-30T12:00:00Z")).toBeNull();
+    expect(asIsoDateTime.parse("2024-02-29T12:00:00")).toBeNull();
+    expect(asIsoDateTime.parse("2024-02-29")).toBeNull();
+    expect(asIsoDateTime.parse("2024-02-29T24:00:00Z")).toBeNull();
+
+    const fallback = new Date("2000-01-01T00:00:00.000Z");
+    expect(asIsoDateTime.withDefault!(fallback).parse("tomorrow")).toBe(fallback);
   });
 });

--- a/packages/farm/src/query/parsers.ts
+++ b/packages/farm/src/query/parsers.ts
@@ -12,6 +12,9 @@ export interface Parser<T> {
 
 const INTEGER_PATTERN = /^[+-]?\d+$/;
 const FLOAT_PATTERN = /^[+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?$/;
+const ISO_DATE_PATTERN = /^(\d{4})-(\d{2})-(\d{2})$/;
+const ISO_DATE_TIME_PATTERN =
+  /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.\d+)?(Z|[+-]\d{2}:\d{2})$/;
 
 function parseInteger(value: string): number | null {
   if (!INTEGER_PATTERN.test(value)) return null;
@@ -23,6 +26,52 @@ function parseFloatValue(value: string): number | null {
   if (!FLOAT_PATTERN.test(value)) return null;
   const parsed = Number(value);
   return Number.isFinite(parsed) ? parsed : null;
+}
+
+function isValidCalendarDate(year: number, month: number, day: number): boolean {
+  if (month < 1 || month > 12 || day < 1) return false;
+  const leapYear = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+  const daysInMonth = [31, leapYear ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+  return day <= daysInMonth[month - 1];
+}
+
+function parseIsoDate(value: string): Date | null {
+  const match = value.match(ISO_DATE_PATTERN);
+  if (!match) return null;
+
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  if (!isValidCalendarDate(year, month, day)) return null;
+
+  const date = new Date(0);
+  date.setUTCHours(0, 0, 0, 0);
+  date.setUTCFullYear(year, month - 1, day);
+  return date;
+}
+
+function parseIsoDateTime(value: string): Date | null {
+  const match = value.match(ISO_DATE_TIME_PATTERN);
+  if (!match) return null;
+
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const hour = Number(match[4]);
+  const minute = Number(match[5]);
+  const second = Number(match[6]);
+  const timezone = match[7];
+  if (!isValidCalendarDate(year, month, day) || hour > 23 || minute > 59 || second > 59) {
+    return null;
+  }
+
+  if (timezone !== "Z") {
+    const [offsetHour, offsetMinute] = timezone.slice(1).split(":").map(Number);
+    if (offsetHour > 23 || offsetMinute > 59) return null;
+  }
+
+  const date = new Date(value);
+  return Number.isFinite(date.getTime()) ? date : null;
 }
 
 // String parser
@@ -125,32 +174,20 @@ export function asJson<T>(): Parser<T> {
 
 // ISO Date parser
 export const asIsoDate: Parser<Date> = {
-  parse: (value: string) => {
-    const date = new Date(value);
-    return isNaN(date.getTime()) ? null : date;
-  },
-  serialize: (value: Date) => value.toISOString(),
+  parse: parseIsoDate,
+  serialize: (value: Date) => value.toISOString().slice(0, 10),
   withDefault: (defaultValue: Date) => ({
-    parse: (value: string) => {
-      const date = new Date(value);
-      return isNaN(date.getTime()) ? defaultValue : date;
-    },
-    serialize: (value: Date) => value.toISOString(),
+    parse: (value: string) => parseIsoDate(value) ?? defaultValue,
+    serialize: (value: Date) => value.toISOString().slice(0, 10),
   }),
 };
 
 // ISO DateTime parser
 export const asIsoDateTime: Parser<Date> = {
-  parse: (value: string) => {
-    const date = new Date(value);
-    return isNaN(date.getTime()) ? null : date;
-  },
+  parse: parseIsoDateTime,
   serialize: (value: Date) => value.toISOString(),
   withDefault: (defaultValue: Date) => ({
-    parse: (value: string) => {
-      const date = new Date(value);
-      return isNaN(date.getTime()) ? defaultValue : date;
-    },
+    parse: (value: string) => parseIsoDateTime(value) ?? defaultValue,
     serialize: (value: Date) => value.toISOString(),
   }),
 };


### PR DESCRIPTION
## Problem

The ISO parsers delegated to JavaScript `Date`, accepting prose, calendar overflows, and date/time shapes interchangeably. `asIsoDate` also serialized a full timestamp instead of its documented date-only shape.

## Root cause

There was no format or calendar validation before constructing a Date. Both parsers shared the same permissive implementation.

## Change

Require calendar-valid `YYYY-MM-DD` for `asIsoDate`; require a full ISO date-time with seconds and `Z`/numeric offset for `asIsoDateTime`; validate time and offset ranges; and serialize date-only values as `YYYY-MM-DD`. Defaulted parsers share the same validation.

## Safety and compatibility

Canonical ISO inputs continue to produce Date objects. Ambiguous local times, prose, overflow dates, and cross-shape inputs now return `null` or the configured default. Date-time serialization remains `toISOString()`.

## Verification

- `pnpm --filter @farm.js/core test -- query-params.test.ts --reporter=dot` (11 tests across matched files)
- `pnpm --filter @farm.js/core type-check`
- `pnpm exec oxlint packages/farm/src/query/parsers.ts packages/farm/src/__tests__/query-params.test.ts`
- `git diff --check`

The invalid calendar/prose/shape assertions fail on `main`, and date-only serialization includes a time.

## Documentation and release

Clarified exact date and date-time formats in the parser reference.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightens the ISO date and date-time query parsers so they no longer accept prose, calendar overflows, or mismatched date/date-time shapes. `asIsoDate` now requires a calendar-valid `YYYY-MM-DD` value and serializes as date-only; `asIsoDateTime` requires a full ISO date-time with seconds and a `Z` or numeric offset.

**Bug Fixes**

- Invalid values now return `null` or the configured default instead of a permissive `Date`.
- Date-time serialization behavior is unchanged (`toISOString()`).
- Parser reference docs now list the exact accepted formats.

<sup>Written for commit 287b1ffdb915fa54ba69464a432c1568ba61aea2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/650?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

