### PR TITLE
fix(agent-runtime): strip connection-nominated proxy headers

### DIFF
--- a/packages/farm/src/__tests__/agent-runtime.test.ts
+++ b/packages/farm/src/__tests__/agent-runtime.test.ts
@@ -152,6 +152,40 @@ describe("agent runtime proxy", () => {
     expect(await response.text()).toBe("POST:hello:done");
   });
 
+  it("removes headers named by Connection in both proxy directions", async () => {
+    let forwardedHeaders: Headers | undefined;
+    const fetch = async (_input: string | URL | Request, init?: RequestInit) => {
+      forwardedHeaders = new Headers(init?.headers);
+      return new Response("ok", {
+        headers: {
+          connection: "x-response-hop, x-response-second",
+          "x-response-hop": "private",
+          "x-response-second": "private",
+        },
+      });
+    };
+
+    const response = await proxyAgentRuntimeRequest(
+      new Request("https://farm.test/agents/demo", {
+        headers: {
+          connection: "x-request-hop, x-request-second",
+          "x-request-hop": "private",
+          "x-request-second": "private",
+        },
+      }),
+      "https://runtime.test",
+      { fetch },
+    );
+
+    expect(response.status).toBe(200);
+    expect(forwardedHeaders?.get("connection")).toBeNull();
+    expect(forwardedHeaders?.get("x-request-hop")).toBeNull();
+    expect(forwardedHeaders?.get("x-request-second")).toBeNull();
+    expect(response.headers.get("connection")).toBeNull();
+    expect(response.headers.get("x-response-hop")).toBeNull();
+    expect(response.headers.get("x-response-second")).toBeNull();
+  });
+
   it("rewrites upstream redirects and sanitizes connection failures", async () => {
     const server = createServer((_request, response) => {
       response.writeHead(302, { location: "/agents/next" });

--- a/packages/farm/src/__tests__/agent-runtime.test.ts
+++ b/packages/farm/src/__tests__/agent-runtime.test.ts
@@ -158,7 +158,7 @@ describe("agent runtime proxy", () => {
       forwardedHeaders = new Headers(init?.headers);
       return new Response("ok", {
         headers: {
-          connection: "x-response-hop, x-response-second",
+          connection: "x-response-hop, invalid response token, x-response-second",
           "x-response-hop": "private",
           "x-response-second": "private",
         },
@@ -168,7 +168,7 @@ describe("agent runtime proxy", () => {
     const response = await proxyAgentRuntimeRequest(
       new Request("https://farm.test/agents/demo", {
         headers: {
-          connection: "x-request-hop, x-request-second",
+          connection: "x-request-hop, invalid request token, x-request-second",
           "x-request-hop": "private",
           "x-request-second": "private",
         },

--- a/packages/farm/src/agent-runtime.ts
+++ b/packages/farm/src/agent-runtime.ts
@@ -27,6 +27,7 @@ const HOP_BY_HOP_HEADERS = [
   "transfer-encoding",
   "upgrade",
 ] as const;
+const HTTP_HEADER_NAME = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/;
 
 export interface FarmAgentRuntimeInstance {
   readonly provider: string;
@@ -525,6 +526,16 @@ function createProxyRequestHeaders(input: Headers, incomingUrl: URL): Headers {
 }
 
 function removeHopByHopHeaders(headers: Headers): void {
+  const connection = headers.get("connection");
+  if (connection) {
+    for (const value of connection.split(",")) {
+      const header = value.trim();
+      if (HTTP_HEADER_NAME.test(header)) {
+        headers.delete(header);
+      }
+    }
+  }
+
   for (const header of HOP_BY_HOP_HEADERS) {
     headers.delete(header);
   }


### PR DESCRIPTION
## Problem

The production agent-runtime proxy removes a fixed list of hop-by-hop headers but forwards additional fields named by the HTTP `Connection` header. A request such as `Connection: x-request-hop` therefore sends `X-Request-Hop` upstream, and the same leak occurs from upstream responses back to the Farm client.

The focused regression test fails before this change in both proxy directions.

## Root cause

`removeHopByHopHeaders()` deleted `Connection` together with the standard fixed fields without first reading its comma-separated field-name tokens. Once `Connection` was removed, the proxy no longer knew which additional headers were scoped to that connection.

## Change

Read and validate every `Connection` field-name token before removing headers, delete each nominated field, and then remove the standard hop-by-hop set. Regression coverage exercises multiple nominated request and response fields and verifies that `Connection` itself remains stripped.

## Safety and compatibility

The change affects only the agent-runtime HTTP proxy. End-to-end headers, request bodies, redirects, streaming responses, and existing forwarded metadata remain unchanged. Malformed connection tokens are ignored instead of being passed to `Headers.delete()`. No public API changes.

## Verification

- Regression test confirmed failing before the fix
- `pnpm --filter @farm.js/core exec vitest run src/__tests__/agent-runtime.test.ts --reporter=dot` — 9 tests passed
- `pnpm --filter @farm.js/core type-check`
- `pnpm exec oxlint packages/farm/src/agent-runtime.ts packages/farm/src/__tests__/agent-runtime.test.ts`
- `pnpm exec oxfmt packages/farm/src/agent-runtime.ts packages/farm/src/__tests__/agent-runtime.test.ts`
- Full core run reached 166 passing files; 15 unrelated integration suites could not collect because their sibling workspace package builds were absent in the fresh worktree. The focused production proxy suite and type-check are clean.

Environment: macOS, Node 23.11.0, pnpm 8.12.1.

## Documentation and release

None. This restores standard proxy behavior without changing configuration or public APIs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The agent-runtime proxy now strips headers named by the `Connection` header before forwarding, so those headers no longer leak upstream or back to the client. Previously only a fixed set of hop-by-hop headers were removed; now any header listed in `Connection` is deleted as well, and malformed tokens are ignored. Regression tests cover both proxy directions, including malformed connection tokens.

<sup>Written for commit f8b4b84d9cf5dd3c0214fb6075c76d58c83fb44a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/661?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

