### PR TITLE
perf(react): compose overlapping fresh-key windows

### DIFF
--- a/docs/src/app/docs/renderers/react/page.md
+++ b/docs/src/app/docs/renderers/react/page.md
@@ -1069,13 +1069,14 @@ Farm first evaluates all keys and binding snapshots and resolves every changed t
 complete interval. It then patches only changed bindings in place and updates each stored row
 object, so later delegated or cached handlers observe the latest data. No descriptor or DOM row is
 created, and every row keeps its identity, focus, and text selection. Multiple length-preserving
-same-key windows queued before one compiler flush compose into one atomic refresh. Disjoint and
-overlapping windows are supported; an overlapping position uses the last queued value. Farm
-validates the complete chain and prepares every touched key, binding value, and DOM target before
-applying any write. Disjoint fixed-length queued windows may also mix same-key rows with globally
-new keys. Farm prepares every new descriptor, binding snapshot, and disconnected DOM row before
-the first write, then patches the same-key positions and swaps only the fresh-key positions.
-Untouched rows retain their identity. Reordered, partially reused, or duplicate keys take complete
+same-key windows queued before one compiler flush compose into one atomic refresh. Fixed-length
+queued windows may mix same-key rows with globally new final keys, and both disjoint and
+overlapping windows are supported. An overlapping position uses the last queued value;
+intermediate identities are never mounted. Farm validates the complete chain and final key set,
+then prepares every touched key, binding value, DOM target, new descriptor, binding snapshot, and
+disconnected DOM row before the first write. It patches same-key positions and swaps only final
+fresh-key positions. Untouched rows retain their identity. Reordered, partially reused, or
+duplicate final keys take complete
 reconciliation before fast-path mutation. A single insertion
 creates one row at that position. A removal cleans up and removes only the known row or contiguous
 range while preserving every
@@ -1087,10 +1088,10 @@ The proof requires compiler-owned host rows whose render and key do not observe 
 Effectful position expressions, runtime values that are fractional or otherwise not safe integers,
 dynamic, zero, negative, or fractional removal counts, other `toSpliced()` shapes, block-bodied
 updaters, unsafe incoming expressions, custom methods, queued chains containing a structural
-window or unhinted intermediate update, an overlapping window whose final key changes, an existing
-key moved from another position, duplicate or partially reused incoming keys, collection-reading
-bindings, React-owned rows, nested host blocks, row conditionals, unrelated dirty dependencies, and
-failed runtime checks keep complete keyed reconciliation.
+window or unhinted intermediate update, an existing key moved from another position, duplicate or
+partially reused final keys, collection-reading bindings, React-owned rows, nested host blocks, row
+conditionals, unrelated dirty dependencies, and failed runtime checks keep complete keyed
+reconciliation.
 Negative safe-integer positions and counts larger than the remaining suffix use the native
 method's normal clamping rules. No new option or component is required. Reports expose emitted
 sites as `keyedArrayPositionHints`. Batch insertion and exact-window replacement select
@@ -1983,8 +1984,10 @@ The package and example test suites verify more than generated code:
   1,000 deterministic queued same-key window refreshes match normal React while disjoint and
   overlapping targeted tests preserve row identity and perform no descriptor work; 1,000 queued
   mixed fresh-key and same-key replacements also match React while targeted tests require only the
-  64 incoming descriptors, preserve every untouched row, prepare all new rows before mutation, and
-  cover overlapping-key-change and existing-key-move fallback;
+  64 incoming descriptors, preserve every untouched row, and prepare all new rows before mutation;
+  another 1,000 queued overlapping fresh-key replacements match React while targeted tests require
+  work to equal only the final touched union, preserve untouched DOM identity, and cover atomic
+  preparation, existing-key-move fallback, Strict Mode hydration, and unmount cleanup;
 - 2,000 deterministic randomized reversals match normal React; a 4,096-row targeted test requires
   exactly `n - 1` connected DOM moves and zero key, descriptor, or binding reads, while fallback
   tests cover custom methods, queued updates, collection-reading rows, StrictMode hydration, and

--- a/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
+++ b/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
@@ -2,6 +2,31 @@
 
 Date: 2026-08-29
 
+## Overlapping fresh-key exact-window replacement follow-up — 2026-09-01
+
+The full bracketed production-browser run changed the 10,000-row queued replacement workload to
+two overlapping 32-row windows. Their final union contains 48 rows: the later update wins in the
+16-row overlap, intermediate identities are never mounted, both surrounding anchor rows retain
+their DOM identity, and all 48 committed rows receive fresh keys. Both compiler builds emitted all
+11 expected `keyedArrayPositionHints` sites, produced zero owner executions, and passed every
+existing correctness, performance, persistence, and scalability gate without lowering a threshold.
+
+| Mode   | React median | Overlapping replacement | Compiled control | vs React | vs control |
+| ------ | -----------: | ----------------------: | ---------------: | -------: | ---------: |
+| Static |     53.35 ms |                 8.80 ms |         20.00 ms |    6.06x |      2.27x |
+| Hybrid |     53.35 ms |                 8.40 ms |         20.10 ms |    6.35x |      2.39x |
+
+The independent gate still requires at least 4x versus React and 1.5x versus the block-bodied
+compiled control in both modes. Package tests separately prove exact final-union work, committed-key
+restoration, final-state validation after an intermediate collision, preparation before the first
+DOM replacement, existing-key move and duplicate-key fallback, 1,000 deterministic differential
+updates, controlled-input focus and selection, delegated events, hydration, Strict Mode, React
+18/19 compatibility, and unmount cleanup. The isolated exact-window fixture has a 13,517 B gzip
+compiler premium, 8 B smaller than the preceding disjoint-window result and inside the unchanged
+runtime-size limit. Every unrelated size fixture remains within its existing budget; the isolated
+full-runtime bundle still removes 81.8% when the compiler is disabled. The measured environment was
+Chrome 145.0.7632.6, Node.js 23.11.0, and Apple M1 macOS arm64.
+
 ## Queued fresh-key exact-window replacement follow-up — 2026-09-01
 
 The full bracketed production-browser run added a separate 10,000-row workload that queues two

--- a/examples/react-compiler-dashboard/README.md
+++ b/examples/react-compiler-dashboard/README.md
@@ -139,13 +139,15 @@ last-update-wins semantics, atomic preparation, structural fallback, controlled-
 events, Strict Mode hydration, and cleanup.
 
 Queued fresh-key exact-window replacement has a separate 10,000-row gate. One event replaces two
-disjoint 32-row windows with globally new keys. The benchmark requires the 64 old rows to disconnect,
-all four surrounding anchors to retain identity, both new labels to reach the DOM, and zero compiled
-owner executions. Static and hybrid modes must remain at least 4x faster than React and 1.5x faster
-than the equivalent block-bodied compiled control. Together with the existing position workloads,
-the compiler report must contain all eleven dashboard `keyedArrayPositionHints`. Package tests also
-cover mixed same-key/fresh-key commits, atomic preparation, overlap and existing-key-move fallback,
-events, controlled-input selection, Strict Mode hydration, cleanup, and 1,000 differential updates.
+overlapping 32-row windows with globally new final keys; their 16-row overlap leaves one 48-row
+final union. The benchmark requires the 48 old rows to disconnect, both surrounding anchors to
+retain identity, both final labels to reach the DOM, and zero compiled owner executions. Static and
+hybrid modes must remain at least 4x faster than React and 1.5x faster than the equivalent
+block-bodied compiled control. Together with the existing position workloads, the compiler report
+must contain all eleven dashboard `keyedArrayPositionHints`. Package tests also cover disjoint and
+overlapping fresh-key commits, mixed same-key/fresh-key commits, atomic preparation,
+existing-key-move fallback, events, controlled-input selection, Strict Mode hydration, cleanup,
+and 1,000 differential overlapping updates.
 
 Native keyed-array reversal has a separate 10,000-row comparison. Concise `toReversed()` is
 measured against bracketed React and an equivalent block-bodied compiled control. Both compiler

--- a/examples/react-compiler-dashboard/scripts/benchmark.mjs
+++ b/examples/react-compiler-dashboard/scripts/benchmark.mjs
@@ -766,32 +766,24 @@ async function measureTrial(browser, trial, compilerMode, port) {
 
         const measureQueuedWindowReplacement = async (action) => {
           const rows = table.querySelectorAll("tbody tr");
-          const firstRemoved = [...rows].slice(2_500, 2_532);
-          const secondRemoved = [...rows].slice(7_500, 7_532);
-          const beforeFirst = rows[2_499];
-          const afterFirst = rows[2_532];
-          const beforeSecond = rows[7_499];
-          const afterSecond = rows[7_532];
-          const firstOldKey = firstRemoved[16]?.getAttribute("data-row-id");
-          const secondOldKey = secondRemoved[16]?.getAttribute("data-row-id");
+          const removed = [...rows].slice(2_500, 2_548);
+          const before = rows[2_499];
+          const after = rows[2_548];
+          const firstOldKey = removed[8]?.getAttribute("data-row-id");
+          const secondOldKey = removed[32]?.getAttribute("data-row-id");
           await runTableAction(action, () => {
             const nextRows = table.querySelectorAll("tbody tr");
             return (
               rowCount() === 10_000 &&
-              nextRows[2_499] === beforeFirst &&
-              nextRows[2_532] === afterFirst &&
-              nextRows[7_499] === beforeSecond &&
-              nextRows[7_532] === afterSecond &&
-              firstRemoved.every((row, offset) =>
+              nextRows[2_499] === before &&
+              nextRows[2_548] === after &&
+              removed.every((row, offset) =>
                 Boolean(!row.isConnected && nextRows[2_500 + offset] !== row),
               ) &&
-              secondRemoved.every((row, offset) =>
-                Boolean(!row.isConnected && nextRows[7_500 + offset] !== row),
-              ) &&
-              nextRows[2_516]?.getAttribute("data-row-id") !== firstOldKey &&
-              nextRows[7_516]?.getAttribute("data-row-id") !== secondOldKey &&
-              nextRows[2_516]?.children[1]?.textContent?.endsWith(" queued replacement") &&
-              nextRows[7_516]?.children[1]?.textContent?.endsWith(" queued replacement")
+              nextRows[2_508]?.getAttribute("data-row-id") !== firstOldKey &&
+              nextRows[2_532]?.getAttribute("data-row-id") !== secondOldKey &&
+              nextRows[2_508]?.children[1]?.textContent?.endsWith(" queued replacement") &&
+              nextRows[2_532]?.children[1]?.textContent?.endsWith(" queued replacement")
             );
           });
         };
@@ -1915,7 +1907,7 @@ const keyedQueuedWindowRefreshRegressions = keyedQueuedWindowRefreshResults.filt
     !Number.isFinite(snapshotSpeedup) ||
     snapshotSpeedup < keyedQueuedWindowRefreshMinimumSnapshotSpeedup,
 );
-// Two disjoint fixed-length fresh-key windows should create and swap only their incoming rows.
+// Two overlapping fixed-length fresh-key windows should create and swap only the final union.
 // Protect the queued replacement path separately from both the single-window replacement and the
 // queued same-key refresh so neither can hide a regression to complete reconciliation.
 const keyedQueuedWindowReplaceMinimumSpeedup = 4;

--- a/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
+++ b/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
@@ -441,11 +441,11 @@ export function StandardTableBenchmark() {
           type="button"
           onClick={() => {
             const firstPosition = 2_500;
-            const secondPosition = 7_500;
+            const secondPosition = 2_516;
             const firstSeed = seed + 1;
             const secondSeed = seed + 2;
             const first = buildRows(32, firstSeed).map((row, offset) =>
-              offset === 16 ? { ...row, label: `${row.label} queued replacement` } : row,
+              offset === 8 ? { ...row, label: `${row.label} queued replacement` } : row,
             );
             const second = buildRows(32, secondSeed).map((row, offset) =>
               offset === 16 ? { ...row, label: `${row.label} queued replacement` } : row,
@@ -453,22 +453,22 @@ export function StandardTableBenchmark() {
             setSeed(secondSeed);
             setRows((current) => current.toSpliced(firstPosition, 32, ...first));
             setRows((current) => current.toSpliced(secondPosition, 32, ...second));
-            setOperation("replace two queued fresh-key windows");
+            setOperation("replace two overlapping queued fresh-key windows");
             setRevision((value) => value + 1);
           }}
         >
-          Replace two queued fresh-key windows
+          Replace two overlapping queued fresh-key windows
         </button>
         <button
           data-action="table-position-window-replace-queued-snapshot"
           type="button"
           onClick={() => {
             const firstPosition = 2_500;
-            const secondPosition = 7_500;
+            const secondPosition = 2_516;
             const firstSeed = seed + 1;
             const secondSeed = seed + 2;
             const first = buildRows(32, firstSeed).map((row, offset) =>
-              offset === 16 ? { ...row, label: `${row.label} queued replacement` } : row,
+              offset === 8 ? { ...row, label: `${row.label} queued replacement` } : row,
             );
             const second = buildRows(32, secondSeed).map((row, offset) =>
               offset === 16 ? { ...row, label: `${row.label} queued replacement` } : row,
@@ -480,11 +480,11 @@ export function StandardTableBenchmark() {
             setRows((current) => {
               return current.toSpliced(secondPosition, 32, ...second);
             });
-            setOperation("replace two queued fresh-key windows (snapshot control)");
+            setOperation("replace two overlapping queued fresh-key windows (snapshot control)");
             setRevision((value) => value + 1);
           }}
         >
-          Replace two queued fresh-key windows (snapshot control)
+          Replace two overlapping queued fresh-key windows (snapshot control)
         </button>
         <button
           data-action="table-position-remove"

--- a/packages/farm-react/README.md
+++ b/packages/farm-react/README.md
@@ -331,22 +331,21 @@ has the same length and the same keys in the same order, Farm prepares every bin
 changed DOM target across the complete window first, patches the existing rows in place, and
 updates the stored row objects used by later events. That path creates no descriptors or DOM rows,
 and preserves row identity, focus, and selection. Multiple length-preserving same-key windows
-queued before one compiler flush compose into one atomic refresh. Disjoint and overlapping windows
-are both supported; overlapping positions use the last queued value. Farm validates the complete
-chain and prepares every touched key, binding value, and DOM target before applying any write.
-Disjoint fixed-length queued windows may also mix same-key refreshes with globally new keys. Farm
-prepares every new descriptor, binding snapshot, and disconnected DOM row first, then patches the
-same-key positions and swaps only the fresh-key positions. Untouched rows keep their identity and
-are not recreated. The runtime otherwise creates one inserted row,
+queued before one compiler flush compose into one atomic refresh. Fixed-length queued windows may
+mix same-key refreshes with globally new final keys, and both disjoint and overlapping windows are
+supported. An overlapping position uses the last queued value; intermediate identities are never
+mounted. Farm validates the complete chain and final key set, then prepares every touched key,
+binding value, DOM target, new descriptor, binding snapshot, and disconnected DOM row before the
+first write. It patches same-key positions and swaps only final fresh-key positions. Untouched rows
+keep their identity and are not recreated. The runtime otherwise creates one inserted row,
 removes only the known row or range, or patches/replaces one row at that position without rereading
 every existing key, descriptor, and binding. Surviving rows keep their DOM identity. Index-aware or
 collection-reading rows, custom methods, position expressions with user calls or mutations,
 runtime positions that are not safe integers, dynamic, zero, negative, or fractional removal
 counts, other `toSpliced()` forms, block-bodied updaters, unsafe incoming expressions, queued
-chains containing a structural window or unhinted intermediate update, an overlapping window whose
-final key changes, existing keys moved from another position, partially reused windows, duplicate
-keys, nested or React-owned rows, and failed checks use complete keyed reconciliation before the
-fast path mutates the DOM.
+chains containing a structural window or unhinted intermediate update, existing keys moved from
+another position, partially reused windows, duplicate final keys, nested or React-owned rows, and
+failed checks use complete keyed reconciliation before the fast path mutates the DOM.
 Reports expose the site count as `keyedArrayPositionHints`. Batch insertion and exact-window
 replacement use progressively separate optional runtime capabilities, so existing single-position
 and batch-only bundles do not retain window validation or replacement code.

--- a/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-window-replace-hints.test.tsx
+++ b/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-window-replace-hints.test.tsx
@@ -551,6 +551,53 @@ describe("compiled keyed-array window replacement hints", () => {
     expect(container.textContent).toBe("EpsilonBetaPhiDelta");
   });
 
+  it("prepares every overlapping final row before replacing the first DOM row", async () => {
+    const harness = createWindowHarness([
+      { id: "a", label: "Alpha" },
+      { id: "b", label: "Beta" },
+      { id: "c", label: "Gamma" },
+      { id: "d", label: "Delta" },
+    ]);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Table />));
+    const trace: string[] = [];
+    const replaceWith = Element.prototype.replaceWith;
+    vi.spyOn(Element.prototype, "replaceWith").mockImplementation(function (
+      this: Element,
+      ...nodes: (Node | string)[]
+    ) {
+      trace.push(`replace:${this.getAttribute("data-key")}`);
+      replaceWith.call(this, ...nodes);
+    });
+    harness.traceBindings(trace);
+    harness.failNextDescriptorFor("h");
+
+    await act(async () => {
+      harness.queueRefreshes(
+        0,
+        [
+          { id: "e", label: "Epsilon" },
+          { id: "f", label: "Intermediate Phi" },
+        ],
+        1,
+        [
+          { id: "g", label: "Gamma replacement" },
+          { id: "h", label: "Eta" },
+        ],
+      );
+      await flushCompilerUpdates();
+    });
+
+    const failedCreate = trace.indexOf("create:h");
+    const firstReplace = trace.findIndex((entry) => entry.startsWith("replace:"));
+    expect(failedCreate).toBeGreaterThanOrEqual(0);
+    expect(firstReplace === -1 || firstReplace > failedCreate).toBe(true);
+    expect(container.textContent).toBe("EpsilonGamma replacementEtaDelta");
+  });
+
   it("supports empty incoming spreads, negative positions, and clamped delete counts", async () => {
     const harness = createWindowHarness([
       { id: "a", label: "Alpha" },
@@ -756,45 +803,161 @@ describe("compiled keyed-array window replacement hints", () => {
     });
   });
 
-  it("falls back for overlapping fresh keys and existing-key moves", async () => {
+  it("replaces overlapping queued fresh-key windows without scanning untouched rows", async () => {
     const initialItems = [
       { id: "a", label: "Alpha" },
       { id: "b", label: "Beta" },
       { id: "c", label: "Gamma" },
       { id: "d", label: "Delta" },
     ];
-    for (const operation of ["overlap", "move"] as const) {
-      const harness = createWindowHarness(initialItems);
-      const container = document.createElement("div");
-      document.body.append(container);
-      const root = createRoot(container);
-      roots.push(root);
-      await act(async () => root.render(<harness.Table />));
-      harness.counters.keys = 0;
-      harness.counters.descriptors = 0;
+    const harness = createWindowHarness(initialItems);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Table />));
+    const alpha = container.querySelector('[data-key="a"]');
+    const beta = container.querySelector('[data-key="b"]');
+    const gamma = container.querySelector('[data-key="c"]');
+    const delta = container.querySelector('[data-key="d"]');
+    harness.counters.keys = 0;
+    harness.counters.descriptors = 0;
+    harness.counters.bindings = 0;
 
-      await act(async () => {
-        if (operation === "overlap") {
-          harness.queueRefreshes(
-            0,
-            [
-              { id: "e", label: "Epsilon" },
-              { id: "f", label: "Phi" },
-            ],
-            1,
-            [{ id: "g", label: "Gamma replacement" }],
-          );
-        } else {
-          harness.queueRefreshes(0, [initialItems[2]], 2, [initialItems[0]]);
-        }
-        await flushCompilerUpdates();
-      });
-
-      expect(container.textContent).toBe(
-        operation === "overlap" ? "EpsilonGamma replacementGammaDelta" : "GammaBetaAlphaDelta",
+    await act(async () => {
+      harness.queueRefreshes(
+        0,
+        [
+          { id: "e", label: "Epsilon" },
+          { id: "f", label: "Intermediate Phi" },
+        ],
+        1,
+        [{ id: "g", label: "Gamma replacement" }],
       );
-      expect(harness.counters.keys).toBeGreaterThan(operation === "overlap" ? 3 : 2);
-    }
+      await flushCompilerUpdates();
+    });
+
+    expect(container.textContent).toBe("EpsilonGamma replacementGammaDelta");
+    expect(container.querySelector('[data-key="e"]')).not.toBe(alpha);
+    expect(container.querySelector('[data-key="g"]')).not.toBe(beta);
+    expect(container.querySelector('[data-key="f"]')).toBeNull();
+    expect(alpha?.isConnected).toBe(false);
+    expect(beta?.isConnected).toBe(false);
+    expect(container.querySelector('[data-key="c"]')).toBe(gamma);
+    expect(container.querySelector('[data-key="d"]')).toBe(delta);
+    expect(harness.counters).toEqual({
+      executions: 1,
+      renders: 1,
+      keys: 2,
+      descriptors: 2,
+      bindings: 2,
+    });
+  });
+
+  it("preserves a committed row when a later overlap restores its key", async () => {
+    const initialItems = [
+      { id: "a", label: "Alpha" },
+      { id: "b", label: "Beta" },
+      { id: "c", label: "Gamma" },
+    ];
+    const harness = createWindowHarness(initialItems);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Table />));
+    const alpha = container.querySelector('[data-key="a"]');
+    harness.counters.keys = 0;
+    harness.counters.descriptors = 0;
+    harness.counters.bindings = 0;
+
+    await act(async () => {
+      harness.queueRefreshes(0, [{ id: "intermediate", label: "Intermediate" }], 0, [
+        { id: "a", label: "Alpha restored" },
+      ]);
+      await flushCompilerUpdates();
+    });
+
+    expect(container.textContent).toBe("Alpha restoredBetaGamma");
+    expect(container.querySelector('[data-key="a"]')).toBe(alpha);
+    expect(container.querySelector('[data-key="intermediate"]')).toBeNull();
+    expect(harness.counters).toEqual({
+      executions: 1,
+      renders: 1,
+      keys: 1,
+      descriptors: 0,
+      bindings: 1,
+    });
+  });
+
+  it("validates the final keys instead of an uncommitted overlapping identity", async () => {
+    const initialItems = [
+      { id: "a", label: "Alpha" },
+      { id: "b", label: "Beta" },
+      { id: "c", label: "Gamma" },
+      { id: "d", label: "Delta" },
+    ];
+    const harness = createWindowHarness(initialItems);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Table />));
+    const gamma = container.querySelector('[data-key="c"]');
+    const delta = container.querySelector('[data-key="d"]');
+    harness.counters.keys = 0;
+    harness.counters.descriptors = 0;
+    harness.counters.bindings = 0;
+
+    await act(async () => {
+      harness.queueRefreshes(
+        0,
+        [initialItems[2], { id: "intermediate", label: "Intermediate" }],
+        0,
+        [
+          { id: "e", label: "Epsilon" },
+          { id: "f", label: "Phi" },
+        ],
+      );
+      await flushCompilerUpdates();
+    });
+
+    expect(container.textContent).toBe("EpsilonPhiGammaDelta");
+    expect(container.querySelectorAll('[data-key="c"]')).toHaveLength(1);
+    expect(container.querySelector('[data-key="c"]')).toBe(gamma);
+    expect(container.querySelector('[data-key="d"]')).toBe(delta);
+    expect(container.querySelector('[data-key="intermediate"]')).toBeNull();
+    expect(harness.counters).toEqual({
+      executions: 1,
+      renders: 1,
+      keys: 2,
+      descriptors: 2,
+      bindings: 2,
+    });
+  });
+
+  it("falls back for queued existing-key moves", async () => {
+    const initialItems = [
+      { id: "a", label: "Alpha" },
+      { id: "b", label: "Beta" },
+      { id: "c", label: "Gamma" },
+      { id: "d", label: "Delta" },
+    ];
+    const harness = createWindowHarness(initialItems);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Table />));
+    harness.counters.keys = 0;
+
+    await act(async () => {
+      harness.queueRefreshes(0, [initialItems[2]], 2, [initialItems[0]]);
+      await flushCompilerUpdates();
+    });
+
+    expect(container.textContent).toBe("GammaBetaAlphaDelta");
+    expect(harness.counters.keys).toBeGreaterThan(2);
   });
 
   it("falls back when an unhinted update breaks the queued chain", async () => {
@@ -1223,6 +1386,114 @@ describe("compiled keyed-array window replacement hints", () => {
     });
   }, 15_000);
 
+  it("matches React through 1,000 queued overlapping fresh-key replacements", async () => {
+    const initialItems = Array.from(
+      { length: 64 },
+      (_, index): Item => ({ id: `row-${index}`, label: `Row ${index}` }),
+    );
+    const harness = createWindowHarness(initialItems);
+    let queueReact: (
+      firstPosition: number,
+      first: readonly Item[],
+      secondPosition: number,
+      second: readonly Item[],
+    ) => void = () => undefined;
+    function NormalTable() {
+      const [items, setItems] = useState(initialItems);
+      queueReact = (firstPosition, first, secondPosition, second) => {
+        setItems((previous) =>
+          (previous as WindowArray).toSpliced(firstPosition, first.length, ...first),
+        );
+        setItems((previous) =>
+          (previous as WindowArray).toSpliced(secondPosition, second.length, ...second),
+        );
+      };
+      return (
+        <ol>
+          {items.map((item) => (
+            <li data-key={item.id} key={item.id}>
+              {item.label}
+            </li>
+          ))}
+        </ol>
+      );
+    }
+    const compiledContainer = document.createElement("div");
+    const reactContainer = document.createElement("div");
+    document.body.append(compiledContainer, reactContainer);
+    const compiledRoot = createRoot(compiledContainer);
+    const reactRoot = createRoot(reactContainer);
+    roots.push(compiledRoot, reactRoot);
+    await act(async () => {
+      compiledRoot.render(<harness.Table />);
+      reactRoot.render(<NormalTable />);
+    });
+    harness.counters.keys = 0;
+    harness.counters.descriptors = 0;
+    harness.counters.bindings = 0;
+    let expected = initialItems;
+    let touchedRows = 0;
+    let random = 0x8d31_b70f;
+    const nextRandom = () => {
+      random = (Math.imul(random, 1_664_525) + 1_013_904_223) >>> 0;
+      return random;
+    };
+
+    for (let step = 0; step < 500; step += 1) {
+      const firstCount = (nextRandom() % 8) + 1;
+      const firstPosition = nextRandom() % (expected.length - firstCount + 1);
+      const first = Array.from(
+        { length: firstCount },
+        (_, offset): Item => ({
+          id: `first-${step}-${offset}`,
+          label: `First ${step}.${offset}`,
+        }),
+      );
+      const afterFirst = (expected as WindowArray).toSpliced(firstPosition, firstCount, ...first);
+      const secondPosition = firstPosition + (nextRandom() % firstCount);
+      const secondLimit = Math.min(8, afterFirst.length - secondPosition);
+      const secondCount = (nextRandom() % secondLimit) + 1;
+      const second = Array.from(
+        { length: secondCount },
+        (_, offset): Item => ({
+          id: `second-${step}-${offset}`,
+          label: `Second ${step}.${offset}`,
+        }),
+      );
+      const beforeRows = [...compiledContainer.querySelectorAll("li")];
+      expected = (afterFirst as WindowArray).toSpliced(secondPosition, secondCount, ...second);
+      const touchedEnd = Math.max(firstPosition + firstCount, secondPosition + secondCount);
+      touchedRows += touchedEnd - firstPosition;
+
+      await act(async () => {
+        harness.queueRefreshes(firstPosition, first, secondPosition, second);
+        queueReact(firstPosition, first, secondPosition, second);
+        await flushCompilerUpdates();
+      });
+
+      expect(compiledContainer.querySelector("ul")?.textContent).toBe(
+        reactContainer.querySelector("ol")?.textContent,
+      );
+      const nextRows = [...compiledContainer.querySelectorAll("li")];
+      nextRows.forEach((row, index) => {
+        if (index >= firstPosition && index < touchedEnd) {
+          expect(row).not.toBe(beforeRows[index]);
+          expect(beforeRows[index]?.isConnected).toBe(false);
+        } else {
+          expect(row).toBe(beforeRows[index]);
+        }
+      });
+    }
+
+    expect(harness.counters).toEqual({
+      executions: 1,
+      renders: 1,
+      keys: touchedRows,
+      descriptors: touchedRows,
+      bindings: touchedRows,
+    });
+  }, 15_000);
+
   it("hydrates in StrictMode and drops a queued replacement after unmount", async () => {
     const harness = createWindowHarness([
       { id: "a", label: "Alpha" },
@@ -1262,20 +1533,40 @@ describe("compiled keyed-array window replacement hints", () => {
     expect(container.querySelector('[data-key="c"]')).toBe(gamma);
     expect(recoverable).toEqual([]);
 
+    const alpha = container.querySelector('[data-key="a"]');
     await act(async () => {
-      harness.queueRefreshes(1, [{ id: "e", label: "Epsilon hydrated" }], 2, [
-        { id: "f", label: "Phi hydrated" },
-      ]);
+      harness.queueRefreshes(
+        0,
+        [
+          { id: "e", label: "Epsilon hydrated" },
+          { id: "f", label: "Intermediate Phi hydrated" },
+        ],
+        1,
+        [
+          { id: "g", label: "Gamma replacement hydrated" },
+          { id: "h", label: "Eta hydrated" },
+        ],
+      );
       await flushCompilerUpdates();
     });
-    expect(container.textContent).toBe("AlphaEpsilon hydratedPhi hydrated");
+    expect(container.textContent).toBe("Epsilon hydratedGamma replacement hydratedEta hydrated");
+    expect(alpha?.isConnected).toBe(false);
     expect(beta?.isConnected).toBe(false);
     expect(gamma?.isConnected).toBe(false);
+    expect(container.querySelector('[data-key="f"]')).toBeNull();
     expect(recoverable).toEqual([]);
 
     roots.pop();
     act(() => {
-      harness.replace(0, 2, [{ id: "f", label: "Phi" }]);
+      harness.queueRefreshes(
+        0,
+        [
+          { id: "i", label: "Iota" },
+          { id: "j", label: "Jota" },
+        ],
+        1,
+        [{ id: "k", label: "Kappa" }],
+      );
       root.unmount();
     });
     await flushCompilerUpdates();

--- a/packages/farm-react/src/compiler-runtime.tsx
+++ b/packages/farm-react/src/compiler-runtime.tsx
@@ -4792,11 +4792,9 @@ function reconcileCompilerKeyedArrayWindowReplace(
   const previousInstances = [...instances.values()];
   if (updates.length > 1) {
     const touchedIndices = new Set<number>();
-    let overlaps = false;
     for (const update of updates) {
       if (update.insertedCount !== update.removedCount) return undefined;
       for (let index = update.position; index < update.position + update.removedCount; index += 1) {
-        overlaps ||= touchedIndices.has(index);
         touchedIndices.add(index);
       }
     }
@@ -4833,10 +4831,11 @@ function reconcileCompilerKeyedArrayWindowReplace(
         const item = finalValue[index];
         const key = keyedRowIdentity(props.rowKey(item, index));
         if (key !== instance.key) {
-          // Overlapping fresh-key windows can introduce and then remove an
-          // intermediate identity. Keep that edit history on complete keyed
-          // reconciliation until it has a separate proof.
-          if (overlaps || knownKeys.has(key) || incomingKeys.has(key)) return undefined;
+          // Fixed-length queued windows never shift positions, and React only
+          // commits their final array. Intermediate identities were never
+          // mounted, so only the final key must be new to the committed
+          // rows and unique across the prepared replacements.
+          if (knownKeys.has(key) || incomingKeys.has(key)) return undefined;
           incomingKeys.add(key);
           replacesRows = true;
           const descriptor = props.create(item, index);


### PR DESCRIPTION
## Problem

The compiler can already compose disjoint fixed-length queued fresh-key replacements, but overlapping windows fall back to complete keyed reconciliation even when the final committed array is unambiguous. That fallback scans and reconciles the full keyed collection instead of touching only the final changed union.

## Root cause

The runtime rejected every overlapping fresh-key chain before considering its final state. Fixed-length windows do not shift positions, and queued React updates commit their final array rather than mounting overwritten intermediate identities. The old overlap check therefore discarded a safe case that the existing complete-chain validation could prove.

## Change

- Validate the final touched positions for fixed-length queued windows instead of rejecting overlap itself.
- Preserve a committed row when the final key at that position is unchanged.
- Create and replace rows only for globally fresh, unique final keys.
- Preflight every key, descriptor, binding snapshot, target, and disconnected row before the first live DOM write.
- Extend the production dashboard workload to two overlapping 32-row windows with a 48-row final union.
- Document eligibility, last-update-wins behavior, fallback limits, test coverage, and measured results.

## Safety and compatibility

This remains an optional React compiler runtime fast path. Structural windows, unhinted chains, existing-key moves or reuse, duplicate final keys, custom methods, index-aware or collection-reading rows, React-owned or nested rows, failed validation, and unsupported syntax continue through complete React reconciliation.

The test suite covers final-state collisions, committed-key restoration, atomic preparation failures, DOM identity, controlled inputs, focus and selection, delegated events, hydration, Strict Mode, unmount cleanup, and 1,000 randomized overlapping update pairs compared with normal React. React 18.3.1 and 19.2.8 packaged compatibility both pass.

## Verification

- `pnpm --filter @farm.js/react test -- --maxWorkers=2` — 68 files and 604 tests passed.
- `pnpm --filter @farm.js/react type-check`
- `pnpm --filter @farm.js/react test:compat` — React 18.3.1 and 19.2.8 passed.
- `pnpm --filter @farm.js/react test:runtime-size` — passed; exact-window premium is 13,517 B gzip, 8 B smaller than the preceding result.
- `pnpm --dir examples/react-compiler-dashboard type-check`
- `pnpm --dir examples/react-compiler-dashboard build`
- `pnpm --dir examples/react-compiler-dashboard benchmark` — full bracketed production-browser suite passed with no lowered thresholds:
  - static: 8.80 ms, 6.06x versus React and 2.27x versus the compiled control;
  - hybrid: 8.40 ms, 6.35x versus React and 2.39x versus the compiled control;
  - every existing correctness, performance, persistence, and scalability gate passed.
- `pnpm docs:check-navigation`
- `pnpm --dir docs exec farm generate --check`
- `pnpm docs:build` — Vercel/Nitro production output passed.
- Focused `oxfmt`, `oxlint`, and `git diff --check` passed.

Measured benchmark environment: Chrome 145.0.7632.6, Node.js 23.11.0, Apple M1 macOS arm64.

## Documentation and release

Updated the React renderer docs, package README, dashboard README, executable benchmark workload, and benchmark results. No public option, template, generated route, version, or release-flow change.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Composes overlapping fixed-length fresh-key window replacements in the React compiler runtime so they use the same atomic fast path as disjoint windows instead of falling back to complete keyed reconciliation. Queued updates commit only the final array, so intermediate overlapping identities are never mounted and only the final keys need validation.

The runtime now validates the final touched positions and final key set before any DOM write, preserves committed rows whose final key is unchanged, and swaps only globally fresh, unique final keys. The dashboard benchmark and docs were updated to cover two overlapping 32-row windows with a 48-row final union, with new differential and targeted tests passing alongside React 18.3.1 and 19.2.8.

<sup>Written for commit e274cd98c8213f3744954f7d1214e8c36a59718b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/654?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

