### PR TITLE
chore(react): prepare beta.8 release

### DIFF
--- a/packages/create-farm-app/templates/react-compiler/package.json
+++ b/packages/create-farm-app/templates/react-compiler/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@farm.js/core": "0.1.0-beta.75",
-    "@farm.js/react": "0.1.0-beta.7",
+    "@farm.js/react": "0.1.0-beta.8",
     "@farming-labs/docs": "0.2.111",
     "@farming-labs/farmjs": "0.2.111",
     "@farming-labs/theme": "0.2.111",

--- a/packages/farm-react/package.json
+++ b/packages/farm-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farm.js/react",
-  "version": "0.1.0-beta.7",
+  "version": "0.1.0-beta.8",
   "description": "React renderer and experimental AOT compiler for FARMJS applications",
   "keywords": [
     "aot",


### PR DESCRIPTION
## Problem

The React compiler runtime optimizations merged after `@farm.js/react@0.1.0-beta.7`, but renderer packages use an independent version line. The shared framework beta release would not publish those changes under a new React package version.

## Root cause

`@farm.js/react` is not part of the shared framework Bumpp file set, so it must be versioned separately before the workspace beta publish.

## Change

Bump `@farm.js/react` to `0.1.0-beta.8` and align the React compiler starter dependency.

## Safety and compatibility

This changes package metadata only. Runtime behavior and peer dependency ranges are unchanged.

## Verification

- `pnpm --filter @farm.js/react type-check`
- `pnpm --filter @farm.js/react test:compat`
- `pnpm --filter @farm.js/react test:runtime-size`
- `pnpm --filter @farm.js/create-app test`
- `pnpm exec oxfmt --check packages/farm-react/package.json packages/create-farm-app/templates/react-compiler/package.json`

## Documentation and release

The React compiler starter is synchronized to the new renderer beta.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps `@farm.js/react` to `0.1.0-beta.8` and syncs the React compiler starter to the same version. The renderer package versions independently from the shared framework, so this separate bump ensures the React compiler runtime optimizations merged after beta.7 are included in the workspace beta publish.

This changes package metadata only; runtime behavior and peer dependency ranges are unchanged.

<sup>Written for commit 86d17125631205371593e5e0895f891f1488665e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/664?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

