### PR TITLE
fix(compression): vary identity responses by encoding

### DIFF
--- a/packages/farm/src/__tests__/compression.test.ts
+++ b/packages/farm/src/__tests__/compression.test.ts
@@ -50,6 +50,23 @@ describe("compression plugin", () => {
     expect(brotliDecompressSync(Buffer.from(await response.arrayBuffer())).toString()).toBe(body);
   });
 
+  it("varies eligible identity responses by Accept-Encoding", async () => {
+    const manager = createManager();
+    const response = await manager.runRuntimeRequest(
+      new Request("https://farm.test/", {
+        headers: { "accept-encoding": "br;q=0, gzip;q=0" },
+      }),
+      () =>
+        new Response("identity", {
+          headers: { vary: "Accept-Language" },
+        }),
+    );
+
+    expect(response.headers.get("content-encoding")).toBeNull();
+    expect(response.headers.get("vary")).toBe("Accept-Language, Accept-Encoding");
+    expect(await response.text()).toBe("identity");
+  });
+
   it("leaves existing encodings and streaming event responses untouched", async () => {
     const manager = createManager();
     const encoded = await manager.runRuntimeRequest(

--- a/packages/farm/src/__tests__/compression.test.ts
+++ b/packages/farm/src/__tests__/compression.test.ts
@@ -81,6 +81,27 @@ describe("compression plugin", () => {
     expect(gunzipSync(Buffer.from(await response.arrayBuffer())).toString()).toBe("wildcard");
   });
 
+  it("varies eligible HEAD responses without compressing them", async () => {
+    const manager = createManager();
+    const response = await manager.runRuntimeRequest(
+      new Request("https://farm.test/", {
+        method: "HEAD",
+        headers: { "accept-encoding": "gzip" },
+      }),
+      () =>
+        new Response(null, {
+          headers: {
+            "content-type": "text/plain",
+            vary: "Accept-Language",
+          },
+        }),
+    );
+
+    expect(response.body).toBeNull();
+    expect(response.headers.get("content-encoding")).toBeNull();
+    expect(response.headers.get("vary")).toBe("Accept-Language, Accept-Encoding");
+  });
+
   it("leaves existing encodings and streaming event responses untouched", async () => {
     const manager = createManager();
     const encoded = await manager.runRuntimeRequest(

--- a/packages/farm/src/__tests__/compression.test.ts
+++ b/packages/farm/src/__tests__/compression.test.ts
@@ -67,6 +67,20 @@ describe("compression plugin", () => {
     expect(await response.text()).toBe("identity");
   });
 
+  it("preserves a wildcard Vary value", async () => {
+    const manager = createManager();
+    const response = await manager.runRuntimeRequest(
+      new Request("https://farm.test/", {
+        headers: { "accept-encoding": "gzip" },
+      }),
+      () => new Response("wildcard", { headers: { vary: "*" } }),
+    );
+
+    expect(response.headers.get("content-encoding")).toBe("gzip");
+    expect(response.headers.get("vary")).toBe("*");
+    expect(gunzipSync(Buffer.from(await response.arrayBuffer())).toString()).toBe("wildcard");
+  });
+
   it("leaves existing encodings and streaming event responses untouched", async () => {
     const manager = createManager();
     const encoded = await manager.runRuntimeRequest(

--- a/packages/farm/src/plugins/compression.ts
+++ b/packages/farm/src/plugins/compression.ts
@@ -42,10 +42,9 @@ function selectEncoding(header: string): SupportedEncoding | undefined {
   return brotli >= gzip ? "br" : "gzip";
 }
 
-function canCompress(request: Request, response: Response): boolean {
+function isCompressionEligible(request: Request, response: Response): boolean {
   if (
-    request.method === "HEAD" ||
-    !response.body ||
+    (request.method !== "HEAD" && !response.body) ||
     response.status === 204 ||
     response.status === 205 ||
     response.status === 304 ||
@@ -130,7 +129,9 @@ export function createCompressionPlugin({
 
     runtime: {
       after({ request, response, isProd }) {
-        if (!isProd || !canCompress(request, response)) return;
+        if (!isProd || !isCompressionEligible(request, response)) return;
+
+        if (request.method === "HEAD") return varyIdentityResponse(response);
 
         const encoding = selectEncoding(request.headers.get("accept-encoding") ?? "");
         if (!encoding) return varyIdentityResponse(response);

--- a/packages/farm/src/plugins/compression.ts
+++ b/packages/farm/src/plugins/compression.ts
@@ -97,6 +97,17 @@ function compressResponse(response: Response, encoding: SupportedEncoding): Resp
   });
 }
 
+function varyIdentityResponse(response: Response): Response {
+  const headers = new Headers(response.headers);
+  appendVary(headers, "Accept-Encoding");
+
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
+
 export function createCompressionPlugin({
   beforeRequest: overrideBeforeRequest,
   afterResponse: overrideAfterResponse,
@@ -121,7 +132,7 @@ export function createCompressionPlugin({
         if (!isProd || !canCompress(request, response)) return;
 
         const encoding = selectEncoding(request.headers.get("accept-encoding") ?? "");
-        if (!encoding) return;
+        if (!encoding) return varyIdentityResponse(response);
         return compressResponse(response, encoding);
       },
     },

--- a/packages/farm/src/plugins/compression.ts
+++ b/packages/farm/src/plugins/compression.ts
@@ -68,6 +68,7 @@ function appendVary(headers: Headers, value: string): void {
         .map((item) => item.trim())
         .filter(Boolean)
     : [];
+  if (values.includes("*")) return;
   if (!values.some((item) => item.toLowerCase() === value.toLowerCase())) {
     values.push(value);
   }


### PR DESCRIPTION
## Problem

When compression negotiation selected the identity representation, the production compression plugin returned the response without `Vary: Accept-Encoding`. A shared cache could then reuse that uncompressed representation for a client that supports compression. Eligible `HEAD` responses had the same mismatch and could replace the cached metadata for their corresponding `GET` representation during revalidation.

## Root cause

The plugin appended `Accept-Encoding` only inside the branch that produced gzip or Brotli output. It also exited before applying representation metadata to `HEAD` responses.

## Change

Return an equivalent identity response with `Accept-Encoding` appended to its `Vary` header whenever the response is otherwise eligible for compression but no supported encoding is selected. Apply the same variation to eligible `HEAD` responses without attempting to compress them, and preserve a wildcard `Vary: *` value unchanged.

## Safety and compatibility

The response body, status, status text, and existing headers are preserved. Existing `Vary` values are retained without duplicates, including the wildcard form. Responses excluded from compression, including event streams, pre-encoded bodies, range responses, and `no-transform` responses, remain unchanged. There is no public API change.

## Verification

- `pnpm exec oxfmt packages/farm/src/plugins/compression.ts packages/farm/src/__tests__/compression.test.ts`
- `pnpm exec oxlint packages/farm/src/plugins/compression.ts packages/farm/src/__tests__/compression.test.ts`
- `pnpm --filter @farm.js/core type-check`
- `pnpm --filter @farm.js/core exec vitest run src/__tests__/compression.test.ts --reporter=dot` — 6 tests passed
- `git diff --check`

The identity regression test fails before the fix because the response retains only its existing `Accept-Language` variation. The added tests also cover wildcard `Vary` semantics and `HEAD` revalidation metadata.

Environment: macOS, Node 23.11.0, pnpm 8.12.1.

## Documentation and release

None. This restores HTTP cache semantics without changing configuration or public APIs.
