### PR TITLE
test(storage): run the Postgres adapter in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,46 @@ jobs:
         env:
           NODE_OPTIONS: --max-old-space-size=8192
 
+  postgres-storage:
+    name: Postgres Storage
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: farm
+          POSTGRES_PASSWORD: farm
+          POSTGRES_DB: farm_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run Postgres storage tests
+        run: pnpm --dir packages/farm exec vitest run src/__tests__/storage.test.ts
+        env:
+          FARM_REQUIRE_TEST_POSTGRES: "1"
+          FARM_TEST_POSTGRES_URL: postgresql://farm:farm@127.0.0.1:5432/farm_test
+
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/packages/farm/src/__tests__/storage.test.ts
+++ b/packages/farm/src/__tests__/storage.test.ts
@@ -425,14 +425,18 @@ describe("Storage", () => {
     expect(typeof vercelKV.hasItem).toBe("function");
   });
 
-  const itWithPostgres = process.env.FARM_TEST_POSTGRES_URL ? it : it.skip;
+  const postgresTestUrl = process.env.FARM_TEST_POSTGRES_URL;
+  if (process.env.FARM_REQUIRE_TEST_POSTGRES === "1" && !postgresTestUrl) {
+    throw new Error("FARM_TEST_POSTGRES_URL is required for the Postgres storage test job.");
+  }
+  const itWithPostgres = postgresTestUrl ? it : it.skip;
 
   itWithPostgres(
     "supports postgres storage against a real database",
     async () => {
       const tableName = `farm_pg_${Date.now()}_${Math.floor(Math.random() * 1_000_000)}`;
       const pg = postgresStorage({
-        url: process.env.FARM_TEST_POSTGRES_URL!,
+        url: postgresTestUrl!,
         tableName,
       });
 


### PR DESCRIPTION
## Problem

The real Postgres storage test only runs when `FARM_TEST_POSTGRES_URL` exists, but no CI workflow provided one. Postgres-specific behavior could regress while the suite remained green with the test skipped.

## Root cause

The test was added as opt-in coverage without a database service or a CI job that opted into it.

## Change

CI now starts a health-checked Postgres 16 service and runs the focused storage suite with its connection URL. The job also sets a required-coverage flag; the test fails clearly if that job ever loses its URL instead of silently skipping.

## Safety and compatibility

The service is isolated to one Linux job and uses non-production credentials. Ordinary local test runs still skip the real database test when no URL is supplied.

## Verification

- workflow YAML parses successfully
- focused storage suite passes locally with the database test skipped
- required-coverage mode fails with the intended message when the URL is absent
- GitHub CI Postgres Storage job provides the real database verification
- formatting and `git diff --check`

## Documentation and release

None.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a CI job that runs the Postgres storage tests against a real Postgres 16 service, so Postgres-specific behavior is no longer silently skipped.

- The job starts Postgres 16 with health checks and runs the storage suite with a test connection URL.
- The test now fails if `FARM_REQUIRE_TEST_POSTGRES` is set but `FARM_TEST_POSTGRES_URL` is missing.
- Local test runs still skip the Postgres test when no URL is supplied.

<sup>Written for commit 817ff379d7569e55a1e919e285026e3f6704265b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/668?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

