### PR TITLE
docs(release): describe package version groups

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -26,9 +26,12 @@ pnpm release:beta
 
 Bumpp uses `beta` as the prerelease identifier for the shared release group, then pnpm publishes
 the new shared versions with the `beta` tag while leaving independently versioned packages at
-their current versions. After every current public package version is visible, the release promotes
-each current beta to npm's `latest` tag so unqualified installs receive the newest beta. If a
-package already has a stable `latest` version, the stable tag is preserved.
+their current versions. Before starting, confirm that every public package's current manifest
+version, including every independently versioned package, is a beta. The promotion step rejects a
+stable current version instead of skipping that package, which aborts the release after publishing.
+After every current beta is visible, the release promotes it to npm's `latest` tag so unqualified
+installs receive the newest beta. If a package already has a stable `latest` version, that stable tag
+is preserved.
 
 To build and publish a beta without running the test suite, pass `--no-test`:
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,8 +1,11 @@
 # Releasing Farm.js
 
-Farm.js releases every public package under `packages/*` through one Bumpp flow. Bumpp updates every package manifest to the selected version, builds the workspace, creates the release commit and Git
-tag, and pushes them before pnpm publishes the packages to npm. The first release through
-this flow also aligns any currently different package versions.
+Farm.js has a shared release group defined by the package manifests listed in `bump.config.ts`.
+Bumpp updates that group to the selected version, builds the workspace, creates the release commit
+and Git tag, and pushes them before pnpm publishes packages to npm. Public packages omitted from
+the Bumpp list keep their independently managed versions. Release preparation synchronizes starter
+dependencies to the actual version of each workspace package instead of forcing those packages into
+the shared version.
 
 ## Stable release
 
@@ -11,8 +14,9 @@ pnpm release
 ```
 
 `pnpm release` is an alias for `pnpm release:latest`. Choose the next version in the Bumpp
-prompt. After the build and Git release steps pass, every package is published with npm's
-`latest` tag.
+prompt. After the build and Git release steps pass, newly versioned shared packages are published
+with npm's `latest` tag. An independently versioned package is not bumped by this command; pnpm
+publishes it only when its current version is not already present on npm.
 
 ## Beta release
 
@@ -20,10 +24,11 @@ prompt. After the build and Git release steps pass, every package is published w
 pnpm release:beta
 ```
 
-Bumpp uses `beta` as the prerelease identifier, then pnpm publishes every package with the
-`beta` tag. After every package is published successfully, the release promotes each current
-beta to npm's `latest` tag so unqualified installs receive the newest beta. If a package already
-has a stable `latest` version, the stable tag is preserved.
+Bumpp uses `beta` as the prerelease identifier for the shared release group, then pnpm publishes
+the new shared versions with the `beta` tag while leaving independently versioned packages at
+their current versions. After every current public package version is visible, the release promotes
+each current beta to npm's `latest` tag so unqualified installs receive the newest beta. If a
+package already has a stable `latest` version, the stable tag is preserved.
 
 To build and publish a beta without running the test suite, pass `--no-test`:
 
@@ -49,8 +54,8 @@ This follows the same flow with a `canary` prerelease identifier and npm tag.
 pnpm bump
 ```
 
-This updates the shared version, builds, commits, tags, and pushes without publishing to
-npm.
+This updates the packages in the shared Bumpp group, builds, commits, tags, and pushes without
+publishing to npm. Independently versioned packages remain unchanged.
 
 ## Retry a publish
 


### PR DESCRIPTION
## Problem

The release guide says Bumpp updates and aligns every public package, but `bump.config.ts` intentionally contains only the shared release group. Renderer and other independently versioned packages keep their own versions.

## Root cause

The guide still described the older all-packages release model after independent package versioning was introduced.

## Change

The guide now explains the shared Bumpp group, independent package versions, starter dependency synchronization, and what stable, beta, and bump commands actually change.

## Safety and compatibility

Documentation only. The wording follows `bump.config.ts`, `sync-release-versions.js`, and the current publish scripts; no release behavior changes.

## Verification

- compared every statement with `bump.config.ts` and the release/publish scripts
- `pnpm exec oxfmt RELEASING.md`
- `git diff --check`

## Documentation and release

Updated `RELEASING.md`; no package or release-flow changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the release guide to reflect that Bumpp versions only the shared package group rather than every public package. It now documents independent package versions, starter dependency synchronization, and the beta prerequisite that all public packages have beta versions; a stable package can cause promotion to abort after publishing.

**Documentation**

- Clarifies what `release`, `release:beta`, and `bump` change and how stable and beta tags are applied.
- Notes that independently versioned packages publish only when their current version is not already on npm.
- Documentation-only; release scripts and behavior are unchanged.

<sup>Written for commit bb875da639837628346b00c242f91cdf40c1d256. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/667?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

