### PR TITLE
fix(dev): link stylesheets imported by server components

### DIFF
--- a/packages/farm/src/__tests__/dev-styles.test.ts
+++ b/packages/farm/src/__tests__/dev-styles.test.ts
@@ -1,0 +1,45 @@
+// @vitest-environment node
+
+import { describe, expect, it } from "vitest";
+import { collectDevStylesheetUrls } from "../server/dev-styles";
+
+describe("collectDevStylesheetUrls", () => {
+  it("collects JS-imported stylesheets, skipping what the shell already links", () => {
+    const urls = collectDevStylesheetUrls([
+      { id: "/src/app/globals.css", url: "/src/app/globals.css" },
+      {
+        id: "/node_modules/@fontsource-variable/geist/index.css",
+        url: "/node_modules/@fontsource-variable/geist/index.css",
+      },
+      {
+        id: "/node_modules/@fontsource-variable/geist-mono/index.css",
+        url: "/node_modules/@fontsource-variable/geist-mono/index.css",
+      },
+      { id: "/src/app/layout.tsx", url: "/src/app/layout.tsx" },
+      { id: "/src/components/chart.ts", url: "/src/components/chart.ts" },
+    ]);
+    expect(urls).toEqual([
+      "/node_modules/@fontsource-variable/geist-mono/index.css",
+      "/node_modules/@fontsource-variable/geist/index.css",
+    ]);
+  });
+
+  it("dedupes query variants and keeps output deterministic", () => {
+    const urls = collectDevStylesheetUrls([
+      { id: "/src/styles/vendor.css?v=1", url: "/src/styles/vendor.css?v=1" },
+      { id: "/src/styles/vendor.css", url: "/src/styles/vendor.css" },
+      { id: "/src/styles/app.scss", url: "/src/styles/app.scss" },
+      { id: "/src/app/globals.css?direct", url: "/src/app/globals.css?direct" },
+    ]);
+    expect(urls).toEqual(["/src/styles/app.scss", "/src/styles/vendor.css"]);
+  });
+
+  it("excludes CSS modules and non-rooted or missing urls", () => {
+    const urls = collectDevStylesheetUrls([
+      { id: "/src/button.module.css", url: "/src/button.module.css" },
+      { id: "virtual:whatever.css", url: null },
+      { id: "/abs/outside.css", url: "outside.css" },
+    ]);
+    expect(urls).toEqual([]);
+  });
+});

--- a/packages/farm/src/server/dev-styles.ts
+++ b/packages/farm/src/server/dev-styles.ts
@@ -1,0 +1,41 @@
+// Stylesheets the dev document must link beyond globals.css.
+//
+// The dev shell links `/src/app/globals.css` and nothing else, so CSS that
+// enters through a JS import — `import "@fontsource-variable/geist"` in a
+// layout, a component stylesheet, vendor CSS — never reaches the page: no
+// error, just silently missing rules (farming-labs/farm.js#658). Vite's module
+// graph knows every stylesheet the app touched; collecting it closes the gap.
+
+/** The slice of Vite's ModuleNode this module reads, kept minimal for tests. */
+export interface DevStyleModule {
+  url?: string | null;
+  id?: string | null;
+  file?: string | null;
+}
+
+const STYLE_EXTENSIONS = /\.(css|scss|sass|less|styl|stylus)(?:$|\?)/;
+
+/** The stylesheet link the shell already emits; its own `@import`s resolve
+ * inside that response, so neither it nor its query variants repeat here. */
+const ALREADY_LINKED = "/src/app/globals.css";
+
+/**
+ * Stylesheet URLs from the module graph that the document should link,
+ * deduped and sorted for a deterministic head. CSS modules (`.module.css`)
+ * are excluded: their classes are hashed through the JS pipeline and a plain
+ * link would apply nothing useful.
+ */
+export function collectDevStylesheetUrls(modules: Iterable<DevStyleModule>): string[] {
+  const seen = new Set<string>();
+  for (const mod of modules) {
+    const id = mod.id ?? mod.file ?? "";
+    if (!STYLE_EXTENSIONS.test(id)) continue;
+    if (id.includes(".module.")) continue;
+    const url = mod.url;
+    if (!url || !url.startsWith("/")) continue;
+    const bare = url.split("?")[0]!;
+    if (bare === ALREADY_LINKED) continue;
+    seen.add(bare);
+  }
+  return [...seen].sort();
+}

--- a/packages/farm/src/server/renderer.ts
+++ b/packages/farm/src/server/renderer.ts
@@ -11,6 +11,7 @@ import type {
 } from "../types";
 import type { MatchedRouteSlot, RouteManager } from "../routing/route-manager";
 import { logger, toRootRelativeUrlPath } from "../utils";
+import { collectDevStylesheetUrls } from "./dev-styles";
 import {
   composeFarmFullDocument,
   extractFarmFullDocument,
@@ -525,6 +526,20 @@ export class ServerRenderer {
         "data-farm-island-strategy": options.islandStrategy || "load",
       },
       pageElement,
+    );
+  }
+
+  /// Stylesheets the app imported through JS (fontsource packages, component
+  /// CSS) that the document must link alongside globals.css — see #658.
+  private collectDevStyleHrefs(): string[] {
+    const graph = this.viteServer?.moduleGraph;
+    if (!graph) return [];
+    return collectDevStylesheetUrls(graph.idToModuleMap.values());
+  }
+
+  private collectDevStyleLinks(): string[] {
+    return this.collectDevStyleHrefs().map(
+      (href) => `<link rel="stylesheet" href="${escapeHtmlAttribute(href)}">`,
     );
   }
 
@@ -2058,6 +2073,10 @@ export class ServerRenderer {
             tag: "link",
             attrs: { rel: "stylesheet", href: "/src/app/globals.css" },
           },
+          ...this.collectDevStyleHrefs().map((href) => ({
+            tag: "link",
+            attrs: { rel: "stylesheet", href },
+          })),
         ],
       };
 
@@ -2176,6 +2195,7 @@ ${getFarmI18nClientSnapshot() ? `window.__FARM_I18N__ = ${serializeInlineValue(g
             rendererHead,
             renderFarmFontDevHead(this.config.root || process.cwd()),
             `<link rel="stylesheet" href="/src/app/globals.css">`,
+            ...this.collectDevStyleLinks(),
             `<script type="module" src="/@vite/client"></script>`,
             rendererHydrationScript,
             bootstrapScript,
@@ -2199,7 +2219,9 @@ ${getFarmI18nClientSnapshot() ? `window.__FARM_I18N__ = ${serializeInlineValue(g
   ${hasFavicon ? "" : '<link rel="icon" href="data:,">'}
   ${documentTitleTag}${metaTags}${alternateTags}${rendererHead ? `\n  ${rendererHead}` : ""}
   ${renderFarmFontDevHead(this.config.root || process.cwd())}
-  <link rel="stylesheet" href="/src/app/globals.css">
+  <link rel="stylesheet" href="/src/app/globals.css">${this.collectDevStyleLinks()
+    .map((l) => `\n  ${l}`)
+    .join("")}
   <script type="module" src="/@vite/client"></script>
   ${rendererHydrationScript}
   ${bootstrapScript}
@@ -2296,6 +2318,10 @@ ${getFarmI18nClientSnapshot() ? `window.__FARM_I18N__ = ${serializeInlineValue(g
             tag: "link",
             attrs: { rel: "stylesheet", href: "/src/app/globals.css" },
           },
+          ...this.collectDevStyleHrefs().map((href) => ({
+            tag: "link",
+            attrs: { rel: "stylesheet", href },
+          })),
         ],
       };
 
@@ -2407,6 +2433,7 @@ ${getFarmI18nClientSnapshot() ? `window.__FARM_I18N__ = ${serializeInlineValue(g
         { style: { display: "contents" } },
         element,
       );
+      const devStyleLinks = this.collectDevStyleLinks();
       const { pipe } = renderToPipeableStream(streamRoot, {
         onShellReady() {
           const shellReadyMs = Date.now() - streamStartTime;
@@ -2430,7 +2457,9 @@ ${getFarmI18nClientSnapshot() ? `window.__FARM_I18N__ = ${serializeInlineValue(g
   ${hasFavicon ? "" : '<link rel="icon" href="data:,">'}
   <title>${title}</title>${metaTags}${i18nAlternateTags}
   ${fontHead}
-  <link rel="stylesheet" href="/src/app/globals.css" />
+  <link rel="stylesheet" href="/src/app/globals.css" />${devStyleLinks
+    .map((l) => `\n  ${l}`)
+    .join("")}
   <script type="module" src="/@vite/client"></script>
   ${propsScript}
   ${hydrationClickQueueScript}
@@ -2714,6 +2743,7 @@ ${i18nSnapshot ? `window.__FARM_I18N__ = ${serializeInlineValue(i18nSnapshot)};`
           alternateLinks,
           fontHead,
           `<link rel="stylesheet" href="/src/app/globals.css" />`,
+          ...this.collectDevStyleLinks(),
           `<script type="module" src="/@vite/client"></script>`,
           rendererHydrationScript,
           integrationManifestScript,
@@ -2736,7 +2766,9 @@ ${i18nSnapshot ? `window.__FARM_I18N__ = ${serializeInlineValue(i18nSnapshot)};`
   <link rel="icon" href="data:,">
   <title>${escapeHtmlAttribute(documentTitle)}</title>${alternateLinks}
   ${fontHead}
-  <link rel="stylesheet" href="/src/app/globals.css" />
+  <link rel="stylesheet" href="/src/app/globals.css" />${this.collectDevStyleLinks()
+    .map((l) => `\n  ${l}`)
+    .join("")}
   <script type="module" src="/@vite/client"></script>
   ${rendererHydrationScript}
   ${integrationManifestScript}


### PR DESCRIPTION
Fixes #658.

## Problem
The dev document links **only** `/src/app/globals.css` (four hardcoded sites in `server/renderer.ts`), so CSS that enters through a JS import — `import "@fontsource-variable/geist"` in a root layout, component styles, vendor CSS — never reaches the page. No error, no warning: `document.fonts.size === 0` and every family reference silently falls back. Found in a real app shipping system-font fallbacks while believing it used Geist.

## Fix
**`server/dev-styles.ts`** — `collectDevStylesheetUrls(modules)`: pure, testable filter over Vite's module graph. Style extensions only (`css/scss/sass/less/styl`), dedup across query variants, deterministic (sorted) output; excludes `.module.css` (hashed through the JS pipeline — a plain link applies nothing useful), non-rooted URLs, and `globals.css` itself (its `@import`s already resolve inside that response).

**`server/renderer.ts`** — two small private helpers reading `this.viteServer.moduleGraph`, wired into **every** dev shell site: the client manifest's `sharedAssets` (both), the buffered head list, the full-document head, the buffered template, the streaming shell (hoisted local — `onShellReady`'s `this` is the callback object, not the renderer), and `createFullHTML`. **Empty collections render nothing** — output is byte-identical to today when no extra CSS exists (no vite server → `[]`).

## Tests
- `dev-styles.test.ts`: fontsource-style collection with globals skipped; query-variant dedup + determinism; CSS-module/non-rooted/missing-url exclusion.
- Renderer regression: `renderer`, `server-renderer-route-states`, `full-document`, `renderer-capabilities` — 42 tests green (they exercise every shell with an empty collection).
- `tsc --noEmit`, core build, oxlint/oxfmt clean.

## Notes
Production has a related nuance (imported CSS bundles into `assets/_virtual_farm-ssr-entry-*.css`; whether it's linked depends on the page) — left out of this PR deliberately, tracked in #658's triage comment.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the dev server so stylesheets that enter through JS imports — like `@fontsource-variable/geist` in a root layout or component styles — are linked in the document. Previously the shell linked only `/src/app/globals.css`, so imported CSS silently never reached the page (no error, no warning).

**Bug Fixes**
- Adds `collectDevStylesheetUrls` to filter Vite's module graph for linkable stylesheets.
- Dedupes query variants, sorts output, and excludes `.module.css`, non-rooted URLs, and `globals.css`.
- Wires the collected links into every dev shell site in `renderer.ts`.
- Empty collections render nothing, keeping output byte-identical when no extra CSS exists.
- Adds tests for fontsource-style collection, dedup determinism, and exclusions.
- Leaves the related production nuance out deliberately, tracked in #658.

<sup>Written for commit e4974c8252a8a66aa181cdbf4e741db071e8db2f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/663?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

