### PR TITLE
fix(i18n): validate Accept-Language quality

### DIFF
--- a/docs/src/app/docs/internationalization/page.md
+++ b/docs/src/app/docs/internationalization/page.md
@@ -183,6 +183,9 @@ For a request without an explicit locale prefix, Farm resolves the locale in thi
 4. `defaultLocale`.
 
 Regional values match a supported base language, so `fr-CA` can resolve to `fr`. Explicit URLs always win because they are canonical, shareable, and safe to cache.
+`Accept-Language` quality values must be between 0 and 1 with at most three decimal places. Farm
+honors `q=0` exclusions when expanding a positive `*` wildcard; an invalid quality is treated as
+unacceptable rather than outranking a valid language.
 
 Change the fallback signals with `detection`:
 

--- a/packages/farm/src/__tests__/i18n.test.ts
+++ b/packages/farm/src/__tests__/i18n.test.ts
@@ -146,6 +146,35 @@ describe("Farm locale request signals", () => {
     });
   });
 
+  it("validates Accept-Language quality values and honors wildcard exclusions", () => {
+    expect(
+      resolveFarmLocaleRequest(
+        new Request("https://farm.test/", {
+          headers: { "accept-language": "fr;q=2,am;q=0.8" },
+        }),
+        config,
+      ),
+    ).toMatchObject({ locale: "am", source: "accept-language", redirect: "/am" });
+
+    expect(
+      resolveFarmLocaleRequest(
+        new Request("https://farm.test/", {
+          headers: { "accept-language": "*;q=0.8,en;q=0" },
+        }),
+        config,
+      ),
+    ).toMatchObject({ locale: "am", source: "accept-language", redirect: "/am" });
+
+    expect(
+      resolveFarmLocaleRequest(
+        new Request("https://farm.test/", {
+          headers: { "accept-language": "*;q=0" },
+        }),
+        config,
+      ),
+    ).toMatchObject({ locale: "en", source: "default" });
+  });
+
   it("ignores malformed cookie names instead of failing the request", () => {
     expect(
       resolveFarmLocaleRequest(

--- a/packages/farm/src/i18n/resolver.ts
+++ b/packages/farm/src/i18n/resolver.ts
@@ -133,20 +133,43 @@ function resolveAcceptLanguage(
   locales: readonly string[],
 ): string | undefined {
   if (!header) return undefined;
-  const candidates = header
-    .split(",")
-    .map((entry, index) => {
-      const [locale = "", ...parameters] = entry.trim().split(";");
-      const qualityValue = parameters
-        .map((parameter) => parameter.trim())
-        .find((parameter) => parameter.startsWith("q="));
-      const quality = qualityValue ? Number(qualityValue.slice(2)) : 1;
-      return { locale, quality: Number.isFinite(quality) ? quality : 0, index };
-    })
-    .filter((candidate) => candidate.locale && candidate.locale !== "*" && candidate.quality > 0)
+
+  const byRange = new Map<string, { locale: string; quality: number; index: number }>();
+  for (const [index, entry] of header.split(",").entries()) {
+    const [rawLocale = "", ...parameters] = entry.trim().split(";");
+    const locale = rawLocale.trim();
+    if (!locale) continue;
+
+    let quality = 1;
+    for (const parameter of parameters) {
+      const [rawName, rawValue] = parameter.trim().split("=", 2);
+      if (rawName?.trim().toLowerCase() !== "q") continue;
+      const value = rawValue?.trim() ?? "";
+      quality = /^(?:0(?:\.\d{0,3})?|1(?:\.0{0,3})?)$/.test(value) ? Number(value) : 0;
+    }
+
+    const key = locale.toLowerCase();
+    const previous = byRange.get(key);
+    if (!previous || quality > previous.quality) {
+      byRange.set(key, { locale, quality, index: previous?.index ?? index });
+    }
+  }
+
+  const candidates = [...byRange.values()]
+    .filter((candidate) => candidate.quality > 0)
     .sort((a, b) => b.quality - a.quality || a.index - b.index);
+  const explicitRanges = [...byRange.values()].filter(({ locale }) => locale !== "*");
 
   for (const candidate of candidates) {
+    if (candidate.locale === "*") {
+      const wildcardMatch = locales.find(
+        (locale) =>
+          !explicitRanges.some((range) => matchFarmLocale(range.locale, [locale]) !== undefined),
+      );
+      if (wildcardMatch) return wildcardMatch;
+      continue;
+    }
+
     const locale = matchFarmLocale(candidate.locale, locales);
     if (locale) return locale;
   }


### PR DESCRIPTION
## Problem

Accept-Language detection accepted out-of-range quality values such as `q=2` and ignored positive wildcards, including exclusions such as `*;q=0.8,en;q=0`.

## Root cause

The parser used unrestricted `Number()` conversion and dropped every wildcard candidate before negotiation.

## Change

Parse RFC-style q-values in the 0–1 range with at most three decimals, consolidate duplicate ranges, order valid candidates deterministically, and expand positive wildcards only to supported locales without an explicit range. Add invalid-q, wildcard-exclusion, and wildcard-zero regressions.

## Safety and compatibility

Existing exact, weighted, and regional-to-base matching remains. Invalid qualities are treated as unacceptable; `q=0` never selects a locale; a positive wildcard can now supply a supported fallback without overriding explicit ranges.

## Verification

- `pnpm --filter @farm.js/core test -- i18n.test.ts --reporter=dot` (19 tests)
- `pnpm --filter @farm.js/core type-check`
- `pnpm exec oxlint packages/farm/src/i18n/resolver.ts packages/farm/src/__tests__/i18n.test.ts`
- `git diff --check`

The invalid-q and positive-wildcard assertions fail on `main`.

## Documentation and release

Documented accepted quality syntax and wildcard exclusion behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Accept-Language quality handling so out-of-range q values (e.g., `q=2`) no longer win, and positive wildcards are expanded to supported locales instead of being dropped. Invalid qualities are treated as unacceptable, `q=0` never selects a locale, and duplicate ranges are consolidated. Adds regressions for invalid q, wildcard exclusion, and wildcard zero, and documents the accepted syntax.

<sup>Written for commit 2f2874b22092a2298c3fa9b324f75b0f2da0400b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/651?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

