### PR TITLE
fix(server): support Node-compatible response adapters

### DIFF
--- a/packages/farm/src/__tests__/endpoint-errors.test.ts
+++ b/packages/farm/src/__tests__/endpoint-errors.test.ts
@@ -78,10 +78,10 @@ describe("typed endpoint errors", () => {
 
   it("rejects malformed JSON before an endpoint handler executes", async () => {
     let executed = false;
-    const handler = (ctx: { body: unknown }) => {
+    const handler = createEndpoint({ method: "POST" }, (ctx) => {
       executed = true;
       return { body: ctx.body };
-    };
+    });
     const response = await invokeAPIRouteEndpoint(
       handler,
       new Request("https://farm.test/api/products", {

--- a/packages/farm/src/__tests__/server-response.test.ts
+++ b/packages/farm/src/__tests__/server-response.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { sendWebResponse } from "../server/response";
 
 describe("sendWebResponse", () => {
-  it("streams Web Response bodies to Node-style responses", async () => {
+  it("streams bodies to Node-compatible response adapters without EventEmitter internals", async () => {
     const chunks: Buffer[] = [];
     const headers = new Map<string, string | string[]>();
     const res = {

--- a/packages/farm/src/server/response.ts
+++ b/packages/farm/src/server/response.ts
@@ -1,5 +1,49 @@
-import { once } from "node:events";
 import type { ServerResponse } from "node:http";
+
+interface ResponseEventWatcher<T> {
+  promise: Promise<T>;
+  dispose(): void;
+}
+
+/**
+ * Watch a real Node response without requiring every Node-compatible response
+ * adapter or test double to extend EventEmitter. The framework only needs
+ * disconnect handling when the response exposes both halves of the listener
+ * lifecycle; otherwise callers can still send ordinary non-blocked bodies.
+ */
+function watchResponseEvent<T>(
+  res: ServerResponse,
+  events: ReadonlyArray<readonly [event: string, value: T]>,
+): ResponseEventWatcher<T> | null {
+  if (typeof res.once !== "function" || typeof res.removeListener !== "function") {
+    return null;
+  }
+
+  let settled = false;
+  const listeners = events.map(([event, value]) => {
+    const listener = () => {
+      if (settled) return;
+      settled = true;
+      dispose();
+      resolvePromise(value);
+    };
+    return { event, listener };
+  });
+  let resolvePromise!: (value: T) => void;
+  const promise = new Promise<T>((resolve) => {
+    resolvePromise = resolve;
+    for (const { event, listener } of listeners) {
+      res.once(event, listener);
+    }
+  });
+  const dispose = () => {
+    for (const { event, listener } of listeners) {
+      res.removeListener(event, listener);
+    }
+  };
+
+  return { promise, dispose };
+}
 
 /**
  * Waits until the response can accept more writes. Resolves false when the
@@ -12,17 +56,19 @@ async function waitForWritable(res: ServerResponse): Promise<boolean> {
     return false;
   }
 
-  const abort = new AbortController();
-  try {
-    return await Promise.race([
-      once(res, "drain", { signal: abort.signal }).then(() => true),
-      once(res, "close", { signal: abort.signal }).then(() => false),
-    ]);
-  } catch {
-    // events.once rejects when the emitter emits "error".
+  const watcher = watchResponseEvent(res, [
+    ["drain", true],
+    ["close", false],
+    ["error", false],
+  ]);
+  if (!watcher) {
     return false;
+  }
+
+  try {
+    return await watcher.promise;
   } finally {
-    abort.abort();
+    watcher.dispose();
   }
 }
 
@@ -56,11 +102,10 @@ export async function sendWebResponse(res: ServerResponse, response: Response): 
   }
 
   const reader = response.body.getReader();
-  const disconnectAbort = new AbortController();
-  const disconnected = once(res, "close", { signal: disconnectAbort.signal }).then(
-    () => true,
-    (error) => error?.name !== "AbortError",
-  );
+  const disconnectWatcher = watchResponseEvent(res, [
+    ["close", true],
+    ["error", true],
+  ]);
 
   try {
     while (true) {
@@ -71,16 +116,16 @@ export async function sendWebResponse(res: ServerResponse, response: Response): 
         return;
       }
 
-      const next = await Promise.race([
-        reader.read().then((result) => ({ type: "read" as const, result })),
-        disconnected.then((closed) => ({ type: "disconnect" as const, closed })),
-      ]);
-      if (next.type === "disconnect" && next.closed) {
+      const read = reader.read().then((result) => ({ type: "read" as const, result }));
+      const next = disconnectWatcher
+        ? await Promise.race([
+            read,
+            disconnectWatcher.promise.then(() => ({ type: "disconnect" as const })),
+          ])
+        : await read;
+      if (next.type === "disconnect") {
         void reader.cancel().catch(() => {});
         return;
-      }
-      if (next.type !== "read") {
-        continue;
       }
 
       const { done, value } = next.result;
@@ -112,7 +157,7 @@ export async function sendWebResponse(res: ServerResponse, response: Response): 
     }
     throw error;
   } finally {
-    disconnectAbort.abort();
+    disconnectWatcher?.dispose();
     try {
       reader.releaseLock();
     } catch {


### PR DESCRIPTION
## Problem

After the disconnect cleanup fix landed, the cumulative core suite failed on Node 20 and Windows when API middleware used a lightweight Node-compatible response adapter. `sendWebResponse()` completed the body, but aborting the `node:events.once()` watcher tried to remove listeners through EventEmitter internals the adapter did not implement. The same run also exposed a malformed-JSON assertion that still passed a plain route handler using the removed parsed-context heuristic.

## Root cause

The disconnect watcher assumed every response with Node response methods was a real `EventEmitter`. Farm supports Node-compatible adapters and several dev/runtime tests intentionally use that smaller contract. The malformed-body test was meant to cover `createEndpoint` parsing but constructed an unbranded plain handler, which now correctly receives a Web `Request`.

## Change

- Register and dispose response lifecycle listeners directly when both `once()` and `removeListener()` are available.
- Keep ordinary streaming available to adapters without EventEmitter listener internals.
- Continue treating `close` and `error` as terminal while waiting for body data or backpressure.
- Exercise malformed JSON through an explicitly branded `createEndpoint` handler.
- Clarify the response-adapter regression test name.

## Safety and compatibility

Real `ServerResponse` instances retain disconnect cancellation and backpressure cleanup. Adapters without a complete listener lifecycle can stream normal bodies but fail closed if they report backpressure, since Farm cannot safely wait for `drain` or detect disconnects. Plain route handlers continue receiving Web `Request`; parsed input remains exclusive to `createEndpoint`.

## Verification

- `pnpm exec oxlint packages/farm/src/server/response.ts packages/farm/src/__tests__/endpoint-errors.test.ts packages/farm/src/__tests__/server-response.test.ts`
- `pnpm --filter @farm.js/core exec vitest run src/__tests__/send-web-response.test.ts src/__tests__/server-response.test.ts src/__tests__/endpoint-errors.test.ts src/__tests__/api-vite-plugin-rewrite.test.ts` — 13 tests passed
- `pnpm --filter @farm.js/core type-check`
- `pnpm --filter @farm.js/core test` — 181 files passed; 1,435 tests passed and 1 skipped

## Documentation and release

None. This restores the documented response-adapter and endpoint contracts without changing public API.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `sendWebResponse()` so Node-compatible response adapters without full EventEmitter listener internals can stream bodies without crashing. The disconnect watcher previously assumed every Node-style response had `once()`/`removeListener()` and threw during cleanup; it now detects the listener lifecycle and disposes directly when available. Adapters without it still stream normal bodies but fail closed on backpressure, while real `ServerResponse` instances keep disconnect cancellation.

**Changes**
- Register and dispose response lifecycle listeners directly when both `once()` and `removeListener()` are present; fall back to no watcher otherwise.
- Treat `close` and `error` as terminal for both backpressure waits and disconnect detection.
- Switch the malformed-JSON test to an explicitly branded `createEndpoint` handler so it covers endpoint parsing.
- Rename the response-adapter regression test to clarify its scope.

Public API is unchanged; no migration steps or documentation updates needed.

<sup>Written for commit 88c145da85f5656e798827e1bfac689f318c66d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/653?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

