### PR TITLE
perf(react): reuse keyed rows across resized windows

### DIFF
--- a/docs/src/app/docs/renderers/react/page.md
+++ b/docs/src/app/docs/renderers/react/page.md
@@ -1068,22 +1068,22 @@ prepared. If the incoming interval has the same length and exactly the same keys
 Farm first evaluates all keys and binding snapshots and resolves every changed target across the
 complete interval. It then patches only changed bindings in place and updates each stored row
 object, so later delegated or cached handlers observe the latest data. No descriptor or DOM row is
-created, and every row keeps its identity, focus, and text selection. A fixed-length window may
-instead reorder keys from inside its own removed interval and mix them with globally fresh keys.
-Farm prepares all reused binding updates, new descriptors, binding snapshots, and detached rows
-before the first DOM write. It removes only retired rows, preserves each reused row, batches
-adjacent new rows in a fragment, and applies LIS only to the reused part of that interval so it
-moves the fewest connected rows needed by the local permutation. Rows outside the interval are not
-rerendered or rebound. Multiple length-preserving
+created, and every row keeps its identity, focus, and text selection. A window may instead grow or
+shrink while it reorders keys from inside its own removed interval and mixes them with globally
+fresh keys. Farm prepares all reused binding updates, new descriptors, binding snapshots, and
+detached rows before the first DOM write. It removes only retired rows, preserves each reused row,
+batches adjacent new rows in a fragment, updates shifted suffix indexes, and applies LIS only to
+the reused part of that interval so it moves the fewest connected rows needed by the local
+permutation. Rows outside the interval are not rerendered or rebound. Multiple length-preserving
 same-key windows queued before one compiler flush compose into one atomic refresh. Fixed-length
 queued windows may mix same-key rows with globally new final keys, and both disjoint and
 overlapping windows are supported. An overlapping position uses the last queued value;
 intermediate identities are never mounted. Farm validates the complete chain and final key set,
 then prepares every touched key, binding value, DOM target, new descriptor, binding snapshot, and
 disconnected DOM row before the first write. It patches same-key positions and swaps only final
-fresh-key positions. Untouched rows retain their identity. Duplicate final keys, keys reused from
-outside a single removed interval, and length-changing partially reused windows take complete
-reconciliation before fast-path mutation. A single insertion
+fresh-key positions. Untouched rows retain their identity. Duplicate final keys and keys reused
+from outside a single removed interval take complete reconciliation before fast-path mutation. A
+single insertion
 creates one row at that position. A removal cleans up and removes only the known row or contiguous
 range while preserving every
 surviving element. A same-key replacement patches that row in place; a new-key replacement creates
@@ -1095,8 +1095,7 @@ Effectful position expressions, runtime values that are fractional or otherwise 
 dynamic, zero, negative, or fractional removal counts, other `toSpliced()` shapes, block-bodied
 updaters, unsafe incoming expressions, custom methods, queued chains containing a structural
 window or unhinted intermediate update, an existing key moved from outside the removed interval,
-duplicate or length-changing partially reused final keys, collection-reading bindings, React-owned
-rows, nested host blocks, row
+duplicate final keys, collection-reading bindings, React-owned rows, nested host blocks, row
 conditionals, unrelated dirty dependencies, and failed runtime checks keep complete keyed
 reconciliation.
 Negative safe-integer positions and counts larger than the remaining suffix use the native
@@ -1988,9 +1987,12 @@ The package and example test suites verify more than generated code:
   perform zero descriptor creation while preserving all 64 refreshed DOM rows; a 4,096-row mixed
   window reuses and reorders 48 keyed rows, creates only 16 descriptors, evaluates only the 64
   local keys and bindings, and performs the exact 47 local LIS moves plus one fresh-row fragment;
-  another 1,000 randomized mixed local-window updates match normal React; tests also cover atomic
-  binding preparation, empty spreads, duplicate and outside-window key fallback, latest delegated
-  event data, focus, selection, hydration, Strict Mode, and queued structural fallback; another
+  a separate 4,096-row sequence grows a 64-row interval to 80 rows and then shrinks it to 40 while
+  preserving both surrounding anchors, reusing every retained row, creating only fresh rows, and
+  performing the exact local LIS moves; another 1,000 randomized variable-length mixed-window
+  updates match normal React; tests also cover atomic binding preparation, empty spreads,
+  duplicate and outside-window key fallback, latest delegated event data, focus, selection,
+  hydration, Strict Mode, and queued structural fallback; another
   1,000 deterministic queued same-key window refreshes match normal React while disjoint and
   overlapping targeted tests preserve row identity and perform no descriptor work; 1,000 queued
   mixed fresh-key and same-key replacements also match React while targeted tests require only the

--- a/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
+++ b/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
@@ -2,6 +2,32 @@
 
 Date: 2026-08-29
 
+## Variable-length local-key window reuse follow-up — 2026-09-02
+
+The full bracketed production-browser run added a separate 10,000-row workload that grows one
+64-row window to 80 rows. The update reverses and refreshes 48 keys retained from that interval,
+retires 16 old keys, adds 32 globally fresh keys, and shifts the untouched suffix without
+recreating either surrounding anchor. Both compiler builds emitted all 13 expected
+`keyedArrayPositionHints` sites, produced zero owner executions, and passed every existing
+correctness, performance, persistence, and scalability gate without lowering a threshold.
+
+| Mode   | React median | Variable local window | Compiled control | vs React | vs control |
+| ------ | -----------: | --------------------: | ---------------: | -------: | ---------: |
+| Static |    114.75 ms |              15.90 ms |         31.90 ms |    7.22x |      2.01x |
+| Hybrid |    114.75 ms |              19.10 ms |         34.80 ms |    6.01x |      1.82x |
+
+The independent gate requires at least 4x versus React and 1.5x versus the equivalent block-bodied
+compiled control in both modes. Package tests separately grow a 4,096-row table from a 64-row
+window to 80 rows and shrink it to 40, requiring exact local LIS moves, retained DOM identity,
+fresh-row-only descriptor work, retired-row cleanup, and preserved surrounding anchors. Another
+1,000 deterministic randomized variable-length updates match normal React. Atomic preparation,
+outside-window and duplicate-key fallback, controlled-input focus and selection, delegated event
+indexes, hydration, Strict Mode, unmount cleanup, and packaged React 18.3.1/19.2.8 compatibility
+also pass. The isolated exact-window runtime grows by 13 B gzip to a 13,757 B compiler premium,
+inside the unchanged 256 B allowance; the compiler-selected core still removes 82.2% of the full
+compatibility runtime. The measured environment was Chrome 145.0.7632.6, Node.js 23.11.0, and
+Apple M1 macOS arm64.
+
 ## Mixed local-key exact-window replacement follow-up — 2026-09-01
 
 The full bracketed production-browser run added a separate 10,000-row workload for one fixed

--- a/examples/react-compiler-dashboard/README.md
+++ b/examples/react-compiler-dashboard/README.md
@@ -163,7 +163,7 @@ final union. The benchmark requires the 48 old rows to disconnect, both surround
 retain identity, both final labels to reach the DOM, and zero compiled owner executions. Static and
 hybrid modes must remain at least 4x faster than React and 1.5x faster than the equivalent
 block-bodied compiled control. Together with the existing position workloads, the compiler report
-must contain all twelve dashboard `keyedArrayPositionHints`. Package tests also cover disjoint and
+must contain all thirteen dashboard `keyedArrayPositionHints`. Package tests also cover disjoint and
 overlapping fresh-key commits, mixed same-key/fresh-key commits, atomic preparation,
 existing-key-move fallback, events, controlled-input selection, Strict Mode hydration, cleanup,
 and 1,000 differential overlapping updates.

--- a/examples/react-compiler-dashboard/README.md
+++ b/examples/react-compiler-dashboard/README.md
@@ -130,6 +130,15 @@ binding work, descriptors only for fresh rows, exact local LIS moves, preparatio
 DOM write, controlled-input focus and selection, current delegated event data, hydration, Strict
 Mode, cleanup, and 1,000 randomized differential updates.
 
+Variable-length local-key reuse has a separate 10,000-row gate. It grows one 64-row interval to 80
+rows while reversing and refreshing 48 retained keys and adding 32 fresh keys. The benchmark
+requires every retained DOM row to keep its identity, every retired row to disconnect, every fresh
+row to be globally new, and both surrounding anchors to remain attached after the untouched suffix
+shifts. Static and hybrid modes must remain at least 4x faster than React and 1.5x faster than the
+equivalent block-bodied compiled control. Package tests additionally cover shrinking windows,
+exact local LIS moves, atomic preparation, delegated event indexes, focused-input selection,
+Strict Mode hydration, and 1,000 randomized grow/shrink differential updates.
+
 Same-key exact-window refresh has a separate 10,000-row gate. The benchmark replaces a 64-row
 snapshot with 64 new objects carrying the same keys in the same order and changes one visible row,
 which isolates the avoided full-list key scan without hiding the required binding update. All 64

--- a/examples/react-compiler-dashboard/scripts/benchmark.mjs
+++ b/examples/react-compiler-dashboard/scripts/benchmark.mjs
@@ -682,7 +682,10 @@ async function measureTrial(browser, trial, compilerMode, port) {
           },
         );
 
-        const measureWindowReuse = async (action) => {
+        const measureWindowReuse = async (
+          action,
+          { expectedRows, windowEnd, afterIndex, labelSuffix },
+        ) => {
           const rows = [...table.querySelectorAll("tbody tr")];
           const previousRows = new Set(rows);
           const before = rows[2_499];
@@ -692,15 +695,15 @@ async function measureTrial(browser, trial, compilerMode, port) {
           const retired = windowRows.slice(48);
           await runTableAction(action, () => {
             const nextRows = table.querySelectorAll("tbody tr");
-            const nextWindow = [...nextRows].slice(2_500, 2_564);
+            const nextWindow = [...nextRows].slice(2_500, windowEnd);
             return (
-              rowCount() === 10_000 &&
+              rowCount() === expectedRows &&
               nextRows[2_499] === before &&
-              nextRows[2_564] === after &&
+              nextRows[afterIndex] === after &&
               retained.every(
                 (row, offset) =>
                   nextWindow[offset] === row &&
-                  row.children[1]?.textContent?.endsWith(" retained"),
+                  row.children[1]?.textContent?.endsWith(labelSuffix),
               ) &&
               retired.every((row) => !row.isConnected) &&
               nextWindow.slice(48).every((row) => !previousRows.has(row))
@@ -711,55 +714,53 @@ async function measureTrial(browser, trial, compilerMode, port) {
         const tablePositionWindowReuse = await measureTable(
           async () => ensure10000(),
           async () =>
-            measureWindowReuse(() => tableButton("table-position-window-reuse").click()),
+            measureWindowReuse(() => tableButton("table-position-window-reuse").click(), {
+              expectedRows: 10_000,
+              windowEnd: 2_564,
+              afterIndex: 2_564,
+              labelSuffix: " retained",
+            }),
         );
 
         const tablePositionWindowReuseSnapshot = await measureTable(
           async () => ensure10000(),
           async () =>
-            measureWindowReuse(() =>
-              tableButton("table-position-window-reuse-snapshot").click(),
+            measureWindowReuse(
+              () => tableButton("table-position-window-reuse-snapshot").click(),
+              {
+                expectedRows: 10_000,
+                windowEnd: 2_564,
+                afterIndex: 2_564,
+                labelSuffix: " retained",
+              },
             ),
         );
-
-        const measureWindowResizeReuse = async (action) => {
-          const rows = [...table.querySelectorAll("tbody tr")];
-          const previousRows = new Set(rows);
-          const before = rows[2_499];
-          const windowRows = rows.slice(2_500, 2_564);
-          const after = rows[2_564];
-          const retained = windowRows.slice(0, 48).reverse();
-          const retired = windowRows.slice(48);
-          await runTableAction(action, () => {
-            const nextRows = table.querySelectorAll("tbody tr");
-            const nextWindow = [...nextRows].slice(2_500, 2_580);
-            return (
-              rowCount() === 10_016 &&
-              nextRows[2_499] === before &&
-              nextRows[2_580] === after &&
-              retained.every(
-                (row, offset) =>
-                  nextWindow[offset] === row && row.children[1]?.textContent?.endsWith(" resized"),
-              ) &&
-              retired.every((row) => !row.isConnected) &&
-              nextWindow.slice(48).every((row) => !previousRows.has(row))
-            );
-          });
-        };
 
         const tablePositionWindowResizeReuse = await measureTable(
           async () => ensure10000(),
           async () =>
-            measureWindowResizeReuse(() =>
-              tableButton("table-position-window-resize-reuse").click(),
+            measureWindowReuse(
+              () => tableButton("table-position-window-resize-reuse").click(),
+              {
+                expectedRows: 10_016,
+                windowEnd: 2_580,
+                afterIndex: 2_580,
+                labelSuffix: " resized",
+              },
             ),
         );
 
         const tablePositionWindowResizeReuseSnapshot = await measureTable(
           async () => ensure10000(),
           async () =>
-            measureWindowResizeReuse(() =>
-              tableButton("table-position-window-resize-reuse-snapshot").click(),
+            measureWindowReuse(
+              () => tableButton("table-position-window-resize-reuse-snapshot").click(),
+              {
+                expectedRows: 10_016,
+                windowEnd: 2_580,
+                afterIndex: 2_580,
+                labelSuffix: " resized",
+              },
             ),
         );
 

--- a/examples/react-compiler-dashboard/scripts/benchmark.mjs
+++ b/examples/react-compiler-dashboard/scripts/benchmark.mjs
@@ -143,7 +143,7 @@ async function inspectBuild(compilerMode) {
       "The compiler build did not emit a keyed-array prepend hint.",
     );
     assert(
-      compilerReport.summary.keyedArrayPositionHints >= 12,
+      compilerReport.summary.keyedArrayPositionHints >= 13,
       "The compiler build did not emit the keyed-array exact-position hints.",
     );
     assert(
@@ -719,6 +719,47 @@ async function measureTrial(browser, trial, compilerMode, port) {
           async () =>
             measureWindowReuse(() =>
               tableButton("table-position-window-reuse-snapshot").click(),
+            ),
+        );
+
+        const measureWindowResizeReuse = async (action) => {
+          const rows = [...table.querySelectorAll("tbody tr")];
+          const previousRows = new Set(rows);
+          const before = rows[2_499];
+          const windowRows = rows.slice(2_500, 2_564);
+          const after = rows[2_564];
+          const retained = windowRows.slice(0, 48).reverse();
+          const retired = windowRows.slice(48);
+          await runTableAction(action, () => {
+            const nextRows = table.querySelectorAll("tbody tr");
+            const nextWindow = [...nextRows].slice(2_500, 2_580);
+            return (
+              rowCount() === 10_016 &&
+              nextRows[2_499] === before &&
+              nextRows[2_580] === after &&
+              retained.every(
+                (row, offset) =>
+                  nextWindow[offset] === row && row.children[1]?.textContent?.endsWith(" resized"),
+              ) &&
+              retired.every((row) => !row.isConnected) &&
+              nextWindow.slice(48).every((row) => !previousRows.has(row))
+            );
+          });
+        };
+
+        const tablePositionWindowResizeReuse = await measureTable(
+          async () => ensure10000(),
+          async () =>
+            measureWindowResizeReuse(() =>
+              tableButton("table-position-window-resize-reuse").click(),
+            ),
+        );
+
+        const tablePositionWindowResizeReuseSnapshot = await measureTable(
+          async () => ensure10000(),
+          async () =>
+            measureWindowResizeReuse(() =>
+              tableButton("table-position-window-resize-reuse-snapshot").click(),
             ),
         );
 
@@ -1384,6 +1425,8 @@ async function measureTrial(browser, trial, compilerMode, port) {
             positionWindowReplaceSnapshot: tablePositionWindowReplaceSnapshot,
             positionWindowReuse: tablePositionWindowReuse,
             positionWindowReuseSnapshot: tablePositionWindowReuseSnapshot,
+            positionWindowResizeReuse: tablePositionWindowResizeReuse,
+            positionWindowResizeReuseSnapshot: tablePositionWindowResizeReuseSnapshot,
             positionWindowRefresh: tablePositionWindowRefresh,
             positionWindowRefreshQueued: tablePositionWindowRefreshQueued,
             positionWindowRefreshQueuedSnapshot: tablePositionWindowRefreshQueuedSnapshot,
@@ -1498,6 +1541,10 @@ async function measureTrial(browser, trial, compilerMode, port) {
         ),
         positionWindowReuse: timingSummary(result.table.positionWindowReuse),
         positionWindowReuseSnapshot: timingSummary(result.table.positionWindowReuseSnapshot),
+        positionWindowResizeReuse: timingSummary(result.table.positionWindowResizeReuse),
+        positionWindowResizeReuseSnapshot: timingSummary(
+          result.table.positionWindowResizeReuseSnapshot,
+        ),
         positionWindowRefresh: timingSummary(result.table.positionWindowRefresh),
         positionWindowRefreshQueued: timingSummary(result.table.positionWindowRefreshQueued),
         positionWindowRefreshQueuedSnapshot: timingSummary(
@@ -1608,6 +1655,8 @@ const tableMetrics = [
   "positionWindowReplaceSnapshot",
   "positionWindowReuse",
   "positionWindowReuseSnapshot",
+  "positionWindowResizeReuse",
+  "positionWindowResizeReuseSnapshot",
   "positionWindowRefresh",
   "positionWindowRefreshQueued",
   "positionWindowRefreshQueuedSnapshot",
@@ -1929,6 +1978,29 @@ const keyedWindowReuseRegressions = keyedWindowReuseResults.filter(
     speedup < keyedWindowReuseMinimumSpeedup ||
     !Number.isFinite(snapshotSpeedup) ||
     snapshotSpeedup < keyedWindowReuseMinimumSnapshotSpeedup,
+);
+// A variable-length exact window can retain and reorder keys from its own removed interval while
+// adding fresh rows and shifting the untouched suffix. Keep this separate from fixed-length reuse
+// so a fallback to complete list reconciliation cannot hide behind the existing gate.
+const keyedWindowResizeReuseMinimumSpeedup = 4;
+const keyedWindowResizeReuseMinimumSnapshotSpeedup = 1.5;
+const keyedWindowResizeReuseResults = ["static", "hybrid"].map((mode) => {
+  const reuseMedianMs = comparisons.table.positionWindowResizeReuse[mode].medianMs;
+  const snapshotMedianMs = comparisons.table.positionWindowResizeReuseSnapshot[mode].medianMs;
+  return {
+    mode,
+    reuseMedianMs,
+    snapshotMedianMs,
+    snapshotSpeedup: snapshotMedianMs / reuseMedianMs,
+    speedup: comparisons.table.positionWindowResizeReuse[`${mode}VsBaseline`].speedup,
+  };
+});
+const keyedWindowResizeReuseRegressions = keyedWindowResizeReuseResults.filter(
+  ({ snapshotSpeedup, speedup }) =>
+    !Number.isFinite(speedup) ||
+    speedup < keyedWindowResizeReuseMinimumSpeedup ||
+    !Number.isFinite(snapshotSpeedup) ||
+    snapshotSpeedup < keyedWindowResizeReuseMinimumSnapshotSpeedup,
 );
 // A same-key exact window should retain every row and patch only the changed bindings. Keep this
 // gate separate from fresh-key replacement so descriptor/DOM work cannot hide a refresh regression.
@@ -2275,6 +2347,7 @@ const passed =
   keyedBatchInsertRegressions.length === 0 &&
   keyedWindowReplaceRegressions.length === 0 &&
   keyedWindowReuseRegressions.length === 0 &&
+  keyedWindowResizeReuseRegressions.length === 0 &&
   keyedWindowRefreshRegressions.length === 0 &&
   keyedQueuedWindowRefreshRegressions.length === 0 &&
   keyedQueuedWindowReplaceRegressions.length === 0 &&
@@ -2351,6 +2424,13 @@ const report = {
     regressions: keyedWindowReuseRegressions,
     results: keyedWindowReuseResults,
     status: keyedWindowReuseRegressions.length === 0 ? "PASS" : "FAIL",
+  },
+  keyedWindowResizeReuseHintGate: {
+    minimumSnapshotSpeedup: keyedWindowResizeReuseMinimumSnapshotSpeedup,
+    minimumSpeedup: keyedWindowResizeReuseMinimumSpeedup,
+    regressions: keyedWindowResizeReuseRegressions,
+    results: keyedWindowResizeReuseResults,
+    status: keyedWindowResizeReuseRegressions.length === 0 ? "PASS" : "FAIL",
   },
   keyedWindowRefreshHintGate: {
     minimumSnapshotSpeedup: keyedWindowRefreshMinimumSnapshotSpeedup,

--- a/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
+++ b/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
@@ -391,6 +391,48 @@ export function StandardTableBenchmark() {
           Reuse and reorder a 64-row runtime window (snapshot control)
         </button>
         <button
+          data-action="table-position-window-resize-reuse"
+          type="button"
+          onClick={() => {
+            const nextSeed = seed + 1;
+            const position = 2_500;
+            const retained = rows
+              .slice(position, position + 48)
+              .toReversed()
+              .map((row) => ({ ...row, label: `${row.label} resized` }));
+            const additions = buildRows(32, nextSeed);
+            const replacements = [...retained, ...additions];
+            setSeed(nextSeed);
+            setRows((current) => current.toSpliced(position, 64, ...replacements));
+            setOperation("grow and reuse a runtime window");
+            setRevision((value) => value + 1);
+          }}
+        >
+          Grow and reuse a runtime window
+        </button>
+        <button
+          data-action="table-position-window-resize-reuse-snapshot"
+          type="button"
+          onClick={() => {
+            const nextSeed = seed + 1;
+            const position = 2_500;
+            const retained = rows
+              .slice(position, position + 48)
+              .toReversed()
+              .map((row) => ({ ...row, label: `${row.label} resized` }));
+            const additions = buildRows(32, nextSeed);
+            const replacements = [...retained, ...additions];
+            setSeed(nextSeed);
+            setRows((current) => {
+              return current.toSpliced(position, 64, ...replacements);
+            });
+            setOperation("grow and reuse a runtime window (snapshot control)");
+            setRevision((value) => value + 1);
+          }}
+        >
+          Grow and reuse a runtime window (snapshot control)
+        </button>
+        <button
           data-action="table-position-window-refresh"
           type="button"
           onClick={() => {

--- a/packages/farm-react/README.md
+++ b/packages/farm-react/README.md
@@ -330,12 +330,13 @@ through one document fragment. It then removes only the replaced window. When th
 has the same length and the same keys in the same order, Farm prepares every binding read and
 changed DOM target across the complete window first, patches the existing rows in place, and
 updates the stored row objects used by later events. That path creates no descriptors or DOM rows,
-and preserves row identity, focus, and selection. A fixed-length window may instead reorder keys
-from inside its own removed interval and mix them with globally fresh keys. Farm prepares all
-reused binding updates, new descriptors, binding snapshots, and detached rows before the first DOM
-write. It removes only retired rows, preserves each reused row, batches adjacent new rows in a
-fragment, and applies LIS only to the reused part of that interval so it moves the fewest connected
-rows needed by the local permutation. Rows outside the interval are not rerendered or rebound.
+and preserves row identity, focus, and selection. A window may instead grow or shrink while it
+reorders keys from inside its own removed interval and mixes them with globally fresh keys. Farm
+prepares all reused binding updates, new descriptors, binding snapshots, and detached rows before
+the first DOM write. It removes only retired rows, preserves each reused row, batches adjacent new
+rows in a fragment, updates shifted suffix indexes, and applies LIS only to the reused part of that
+interval so it moves the fewest connected rows needed by the local permutation. Rows outside the
+interval are not rerendered or rebound.
 Multiple length-preserving same-key windows
 queued before one compiler flush compose into one atomic refresh. Fixed-length queued windows may
 mix same-key refreshes with globally new final keys, and both disjoint and overlapping windows are
@@ -350,9 +351,8 @@ collection-reading rows, custom methods, position expressions with user calls or
 runtime positions that are not safe integers, dynamic, zero, negative, or fractional removal
 counts, other `toSpliced()` forms, block-bodied updaters, unsafe incoming expressions, queued
 chains containing a structural window or unhinted intermediate update, existing keys moved from
-outside the removed interval, length-changing partially reused windows, duplicate final keys,
-nested or React-owned rows, and failed checks use complete keyed reconciliation before the fast
-path mutates the DOM.
+outside the removed interval, duplicate final keys, nested or React-owned rows, and failed checks
+use complete keyed reconciliation before the fast path mutates the DOM.
 Reports expose the site count as `keyedArrayPositionHints`. Batch insertion and exact-window
 replacement use progressively separate optional runtime capabilities, so existing single-position
 and batch-only bundles do not retain window validation or replacement code.

--- a/packages/farm-react/RUNTIME_SIZE_RESULTS.json
+++ b/packages/farm-react/RUNTIME_SIZE_RESULTS.json
@@ -128,14 +128,14 @@
         "brotli": 51793
       },
       "compilerOn": {
-        "raw": 242385,
-        "gzip": 73868,
-        "brotli": 63228
+        "raw": 242411,
+        "gzip": 73881,
+        "brotli": 63239
       },
       "compilerPremium": {
-        "raw": 49394,
-        "gzip": 13744,
-        "brotli": 11435
+        "raw": 49420,
+        "gzip": 13757,
+        "brotli": 11446
       }
     },
     "keyedReorder": {
@@ -213,16 +213,16 @@
         "brotli": 51666
       },
       "full": {
-        "raw": 285969,
-        "gzip": 81027,
-        "brotli": 69009
+        "raw": 285995,
+        "gzip": 81068,
+        "brotli": 69105
       },
       "coreOnly": {
         "raw": 204922,
         "gzip": 63685,
         "brotli": 54902
       },
-      "fullRuntimePremiumGzip": 21108,
+      "fullRuntimePremiumGzip": 21149,
       "coreRuntimePremiumGzip": 3766,
       "gzipReductionPercent": 82.2
     }

--- a/packages/farm-react/RUNTIME_SIZE_RESULTS.md
+++ b/packages/farm-react/RUNTIME_SIZE_RESULTS.md
@@ -31,12 +31,12 @@ is enforced on every pull request instead of serving only as a manually recorded
 | Keyed rows with slice hints                       |          60,075 B |         72,297 B |         12,222 B |
 | Keyed rows with known-position hints              |          60,076 B |         72,344 B |         12,268 B |
 | Keyed rows with batch-position hints              |          60,091 B |         72,534 B |         12,443 B |
-| Keyed rows with exact-window hints                |          60,124 B |         73,868 B |         13,744 B |
+| Keyed rows with exact-window hints                |          60,124 B |         73,881 B |         13,757 B |
 | Keyed rows with reverse hints                     |          60,058 B |         72,115 B |         12,057 B |
 | Keyed rows with sort hints                        |          60,077 B |         72,172 B |         12,095 B |
 | Keyed rows with rolling-window hints              |          60,098 B |         73,038 B |         12,940 B |
 
-The isolated compatibility runtime contributes 21,108 B gzip over the React control. The
+The isolated compatibility runtime contributes 21,149 B gzip over the React control. The
 compiler-selected core contributes 3,766 B, an **82.2% reduction**. This comparison uses the same
 hand-authored compiled definition and changes only the runtime entry used to create it.
 
@@ -48,12 +48,12 @@ reuses the filter removal capability. Position-only, batch-position, exact-windo
 rolling-window modules select separate hint runtimes only when the compiler emits those update
 shapes. Reverse and sort share the optional reorder capability; the direct and isolated core
 results remain byte-for-byte unchanged. Over the ordinary keyed fixture, position pays 1,074 B
-gzip, batch-position pays 1,249 B, exact-window pays 2,550 B, reverse pays 863 B, sort pays 901 B,
+gzip, batch-position pays 1,249 B, exact-window pays 2,563 B, reverse pays 863 B, sort pays 901 B,
 slice pays 1,028 B, and rolling-window pays 1,746 B. The exact-window figure includes fresh-key
-replacement, atomic same-key binding refresh, window-local keyed reuse and LIS movement, queued
-same-key window composition, and disjoint queued fresh-key replacement. Unrelated bundles reject
-the optional position and reorder runtime markers, and the direct fixture rejects every structural
-runtime marker. The checked machine-readable result is
+replacement, atomic same-key binding refresh, fixed- and variable-length window-local keyed reuse
+with LIS movement, queued same-key window composition, and disjoint queued fresh-key replacement.
+Unrelated bundles reject the optional position and reorder runtime markers, and the direct fixture
+rejects every structural runtime marker. The checked machine-readable result is
 [`RUNTIME_SIZE_RESULTS.json`](./RUNTIME_SIZE_RESULTS.json).
 
 ## Existing production benchmark audit

--- a/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-window-replace-hints.test.tsx
+++ b/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-window-replace-hints.test.tsx
@@ -681,6 +681,101 @@ describe("compiled keyed-array window replacement hints", () => {
     });
   }, 15_000);
 
+  it("grows and shrinks one window while reusing only its retained rows", async () => {
+    const initialItems = Array.from(
+      { length: 4_096 },
+      (_, index): Item => ({ id: `row-${index}`, label: `Row ${index}` }),
+    );
+    const harness = createWindowHarness(initialItems);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Table />));
+    const position = 1_024;
+    const initialRows = [...container.querySelectorAll("li")];
+    const initialRowSet = new Set(initialRows);
+    const retainedForGrowth = initialItems.slice(position, position + 48).reverse();
+    const freshForGrowth = Array.from(
+      { length: 32 },
+      (_, offset): Item => ({ id: `grow-${offset}`, label: `Grow ${offset}` }),
+    );
+    const list = container.querySelector("ul")!;
+    const insertBefore = vi.spyOn(list, "insertBefore");
+    harness.counters.keys = 0;
+    harness.counters.descriptors = 0;
+    harness.counters.bindings = 0;
+
+    await act(async () => {
+      harness.replace(position, 64, [...retainedForGrowth, ...freshForGrowth]);
+      await flushCompilerUpdates();
+    });
+
+    let nextRows = [...container.querySelectorAll("li")];
+    expect(nextRows).toHaveLength(4_112);
+    expect(nextRows[position - 1]).toBe(initialRows[position - 1]);
+    expect(nextRows[position + 80]).toBe(initialRows[position + 64]);
+    retainedForGrowth.forEach((item, offset) => {
+      expect(nextRows[position + offset]).toBe(initialRows[position + 47 - offset]);
+      expect(nextRows[position + offset]?.textContent).toBe(item.label);
+    });
+    nextRows.slice(position + 48, position + 80).forEach((row) => {
+      expect(initialRowSet.has(row)).toBe(false);
+    });
+    initialRows.slice(position + 48, position + 64).forEach((row) => {
+      expect(row.isConnected).toBe(false);
+    });
+    expect(insertBefore).toHaveBeenCalledTimes(48);
+    expect(harness.counters).toEqual({
+      executions: 1,
+      renders: 1,
+      keys: 80,
+      descriptors: 32,
+      bindings: 80,
+    });
+
+    const rowsBeforeShrink = nextRows;
+    const itemsBeforeShrink = [...retainedForGrowth, ...freshForGrowth];
+    const retainedForShrink = itemsBeforeShrink.slice(0, 32).reverse();
+    const freshForShrink = Array.from(
+      { length: 8 },
+      (_, offset): Item => ({ id: `shrink-${offset}`, label: `Shrink ${offset}` }),
+    );
+    const rowsBeforeShrinkSet = new Set(rowsBeforeShrink);
+    insertBefore.mockClear();
+    harness.counters.keys = 0;
+    harness.counters.descriptors = 0;
+    harness.counters.bindings = 0;
+
+    await act(async () => {
+      harness.replace(position, 80, [...retainedForShrink, ...freshForShrink]);
+      await flushCompilerUpdates();
+    });
+
+    nextRows = [...container.querySelectorAll("li")];
+    expect(nextRows).toHaveLength(4_072);
+    expect(nextRows[position - 1]).toBe(rowsBeforeShrink[position - 1]);
+    expect(nextRows[position + 40]).toBe(rowsBeforeShrink[position + 80]);
+    retainedForShrink.forEach((item, offset) => {
+      expect(nextRows[position + offset]).toBe(rowsBeforeShrink[position + 31 - offset]);
+      expect(nextRows[position + offset]?.textContent).toBe(item.label);
+    });
+    nextRows.slice(position + 32, position + 40).forEach((row) => {
+      expect(rowsBeforeShrinkSet.has(row)).toBe(false);
+    });
+    rowsBeforeShrink.slice(position + 32, position + 80).forEach((row) => {
+      expect(row.isConnected).toBe(false);
+    });
+    expect(insertBefore).toHaveBeenCalledTimes(32);
+    expect(harness.counters).toEqual({
+      executions: 1,
+      renders: 1,
+      keys: 40,
+      descriptors: 8,
+      bindings: 40,
+    });
+  }, 15_000);
+
   it("prepares a mixed local window before the first structural DOM write", async () => {
     const harness = createWindowHarness([
       { id: "a", label: "Alpha" },
@@ -712,6 +807,7 @@ describe("compiled keyed-array window replacement hints", () => {
       harness.replace(1, 2, [
         { id: "c", label: "Gamma retained" },
         { id: "e", label: "Epsilon" },
+        { id: "f", label: "Phi" },
       ]);
       await flushCompilerUpdates();
     });
@@ -720,7 +816,7 @@ describe("compiled keyed-array window replacement hints", () => {
     const firstDomWrite = trace.findIndex((entry) => entry.startsWith("dom:"));
     expect(failedCreate).toBeGreaterThanOrEqual(0);
     expect(firstDomWrite).toBeGreaterThan(failedCreate);
-    expect(container.textContent).toBe("AlphaGamma retainedEpsilonDelta");
+    expect(container.textContent).toBe("AlphaGamma retainedEpsilonPhiDelta");
   });
 
   it("takes complete reconciliation for duplicate or outside-window reused keys", async () => {
@@ -742,16 +838,17 @@ describe("compiled keyed-array window replacement hints", () => {
       harness.replace(1, 2, [
         { id: "a", label: "Alpha duplicated" },
         { id: "e", label: "Epsilon" },
+        { id: "g", label: "Gamma replacement" },
       ]);
       await flushCompilerUpdates();
     });
-    expect(container.textContent).toBe("AlphaAlpha duplicatedEpsilonDelta");
+    expect(container.textContent).toBe("AlphaAlpha duplicatedEpsilonGamma replacementDelta");
     expect(container.querySelectorAll('[data-key="a"]')).toHaveLength(2);
-    expect(harness.counters.keys).toBeGreaterThan(2);
+    expect(harness.counters.keys).toBeGreaterThan(3);
 
     harness.counters.keys = 0;
     await act(async () => {
-      harness.replace(1, 2, [
+      harness.replace(1, 3, [
         { id: "f", label: "Phi one" },
         { id: "f", label: "Phi two" },
       ]);
@@ -1091,6 +1188,7 @@ describe("compiled keyed-array window replacement hints", () => {
     let replace = () => undefined;
     let refresh = () => undefined;
     let reuse = () => undefined;
+    let resize = () => undefined;
     const InteractiveRows = createCompiledComponentWithFeatures(
       {
         displayName: "WindowInteractiveRows",
@@ -1116,6 +1214,14 @@ describe("compiled keyed-array window replacement hints", () => {
               hintedWindowReplace(previous as Item[], 1, 2, [
                 { id: "c", label: "Gamma moved" },
                 { id: "b", label: "Beta moved" },
+              ]),
+            );
+          resize = () =>
+            state[0].set((previous) =>
+              hintedWindowReplace(previous as Item[], 1, 2, [
+                { id: "d", label: "Delta resized" },
+                { id: "f", label: "Phi resized" },
+                { id: "g", label: "Gamma fresh" },
               ]),
             );
           return (
@@ -1264,6 +1370,26 @@ describe("compiled keyed-array window replacement hints", () => {
       (container.querySelector('[data-row-button="d"]') as HTMLButtonElement).click();
     });
     expect(calls).toEqual(["f:Phi refreshed:1", "d:Delta refreshed:2"]);
+    calls.length = 0;
+
+    await act(async () => {
+      resize();
+      await flushCompilerUpdates();
+    });
+    expect(
+      [...container.querySelectorAll("li")].map((row) => row.getAttribute("data-key")),
+    ).toEqual(["a", "d", "f", "g"]);
+    expect(container.querySelector('[data-key="d"]')).toBe(deltaRow);
+    expect(container.querySelector('[aria-label="Edit d"]')).toBe(input);
+    expect(input.value).toBe("Delta resized");
+    expect(document.activeElement).toBe(input);
+    expect([input.selectionStart, input.selectionEnd]).toEqual([1, 3]);
+    await act(async () => {
+      (container.querySelector('[data-row-button="d"]') as HTMLButtonElement).click();
+      (container.querySelector('[data-row-button="f"]') as HTMLButtonElement).click();
+      (container.querySelector('[data-row-button="g"]') as HTMLButtonElement).click();
+    });
+    expect(calls).toEqual(["d:Delta resized:1", "f:Phi resized:2", "g:Gamma fresh:3"]);
   });
 
   it("matches normal React through 1,000 deterministic bounded replacements", async () => {
@@ -1338,7 +1464,7 @@ describe("compiled keyed-array window replacement hints", () => {
     expect(harness.counters.renders).toBe(1);
   }, 15_000);
 
-  it("matches React through 1,000 randomized window-local reuse and reorder updates", async () => {
+  it("matches React through 1,000 randomized variable-length local-window updates", async () => {
     const initialItems = Array.from(
       { length: 64 },
       (_, index): Item => ({ id: `row-${index}`, label: `Row ${index}` }),
@@ -1383,37 +1509,51 @@ describe("compiled keyed-array window replacement hints", () => {
     };
 
     for (let step = 0; step < 1_000; step += 1) {
-      const count = (nextRandom() % 8) + 2;
-      const position = nextRandom() % (expected.length - count + 1);
-      const previousWindow = expected.slice(position, position + count);
+      const removedCount = Math.min((nextRandom() % 8) + 2, expected.length);
+      const position = nextRandom() % (expected.length - removedCount + 1);
+      let delta = (nextRandom() % 5) - 2;
+      if (expected.length <= 40) delta = Math.abs(delta) + 1;
+      if (expected.length >= 88) delta = -(Math.abs(delta) + 1);
+      const incomingCount = Math.max(2, removedCount + delta);
+      const previousWindow = expected.slice(position, position + removedCount);
       const shuffled = [...previousWindow];
       for (let index = shuffled.length - 1; index > 0; index -= 1) {
         const target = nextRandom() % (index + 1);
         [shuffled[index], shuffled[target]] = [shuffled[target], shuffled[index]];
       }
-      let freshCount = 0;
-      const incoming = shuffled.map((item, offset): Item => {
-        if (offset === 1 || (offset > 1 && nextRandom() % 3 === 0)) {
-          freshCount += 1;
-          return {
+      const maximumRetained = Math.min(removedCount, incomingCount - 1);
+      const retainedCount = (nextRandom() % maximumRetained) + 1;
+      const incoming: Item[] = shuffled.slice(0, retainedCount).map((item, offset) => ({
+        ...item,
+        label: `Reuse ${step}.${offset}`,
+      }));
+      const freshCount = incomingCount - retainedCount;
+      incoming.push(
+        ...Array.from(
+          { length: freshCount },
+          (_, offset): Item => ({
             id: `fresh-${step}-${offset}`,
             label: `Fresh ${step}.${offset}`,
-          };
-        }
-        return { ...item, label: `Reuse ${step}.${offset}` };
-      });
+          }),
+        ),
+      );
+      for (let index = incoming.length - 1; index > 0; index -= 1) {
+        const target = nextRandom() % (index + 1);
+        [incoming[index], incoming[target]] = [incoming[target], incoming[index]];
+      }
       const beforeRows = [...compiledContainer.querySelectorAll("li")];
+      const beforeRowSet = new Set(beforeRows);
       const previousRowsByKey = new Map(
         previousWindow.map((item, offset) => [item.id, beforeRows[position + offset]]),
       );
       const incomingKeys = new Set(incoming.map((item) => item.id));
-      expected = (expected as WindowArray).toSpliced(position, count, ...incoming);
+      expected = (expected as WindowArray).toSpliced(position, removedCount, ...incoming);
       expectedFresh += freshCount;
-      expectedWork += count;
+      expectedWork += incomingCount;
 
       await act(async () => {
-        harness.replace(position, count, incoming);
-        replaceReact(position, count, incoming);
+        harness.replace(position, removedCount, incoming);
+        replaceReact(position, removedCount, incoming);
         await flushCompilerUpdates();
       });
 
@@ -1422,13 +1562,13 @@ describe("compiled keyed-array window replacement hints", () => {
       );
       const nextRows = [...compiledContainer.querySelectorAll("li")];
       if (position > 0) expect(nextRows[position - 1]).toBe(beforeRows[position - 1]);
-      if (position + count < nextRows.length) {
-        expect(nextRows[position + count]).toBe(beforeRows[position + count]);
+      if (position + removedCount < beforeRows.length) {
+        expect(nextRows[position + incomingCount]).toBe(beforeRows[position + removedCount]);
       }
       incoming.forEach((item, offset) => {
         const previousRow = previousRowsByKey.get(item.id);
         if (previousRow) expect(nextRows[position + offset]).toBe(previousRow);
-        else expect([...previousRowsByKey.values()]).not.toContain(nextRows[position + offset]);
+        else expect(beforeRowSet.has(nextRows[position + offset])).toBe(false);
       });
       previousWindow.forEach((item) => {
         if (!incomingKeys.has(item.id)) {
@@ -1772,13 +1912,29 @@ describe("compiled keyed-array window replacement hints", () => {
       harness.replace(0, 2, [
         { id: "b", label: "Beta moved" },
         { id: "a", label: "Alpha moved" },
+        { id: "d", label: "Delta fresh" },
       ]);
       await flushCompilerUpdates();
     });
-    expect(container.textContent).toBe("Beta movedAlpha movedGamma hydrated");
+    expect(container.textContent).toBe("Beta movedAlpha movedDelta freshGamma hydrated");
     expect(container.querySelector('[data-key="b"]')).toBe(beta);
     expect(container.querySelector('[data-key="a"]')).toBe(alpha);
     expect(container.querySelector('[data-key="c"]')).toBe(gamma);
+    expect(recoverable).toEqual([]);
+
+    const fresh = container.querySelector('[data-key="d"]');
+    await act(async () => {
+      harness.replace(0, 3, [
+        { id: "a", label: "Alpha restored" },
+        { id: "b", label: "Beta restored" },
+      ]);
+      await flushCompilerUpdates();
+    });
+    expect(container.textContent).toBe("Alpha restoredBeta restoredGamma hydrated");
+    expect(container.querySelector('[data-key="a"]')).toBe(alpha);
+    expect(container.querySelector('[data-key="b"]')).toBe(beta);
+    expect(container.querySelector('[data-key="c"]')).toBe(gamma);
+    expect(fresh?.isConnected).toBe(false);
     expect(recoverable).toEqual([]);
 
     await act(async () => {

--- a/packages/farm-react/src/compiler-runtime.tsx
+++ b/packages/farm-react/src/compiler-runtime.tsx
@@ -4980,10 +4980,10 @@ function reconcileCompilerKeyedArrayWindowReplace(
 
   const incomingKeySet = new Set(incomingKeys);
   if (incomingKeySet.size !== incomingKeys.length) return undefined;
-  const removedByKey = new Map(
-    removed.map((instance, offset) => [instance.key, { instance, offset }] as const),
-  );
-  if (incomingKeys.some((key) => removedByKey.has(key))) {
+  if (removed.some((instance) => incomingKeySet.has(instance.key))) {
+    const removedByKey = new Map(
+      removed.map((instance, offset) => [instance.key, { instance, offset }] as const),
+    );
     const nextWindow: CompilerKeyedRowInstance[] = [];
     const sequence: number[] = [];
     const preparedBindings: Array<readonly CompilerPreparedKeyedRowBindingUpdate[] | undefined> =

--- a/packages/farm-react/src/compiler-runtime.tsx
+++ b/packages/farm-react/src/compiler-runtime.tsx
@@ -4978,75 +4978,80 @@ function reconcileCompilerKeyedArrayWindowReplace(
     return instances;
   }
 
-  if (update.insertedCount === update.removedCount) {
-    const incomingKeySet = new Set(incomingKeys);
-    if (incomingKeySet.size !== incomingKeys.length) return undefined;
-    const removedByKey = new Map(
-      removed.map((instance, offset) => [instance.key, { instance, offset }] as const),
-    );
-    if (incomingKeys.some((key) => removedByKey.has(key))) {
-      const nextWindow: CompilerKeyedRowInstance[] = [];
-      const sequence: number[] = [];
-      const preparedBindings: Array<readonly CompilerPreparedKeyedRowBindingUpdate[] | undefined> =
-        [];
-      try {
-        for (let offset = 0; offset < update.insertedCount; offset += 1) {
-          const index = update.position + offset;
-          const item = incomingItems[offset];
-          const key = incomingKeys[offset];
-          const retained = removedByKey.get(key);
-          if (retained) {
-            const bindingUpdates = prepareKeyedRowBindingUpdates(
-              props,
-              retained.instance,
-              item,
-              index,
-            );
-            if (!bindingUpdates) return undefined;
-            nextWindow.push(retained.instance);
-            sequence.push(retained.offset);
-            preparedBindings.push(bindingUpdates);
-            continue;
-          }
-          // A key owned outside this exact window would duplicate or move a
-          // row across the proven boundary. Complete keyed reconciliation
-          // remains responsible for that case.
-          if (instances.has(key)) return undefined;
-          const descriptor = props.create(item, index);
-          nextWindow.push({
-            key,
-            element: createCompilerHostElement(root.ownerDocument, descriptor),
-            values: readKeyedRowBindingValues(props, item, index),
+  const incomingKeySet = new Set(incomingKeys);
+  if (incomingKeySet.size !== incomingKeys.length) return undefined;
+  const removedByKey = new Map(
+    removed.map((instance, offset) => [instance.key, { instance, offset }] as const),
+  );
+  if (incomingKeys.some((key) => removedByKey.has(key))) {
+    const nextWindow: CompilerKeyedRowInstance[] = [];
+    const sequence: number[] = [];
+    const preparedBindings: Array<readonly CompilerPreparedKeyedRowBindingUpdate[] | undefined> =
+      [];
+    try {
+      for (let offset = 0; offset < update.insertedCount; offset += 1) {
+        const index = update.position + offset;
+        const item = incomingItems[offset];
+        const key = incomingKeys[offset];
+        const retained = removedByKey.get(key);
+        if (retained) {
+          const bindingUpdates = prepareKeyedRowBindingUpdates(
+            props,
+            retained.instance,
             item,
             index,
-            conditionalValues: EMPTY_KEYED_ROW_CONDITIONAL_VALUES,
-          });
-          sequence.push(-1);
-          preparedBindings.push(undefined);
+          );
+          if (!bindingUpdates) return undefined;
+          nextWindow.push(retained.instance);
+          sequence.push(retained.offset);
+          preparedBindings.push(bindingUpdates);
+          continue;
         }
-      } catch {
-        return undefined;
+        // A key owned outside this exact window would duplicate or move a
+        // row across the proven boundary. Complete keyed reconciliation
+        // remains responsible for that case.
+        if (instances.has(key)) return undefined;
+        const descriptor = props.create(item, index);
+        nextWindow.push({
+          key,
+          element: createCompilerHostElement(root.ownerDocument, descriptor),
+          values: readKeyedRowBindingValues(props, item, index),
+          item,
+          index,
+          conditionalValues: EMPTY_KEYED_ROW_CONDITIONAL_VALUES,
+        });
+        sequence.push(-1);
+        preparedBindings.push(undefined);
       }
-
-      for (const instance of removed) {
-        if (incomingKeySet.has(instance.key)) continue;
-        instance.scope?.cleanup();
-        instance.element.remove();
-      }
-      for (let offset = 0; offset < nextWindow.length; offset += 1) {
-        const bindingUpdates = preparedBindings[offset];
-        if (bindingUpdates) {
-          const instance = nextWindow[offset];
-          applyPreparedKeyedRowBindingUpdates(props, instance, bindingUpdates);
-          instance.item = incomingItems[offset];
-          instance.index = update.position + offset;
-        }
-      }
-
-      reorderCompilerKeyedRows(root, nextWindow, sequence, anchor || null);
-      previousInstances.splice(update.position, update.removedCount, ...nextWindow);
-      return new Map(previousInstances.map((instance) => [instance.key, instance]));
+    } catch {
+      return undefined;
     }
+
+    for (const instance of removed) {
+      if (incomingKeySet.has(instance.key)) continue;
+      instance.scope?.cleanup();
+      instance.element.remove();
+    }
+    for (let offset = 0; offset < nextWindow.length; offset += 1) {
+      const bindingUpdates = preparedBindings[offset];
+      if (bindingUpdates) {
+        const instance = nextWindow[offset];
+        applyPreparedKeyedRowBindingUpdates(props, instance, bindingUpdates);
+        instance.item = incomingItems[offset];
+        instance.index = update.position + offset;
+      }
+    }
+
+    reorderCompilerKeyedRows(root, nextWindow, sequence, anchor || null);
+    previousInstances.splice(update.position, update.removedCount, ...nextWindow);
+    for (
+      let index = update.position + update.insertedCount;
+      index < previousInstances.length;
+      index += 1
+    ) {
+      previousInstances[index].index = index;
+    }
+    return new Map(previousInstances.map((instance) => [instance.key, instance]));
   }
 
   const knownKeys = new Set(instances.keys());


### PR DESCRIPTION
## Problem

Exact-window keyed reuse was limited to length-preserving replacements. A native update such as `current.toSpliced(position, 64, ...eightyRows)` could prove one local window and retain keys from that same removed interval, but growing or shrinking the interval still fell back to complete keyed reconciliation.

## Root cause

The local reuse path required `insertedCount === removedCount`. The runtime already proved the source, result, normalized window, untouched prefix and suffix, local key ownership, and detached-row preparation, but it did not update stored suffix indexes after a reused window changed length.

## Change

- allow a single proven exact window to grow or shrink while reusing keys only from its removed interval;
- prepare every reused binding, fresh descriptor, binding snapshot, and detached row before the first live DOM write;
- remove retired rows, batch adjacent fresh rows, use the existing local LIS mover, and update shifted suffix indexes;
- add a separate 10,000-row production benchmark and persistence gate for variable-length local-key reuse;
- document the behavior, fallback boundaries, reproducible results, and runtime-size effect.

## Safety and compatibility

- Duplicate final keys, keys owned outside the removed interval, unsupported row structures, failed preparation, custom methods, and queued structural chains still use complete React reconciliation before mutation.
- Rows outside the proven interval retain DOM identity and are not rebound or recreated.
- Controlled input focus and selection, delegated event indexes, hydration, Strict Mode, unmount cleanup, native method behavior, and atomic preparation remain covered.
- No public API or configuration changes. The optimization stays inside the existing optional exact-window compiler runtime.
- Packaged compatibility passes with React 18.3.1 and React 19.2.8.

## Verification

- `pnpm --filter @farm.js/react test -- --maxWorkers=1` — 68 files, 608 tests passed.
- `pnpm --filter @farm.js/react type-check`
- `pnpm --filter @farm.js/react build`
- `pnpm --filter @farm.js/react test:compat`
- `pnpm --filter @farm.js/react test:runtime-size`
- `pnpm --filter farm-react-compiler-dashboard-example type-check`
- `pnpm --filter farm-react-compiler-dashboard-example build`
- `pnpm --filter farm-react-compiler-dashboard-example benchmark` — all correctness, performance, persistence, and scalability gates passed.
- `pnpm docs:check-navigation`
- `pnpm docs:build`
- focused formatting, lint, and diff checks passed.

The new 10,000-row grow-and-reuse workload measured:

| Mode | React | Hinted window | Compiled control | vs React | vs control |
| --- | ---: | ---: | ---: | ---: | ---: |
| Static | 114.75 ms | 15.90 ms | 31.90 ms | 7.22x | 2.01x |
| Hybrid | 114.75 ms | 19.10 ms | 34.80 ms | 6.01x | 1.82x |

The isolated exact-window runtime grows by 13 B gzip to a 13,757 B compiler premium, within the unchanged 256 B gate. Unrelated optional runtime fixtures remain unchanged, and the compiler-selected core still removes 82.2% of the full compatibility runtime.

## Documentation and release

Updated the React renderer package README, renderer documentation, dashboard benchmark guide, persisted benchmark results, and runtime-size results. No version or release-flow change is included.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extends `@farm.js/react` exact-window keyed reuse beyond fixed-length replacements: windows can now grow or shrink while retaining and reordering keys from the removed interval instead of falling back to complete keyed reconciliation. The fast path preserves retained and surrounding DOM rows, focus, and selection while updating shifted suffix indexes.

**Verification**
- Adds 4,096-row grow/shrink coverage and 1,000 randomized variable-length differential updates against React.
- Adds a separate 10,000-row production benchmark gate; the new workload runs 6.01x faster than React in hybrid mode and 7.22x faster in static mode.
- Falls back for duplicate keys, keys owned outside the removed interval, unsupported structures, failed preparation, custom methods, and queued structural chains.
- Updates documentation and runtime-size results; the exact-window runtime grows by 13 B gzip and remains within the 256 B gate.

<sup>Written for commit 761706a9c012efd6ca8135a8ce94313b7e8c1305. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/665?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

