### PR TITLE
fix(config): reject invalid redirect statuses

### DIFF
--- a/docs/src/app/docs/configuration/page.md
+++ b/docs/src/app/docs/configuration/page.md
@@ -581,6 +581,11 @@ export default defineConfig({
 });
 ```
 
+Redirect `statusCode` accepts only HTTP redirect statuses `301`, `302`, `303`, `307`, or `308`.
+Use `permanent: true` for the default permanent `308`; otherwise Farm defaults to temporary `307`.
+Invalid values fail config resolution instead of producing a non-redirect response with a Location
+header.
+
 Use `routeRules` when behavior belongs to a URL pattern instead of one page file. Rules are normalized into Farm redirects/headers and passed to Nitro route rules for production adapters.
 
 ```ts

--- a/packages/farm/src/__tests__/config-route-plugins.test.ts
+++ b/packages/farm/src/__tests__/config-route-plugins.test.ts
@@ -42,6 +42,12 @@ describe("config route plugins", () => {
     { root: "/tmp/farm-config-route-i18n", mode: "development" },
   );
 
+  it("rejects invalid redirect statuses when the plugin is used directly", () => {
+    expect(() =>
+      createRedirectsPlugin([{ source: "/old", destination: "/new", statusCode: 201 as any }]),
+    ).toThrow('Redirect "/old" statusCode must be one of 301, 302, 303, 307, or 308');
+  });
+
   it("keeps named and plain redirect captures in source order", async () => {
     const plugin = createRedirectsPlugin([
       {

--- a/packages/farm/src/__tests__/config.test.ts
+++ b/packages/farm/src/__tests__/config.test.ts
@@ -712,6 +712,40 @@ describe("resolveConfig", () => {
     });
   });
 
+  it("rejects non-redirect status codes in configured redirects", async () => {
+    await expect(
+      resolveConfig(
+        {
+          redirects: [{ source: "/old", destination: "/new", statusCode: 200 as any }],
+        },
+        "production",
+      ),
+    ).rejects.toThrow("redirects[0].statusCode must be one of 301, 302, 303, 307, or 308");
+
+    await expect(
+      resolveConfig(
+        {
+          routeRules: {
+            "/old": { redirect: { to: "/new", statusCode: 404 as any } },
+          },
+        },
+        "production",
+      ),
+    ).rejects.toThrow(
+      'Route rule "/old" redirect.statusCode must be one of 301, 302, 303, 307, or 308',
+    );
+
+    const config = await resolveConfig(
+      {
+        redirects: [{ source: "/see-other", destination: "/next", statusCode: 303 }],
+      },
+      "production",
+    );
+    expect(config.redirects()).toEqual([
+      { source: "/see-other", destination: "/next", statusCode: 303 },
+    ]);
+  });
+
   it("applies security.csp after ordinary and route-rule headers", async () => {
     const config = await resolveConfig(
       {

--- a/packages/farm/src/config.ts
+++ b/packages/farm/src/config.ts
@@ -83,6 +83,7 @@ import {
   type ResolvedFarmCspConfig,
   type ResolvedFarmSecurityConfig,
 } from "./security";
+import { isFarmRedirectStatus } from "./navigation-errors";
 import { resolveFarmThemeConfig } from "./theme/config";
 import type { ResolvedFarmThemeConfig } from "./theme/types";
 import { isReactRenderer, resolveFarmRenderer } from "./renderer";
@@ -204,7 +205,7 @@ export interface RedirectConfig {
   source: string;
   destination: string;
   permanent?: boolean;
-  statusCode?: number;
+  statusCode?: import("./navigation-errors").FarmRedirectStatus;
 }
 
 export interface HeaderConfig {
@@ -851,6 +852,17 @@ export async function resolveDocsConfig(
   };
 }
 
+function validateRedirectConfigs(redirects: RedirectConfig[], field: string): RedirectConfig[] {
+  for (const [index, redirect] of redirects.entries()) {
+    if (redirect.statusCode !== undefined && !isFarmRedirectStatus(redirect.statusCode)) {
+      throw new RangeError(
+        `${field}[${index}].statusCode must be one of 301, 302, 303, 307, or 308.`,
+      );
+    }
+  }
+  return redirects;
+}
+
 export async function resolveConfig(
   userConfig: FarmUserConfig,
   mode: "development" | "production",
@@ -882,10 +894,12 @@ export async function resolveConfig(
     });
   }
 
-  const redirects =
+  const redirects = validateRedirectConfigs(
     typeof userConfig.redirects === "function"
       ? await userConfig.redirects()
-      : userConfig.redirects || [];
+      : userConfig.redirects || [],
+    "redirects",
+  );
 
   const rewrites =
     typeof userConfig.rewrites === "function"

--- a/packages/farm/src/navigation-errors.ts
+++ b/packages/farm/src/navigation-errors.ts
@@ -48,7 +48,7 @@ export function getFarmRedirectError(error: unknown): FarmRedirectSignal | null 
   ) {
     const [, status, ...urlParts] = candidate.digest.split(";");
     const parsedStatus = Number(status);
-    if (isRedirectStatus(parsedStatus)) {
+    if (isFarmRedirectStatus(parsedStatus)) {
       return {
         status: parsedStatus,
         url: urlParts.join(";"),
@@ -72,6 +72,6 @@ function createRedirectError(url: string, status: FarmRedirectStatus): FarmNavig
   return error;
 }
 
-function isRedirectStatus(status: number): status is FarmRedirectStatus {
+export function isFarmRedirectStatus(status: unknown): status is FarmRedirectStatus {
   return status === 301 || status === 302 || status === 303 || status === 307 || status === 308;
 }

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -5164,7 +5164,7 @@ function matchRedirectRoute(pathname, locale) {
         locale && destination.startsWith("/") && !destination.startsWith("//")
           ? localizeFarmHref(destination, locale, farmI18nConfig)
           : destination,
-      statusCode: redirect.statusCode || (redirect.permanent ? 308 : 307),
+      statusCode: redirect.statusCode ?? (redirect.permanent ? 308 : 307),
     };
   }
   return null;

--- a/packages/farm/src/plugins/redirects.ts
+++ b/packages/farm/src/plugins/redirects.ts
@@ -2,6 +2,7 @@ import type { FarmPlugin, FarmPluginContext } from "../plugin";
 import type { RedirectConfig } from "../config";
 import type { FarmRequest, FarmResponse } from "../types";
 import type { ResolvedFarmI18nConfig } from "../i18n/types";
+import { isFarmRedirectStatus } from "../navigation-errors";
 import {
   compileConfigRoutePattern,
   interpolateConfigRouteDestination,
@@ -29,6 +30,13 @@ export function createRedirectsPlugin(
     i18n?: ResolvedFarmI18nConfig;
   } = {},
 ): FarmPlugin {
+  for (const redirect of redirects) {
+    if (redirect.statusCode !== undefined && !isFarmRedirectStatus(redirect.statusCode)) {
+      throw new RangeError(
+        `Redirect "${redirect.source}" statusCode must be one of 301, 302, 303, 307, or 308.`,
+      );
+    }
+  }
   const compiledRedirects = redirects.map((redirect) => ({
     redirect,
     pattern: compileConfigRoutePattern(redirect.source),
@@ -54,7 +62,7 @@ export function createRedirectsPlugin(
             i18n,
           );
 
-          const statusCode = redirect.statusCode || (redirect.permanent ? 308 : 307);
+          const statusCode = redirect.statusCode ?? (redirect.permanent ? 308 : 307);
 
           res.writeHead(statusCode, {
             Location: destination,

--- a/packages/farm/src/route-rules.ts
+++ b/packages/farm/src/route-rules.ts
@@ -1,4 +1,5 @@
 import type { HeaderConfig, RedirectConfig } from "./config";
+import { isFarmRedirectStatus, type FarmRedirectStatus } from "./navigation-errors";
 import type { FarmRouteRuntimeConfig } from "./route-runtime";
 import { normalizeFarmRouteRuntimeConfig } from "./route-runtime";
 
@@ -8,7 +9,7 @@ export type FarmRouteRuleRedirect =
   | string
   | {
       to: string;
-      statusCode?: number;
+      statusCode?: FarmRedirectStatus;
       permanent?: boolean;
     };
 
@@ -40,6 +41,15 @@ export function normalizeRouteRules(routeRules: FarmRouteRules | undefined): Far
   for (const [source, rule] of Object.entries(routeRules)) {
     if (!source || !rule) continue;
     const normalizedSource = normalizeRuleSource(source);
+    if (
+      typeof rule.redirect === "object" &&
+      rule.redirect.statusCode !== undefined &&
+      !isFarmRedirectStatus(rule.redirect.statusCode)
+    ) {
+      throw new RangeError(
+        `Route rule "${normalizedSource}" redirect.statusCode must be one of 301, 302, 303, 307, or 308.`,
+      );
+    }
     normalized[normalizedSource] = {
       ...rule,
       ...normalizeFarmRouteRuntimeConfig(rule, `Route rule "${normalizedSource}"`),


### PR DESCRIPTION
## Problem

Redirect config accepted arbitrary numbers, including successful and error statuses, then emitted them with a `Location` header as if they were redirects.

## Root cause

`RedirectConfig` and route-rule redirect statuses were typed as `number` and were never validated at config or direct plugin boundaries.

## Change

Restrict the public types to 301, 302, 303, 307, or 308; validate top-level config, route rules, and direct redirect-plugin construction; expose one shared status predicate; and use nullish fallback after validation in dev and production.

## Safety and compatibility

All standard redirect statuses remain supported. `permanent: true` still defaults to 308 and other redirects default to 307; an explicit valid status wins. Invalid JavaScript/untyped config now fails early instead of creating a misleading response.

## Verification

- `pnpm --filter @farm.js/core test -- config-route-plugins.test.ts config.test.ts --reporter=dot` (79 tests across matched files)
- `pnpm --filter @farm.js/core type-check`
- focused oxlint on changed config/redirect files
- `git diff --check`

The invalid top-level, route-rule, and direct-plugin assertions fail on `main`.

## Documentation and release

Documented accepted statuses and default temporary/permanent behavior.