### PR TITLE
fix(ssg): bypass prerendered HTML for mutation requests

### DIFF
--- a/docs/src/app/docs/server-rendering/page.md
+++ b/docs/src/app/docs/server-rendering/page.md
@@ -86,6 +86,9 @@ read and keeps the route dynamic instead of freezing request-specific HTML into 
 This check covers the route module itself; continue reviewing imported components and data loaders,
 because request-bound work in transitive imports cannot be proven safe from the route source alone.
 
+Farm serves generated HTML only for `GET` and `HEAD` requests. Other request methods continue through
+the live route instead of receiving a cached page document.
+
 **src/app/about/page.tsx**
 
 ```tsx

--- a/packages/farm/src/__tests__/ssg-manifest.test.ts
+++ b/packages/farm/src/__tests__/ssg-manifest.test.ts
@@ -4,7 +4,7 @@ import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { ServerRenderer } from "../server/renderer";
+import { ServerRenderer, shouldServePrerenderedPage } from "../server/renderer";
 
 const tempDirs = new Set<string>();
 
@@ -67,5 +67,16 @@ describe("SSG manifest loading", () => {
         ]),
       ),
     ).not.toThrow();
+  });
+});
+
+describe("SSG request eligibility", () => {
+  it("only serves pre-rendered HTML for production retrieval requests", () => {
+    expect(shouldServePrerenderedPage("production", "GET")).toBe(true);
+    expect(shouldServePrerenderedPage("production", "head")).toBe(true);
+    expect(shouldServePrerenderedPage("production", undefined)).toBe(true);
+    expect(shouldServePrerenderedPage("production", "POST")).toBe(false);
+    expect(shouldServePrerenderedPage("production", "DELETE")).toBe(false);
+    expect(shouldServePrerenderedPage("development", "GET")).toBe(false);
   });
 });

--- a/packages/farm/src/server/renderer.ts
+++ b/packages/farm/src/server/renderer.ts
@@ -103,6 +103,15 @@ interface CachedPPRShell {
   html: string;
 }
 
+export function shouldServePrerenderedPage(
+  nodeEnv: string | undefined,
+  method: string | undefined,
+): boolean {
+  if (nodeEnv !== "production") return false;
+  const normalizedMethod = (method || "GET").toUpperCase();
+  return normalizedMethod === "GET" || normalizedMethod === "HEAD";
+}
+
 function formatSSGManifestError(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
@@ -1066,8 +1075,9 @@ export class ServerRenderer {
         }
       }
 
-      // Check for pre-rendered SSG page first (production only)
-      if (process.env.NODE_ENV === "production") {
+      // Pre-rendered HTML only represents retrieval requests. Other methods must
+      // continue through the live route so their request semantics are preserved.
+      if (shouldServePrerenderedPage(process.env.NODE_ENV, req.method)) {
         const ssgPage = await this.shouldServeSSG(pathname);
         if (ssgPage) {
           const served = await this.serveSSGPage(req, res, ssgPage);


### PR DESCRIPTION
## Problem

A production page present in the SSG manifest could return its generated HTML for POST, PUT, PATCH, DELETE, and other non-retrieval requests. That discarded the live request semantics and could answer a mutation request with a cached document.

## Root cause

The legacy production renderer checked only NODE_ENV and pathname before serving an SSG cache entry or file. It did not classify the request method. Nitro public assets already serve retrieval requests, so the renderer paths disagreed.

## Change

Limit prerendered page eligibility to GET and HEAD in production. Other methods continue through the existing live route path. Document that behavior in the rendering guide.

## Safety and compatibility

GET and HEAD SSG behavior is unchanged. Development is unchanged. Non-retrieval requests are not forced to a new status code; they retain the current route behavior. The check remains renderer-neutral.

## Verification

- `pnpm --dir packages/farm exec vitest run src/__tests__/ssg-manifest.test.ts`
- `pnpm --filter @farm.js/core type-check`
- `pnpm exec oxlint packages/farm/src/server/renderer.ts packages/farm/src/__tests__/ssg-manifest.test.ts`
- `pnpm docs:check-navigation`
- `git diff --check`

The regression test covers GET, HEAD, missing-method compatibility, POST, DELETE, and development eligibility.

## Documentation and release

Updated the Rendering Model page with the GET and HEAD contract.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes SSG so prerendered HTML is served only for GET and HEAD requests in production. Previously POST, PUT, PATCH, DELETE, and other non-retrieval requests could receive a cached page document instead of hitting the live route.

- GET and HEAD serving is unchanged.
- Other methods continue through the existing live route and keep their status codes.
- Adds a regression test for method eligibility, missing method compatibility, and development mode.
- Documents the GET/HEAD contract on the Rendering Model page.

<sup>Written for commit 29a0304181afa87746b7b6fcdfec0e4a2e339bc3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/670?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

