### PR TITLE
chore(readme): fix dead links and cover renderers and the compiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 </p>
 
 <p align="center">
-  Farm.js combines Vite's instant development experience with a purpose-built React Server Components renderer, secure Server Actions, typed app-directory routing, and production-ready deployment output.
+  Farm.js combines Vite's instant development experience with typed app-directory routing, secure Server Actions, streaming SSR, and production-ready deployment output. React is the default renderer, with first-class Preact, Solid, Vue, and Svelte support behind the same routing and server contracts.
 </p>
 
 <p align="center">
@@ -41,6 +41,8 @@
 | 🧩 **Flexible rendering**          | Choose streaming SSR, static generation, ISR, PPR, or deferred hydration islands route by route.                                                                                                |
 | 🛠️ **Full-stack primitives**       | Build with API routes, server functions, middleware, caching, KV storage, cron handlers, OpenAPI, and post-response work.                                                                       |
 | 🔌 **First-party integrations**    | Add authentication, billing, email, jobs, AI, API keys, databases, and provider-owned routes through one typed integration model.                                                               |
+| 🎭 **Renderer choice**             | React by default, with Preact, Solid, Vue, and Svelte renderers selected by one line of config — same routes, server functions, and integrations everywhere.                                    |
+| 🧪 **AOT React compiler**          | An experimental compiler turns eligible components into direct DOM updates that skip reconciliation (~6.8x faster keyed swaps, ~2x less CPU in the [benchmark](./benchmarks/compiler)), falling back to normal React whenever eligibility can't be proven. |
 | 🚀 **Production-ready output**     | Build deployable server and client output with Nitro-powered adapters and per-route runtime controls.                                                                                           |
 | 🎨 **Great defaults**              | Start with TypeScript, Tailwind CSS, sensible conventions, and a clean project structure—without assembling the framework yourself.                                                             |
 
@@ -319,7 +321,7 @@ export default function Counter() {
 
 ## 📚 Documentation
 
-Visit [farm.js.dev](https://farm.js.dev) for comprehensive documentation, guides, and API reference.
+Visit [farmjs.dev](https://farmjs.dev) for comprehensive documentation, guides, and API reference.
 
 ## 🏗️ Development
 
@@ -373,11 +375,12 @@ farm.js/
 │   ├── farm/              # Core framework
 │   ├── farm-cli/          # @farm.js/cli tools
 │   ├── create-farm-app/   # App creation tool
-│   └── farm-types/        # TypeScript definitions
+│   ├── farm-react/        # React renderer + AOT compiler
+│   └── farm-{preact,solid,vue,svelte}/  # Other renderers
 ├── examples/
 │   ├── basic/             # Basic example
-│   ├── with-database/     # Database integration
-│   └── e-commerce/        # E-commerce example
+│   ├── rsc-demo/          # Server components, actions, and queries
+│   └── stripe-integration/ # Typed integration usage
 ├── docs/                  # Documentation (Farm.js)
 ├── playground/            # Development testing
 └── tests/                 # Integration tests
@@ -396,9 +399,11 @@ We welcome contributions! Please see our [Contributing Guide](CONTRIBUTING.md) f
 
 ## 🌟 Examples
 
-- **[Basic Example](./examples/basic)** - Simple Farm.js application
-- **[With Database](./examples/with-database)** - Database integration patterns
-- **[E-commerce](./examples/e-commerce)** - Full-featured online store
+- **[Basic Example](./examples/basic)** - Routing, boundaries, middleware, storage, and rendering modes in one app
+- **[RSC Demo](./examples/rsc-demo)** - Server components, server actions, and server queries
+- **[React Compiler](./examples/react-compiler)** - The experimental AOT compiler side by side with baseline React
+- **[Stripe Integration](./examples/stripe-integration)** - Typed billing integration with provider-owned routes
+- **[Renderers](./examples/solid-renderer)** - Preact, Solid, Vue, and Svelte apps on the same framework contracts
 
 ## 🔗 Ecosystem
 
@@ -408,7 +413,7 @@ We welcome contributions! Please see our [Contributing Guide](CONTRIBUTING.md) f
 
 ## 📄 License
 
-MIT © [Farm.js Team](https://github.com/farm-js)
+MIT © [Farming Labs](https://github.com/farming-labs)
 
 ## 🙏 Acknowledgments
 
@@ -423,7 +428,7 @@ Farm.js is inspired by:
 
 <div align="center">
 
-**[Documentation](https://farm.js.dev)** • **[Examples](./examples)** • **[Contributing](CONTRIBUTING.md)**
+**[Documentation](https://farmjs.dev)** • **[Examples](./examples)** • **[Contributing](CONTRIBUTING.md)**
 
 Made with ❤️ by&ensp;<a href="https://www.farming-labs.dev"><img src="./.github/assets/farming-labs-mark.svg" alt="" height="18" align="center" />&nbsp;Farming Labs</a> team
 

--- a/README.md
+++ b/README.md
@@ -403,7 +403,10 @@ We welcome contributions! Please see our [Contributing Guide](CONTRIBUTING.md) f
 - **[RSC Demo](./examples/rsc-demo)** - Server components, server actions, and server queries
 - **[React Compiler](./examples/react-compiler)** - The experimental AOT compiler side by side with baseline React
 - **[Stripe Integration](./examples/stripe-integration)** - Typed billing integration with provider-owned routes
-- **[Renderers](./examples/solid-renderer)** - Preact, Solid, Vue, and Svelte apps on the same framework contracts
+- **[Solid Renderer](./examples/solid-renderer)** - A Solid app on the same framework contracts
+- **[Preact Renderer](./examples/preact-renderer)** - A Preact app on the same framework contracts
+- **[Vue Renderer](./examples/vue-renderer)** - A Vue app on the same framework contracts
+- **[Svelte Renderer](./examples/svelte-renderer)** - A Svelte app on the same framework contracts
 
 ## 🔗 Ecosystem
 


### PR DESCRIPTION
## Problem

the readme had two links to farm.js.dev which does not resolve (real domain is farmjs.dev), an examples section linking with-database and e-commerce which do not exist, a project structure block listing the missing farm-types package, and a license line pointing at the wrong github org. it also never mentioned the AOT compiler or the non-react renderers, which are the two most distinctive things in the repo.

## Change

- fixed both farm.js.dev links to farmjs.dev
- replaced dead example links with real ones (rsc-demo, react-compiler, stripe-integration, renderer examples)
- updated the project structure block to real packages
- license now points at farming-labs
- intro and feature table now cover renderer choice (react default, preact/solid/vue/svelte) and the experimental compiler with a link to benchmarks/compiler

## Verification

checked every referenced path exists in the repo and every external url resolves.

## Documentation and release

readme only, no code changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes dead links and outdated content in the README: dead `farm.js.dev` links now point to `farmjs.dev`, removed example links to non-existent apps, corrected the project structure and license, and added coverage of the renderer options and the AOT compiler.

<sup>Written for commit 1f6fce2bcb3920ede2ccfacb58045e294db75dfb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/655?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

