### PR TITLE
fix(agent-runtime): strip connection-scoped proxy headers

### DIFF
--- a/packages/farm/src/__tests__/agent-runtime.test.ts
+++ b/packages/farm/src/__tests__/agent-runtime.test.ts
@@ -116,6 +116,39 @@ describe("agent runtime integration", () => {
 });
 
 describe("agent runtime proxy", () => {
+  it("removes headers named by Connection in both proxy directions", async () => {
+    let forwardedHeaders: Headers | undefined;
+    const response = await proxyAgentRuntimeRequest(
+      new Request("https://farm.test/agents/demo", {
+        headers: {
+          connection: "keep-alive, x-request-hop",
+          "x-request-hop": "request-only",
+          "x-end-to-end": "preserved",
+        },
+      }),
+      "https://agent.example.com",
+      {
+        fetch: async (_input, init) => {
+          forwardedHeaders = new Headers(init?.headers);
+          return new Response("ok", {
+            headers: {
+              connection: "x-response-hop",
+              "x-response-hop": "response-only",
+              "x-upstream": "preserved",
+            },
+          });
+        },
+      },
+    );
+
+    expect(forwardedHeaders?.get("connection")).toBeNull();
+    expect(forwardedHeaders?.get("x-request-hop")).toBeNull();
+    expect(forwardedHeaders?.get("x-end-to-end")).toBe("preserved");
+    expect(response.headers.get("connection")).toBeNull();
+    expect(response.headers.get("x-response-hop")).toBeNull();
+    expect(response.headers.get("x-upstream")).toBe("preserved");
+  });
+
   it("forwards method, body, query, auth, and streaming responses", async () => {
     const server = createServer(async (request, response) => {
       const chunks: Buffer[] = [];

--- a/packages/farm/src/agent-runtime.ts
+++ b/packages/farm/src/agent-runtime.ts
@@ -525,6 +525,14 @@ function createProxyRequestHeaders(input: Headers, incomingUrl: URL): Headers {
 }
 
 function removeHopByHopHeaders(headers: Headers): void {
+  const connectionOptions = headers.get("connection")?.split(",") ?? [];
+  for (const option of connectionOptions) {
+    const header = option.trim();
+    if (/^[!#$%&'*+.^_`|~0-9A-Za-z-]+$/.test(header)) {
+      headers.delete(header);
+    }
+  }
+
   for (const header of HOP_BY_HOP_HEADERS) {
     headers.delete(header);
   }


### PR DESCRIPTION
## Problem

The agent-runtime server proxy removed the standard hop-by-hop header names, but it still forwarded extension headers named by the `Connection` header. Request-only transport metadata could reach the agent runtime, and response-only metadata could reach the client.

## Root cause

The shared sanitizer deleted `Connection` before reading its comma-separated connection options, so it never removed the additional header fields those options identified.

## Change

Read and validate the connection-option field names first, remove those named headers, then remove the standard hop-by-hop set. The shared helper applies this in both request and response directions.

## Safety and compatibility

End-to-end headers remain unchanged. Invalid connection options are ignored safely while `Connection` itself is still removed. There is no public API change.

## Verification

- `pnpm exec oxfmt --check packages/farm/src/agent-runtime.ts packages/farm/src/__tests__/agent-runtime.test.ts`
- `pnpm exec oxlint packages/farm/src/agent-runtime.ts packages/farm/src/__tests__/agent-runtime.test.ts`
- `pnpm --filter @farm.js/core type-check`
- `pnpm --filter @farm.js/core exec vitest run src/__tests__/agent-runtime.test.ts` (9 tests passed)

The regression test fails before the fix because `x-request-hop` is forwarded.

Environment: macOS, Node 23.11.0, pnpm 8.12.1.

## Documentation and release

None.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the agent-runtime proxy to also strip headers named by the `Connection` header, so request-only metadata no longer reaches the agent runtime and response-only metadata no longer reaches the client.

**Bug Fixes**
- Reads `Connection` options before deleting the header, then removes each named header.
- Ignores invalid option names while still removing `Connection` itself.
- Leaves end-to-end headers and the public API unchanged.

<sup>Written for commit c2c0187d0172e001546a49550b3603f8926c9f6f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/659?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

