### PR TITLE
fix(release): pack every public package in dry runs

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -80,5 +80,9 @@ pnpm release:check
 pnpm publish:dry-run
 ```
 
+The package dry-run packs every public package into a temporary directory and removes the
+archives afterward. It does not consult npm, so packages are checked even when their current
+versions are already published.
+
 The release commands require a clean `main` branch. They preserve pnpm's Git checks instead
 of bypassing them.

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "build": "pnpm -r --filter \"./packages/*\" build",
     "dev": "turbo --filter \"./packages/*\" dev",
-    "test": "node --test scripts/release-beta.test.js scripts/publish-beta.test.js scripts/run-prisma-generate.test.js && node scripts/test-packages.js",
+    "test": "node --test scripts/pack-public-packages.test.js scripts/release-beta.test.js scripts/publish-beta.test.js scripts/run-prisma-generate.test.js && node scripts/test-packages.js",
     "test:farm": "pnpm --filter @farm.js/core test",
     "test:renderers": "node scripts/test-renderers.mjs",
     "test:ci": "node scripts/run-tests.js",
@@ -52,7 +52,7 @@
     "release:latest": "bumpp && pnpm run publish:latest",
     "release:beta": "node scripts/release-beta.js",
     "release:canary": "bumpp --preid canary && pnpm run publish:canary",
-    "publish:dry-run": "pnpm -r --filter \"./packages/*\" publish --dry-run --access public --tag beta --publish-branch main",
+    "publish:dry-run": "node scripts/pack-public-packages.js",
     "publish:latest": "pnpm -r --filter \"./packages/*\" publish --access public --tag latest --publish-branch main",
     "publish:beta": "node scripts/publish-beta.js",
     "publish:canary": "pnpm -r --filter \"./packages/*\" publish --access public --tag canary --publish-branch main",

--- a/scripts/pack-public-packages.js
+++ b/scripts/pack-public-packages.js
@@ -2,26 +2,7 @@ const { execFileSync } = require("node:child_process");
 const fs = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
-
-const workspaceRoot = path.resolve(__dirname, "..");
-
-function readPublicPackages(root = workspaceRoot) {
-  const packagesRoot = path.join(root, "packages");
-  return fs
-    .readdirSync(packagesRoot, { withFileTypes: true })
-    .filter((entry) => entry.isDirectory())
-    .map((entry) => {
-      const dir = path.join(packagesRoot, entry.name);
-      const manifestPath = path.join(dir, "package.json");
-      if (!fs.existsSync(manifestPath)) return null;
-      const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
-      return manifest.name && manifest.version && manifest.private !== true
-        ? { dir, name: manifest.name, version: manifest.version }
-        : null;
-    })
-    .filter(Boolean)
-    .sort((left, right) => left.name.localeCompare(right.name));
-}
+const { readPublicPackages } = require("./public-packages");
 
 function packPublicPackages(options = {}) {
   const packages = options.packages ?? readPublicPackages(options.root);
@@ -56,4 +37,4 @@ if (require.main === module) {
   packPublicPackages();
 }
 
-module.exports = { packPublicPackages, readPublicPackages };
+module.exports = { packPublicPackages };

--- a/scripts/pack-public-packages.js
+++ b/scripts/pack-public-packages.js
@@ -1,0 +1,59 @@
+const { execFileSync } = require("node:child_process");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const workspaceRoot = path.resolve(__dirname, "..");
+
+function readPublicPackages(root = workspaceRoot) {
+  const packagesRoot = path.join(root, "packages");
+  return fs
+    .readdirSync(packagesRoot, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => {
+      const dir = path.join(packagesRoot, entry.name);
+      const manifestPath = path.join(dir, "package.json");
+      if (!fs.existsSync(manifestPath)) return null;
+      const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+      return manifest.name && manifest.version && manifest.private !== true
+        ? { dir, name: manifest.name, version: manifest.version }
+        : null;
+    })
+    .filter(Boolean)
+    .sort((left, right) => left.name.localeCompare(right.name));
+}
+
+function packPublicPackages(options = {}) {
+  const packages = options.packages ?? readPublicPackages(options.root);
+  const run = options.run ?? execFileSync;
+  if (packages.length === 0) {
+    throw new Error("No public packages found under packages/.");
+  }
+
+  const packDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "farm-package-dry-run-"));
+  try {
+    for (const pkg of packages) {
+      console.log(`Packing ${pkg.name}@${pkg.version}...`);
+      run("pnpm", ["pack", "--pack-destination", packDirectory], {
+        cwd: pkg.dir,
+        stdio: "inherit",
+      });
+    }
+
+    const archives = fs.readdirSync(packDirectory).filter((file) => file.endsWith(".tgz"));
+    if (archives.length !== packages.length) {
+      throw new Error(
+        `Expected ${packages.length} package archive(s), but pnpm produced ${archives.length}.`,
+      );
+    }
+    console.log(`Packed ${archives.length} public package(s) successfully.`);
+  } finally {
+    fs.rmSync(packDirectory, { recursive: true, force: true });
+  }
+}
+
+if (require.main === module) {
+  packPublicPackages();
+}
+
+module.exports = { packPublicPackages, readPublicPackages };

--- a/scripts/pack-public-packages.test.js
+++ b/scripts/pack-public-packages.test.js
@@ -1,0 +1,73 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { test } = require("node:test");
+
+const { packPublicPackages, readPublicPackages } = require("./pack-public-packages");
+
+test("discovers every public package without consulting the registry", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "farm-public-packages-"));
+  try {
+    for (const [directory, manifest] of [
+      ["public-b", { name: "@farm.js/b", version: "1.0.0" }],
+      ["private", { name: "@farm.js/private", version: "1.0.0", private: true }],
+      ["public-a", { name: "@farm.js/a", version: "2.0.0", private: false }],
+    ]) {
+      const packageDirectory = path.join(root, "packages", directory);
+      fs.mkdirSync(packageDirectory, { recursive: true });
+      fs.writeFileSync(
+        path.join(packageDirectory, "package.json"),
+        `${JSON.stringify(manifest)}\n`,
+      );
+    }
+
+    assert.deepEqual(
+      readPublicPackages(root).map(({ name, version }) => ({ name, version })),
+      [
+        { name: "@farm.js/a", version: "2.0.0" },
+        { name: "@farm.js/b", version: "1.0.0" },
+      ],
+    );
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("packs each public package into an isolated temporary directory", () => {
+  const packages = [
+    { dir: "/workspace/a", name: "@farm.js/a", version: "1.0.0" },
+    { dir: "/workspace/b", name: "@farm.js/b", version: "2.0.0" },
+  ];
+  const calls = [];
+  let packDirectory;
+
+  packPublicPackages({
+    packages,
+    run(command, args, options) {
+      calls.push({ command, args, cwd: options.cwd });
+      packDirectory = args.at(-1);
+      fs.writeFileSync(path.join(packDirectory, `${path.basename(options.cwd)}.tgz`), "archive");
+    },
+  });
+
+  assert.deepEqual(
+    calls.map(({ command, args, cwd }) => ({ command, args: args.slice(0, 2), cwd })),
+    [
+      { command: "pnpm", args: ["pack", "--pack-destination"], cwd: "/workspace/a" },
+      { command: "pnpm", args: ["pack", "--pack-destination"], cwd: "/workspace/b" },
+    ],
+  );
+  assert.equal(fs.existsSync(packDirectory), false);
+});
+
+test("fails when a package does not produce an archive", () => {
+  assert.throws(
+    () =>
+      packPublicPackages({
+        packages: [{ dir: "/workspace/a", name: "@farm.js/a", version: "1.0.0" }],
+        run() {},
+      }),
+    /Expected 1 package archive.*produced 0/,
+  );
+});

--- a/scripts/pack-public-packages.test.js
+++ b/scripts/pack-public-packages.test.js
@@ -4,7 +4,8 @@ const os = require("node:os");
 const path = require("node:path");
 const { test } = require("node:test");
 
-const { packPublicPackages, readPublicPackages } = require("./pack-public-packages");
+const { packPublicPackages } = require("./pack-public-packages");
+const { readPublicPackages } = require("./public-packages");
 
 test("discovers every public package without consulting the registry", () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "farm-public-packages-"));
@@ -62,12 +63,17 @@ test("packs each public package into an isolated temporary directory", () => {
 });
 
 test("fails when a package does not produce an archive", () => {
+  let packDirectory;
   assert.throws(
     () =>
       packPublicPackages({
         packages: [{ dir: "/workspace/a", name: "@farm.js/a", version: "1.0.0" }],
-        run() {},
+        run(_command, args) {
+          packDirectory = args.at(-1);
+        },
       }),
     /Expected 1 package archive.*produced 0/,
   );
+  assert.ok(packDirectory);
+  assert.equal(fs.existsSync(packDirectory), false);
 });

--- a/scripts/pack-public-packages.test.js
+++ b/scripts/pack-public-packages.test.js
@@ -13,6 +13,7 @@ test("discovers every public package without consulting the registry", () => {
     for (const [directory, manifest] of [
       ["public-b", { name: "@farm.js/b", version: "1.0.0" }],
       ["private", { name: "@farm.js/private", version: "1.0.0", private: true }],
+      ["private-string", { name: "@farm.js/private-string", version: "1.0.0", private: "true" }],
       ["public-a", { name: "@farm.js/a", version: "2.0.0", private: false }],
     ]) {
       const packageDirectory = path.join(root, "packages", directory);
@@ -22,12 +23,24 @@ test("discovers every public package without consulting the registry", () => {
         `${JSON.stringify(manifest)}\n`,
       );
     }
+    const linkedPackageDirectory = path.join(root, "linked-package");
+    fs.mkdirSync(linkedPackageDirectory, { recursive: true });
+    fs.writeFileSync(
+      path.join(linkedPackageDirectory, "package.json"),
+      `${JSON.stringify({ name: "@farm.js/linked", version: "3.0.0" })}\n`,
+    );
+    fs.symlinkSync(
+      linkedPackageDirectory,
+      path.join(root, "packages", "linked"),
+      process.platform === "win32" ? "junction" : "dir",
+    );
 
     assert.deepEqual(
       readPublicPackages(root).map(({ name, version }) => ({ name, version })),
       [
         { name: "@farm.js/a", version: "2.0.0" },
         { name: "@farm.js/b", version: "1.0.0" },
+        { name: "@farm.js/linked", version: "3.0.0" },
       ],
     );
   } finally {

--- a/scripts/promote-betas.js
+++ b/scripts/promote-betas.js
@@ -1,21 +1,7 @@
 const { execFileSync } = require("node:child_process");
-const fs = require("node:fs");
-const path = require("node:path");
+const { readPublicPackages } = require("./public-packages");
 
-const workspaceRoot = path.resolve(__dirname, "..");
-const packagesRoot = path.join(workspaceRoot, "packages");
 const dryRun = process.argv.includes("--dry-run");
-
-function readPublicPackages() {
-  return fs
-    .readdirSync(packagesRoot, { withFileTypes: true })
-    .filter((entry) => entry.isDirectory())
-    .map((entry) => path.join(packagesRoot, entry.name, "package.json"))
-    .filter((packageJsonPath) => fs.existsSync(packageJsonPath))
-    .map((packageJsonPath) => JSON.parse(fs.readFileSync(packageJsonPath, "utf8")))
-    .filter((packageJson) => packageJson.name && packageJson.version && !packageJson.private)
-    .sort((left, right) => left.name.localeCompare(right.name));
-}
 
 function readDistTags(packageName) {
   return JSON.parse(

--- a/scripts/public-packages.js
+++ b/scripts/public-packages.js
@@ -1,0 +1,24 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+const workspaceRoot = path.resolve(__dirname, "..");
+
+function readPublicPackages(root = workspaceRoot) {
+  const packagesRoot = path.join(root, "packages");
+  return fs
+    .readdirSync(packagesRoot, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => {
+      const dir = path.join(packagesRoot, entry.name);
+      const manifestPath = path.join(dir, "package.json");
+      if (!fs.existsSync(manifestPath)) return null;
+      const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+      return manifest.name && manifest.version && manifest.private !== true
+        ? { dir, name: manifest.name, version: manifest.version }
+        : null;
+    })
+    .filter(Boolean)
+    .sort((left, right) => left.name.localeCompare(right.name));
+}
+
+module.exports = { readPublicPackages };

--- a/scripts/public-packages.js
+++ b/scripts/public-packages.js
@@ -7,13 +7,13 @@ function readPublicPackages(root = workspaceRoot) {
   const packagesRoot = path.join(root, "packages");
   return fs
     .readdirSync(packagesRoot, { withFileTypes: true })
-    .filter((entry) => entry.isDirectory())
+    .filter((entry) => entry.isDirectory() || entry.isSymbolicLink())
     .map((entry) => {
       const dir = path.join(packagesRoot, entry.name);
       const manifestPath = path.join(dir, "package.json");
       if (!fs.existsSync(manifestPath)) return null;
       const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
-      return manifest.name && manifest.version && manifest.private !== true
+      return manifest.name && manifest.version && !manifest.private
         ? { dir, name: manifest.name, version: manifest.version }
         : null;
     })

--- a/scripts/publish-beta.js
+++ b/scripts/publish-beta.js
@@ -14,11 +14,10 @@
  *                  stragglers, and promote. Useful to resume after a failure.
  */
 const { execFileSync } = require("node:child_process");
-const fs = require("node:fs");
 const path = require("node:path");
+const { readPublicPackages } = require("./public-packages");
 
 const workspaceRoot = path.resolve(__dirname, "..");
-const packagesRoot = path.join(workspaceRoot, "packages");
 
 const VERIFY_ATTEMPTS = 30;
 const VERIFY_DELAY_MS = 30_000;
@@ -50,23 +49,6 @@ function parsePublishBetaArgs(args) {
  */
 function isRetryableStagedPublishError(output) {
   return /previously staged version|previously published versions|E409|409 Conflict/i.test(output);
-}
-
-function readPublicPackages() {
-  return fs
-    .readdirSync(packagesRoot, { withFileTypes: true })
-    .filter((entry) => entry.isDirectory())
-    .map((entry) => ({
-      dir: path.join(packagesRoot, entry.name),
-      packageJsonPath: path.join(packagesRoot, entry.name, "package.json"),
-    }))
-    .filter(({ packageJsonPath }) => fs.existsSync(packageJsonPath))
-    .map(({ dir, packageJsonPath }) => ({
-      dir,
-      ...JSON.parse(fs.readFileSync(packageJsonPath, "utf8")),
-    }))
-    .filter((packageJson) => packageJson.name && packageJson.version && !packageJson.private)
-    .sort((left, right) => left.name.localeCompare(right.name));
 }
 
 function run(command, commandArgs, options = {}) {


### PR DESCRIPTION
## Problem

The recursive `pnpm publish --dry-run` command skips packages when their current versions already exist on npm. Before Bumpp changes versions, that can leave the release tarballs about to be published unverified.

## Root cause

The dry-run depended on registry publication state instead of checking each public workspace package directly.

## Change

`publish:dry-run` now discovers every non-private package under `packages/`, packs each one with pnpm into an isolated temporary directory, verifies that every package produced an archive, and removes the archives afterward.

## Safety and compatibility

No registry write or package version change occurs. The command uses the repository package manager and cleans only the exact temporary directory it creates, including on failure.

## Verification

- `pnpm exec oxlint scripts/pack-public-packages.js scripts/pack-public-packages.test.js`
- `node --test scripts/pack-public-packages.test.js scripts/release-beta.test.js scripts/publish-beta.test.js scripts/run-prisma-generate.test.js`
- `pnpm publish:dry-run` — packed all 34 public packages
- formatting and `git diff --check`

## Documentation and release

Updated `RELEASING.md` to document registry-independent package verification and temporary archive cleanup.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `publish:dry-run` so it packs every public package under `packages/`, including packages whose versions already exist on npm, instead of skipping them. It makes no registry writes or version changes.

- Discovers packages from workspace manifests, including symlinked package directories, without consulting npm.
- Packs each package into a temporary directory, verifies one archive per package, and removes the directory even on failure.
- Reuses shared package discovery in `promote-betas.js` and `publish-beta.js`, with tests and `RELEASING.md` updated.

<sup>Written for commit ae19109cd53d43a13ac7905dad89ea496d7a4c1e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/666?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

