### PR TITLE
perf(react): compose queued resized keyed windows

### DIFF
--- a/docs/src/app/docs/renderers/react/page.md
+++ b/docs/src/app/docs/renderers/react/page.md
@@ -1083,7 +1083,12 @@ then prepares every touched key, binding value, DOM target, new descriptor, bind
 disconnected DOM row before the first write. It patches same-key positions and swaps only final
 fresh-key positions. Untouched rows retain their identity. Duplicate final keys and keys reused
 from outside a single removed interval take complete reconciliation before fast-path mutation. A
-single insertion
+queued chain may also contain disjoint grow or shrink windows. Farm maps every immediate-source
+position through earlier length changes, proves that the source and final intervals remain
+disjoint, and prepares all local key reuse, fresh rows, binding updates, cleanup, and per-window LIS
+moves before changing the DOM. Adjacent windows and empty incoming intervals remain eligible. An
+overlapping structural window or a key transferred between windows keeps complete reconciliation.
+A single insertion
 creates one row at that position. A removal cleans up and removes only the known row or contiguous
 range while preserving every
 surviving element. A same-key replacement patches that row in place; a new-key replacement creates
@@ -1093,11 +1098,11 @@ and bindings are not reread.
 The proof requires compiler-owned host rows whose render and key do not observe the row index.
 Effectful position expressions, runtime values that are fractional or otherwise not safe integers,
 dynamic, zero, negative, or fractional removal counts, other `toSpliced()` shapes, block-bodied
-updaters, unsafe incoming expressions, custom methods, queued chains containing a structural
-window or unhinted intermediate update, an existing key moved from outside the removed interval,
-duplicate final keys, collection-reading bindings, React-owned rows, nested host blocks, row
-conditionals, unrelated dirty dependencies, and failed runtime checks keep complete keyed
-reconciliation.
+updaters, unsafe incoming expressions, custom methods, overlapping queued structural windows,
+unhinted intermediate updates, an existing key moved from outside its local removed interval or
+between queued windows, duplicate final keys, collection-reading bindings, React-owned rows,
+nested host blocks, row conditionals, unrelated dirty dependencies, and failed runtime checks keep
+complete keyed reconciliation.
 Negative safe-integer positions and counts larger than the remaining suffix use the native
 method's normal clamping rules. No new option or component is required. Reports expose emitted
 sites as `keyedArrayPositionHints`. Batch insertion and exact-window replacement select
@@ -1990,9 +1995,11 @@ The package and example test suites verify more than generated code:
   a separate 4,096-row sequence grows a 64-row interval to 80 rows and then shrinks it to 40 while
   preserving both surrounding anchors, reusing every retained row, creating only fresh rows, and
   performing the exact local LIS moves; another 1,000 randomized variable-length mixed-window
-  updates match normal React; tests also cover atomic binding preparation, empty spreads,
-  duplicate and outside-window key fallback, latest delegated event data, focus, selection,
-  hydration, Strict Mode, and queued structural fallback; another
+  updates match normal React; 1,000 queued disjoint grow/shrink updates also match React while
+  targeted tests cover both source orders, adjacent and empty windows, atomic preparation across
+  every window, exact local LIS moves, current delegated event indexes, focus, selection,
+  hydration, Strict Mode, cleanup, and overlapping structural or cross-window key-move fallback;
+  tests also cover duplicate and outside-window key fallback; another
   1,000 deterministic queued same-key window refreshes match normal React while disjoint and
   overlapping targeted tests preserve row identity and perform no descriptor work; 1,000 queued
   mixed fresh-key and same-key replacements also match React while targeted tests require only the

--- a/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
+++ b/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
@@ -2,6 +2,42 @@
 
 Date: 2026-08-29
 
+## Queued disjoint variable-length window follow-up — 2026-09-02
+
+The full bracketed production-browser run added a 10,000-row workload that queues two disjoint
+updates before one compiler flush. The first window grows from 64 to 80 rows while the second
+shrinks from 64 to 48, so the final table remains at 10,000 rows. Both updates reverse and refresh
+locally retained keys, retire old rows, and add globally fresh rows. Static and hybrid builds
+emitted all 15 expected `keyedArrayPositionHints` sites, preserved surrounding anchors and retained
+DOM identities, disconnected retired rows, mounted only fresh rows, and produced zero owner
+executions.
+
+| Mode   | React median | Queued resize | Compiled control | vs React | vs control |
+| ------ | -----------: | ------------: | ---------------: | -------: | ---------: |
+| Static |      72.25 ms |      13.60 ms |         25.40 ms |    5.31x |      1.87x |
+| Hybrid |      72.25 ms |      13.40 ms |         25.40 ms |    5.39x |      1.90x |
+
+The independent gate requires at least 4x versus React and 1.5x versus the equivalent block-bodied
+compiled control in both modes. One initial full run passed correctness and every specialized
+compiler gate but caught a non-reproducing broad hybrid table-creation outlier. An unchanged second
+full run passed every correctness, performance, persistence, and scalability gate; the queued
+resize result remained above both required floors in both runs.
+
+Package coverage separately queues a 32-to-40-row grow and a 32-to-24-row shrink across a
+4,096-row table. It proves 64 key and binding reads, 24 fresh descriptors, exact local LIS moves,
+retained identity, retired-row cleanup, and stable anchors without rerunning the owner. Tests also
+cover high-window-first coordinate normalization, adjacent empty windows, preparation of every
+window before the first DOM write, overlap and cross-window-key fallback, controlled-input focus
+and selection, delegated event indexes, hydration, Strict Mode, unmount-before-flush cleanup, and
+1,000 randomized queued variable-length updates against normal React. Packaged React 18.3.1 and
+19.2.8 compatibility both pass.
+
+The isolated optional window runtime has a 14,173 B gzip compiler premium, 416 B above the previous
+record after reducing the initial implementation by 206 B. The compiler-disabled core runtime
+premium remains unchanged at 3,766 B gzip and still removes 82.5% of the full compatibility
+runtime. The measured environment was Chrome 145.0.7632.6, Node.js 23.11.0, and Apple M1 macOS
+arm64.
+
 ## Variable-length local-key window reuse follow-up — 2026-09-02
 
 The full bracketed production-browser run added a separate 10,000-row workload that grows one

--- a/examples/react-compiler-dashboard/README.md
+++ b/examples/react-compiler-dashboard/README.md
@@ -139,6 +139,16 @@ equivalent block-bodied compiled control. Package tests additionally cover shrin
 exact local LIS moves, atomic preparation, delegated event indexes, focused-input selection,
 Strict Mode hydration, and 1,000 randomized grow/shrink differential updates.
 
+Queued variable-length windows have their own 10,000-row gate. One event grows an early 64-row
+interval to 80 rows and then shrinks a later 64-row interval to 48 rows using the position after
+the first length change. The benchmark requires every locally retained row to keep its identity,
+every retired row to disconnect, every fresh row to be globally new, and all four surrounding
+anchors to remain attached. Static and hybrid modes must remain at least 4x faster than React and
+1.5x faster than the equivalent block-bodied compiled control. Package tests additionally cover
+both source orders, adjacent and empty intervals, exact local LIS moves, atomic preparation,
+delegated event indexes, controlled-input selection, Strict Mode hydration and cleanup, overlap
+and cross-window key-move fallback, and 1,000 randomized queued differential updates.
+
 Same-key exact-window refresh has a separate 10,000-row gate. The benchmark replaces a 64-row
 snapshot with 64 new objects carrying the same keys in the same order and changes one visible row,
 which isolates the avoided full-list key scan without hiding the required binding update. All 64
@@ -154,7 +164,7 @@ identity while both changed labels and amounts reach the DOM. Static and hybrid 
 at least 4x faster than React and 1.5x faster than the equivalent block-bodied compiled control.
 That workload contributes two of the dashboard `keyedArrayPositionHints`. Package tests compare
 1,000 deterministic queued updates with React and cover disjoint windows, overlap with
-last-update-wins semantics, atomic preparation, structural fallback, controlled-input selection,
+last-update-wins semantics, atomic preparation, overlapping structural fallback, controlled-input selection,
 events, Strict Mode hydration, and cleanup.
 
 Queued fresh-key exact-window replacement has a separate 10,000-row gate. One event replaces two
@@ -163,7 +173,7 @@ final union. The benchmark requires the 48 old rows to disconnect, both surround
 retain identity, both final labels to reach the DOM, and zero compiled owner executions. Static and
 hybrid modes must remain at least 4x faster than React and 1.5x faster than the equivalent
 block-bodied compiled control. Together with the existing position workloads, the compiler report
-must contain all thirteen dashboard `keyedArrayPositionHints`. Package tests also cover disjoint and
+must contain all fifteen dashboard `keyedArrayPositionHints`. Package tests also cover disjoint and
 overlapping fresh-key commits, mixed same-key/fresh-key commits, atomic preparation,
 existing-key-move fallback, events, controlled-input selection, Strict Mode hydration, cleanup,
 and 1,000 differential overlapping updates.

--- a/examples/react-compiler-dashboard/scripts/benchmark.mjs
+++ b/examples/react-compiler-dashboard/scripts/benchmark.mjs
@@ -143,7 +143,7 @@ async function inspectBuild(compilerMode) {
       "The compiler build did not emit a keyed-array prepend hint.",
     );
     assert(
-      compilerReport.summary.keyedArrayPositionHints >= 13,
+      compilerReport.summary.keyedArrayPositionHints >= 15,
       "The compiler build did not emit the keyed-array exact-position hints.",
     );
     assert(
@@ -761,6 +761,63 @@ async function measureTrial(browser, trial, compilerMode, port) {
                 afterIndex: 2_580,
                 labelSuffix: " resized",
               },
+            ),
+        );
+
+        const measureQueuedWindowResize = async (action) => {
+          const rows = [...table.querySelectorAll("tbody tr")];
+          const previousRows = new Set(rows);
+          const firstBefore = rows[2_499];
+          const firstWindow = rows.slice(2_500, 2_564);
+          const firstAfter = rows[2_564];
+          const firstRetained = firstWindow.slice(0, 48).reverse();
+          const firstRetired = firstWindow.slice(48);
+          const secondBefore = rows[7_499];
+          const secondWindow = rows.slice(7_500, 7_564);
+          const secondAfter = rows[7_564];
+          const secondRetained = secondWindow.slice(0, 32).reverse();
+          const secondRetired = secondWindow.slice(32);
+          await runTableAction(action, () => {
+            const nextRows = [...table.querySelectorAll("tbody tr")];
+            const firstNextWindow = nextRows.slice(2_500, 2_580);
+            const secondNextWindow = nextRows.slice(7_516, 7_564);
+            return (
+              rowCount() === 10_000 &&
+              nextRows[2_499] === firstBefore &&
+              nextRows[2_580] === firstAfter &&
+              nextRows[7_515] === secondBefore &&
+              nextRows[7_564] === secondAfter &&
+              firstRetained.every(
+                (row, offset) =>
+                  firstNextWindow[offset] === row &&
+                  row.children[1]?.textContent?.endsWith(" queued grow"),
+              ) &&
+              secondRetained.every(
+                (row, offset) =>
+                  secondNextWindow[offset] === row &&
+                  row.children[1]?.textContent?.endsWith(" queued shrink"),
+              ) &&
+              firstRetired.every((row) => !row.isConnected) &&
+              secondRetired.every((row) => !row.isConnected) &&
+              firstNextWindow.slice(48).every((row) => !previousRows.has(row)) &&
+              secondNextWindow.slice(32).every((row) => !previousRows.has(row))
+            );
+          });
+        };
+
+        const tablePositionWindowResizeQueued = await measureTable(
+          async () => ensure10000(),
+          async () =>
+            measureQueuedWindowResize(() =>
+              tableButton("table-position-window-resize-queued").click(),
+            ),
+        );
+
+        const tablePositionWindowResizeQueuedSnapshot = await measureTable(
+          async () => ensure10000(),
+          async () =>
+            measureQueuedWindowResize(() =>
+              tableButton("table-position-window-resize-queued-snapshot").click(),
             ),
         );
 
@@ -1428,6 +1485,8 @@ async function measureTrial(browser, trial, compilerMode, port) {
             positionWindowReuseSnapshot: tablePositionWindowReuseSnapshot,
             positionWindowResizeReuse: tablePositionWindowResizeReuse,
             positionWindowResizeReuseSnapshot: tablePositionWindowResizeReuseSnapshot,
+            positionWindowResizeQueued: tablePositionWindowResizeQueued,
+            positionWindowResizeQueuedSnapshot: tablePositionWindowResizeQueuedSnapshot,
             positionWindowRefresh: tablePositionWindowRefresh,
             positionWindowRefreshQueued: tablePositionWindowRefreshQueued,
             positionWindowRefreshQueuedSnapshot: tablePositionWindowRefreshQueuedSnapshot,
@@ -1546,6 +1605,10 @@ async function measureTrial(browser, trial, compilerMode, port) {
         positionWindowResizeReuseSnapshot: timingSummary(
           result.table.positionWindowResizeReuseSnapshot,
         ),
+        positionWindowResizeQueued: timingSummary(result.table.positionWindowResizeQueued),
+        positionWindowResizeQueuedSnapshot: timingSummary(
+          result.table.positionWindowResizeQueuedSnapshot,
+        ),
         positionWindowRefresh: timingSummary(result.table.positionWindowRefresh),
         positionWindowRefreshQueued: timingSummary(result.table.positionWindowRefreshQueued),
         positionWindowRefreshQueuedSnapshot: timingSummary(
@@ -1658,6 +1721,8 @@ const tableMetrics = [
   "positionWindowReuseSnapshot",
   "positionWindowResizeReuse",
   "positionWindowResizeReuseSnapshot",
+  "positionWindowResizeQueued",
+  "positionWindowResizeQueuedSnapshot",
   "positionWindowRefresh",
   "positionWindowRefreshQueued",
   "positionWindowRefreshQueuedSnapshot",
@@ -2002,6 +2067,30 @@ const keyedWindowResizeReuseRegressions = keyedWindowResizeReuseResults.filter(
     speedup < keyedWindowResizeReuseMinimumSpeedup ||
     !Number.isFinite(snapshotSpeedup) ||
     snapshotSpeedup < keyedWindowResizeReuseMinimumSnapshotSpeedup,
+);
+// Two disjoint grow/shrink windows queued before one flush must normalize their source and final
+// coordinates, preserve local key identity, and commit atomically. Keep this separate from the
+// single resized-window gate so a structural-chain fallback cannot hide behind that result.
+const keyedQueuedWindowResizeMinimumSpeedup = 4;
+const keyedQueuedWindowResizeMinimumSnapshotSpeedup = 1.5;
+const keyedQueuedWindowResizeResults = ["static", "hybrid"].map((mode) => {
+  const resizeMedianMs = comparisons.table.positionWindowResizeQueued[mode].medianMs;
+  const snapshotMedianMs =
+    comparisons.table.positionWindowResizeQueuedSnapshot[mode].medianMs;
+  return {
+    mode,
+    resizeMedianMs,
+    snapshotMedianMs,
+    snapshotSpeedup: snapshotMedianMs / resizeMedianMs,
+    speedup: comparisons.table.positionWindowResizeQueued[`${mode}VsBaseline`].speedup,
+  };
+});
+const keyedQueuedWindowResizeRegressions = keyedQueuedWindowResizeResults.filter(
+  ({ snapshotSpeedup, speedup }) =>
+    !Number.isFinite(speedup) ||
+    speedup < keyedQueuedWindowResizeMinimumSpeedup ||
+    !Number.isFinite(snapshotSpeedup) ||
+    snapshotSpeedup < keyedQueuedWindowResizeMinimumSnapshotSpeedup,
 );
 // A same-key exact window should retain every row and patch only the changed bindings. Keep this
 // gate separate from fresh-key replacement so descriptor/DOM work cannot hide a refresh regression.
@@ -2349,6 +2438,7 @@ const passed =
   keyedWindowReplaceRegressions.length === 0 &&
   keyedWindowReuseRegressions.length === 0 &&
   keyedWindowResizeReuseRegressions.length === 0 &&
+  keyedQueuedWindowResizeRegressions.length === 0 &&
   keyedWindowRefreshRegressions.length === 0 &&
   keyedQueuedWindowRefreshRegressions.length === 0 &&
   keyedQueuedWindowReplaceRegressions.length === 0 &&
@@ -2432,6 +2522,13 @@ const report = {
     regressions: keyedWindowResizeReuseRegressions,
     results: keyedWindowResizeReuseResults,
     status: keyedWindowResizeReuseRegressions.length === 0 ? "PASS" : "FAIL",
+  },
+  keyedQueuedWindowResizeHintGate: {
+    minimumSnapshotSpeedup: keyedQueuedWindowResizeMinimumSnapshotSpeedup,
+    minimumSpeedup: keyedQueuedWindowResizeMinimumSpeedup,
+    regressions: keyedQueuedWindowResizeRegressions,
+    results: keyedQueuedWindowResizeResults,
+    status: keyedQueuedWindowResizeRegressions.length === 0 ? "PASS" : "FAIL",
   },
   keyedWindowRefreshHintGate: {
     minimumSnapshotSpeedup: keyedWindowRefreshMinimumSnapshotSpeedup,

--- a/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
+++ b/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
@@ -433,6 +433,70 @@ export function StandardTableBenchmark() {
           Grow and reuse a runtime window (snapshot control)
         </button>
         <button
+          data-action="table-position-window-resize-queued"
+          type="button"
+          onClick={() => {
+            const firstSeed = seed + 1;
+            const secondSeed = seed + 2;
+            const firstPosition = 2_500;
+            const firstRetained = rows
+              .slice(firstPosition, firstPosition + 48)
+              .toReversed()
+              .map((row) => ({ ...row, label: `${row.label} queued grow` }));
+            const firstReplacements = [...firstRetained, ...buildRows(32, firstSeed)];
+            const secondSourcePosition = 7_500;
+            const secondPosition = secondSourcePosition + 16;
+            const secondRetained = rows
+              .slice(secondSourcePosition, secondSourcePosition + 32)
+              .toReversed()
+              .map((row) => ({ ...row, label: `${row.label} queued shrink` }));
+            const secondReplacements = [...secondRetained, ...buildRows(16, secondSeed)];
+            setSeed(secondSeed);
+            setRows((current) =>
+              current.toSpliced(firstPosition, 64, ...firstReplacements),
+            );
+            setRows((current) =>
+              current.toSpliced(secondPosition, 64, ...secondReplacements),
+            );
+            setOperation("queue disjoint grow and shrink windows");
+            setRevision((value) => value + 1);
+          }}
+        >
+          Queue disjoint grow and shrink windows
+        </button>
+        <button
+          data-action="table-position-window-resize-queued-snapshot"
+          type="button"
+          onClick={() => {
+            const firstSeed = seed + 1;
+            const secondSeed = seed + 2;
+            const firstPosition = 2_500;
+            const firstRetained = rows
+              .slice(firstPosition, firstPosition + 48)
+              .toReversed()
+              .map((row) => ({ ...row, label: `${row.label} queued grow` }));
+            const firstReplacements = [...firstRetained, ...buildRows(32, firstSeed)];
+            const secondSourcePosition = 7_500;
+            const secondPosition = secondSourcePosition + 16;
+            const secondRetained = rows
+              .slice(secondSourcePosition, secondSourcePosition + 32)
+              .toReversed()
+              .map((row) => ({ ...row, label: `${row.label} queued shrink` }));
+            const secondReplacements = [...secondRetained, ...buildRows(16, secondSeed)];
+            setSeed(secondSeed);
+            setRows((current) => {
+              return current.toSpliced(firstPosition, 64, ...firstReplacements);
+            });
+            setRows((current) => {
+              return current.toSpliced(secondPosition, 64, ...secondReplacements);
+            });
+            setOperation("queue disjoint grow and shrink windows (snapshot control)");
+            setRevision((value) => value + 1);
+          }}
+        >
+          Queue disjoint grow and shrink windows (snapshot control)
+        </button>
+        <button
           data-action="table-position-window-refresh"
           type="button"
           onClick={() => {

--- a/packages/farm-react/README.md
+++ b/packages/farm-react/README.md
@@ -42,7 +42,7 @@ definitions, while generated code uses the tree-shakable feature entry.
 
 The persisted production-size fixtures and regression gate live in
 [`RUNTIME_SIZE_RESULTS.md`](./RUNTIME_SIZE_RESULTS.md). The recorded direct-only runtime premium is
-73.6% smaller than the complete compatibility runtime premium; the feature-heavy keyed benchmark
+82.5% smaller than the complete compatibility runtime premium; the feature-heavy keyed benchmark
 application removes 6,185 gzip bytes from its previous compiler-on build.
 
 For selective adoption, use annotation mode:

--- a/packages/farm-react/RUNTIME_SIZE_RESULTS.json
+++ b/packages/farm-react/RUNTIME_SIZE_RESULTS.json
@@ -128,14 +128,14 @@
         "brotli": 51793
       },
       "compilerOn": {
-        "raw": 242411,
-        "gzip": 73881,
-        "brotli": 63239
+        "raw": 243233,
+        "gzip": 74297,
+        "brotli": 63756
       },
       "compilerPremium": {
-        "raw": 49420,
-        "gzip": 13757,
-        "brotli": 11446
+        "raw": 50242,
+        "gzip": 14173,
+        "brotli": 11963
       }
     },
     "keyedReorder": {
@@ -213,18 +213,18 @@
         "brotli": 51666
       },
       "full": {
-        "raw": 285995,
-        "gzip": 81068,
-        "brotli": 69105
+        "raw": 286816,
+        "gzip": 81444,
+        "brotli": 69471
       },
       "coreOnly": {
         "raw": 204922,
         "gzip": 63685,
         "brotli": 54902
       },
-      "fullRuntimePremiumGzip": 21149,
+      "fullRuntimePremiumGzip": 21525,
       "coreRuntimePremiumGzip": 3766,
-      "gzipReductionPercent": 82.2
+      "gzipReductionPercent": 82.5
     }
   }
 }

--- a/packages/farm-react/RUNTIME_SIZE_RESULTS.md
+++ b/packages/farm-react/RUNTIME_SIZE_RESULTS.md
@@ -31,13 +31,13 @@ is enforced on every pull request instead of serving only as a manually recorded
 | Keyed rows with slice hints                       |          60,075 B |         72,297 B |         12,222 B |
 | Keyed rows with known-position hints              |          60,076 B |         72,344 B |         12,268 B |
 | Keyed rows with batch-position hints              |          60,091 B |         72,534 B |         12,443 B |
-| Keyed rows with exact-window hints                |          60,124 B |         73,881 B |         13,757 B |
+| Keyed rows with exact-window hints                |          60,124 B |         74,297 B |         14,173 B |
 | Keyed rows with reverse hints                     |          60,058 B |         72,115 B |         12,057 B |
 | Keyed rows with sort hints                        |          60,077 B |         72,172 B |         12,095 B |
 | Keyed rows with rolling-window hints              |          60,098 B |         73,038 B |         12,940 B |
 
-The isolated compatibility runtime contributes 21,149 B gzip over the React control. The
-compiler-selected core contributes 3,766 B, an **82.2% reduction**. This comparison uses the same
+The isolated compatibility runtime contributes 21,525 B gzip over the React control. The
+compiler-selected core contributes 3,766 B, an **82.5% reduction**. This comparison uses the same
 hand-authored compiled definition and changes only the runtime entry used to create it.
 
 The keyed fixture retains `FarmCompiledKeyedRows` plus compiler-emitted `identityTarget`,
@@ -48,10 +48,11 @@ reuses the filter removal capability. Position-only, batch-position, exact-windo
 rolling-window modules select separate hint runtimes only when the compiler emits those update
 shapes. Reverse and sort share the optional reorder capability; the direct and isolated core
 results remain byte-for-byte unchanged. Over the ordinary keyed fixture, position pays 1,074 B
-gzip, batch-position pays 1,249 B, exact-window pays 2,563 B, reverse pays 863 B, sort pays 901 B,
+gzip, batch-position pays 1,249 B, exact-window pays 2,979 B, reverse pays 863 B, sort pays 901 B,
 slice pays 1,028 B, and rolling-window pays 1,746 B. The exact-window figure includes fresh-key
 replacement, atomic same-key binding refresh, fixed- and variable-length window-local keyed reuse
-with LIS movement, queued same-key window composition, and disjoint queued fresh-key replacement.
+with LIS movement, queued same-key window composition, disjoint queued fresh-key replacement, and
+queued disjoint variable-length local-key reuse.
 Unrelated bundles reject the optional position and reorder runtime markers, and the direct fixture
 rejects every structural runtime marker. The checked machine-readable result is
 [`RUNTIME_SIZE_RESULTS.json`](./RUNTIME_SIZE_RESULTS.json).

--- a/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-window-replace-hints.test.tsx
+++ b/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-window-replace-hints.test.tsx
@@ -82,6 +82,14 @@ function createWindowHarness(initialItems: Item[]) {
     secondPosition: number,
     second: readonly Item[],
   ) => void = () => undefined;
+  let queueWindows: (
+    firstPosition: number,
+    firstRemovedCount: number,
+    first: readonly Item[],
+    secondPosition: number,
+    secondRemovedCount: number,
+    second: readonly Item[],
+  ) => void = () => undefined;
   let queueWithUnhinted: (first: readonly Item[], second: readonly Item[]) => void = () =>
     undefined;
   let customReplace: (items: readonly Item[]) => void = () => undefined;
@@ -100,14 +108,23 @@ function createWindowHarness(initialItems: Item[]) {
           state[0].set((previous) => hintedWindowReplace(previous as Item[], 1, 2, first));
           state[0].set((previous) => hintedWindowReplace(previous as Item[], 2, 1, second));
         };
-        queueRefreshes = (firstPosition, first, secondPosition, second) => {
+        queueWindows = (
+          firstPosition,
+          firstRemovedCount,
+          first,
+          secondPosition,
+          secondRemovedCount,
+          second,
+        ) => {
           state[0].set((previous) =>
-            hintedWindowReplace(previous as Item[], firstPosition, first.length, first),
+            hintedWindowReplace(previous as Item[], firstPosition, firstRemovedCount, first),
           );
           state[0].set((previous) =>
-            hintedWindowReplace(previous as Item[], secondPosition, second.length, second),
+            hintedWindowReplace(previous as Item[], secondPosition, secondRemovedCount, second),
           );
         };
+        queueRefreshes = (firstPosition, first, secondPosition, second) =>
+          queueWindows(firstPosition, first.length, first, secondPosition, second.length, second);
         queueWithUnhinted = (first, second) => {
           state[0].set((previous) =>
             hintedWindowReplace(previous as Item[], 0, first.length, first),
@@ -200,6 +217,22 @@ function createWindowHarness(initialItems: Item[]) {
       secondPosition: number,
       second: readonly Item[],
     ) => queueRefreshes(firstPosition, first, secondPosition, second),
+    queueWindows: (
+      firstPosition: number,
+      firstRemovedCount: number,
+      first: readonly Item[],
+      secondPosition: number,
+      secondRemovedCount: number,
+      second: readonly Item[],
+    ) =>
+      queueWindows(
+        firstPosition,
+        firstRemovedCount,
+        first,
+        secondPosition,
+        secondRemovedCount,
+        second,
+      ),
     queueWithUnhinted: (first: readonly Item[], second: readonly Item[]) =>
       queueWithUnhinted(first, second),
     replace: (position: number, deleteCount: number, items: readonly Item[]) =>
@@ -776,6 +809,301 @@ describe("compiled keyed-array window replacement hints", () => {
     });
   }, 15_000);
 
+  it("composes disjoint queued grow and shrink windows with local LIS reuse", async () => {
+    const initialItems = Array.from(
+      { length: 4_096 },
+      (_, index): Item => ({ id: `row-${index}`, label: `Row ${index}` }),
+    );
+    const harness = createWindowHarness(initialItems);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Table />));
+    const initialRows = [...container.querySelectorAll("li")];
+    const initialRowSet = new Set(initialRows);
+    const firstPosition = 512;
+    const firstRetained = initialItems.slice(firstPosition, firstPosition + 24).reverse();
+    const firstFresh = Array.from(
+      { length: 16 },
+      (_, offset): Item => ({ id: `first-${offset}`, label: `First ${offset}` }),
+    );
+    const secondSourcePosition = 3_072;
+    const secondPosition = secondSourcePosition + 8;
+    const secondRetained = initialItems
+      .slice(secondSourcePosition, secondSourcePosition + 16)
+      .reverse();
+    const secondFresh = Array.from(
+      { length: 8 },
+      (_, offset): Item => ({ id: `second-${offset}`, label: `Second ${offset}` }),
+    );
+    const list = container.querySelector("ul")!;
+    const insertBefore = vi.spyOn(list, "insertBefore");
+    harness.counters.keys = 0;
+    harness.counters.descriptors = 0;
+    harness.counters.bindings = 0;
+
+    await act(async () => {
+      harness.queueWindows(
+        firstPosition,
+        32,
+        [...firstRetained, ...firstFresh],
+        secondPosition,
+        32,
+        [...secondRetained, ...secondFresh],
+      );
+      await flushCompilerUpdates();
+    });
+
+    const nextRows = [...container.querySelectorAll("li")];
+    expect(nextRows).toHaveLength(4_096);
+    expect(nextRows[firstPosition - 1]).toBe(initialRows[firstPosition - 1]);
+    expect(nextRows[firstPosition + 40]).toBe(initialRows[firstPosition + 32]);
+    expect(nextRows[secondPosition - 1]).toBe(initialRows[secondSourcePosition - 1]);
+    expect(nextRows[secondPosition + 24]).toBe(initialRows[secondSourcePosition + 32]);
+    firstRetained.forEach((item, offset) => {
+      expect(nextRows[firstPosition + offset]).toBe(initialRows[firstPosition + 23 - offset]);
+      expect(nextRows[firstPosition + offset]?.textContent).toBe(item.label);
+    });
+    secondRetained.forEach((item, offset) => {
+      expect(nextRows[secondPosition + offset]).toBe(
+        initialRows[secondSourcePosition + 15 - offset],
+      );
+      expect(nextRows[secondPosition + offset]?.textContent).toBe(item.label);
+    });
+    nextRows.slice(firstPosition + 24, firstPosition + 40).forEach((row) => {
+      expect(initialRowSet.has(row)).toBe(false);
+    });
+    nextRows.slice(secondPosition + 16, secondPosition + 24).forEach((row) => {
+      expect(initialRowSet.has(row)).toBe(false);
+    });
+    initialRows.slice(firstPosition + 24, firstPosition + 32).forEach((row) => {
+      expect(row.isConnected).toBe(false);
+    });
+    initialRows
+      .slice(secondSourcePosition + 16, secondSourcePosition + 32)
+      .forEach((row) => expect(row.isConnected).toBe(false));
+    expect(insertBefore).toHaveBeenCalledTimes(40);
+    expect(harness.counters).toEqual({
+      executions: 1,
+      renders: 1,
+      keys: 64,
+      descriptors: 24,
+      bindings: 64,
+    });
+  }, 15_000);
+
+  it("normalizes queued resized windows when the higher source window runs first", async () => {
+    const initialItems = [
+      { id: "a", label: "Alpha" },
+      { id: "b", label: "Beta" },
+      { id: "c", label: "Gamma" },
+      { id: "d", label: "Delta" },
+      { id: "e", label: "Epsilon" },
+      { id: "f", label: "Phi" },
+      { id: "g", label: "Eta" },
+      { id: "h", label: "Theta" },
+    ];
+    const harness = createWindowHarness(initialItems);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Table />));
+    const rows = [...container.querySelectorAll("li")];
+    harness.counters.keys = 0;
+    harness.counters.descriptors = 0;
+    harness.counters.bindings = 0;
+
+    await act(async () => {
+      harness.queueWindows(5, 2, [{ id: "f", label: "Phi high" }], 1, 2, [
+        { id: "c", label: "Gamma low" },
+        { id: "x", label: "Xi" },
+        { id: "b", label: "Beta low" },
+        { id: "y", label: "Upsilon" },
+      ]);
+      await flushCompilerUpdates();
+    });
+
+    expect(container.textContent).toBe("AlphaGamma lowXiBeta lowUpsilonDeltaEpsilonPhi highTheta");
+    expect(container.querySelector('[data-key="c"]')).toBe(rows[2]);
+    expect(container.querySelector('[data-key="b"]')).toBe(rows[1]);
+    expect(container.querySelector('[data-key="f"]')).toBe(rows[5]);
+    expect(rows[6]?.isConnected).toBe(false);
+    expect(harness.counters).toEqual({
+      executions: 1,
+      renders: 1,
+      keys: 5,
+      descriptors: 2,
+      bindings: 5,
+    });
+  });
+
+  it("composes an empty resized window next to another local replacement", async () => {
+    const initialItems = [
+      { id: "a", label: "Alpha" },
+      { id: "b", label: "Beta" },
+      { id: "c", label: "Gamma" },
+      { id: "d", label: "Delta" },
+      { id: "e", label: "Epsilon" },
+      { id: "f", label: "Phi" },
+    ];
+    const harness = createWindowHarness(initialItems);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Table />));
+    const rows = [...container.querySelectorAll("li")];
+    harness.counters.keys = 0;
+    harness.counters.descriptors = 0;
+    harness.counters.bindings = 0;
+
+    await act(async () => {
+      harness.queueWindows(1, 2, [], 1, 2, [
+        { id: "e", label: "Epsilon retained" },
+        { id: "x", label: "Xi" },
+        { id: "d", label: "Delta retained" },
+      ]);
+      await flushCompilerUpdates();
+    });
+
+    expect(container.textContent).toBe("AlphaEpsilon retainedXiDelta retainedPhi");
+    expect(container.querySelector('[data-key="e"]')).toBe(rows[4]);
+    expect(container.querySelector('[data-key="d"]')).toBe(rows[3]);
+    expect(rows[1]?.isConnected).toBe(false);
+    expect(rows[2]?.isConnected).toBe(false);
+    expect(harness.counters).toEqual({
+      executions: 1,
+      renders: 1,
+      keys: 3,
+      descriptors: 1,
+      bindings: 3,
+    });
+  });
+
+  it("prepares every disjoint resized window before the first structural DOM write", async () => {
+    const harness = createWindowHarness([
+      { id: "a", label: "Alpha" },
+      { id: "b", label: "Beta" },
+      { id: "c", label: "Gamma" },
+      { id: "d", label: "Delta" },
+      { id: "e", label: "Epsilon" },
+      { id: "f", label: "Phi" },
+      { id: "g", label: "Eta" },
+    ]);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Table />));
+    const list = container.querySelector("ul")!;
+    const trace: string[] = [];
+    const insertBefore = list.insertBefore.bind(list);
+    vi.spyOn(list, "insertBefore").mockImplementation((node, child) => {
+      trace.push("dom:insert");
+      return insertBefore(node, child);
+    });
+    const remove = Element.prototype.remove;
+    vi.spyOn(Element.prototype, "remove").mockImplementation(function (this: Element) {
+      trace.push(`dom:remove:${this.getAttribute("data-key")}`);
+      remove.call(this);
+    });
+    harness.traceBindings(trace);
+    harness.failNextDescriptorFor("y");
+
+    await act(async () => {
+      harness.queueWindows(
+        0,
+        2,
+        [
+          { id: "b", label: "Beta first" },
+          { id: "x", label: "Xi" },
+          { id: "a", label: "Alpha first" },
+        ],
+        5,
+        2,
+        [
+          { id: "f", label: "Phi second" },
+          { id: "y", label: "Upsilon" },
+          { id: "e", label: "Epsilon second" },
+          { id: "z", label: "Zeta" },
+        ],
+      );
+      await flushCompilerUpdates();
+    });
+
+    const failedCreate = trace.indexOf("create:y");
+    const firstDomWrite = trace.findIndex((entry) => entry.startsWith("dom:"));
+    expect(failedCreate).toBeGreaterThanOrEqual(0);
+    expect(firstDomWrite).toBeGreaterThan(failedCreate);
+    expect(container.textContent).toBe(
+      "Beta firstXiAlpha firstGammaDeltaPhi secondUpsilonEpsilon secondZetaEta",
+    );
+  });
+
+  it("falls back for overlapping resized windows and cross-window key moves", async () => {
+    const initialItems = [
+      { id: "a", label: "Alpha" },
+      { id: "b", label: "Beta" },
+      { id: "c", label: "Gamma" },
+      { id: "d", label: "Delta" },
+      { id: "e", label: "Epsilon" },
+      { id: "f", label: "Phi" },
+      { id: "g", label: "Eta" },
+      { id: "h", label: "Theta" },
+    ];
+    const harness = createWindowHarness(initialItems);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Table />));
+    harness.counters.keys = 0;
+
+    await act(async () => {
+      harness.queueWindows(
+        1,
+        2,
+        [
+          { id: "x", label: "Xi" },
+          { id: "y", label: "Upsilon" },
+          { id: "z", label: "Zeta" },
+        ],
+        2,
+        2,
+        [{ id: "q", label: "Qoppa" }],
+      );
+      await flushCompilerUpdates();
+    });
+    expect(container.textContent).toBe("AlphaXiQoppaDeltaEpsilonPhiEtaTheta");
+    expect(harness.counters.keys).toBeGreaterThan(4);
+
+    harness.counters.keys = 0;
+    await act(async () => {
+      harness.queueWindows(
+        1,
+        2,
+        [
+          { id: "m", label: "Mu" },
+          { id: "n", label: "Nu" },
+          { id: "o", label: "Omicron" },
+        ],
+        6,
+        2,
+        [
+          { id: "x", label: "Xi moved across windows" },
+          { id: "t", label: "Tau" },
+        ],
+      );
+      await flushCompilerUpdates();
+    });
+    expect(container.textContent).toBe(
+      "AlphaMuNuOmicronDeltaEpsilonXi moved across windowsTauTheta",
+    );
+    expect(harness.counters.keys).toBeGreaterThan(5);
+  });
+
   it("prepares a mixed local window before the first structural DOM write", async () => {
     const harness = createWindowHarness([
       { id: "a", label: "Alpha" },
@@ -1189,6 +1517,7 @@ describe("compiled keyed-array window replacement hints", () => {
     let refresh = () => undefined;
     let reuse = () => undefined;
     let resize = () => undefined;
+    let resizeQueued = () => undefined;
     const InteractiveRows = createCompiledComponentWithFeatures(
       {
         displayName: "WindowInteractiveRows",
@@ -1224,6 +1553,20 @@ describe("compiled keyed-array window replacement hints", () => {
                 { id: "g", label: "Gamma fresh" },
               ]),
             );
+          resizeQueued = () => {
+            state[0].set((previous) =>
+              hintedWindowReplace(previous as Item[], 0, 1, [
+                { id: "a", label: "Alpha queued" },
+                { id: "h", label: "Eta queued" },
+              ]),
+            );
+            state[0].set((previous) =>
+              hintedWindowReplace(previous as Item[], 3, 1, [
+                { id: "f", label: "Phi queued" },
+                { id: "i", label: "Iota queued" },
+              ]),
+            );
+          };
           return (
             <main>
               <blocks.KeyedRows
@@ -1390,6 +1733,33 @@ describe("compiled keyed-array window replacement hints", () => {
       (container.querySelector('[data-row-button="g"]') as HTMLButtonElement).click();
     });
     expect(calls).toEqual(["d:Delta resized:1", "f:Phi resized:2", "g:Gamma fresh:3"]);
+    calls.length = 0;
+
+    await act(async () => {
+      resizeQueued();
+      await flushCompilerUpdates();
+    });
+    expect(
+      [...container.querySelectorAll("li")].map((row) => row.getAttribute("data-key")),
+    ).toEqual(["a", "h", "d", "f", "i", "g"]);
+    expect(container.querySelector('[data-key="d"]')).toBe(deltaRow);
+    expect(container.querySelector('[aria-label="Edit d"]')).toBe(input);
+    expect(document.activeElement).toBe(input);
+    expect([input.selectionStart, input.selectionEnd]).toEqual([1, 3]);
+    await act(async () => {
+      (container.querySelector('[data-row-button="a"]') as HTMLButtonElement).click();
+      (container.querySelector('[data-row-button="h"]') as HTMLButtonElement).click();
+      (container.querySelector('[data-row-button="d"]') as HTMLButtonElement).click();
+      (container.querySelector('[data-row-button="f"]') as HTMLButtonElement).click();
+      (container.querySelector('[data-row-button="i"]') as HTMLButtonElement).click();
+    });
+    expect(calls).toEqual([
+      "a:Alpha queued:0",
+      "h:Eta queued:1",
+      "d:Delta resized:2",
+      "f:Phi queued:3",
+      "i:Iota queued:4",
+    ]);
   });
 
   it("matches normal React through 1,000 deterministic bounded replacements", async () => {
@@ -1571,6 +1941,178 @@ describe("compiled keyed-array window replacement hints", () => {
         else expect(beforeRowSet.has(nextRows[position + offset])).toBe(false);
       });
       previousWindow.forEach((item) => {
+        if (!incomingKeys.has(item.id)) {
+          expect(previousRowsByKey.get(item.id)?.isConnected).toBe(false);
+        }
+      });
+    }
+
+    expect(harness.counters).toEqual({
+      executions: 1,
+      renders: 1,
+      keys: expectedWork,
+      descriptors: expectedFresh,
+      bindings: expectedWork,
+    });
+  }, 30_000);
+
+  it("matches React through 1,000 queued disjoint variable-length window updates", async () => {
+    const initialItems = Array.from(
+      { length: 64 },
+      (_, index): Item => ({ id: `row-${index}`, label: `Row ${index}` }),
+    );
+    const harness = createWindowHarness(initialItems);
+    let queueReact: (
+      firstPosition: number,
+      firstRemovedCount: number,
+      first: readonly Item[],
+      secondPosition: number,
+      secondRemovedCount: number,
+      second: readonly Item[],
+    ) => void = () => undefined;
+    function NormalTable() {
+      const [items, setItems] = useState(initialItems);
+      queueReact = (
+        firstPosition,
+        firstRemovedCount,
+        first,
+        secondPosition,
+        secondRemovedCount,
+        second,
+      ) => {
+        setItems((previous) =>
+          (previous as WindowArray).toSpliced(firstPosition, firstRemovedCount, ...first),
+        );
+        setItems((previous) =>
+          (previous as WindowArray).toSpliced(secondPosition, secondRemovedCount, ...second),
+        );
+      };
+      return (
+        <ol>
+          {items.map((item) => (
+            <li data-key={item.id} key={item.id}>
+              {item.label}
+            </li>
+          ))}
+        </ol>
+      );
+    }
+    const compiledContainer = document.createElement("div");
+    const reactContainer = document.createElement("div");
+    document.body.append(compiledContainer, reactContainer);
+    const compiledRoot = createRoot(compiledContainer);
+    const reactRoot = createRoot(reactContainer);
+    roots.push(compiledRoot, reactRoot);
+    await act(async () => {
+      compiledRoot.render(<harness.Table />);
+      reactRoot.render(<NormalTable />);
+    });
+    harness.counters.keys = 0;
+    harness.counters.descriptors = 0;
+    harness.counters.bindings = 0;
+    let expected = initialItems;
+    let expectedFresh = 0;
+    let expectedWork = 0;
+    let random = 0xd41f_8b27;
+    const nextRandom = () => {
+      random = (Math.imul(random, 1_664_525) + 1_013_904_223) >>> 0;
+      return random;
+    };
+
+    for (let step = 0; step < 500; step += 1) {
+      const firstRemovedCount = (nextRandom() % 4) + 3;
+      const firstPosition = (nextRandom() % 8) + 4;
+      const secondRemovedCount = (nextRandom() % 4) + 3;
+      const secondSourcePosition = expected.length - secondRemovedCount - 4 - (nextRandom() % 8);
+      const firstDelta = step % 2 === 0 ? 1 : -1;
+      const secondDelta = -firstDelta;
+      const firstIncomingCount = firstRemovedCount + firstDelta;
+      const secondIncomingCount = secondRemovedCount + secondDelta;
+      const firstPrevious = expected.slice(firstPosition, firstPosition + firstRemovedCount);
+      const secondPrevious = expected.slice(
+        secondSourcePosition,
+        secondSourcePosition + secondRemovedCount,
+      );
+      const makeIncoming = (previous: readonly Item[], count: number, prefix: string): Item[] => {
+        const retainedCount = Math.min(previous.length, count - 1);
+        const retained = previous
+          .slice(0, retainedCount)
+          .reverse()
+          .map((item, offset) => ({ ...item, label: `${prefix} reused ${offset}` }));
+        const fresh = Array.from(
+          { length: count - retainedCount },
+          (_, offset): Item => ({
+            id: `${prefix}-fresh-${offset}`,
+            label: `${prefix} fresh ${offset}`,
+          }),
+        );
+        expectedFresh += fresh.length;
+        return [...retained, ...fresh];
+      };
+      const first = makeIncoming(firstPrevious, firstIncomingCount, `first-${step}`);
+      const second = makeIncoming(secondPrevious, secondIncomingCount, `second-${step}`);
+      const secondPosition = secondSourcePosition + firstDelta;
+      const beforeRows = [...compiledContainer.querySelectorAll("li")];
+      const beforeRowSet = new Set(beforeRows);
+      const previousRowsByKey = new Map(
+        [...firstPrevious, ...secondPrevious].map((item) => [
+          item.id,
+          compiledContainer.querySelector(`[data-key="${item.id}"]`),
+        ]),
+      );
+      const incomingKeys = new Set([...first, ...second].map((item) => item.id));
+      const afterFirst = (expected as WindowArray).toSpliced(
+        firstPosition,
+        firstRemovedCount,
+        ...first,
+      );
+      expected = (afterFirst as WindowArray).toSpliced(
+        secondPosition,
+        secondRemovedCount,
+        ...second,
+      );
+      expectedWork += first.length + second.length;
+
+      await act(async () => {
+        harness.queueWindows(
+          firstPosition,
+          firstRemovedCount,
+          first,
+          secondPosition,
+          secondRemovedCount,
+          second,
+        );
+        queueReact(
+          firstPosition,
+          firstRemovedCount,
+          first,
+          secondPosition,
+          secondRemovedCount,
+          second,
+        );
+        await flushCompilerUpdates();
+      });
+
+      expect(compiledContainer.querySelector("ul")?.textContent).toBe(
+        reactContainer.querySelector("ol")?.textContent,
+      );
+      const nextRows = [...compiledContainer.querySelectorAll("li")];
+      expect(nextRows).toHaveLength(64);
+      expect(nextRows[firstPosition - 1]).toBe(beforeRows[firstPosition - 1]);
+      expect(nextRows[firstPosition + first.length]).toBe(
+        beforeRows[firstPosition + firstRemovedCount],
+      );
+      expect(nextRows[secondPosition - 1]).toBe(beforeRows[secondSourcePosition - 1]);
+      expect(nextRows[secondPosition + second.length]).toBe(
+        beforeRows[secondSourcePosition + secondRemovedCount],
+      );
+      [...first, ...second].forEach((item) => {
+        const nextRow = compiledContainer.querySelector(`[data-key="${item.id}"]`);
+        const previousRow = previousRowsByKey.get(item.id);
+        if (previousRow) expect(nextRow).toBe(previousRow);
+        else expect(beforeRowSet.has(nextRow as Element)).toBe(false);
+      });
+      [...firstPrevious, ...secondPrevious].forEach((item) => {
         if (!incomingKeys.has(item.id)) {
           expect(previousRowsByKey.get(item.id)?.isConnected).toBe(false);
         }
@@ -1959,16 +2501,47 @@ describe("compiled keyed-array window replacement hints", () => {
     expect(container.querySelector('[data-key="f"]')).toBeNull();
     expect(recoverable).toEqual([]);
 
+    const epsilon = container.querySelector('[data-key="e"]');
+    const eta = container.querySelector('[data-key="h"]');
+    await act(async () => {
+      harness.queueWindows(
+        0,
+        1,
+        [
+          { id: "e", label: "Epsilon resized" },
+          { id: "x", label: "Xi hydrated" },
+        ],
+        3,
+        1,
+        [
+          { id: "h", label: "Eta resized" },
+          { id: "y", label: "Upsilon hydrated" },
+        ],
+      );
+      await flushCompilerUpdates();
+    });
+    expect(container.textContent).toBe(
+      "Epsilon resizedXi hydratedGamma replacement hydratedEta resizedUpsilon hydrated",
+    );
+    expect(container.querySelector('[data-key="e"]')).toBe(epsilon);
+    expect(container.querySelector('[data-key="h"]')).toBe(eta);
+    expect(recoverable).toEqual([]);
+
     roots.pop();
     act(() => {
-      harness.queueRefreshes(
+      harness.queueWindows(
         0,
+        1,
         [
           { id: "i", label: "Iota" },
           { id: "j", label: "Jota" },
         ],
+        4,
         1,
-        [{ id: "k", label: "Kappa" }],
+        [
+          { id: "k", label: "Kappa" },
+          { id: "l", label: "Lambda" },
+        ],
       );
       root.unmount();
     });

--- a/packages/farm-react/src/compiler-runtime.tsx
+++ b/packages/farm-react/src/compiler-runtime.tsx
@@ -4797,6 +4797,166 @@ function reconcileCompilerKeyedArrayBatchInsert(
   return new Map(previousInstances.map((instance) => [instance.key, instance]));
 }
 
+type CompilerKeyedArrayDisjointWindow = [
+  sourcePosition: number,
+  currentPosition: number,
+  removedCount: number,
+  insertedCount: number,
+];
+
+function normalizeCompilerKeyedArrayDisjointWindows(
+  updates: readonly CompilerKeyedArrayWindowReplaceHint[],
+): CompilerKeyedArrayDisjointWindow[] | undefined {
+  const windows: CompilerKeyedArrayDisjointWindow[] = [];
+  for (const update of updates) {
+    const updateEnd = update.position + update.removedCount;
+    let sourcePosition = update.position;
+    for (const window of windows) {
+      const windowStart = window[1];
+      const windowEnd = windowStart + window[3];
+      const before = updateEnd <= windowStart;
+      const after = window[3] === 0 ? update.position >= windowStart : update.position >= windowEnd;
+      if (!before && !after) return undefined;
+      if (after) sourcePosition -= window[3] - window[2];
+    }
+
+    const delta = update.insertedCount - update.removedCount;
+    for (const window of windows) {
+      if (updateEnd <= window[1]) window[1] += delta;
+    }
+    windows.push([sourcePosition, update.position, update.removedCount, update.insertedCount]);
+  }
+
+  windows.sort((left, right) => left[0] - right[0]);
+  return windows;
+}
+
+type CompilerKeyedArrayWindowItems = [items: unknown[], keys: string[]];
+
+function readCompilerKeyedArrayWindowItems(
+  props: CompilerKeyedRowsBlockProps,
+  finalValue: readonly unknown[],
+  resultPosition: number,
+  insertedCount: number,
+): CompilerKeyedArrayWindowItems | undefined {
+  const items: unknown[] = [];
+  const keys: string[] = [];
+  try {
+    for (let offset = 0; offset < insertedCount; offset += 1) {
+      const index = resultPosition + offset;
+      const item = finalValue[index];
+      items.push(item);
+      keys.push(keyedRowIdentity(props.rowKey(item, index)));
+    }
+  } catch {
+    return undefined;
+  }
+  return [items, keys];
+}
+
+type CompilerPreparedKeyedArrayWindow = [
+  removed: CompilerKeyedRowInstance[],
+  anchor: ChildNode | null,
+  incomingItems: unknown[],
+  incomingKeySet: ReadonlySet<string>,
+  nextWindow: CompilerKeyedRowInstance[],
+  sequence: number[],
+  preparedBindings: Array<readonly CompilerPreparedKeyedRowBindingUpdate[] | undefined>,
+];
+
+function prepareCompilerKeyedArrayWindow(
+  props: CompilerKeyedRowsBlockProps,
+  instances: ReadonlyMap<string, CompilerKeyedRowInstance>,
+  previousInstances: readonly CompilerKeyedRowInstance[],
+  root: Element,
+  window: CompilerKeyedArrayDisjointWindow,
+  incoming: CompilerKeyedArrayWindowItems,
+  preparedIncomingKeys: Set<string>,
+): CompilerPreparedKeyedArrayWindow | undefined {
+  const removedEnd = window[0] + window[2];
+  const removed = previousInstances.slice(window[0], removedEnd);
+  const anchor = previousInstances[removedEnd]?.element || null;
+  if (
+    removed.length !== window[2] ||
+    removed.some(
+      (instance, offset) =>
+        instance.index !== window[0] + offset || instance.element.parentNode !== root,
+    ) ||
+    (anchor && anchor.parentNode !== root)
+  ) {
+    return undefined;
+  }
+
+  const incomingKeySet = new Set(incoming[1]);
+  if (incomingKeySet.size !== incoming[1].length) return undefined;
+  for (const key of incomingKeySet) {
+    if (preparedIncomingKeys.has(key)) return undefined;
+    preparedIncomingKeys.add(key);
+  }
+
+  const hasLocalReuse = removed.some((instance) => incomingKeySet.has(instance.key));
+  const removedByKey = hasLocalReuse
+    ? new Map(removed.map((instance, offset) => [instance.key, { instance, offset }] as const))
+    : undefined;
+  const nextWindow: CompilerKeyedRowInstance[] = [];
+  const sequence: number[] = [];
+  const preparedBindings: Array<readonly CompilerPreparedKeyedRowBindingUpdate[] | undefined> = [];
+  try {
+    for (let offset = 0; offset < window[3]; offset += 1) {
+      const index = window[1] + offset;
+      const item = incoming[0][offset];
+      const key = incoming[1][offset];
+      const retained = removedByKey?.get(key);
+      if (retained) {
+        const bindingUpdates = prepareKeyedRowBindingUpdates(props, retained.instance, item, index);
+        if (!bindingUpdates) return undefined;
+        nextWindow.push(retained.instance);
+        sequence.push(retained.offset);
+        preparedBindings.push(bindingUpdates);
+        continue;
+      }
+      // A key owned outside this exact source window would move a row across
+      // a compiler-proven boundary. Complete reconciliation owns that case.
+      if (instances.has(key)) return undefined;
+      const descriptor = props.create(item, index);
+      nextWindow.push({
+        key,
+        element: createCompilerHostElement(root.ownerDocument, descriptor),
+        values: readKeyedRowBindingValues(props, item, index),
+        item,
+        index,
+        conditionalValues: EMPTY_KEYED_ROW_CONDITIONAL_VALUES,
+      });
+      sequence.push(-1);
+      preparedBindings.push(undefined);
+    }
+  } catch {
+    return undefined;
+  }
+
+  return [removed, anchor, incoming[0], incomingKeySet, nextWindow, sequence, preparedBindings];
+}
+
+function commitCompilerKeyedArrayWindow(
+  props: CompilerKeyedRowsBlockProps,
+  root: Element,
+  prepared: CompilerPreparedKeyedArrayWindow,
+): void {
+  for (const instance of prepared[0]) {
+    if (prepared[3].has(instance.key)) continue;
+    instance.scope?.cleanup();
+    instance.element.remove();
+  }
+  for (let offset = 0; offset < prepared[4].length; offset += 1) {
+    const bindingUpdates = prepared[6][offset];
+    if (!bindingUpdates) continue;
+    const instance = prepared[4][offset];
+    applyPreparedKeyedRowBindingUpdates(props, instance, bindingUpdates);
+    instance.item = prepared[2][offset];
+  }
+  reorderCompilerKeyedRows(root, prepared[4], prepared[5], prepared[1]);
+}
+
 function reconcileCompilerKeyedArrayWindowReplace(
   props: CompilerKeyedRowsBlockProps,
   dirtyState: ReadonlySet<number>,
@@ -4829,9 +4989,79 @@ function reconcileCompilerKeyedArrayWindowReplace(
   if (!updates || !Array.isArray(finalValue)) return undefined;
   const previousInstances = [...instances.values()];
   if (updates.length > 1) {
+    if (updates.some((update) => update.insertedCount !== update.removedCount)) {
+      const windows = normalizeCompilerKeyedArrayDisjointWindows(updates);
+      if (!windows) return undefined;
+
+      let sourceCursor = 0;
+      let resultCursor = 0;
+      const preparedIncomingKeys = new Set<string>();
+      const preparedWindows: CompilerPreparedKeyedArrayWindow[] = [];
+      const nextInstances: CompilerKeyedRowInstance[] = [];
+      for (const window of windows) {
+        if (window[0] < sourceCursor) return undefined;
+        while (sourceCursor < window[0]) {
+          const instance = previousInstances[sourceCursor];
+          if (
+            !instance ||
+            instance.index !== sourceCursor ||
+            !Object.is(instance.item, finalValue[resultCursor])
+          ) {
+            return undefined;
+          }
+          nextInstances.push(instance);
+          sourceCursor += 1;
+          resultCursor += 1;
+        }
+        const incoming = readCompilerKeyedArrayWindowItems(
+          props,
+          finalValue,
+          resultCursor,
+          window[3],
+        );
+        if (!incoming) return undefined;
+        window[1] = resultCursor;
+        const prepared = prepareCompilerKeyedArrayWindow(
+          props,
+          instances,
+          previousInstances,
+          root,
+          window,
+          incoming,
+          preparedIncomingKeys,
+        );
+        if (!prepared) return undefined;
+        preparedWindows.push(prepared);
+        nextInstances.push(...prepared[4]);
+        sourceCursor += window[2];
+        resultCursor += window[3];
+      }
+      while (sourceCursor < previousInstances.length) {
+        const instance = previousInstances[sourceCursor];
+        if (
+          !instance ||
+          instance.index !== sourceCursor ||
+          !Object.is(instance.item, finalValue[resultCursor])
+        ) {
+          return undefined;
+        }
+        nextInstances.push(instance);
+        sourceCursor += 1;
+        resultCursor += 1;
+      }
+      if (resultCursor !== finalValue.length) return undefined;
+
+      for (const prepared of preparedWindows) {
+        commitCompilerKeyedArrayWindow(props, root, prepared);
+      }
+      for (let index = 0; index < nextInstances.length; index += 1) {
+        nextInstances[index].index = index;
+      }
+      return new Map(nextInstances.map((instance) => [instance.key, instance]));
+    }
+
     const touchedIndices = new Set<number>();
     for (const update of updates) {
-      if (update.insertedCount !== update.removedCount) return undefined;
       for (let index = update.position; index < update.position + update.removedCount; index += 1) {
         touchedIndices.add(index);
       }
@@ -4938,19 +5168,15 @@ function reconcileCompilerKeyedArrayWindowReplace(
     return undefined;
   }
 
-  const incomingItems: unknown[] = [];
-  const incomingKeys: string[] = [];
-  try {
-    for (let offset = 0; offset < update.insertedCount; offset += 1) {
-      const index = update.position + offset;
-      const item = finalValue[index];
-      const key = keyedRowIdentity(props.rowKey(item, index));
-      incomingItems.push(item);
-      incomingKeys.push(key);
-    }
-  } catch {
-    return undefined;
-  }
+  const incoming = readCompilerKeyedArrayWindowItems(
+    props,
+    finalValue,
+    update.position,
+    update.insertedCount,
+  );
+  if (!incoming) return undefined;
+  const incomingItems = incoming[0];
+  const incomingKeys = incoming[1];
 
   if (
     update.insertedCount === update.removedCount &&
@@ -4978,122 +5204,19 @@ function reconcileCompilerKeyedArrayWindowReplace(
     return instances;
   }
 
-  const incomingKeySet = new Set(incomingKeys);
-  if (incomingKeySet.size !== incomingKeys.length) return undefined;
-  if (removed.some((instance) => incomingKeySet.has(instance.key))) {
-    const removedByKey = new Map(
-      removed.map((instance, offset) => [instance.key, { instance, offset }] as const),
-    );
-    const nextWindow: CompilerKeyedRowInstance[] = [];
-    const sequence: number[] = [];
-    const preparedBindings: Array<readonly CompilerPreparedKeyedRowBindingUpdate[] | undefined> =
-      [];
-    try {
-      for (let offset = 0; offset < update.insertedCount; offset += 1) {
-        const index = update.position + offset;
-        const item = incomingItems[offset];
-        const key = incomingKeys[offset];
-        const retained = removedByKey.get(key);
-        if (retained) {
-          const bindingUpdates = prepareKeyedRowBindingUpdates(
-            props,
-            retained.instance,
-            item,
-            index,
-          );
-          if (!bindingUpdates) return undefined;
-          nextWindow.push(retained.instance);
-          sequence.push(retained.offset);
-          preparedBindings.push(bindingUpdates);
-          continue;
-        }
-        // A key owned outside this exact window would duplicate or move a
-        // row across the proven boundary. Complete keyed reconciliation
-        // remains responsible for that case.
-        if (instances.has(key)) return undefined;
-        const descriptor = props.create(item, index);
-        nextWindow.push({
-          key,
-          element: createCompilerHostElement(root.ownerDocument, descriptor),
-          values: readKeyedRowBindingValues(props, item, index),
-          item,
-          index,
-          conditionalValues: EMPTY_KEYED_ROW_CONDITIONAL_VALUES,
-        });
-        sequence.push(-1);
-        preparedBindings.push(undefined);
-      }
-    } catch {
-      return undefined;
-    }
-
-    for (const instance of removed) {
-      if (incomingKeySet.has(instance.key)) continue;
-      instance.scope?.cleanup();
-      instance.element.remove();
-    }
-    for (let offset = 0; offset < nextWindow.length; offset += 1) {
-      const bindingUpdates = preparedBindings[offset];
-      if (bindingUpdates) {
-        const instance = nextWindow[offset];
-        applyPreparedKeyedRowBindingUpdates(props, instance, bindingUpdates);
-        instance.item = incomingItems[offset];
-        instance.index = update.position + offset;
-      }
-    }
-
-    reorderCompilerKeyedRows(root, nextWindow, sequence, anchor || null);
-    previousInstances.splice(update.position, update.removedCount, ...nextWindow);
-    for (
-      let index = update.position + update.insertedCount;
-      index < previousInstances.length;
-      index += 1
-    ) {
-      previousInstances[index].index = index;
-    }
-    return new Map(previousInstances.map((instance) => [instance.key, instance]));
-  }
-
-  const knownKeys = new Set(instances.keys());
-  const incoming: CompilerKeyedRowInstance[] = [];
-  try {
-    for (let offset = 0; offset < update.insertedCount; offset += 1) {
-      const index = update.position + offset;
-      const item = incomingItems[offset];
-      const key = incomingKeys[offset];
-      // Exact same-order reuse already returned above. Any remaining reuse is
-      // reordered or mixed and needs complete keyed reconciliation.
-      if (knownKeys.has(key)) return undefined;
-      knownKeys.add(key);
-      const descriptor = props.create(item, index);
-      incoming.push({
-        key,
-        element: createCompilerHostElement(root.ownerDocument, descriptor),
-        values: readKeyedRowBindingValues(props, item, index),
-        item,
-        index,
-        conditionalValues: EMPTY_KEYED_ROW_CONDITIONAL_VALUES,
-      });
-    }
-  } catch {
-    return undefined;
-  }
-
-  for (const instance of removed) {
-    instance.scope?.cleanup();
-    instance.element.remove();
-  }
-  if (incoming.length > 0) {
-    const fragment = root.ownerDocument.createDocumentFragment();
-    for (const instance of incoming) fragment.append(instance.element);
-    root.insertBefore(fragment, anchor || null);
-  }
-  previousInstances.splice(update.position, update.removedCount, ...incoming);
-  for (
-    let index = update.position + update.insertedCount;
-    index < previousInstances.length;
-    index += 1
-  ) {
+  const prepared = prepareCompilerKeyedArrayWindow(
+    props,
+    instances,
+    previousInstances,
+    root,
+    [update.position, update.position, update.removedCount, update.insertedCount],
+    incoming,
+    new Set(),
+  );
+  if (!prepared) return undefined;
+  commitCompilerKeyedArrayWindow(props, root, prepared);
+  previousInstances.splice(update.position, update.removedCount, ...prepared[4]);
+  for (let index = update.position; index < previousInstances.length; index += 1) {
     previousInstances[index].index = index;
   }
   return new Map(previousInstances.map((instance) => [instance.key, instance]));


### PR DESCRIPTION
## Problem

Two queued immutable updates can resize separate parts of one keyed collection before the compiler flushes. For example, one `toSpliced` call may grow a window while a second call shrinks another window. React receives positions relative to each update's immediate input, but the compiler runtime previously handled only one variable-length window or queued fixed-length windows. It therefore fell back to full React reconciliation for this otherwise exact operation.

## Root cause

Each queued hint used a different coordinate system after earlier windows changed the collection length. The runtime had no way to normalize all source positions back to the committed collection, validate that the windows were truly disjoint, and prepare every window before touching live DOM. Applying the hints independently could target the wrong rows or partially mutate the DOM before a later hint failed validation.

## Change

- Normalize queued variable-length exact-window hints into committed and final coordinates, independent of the order in which the source windows were updated.
- Validate untouched item identity, local key ownership, duplicate keys, overlaps, and cross-window key movement before mutation.
- Prepare keys, row descriptors, bindings, detached rows, cleanup work, and local LIS plans for every window atomically.
- Commit only the affected windows, preserve retained DOM identity, create only fresh rows, clean up retired rows and scopes, then rebuild collection indexes once.
- Cover adjacent and empty incoming windows while retaining the complete React fallback for ambiguous cases.
- Add a reproducible 10,000-row two-window benchmark and document the supported operation and safety boundary.

## Safety and compatibility

- The optimization remains limited to the opt-in React compiler runtime. There is no public API or configuration change and no effect when the compiler is disabled.
- Overlapping structural windows, duplicate keys, sparse or ambiguous ownership, keys moving across windows, failed preparation, host blocks, conditionals, and other unsupported structures use the existing complete React fallback.
- Every window is prepared before the first live DOM write, so a failed later window cannot leave a partially committed update.
- Tests cover Strict Mode, hydration, unmount-before-flush, controlled input focus and selection, event behavior, high-source-first updates, adjacent or empty windows, fallback paths, and 1,000 randomized differential updates against React.
- React 18.3.1 and React 19.2.8 compatibility suites pass.
- Compiler-disabled/core-only runtime size is unchanged. The optional keyed-window runtime is 14,173 B gzip, a 416 B premium over the preceding runtime snapshot (reduced from 622 B during implementation).

## Verification

- `pnpm --filter @farm.js/react type-check`
- `pnpm --filter @farm.js/react test -- --maxWorkers=1` — 611 regular tests passed; all 3 isolated stress controls passed.
- `pnpm --filter @farm.js/react test:compat`
- `pnpm --filter @farm.js/react test:runtime-size`
- `pnpm --filter farm-react-compiler-dashboard-example type-check`
- `pnpm --filter farm-react-compiler-dashboard-example build`
- `pnpm docs:check-navigation`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm docs:build`
- `pnpm --filter farm-react-compiler-dashboard-example benchmark`

The production-browser control performs two disjoint updates over 10,000 rows: a 64-row window grows to 80 while another 64-row window shrinks to 48. It verifies final contents, four untouched anchors, retained DOM identity, retired-row disconnection, fresh rows, and zero compiled owner executions.

| Mode | Compiler | React | Correctness control | vs React | vs control |
| --- | ---: | ---: | ---: | ---: | ---: |
| Static | 13.6 ms | 72.25 ms | 25.4 ms | 5.31x | 1.87x |
| Hybrid | 13.4 ms | 72.25 ms | 25.4 ms | 5.39x | 1.90x |

All correctness, specialized performance, persistence, and scalability gates passed on the identical confirmation run in Chrome 145.0.7632.6, Node 23.11.0, Apple M1, macOS arm64. The first full run also passed this new gate (5.90x/5.36x versus React) but reported one unrelated broad `table.create` timing outlier; that outlier did not reproduce on the unchanged confirmation run, where the complete benchmark result passed.

## Documentation and release

- Expanded the React renderer compiler documentation with queued resized-window behavior, limits, fallback semantics, and benchmark evidence.
- Updated the compiler dashboard example, README, benchmark script, and checked-in benchmark results.
- No template, generated route, version, or release-flow changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The React compiler runtime now composes queued disjoint keyed-array windows that grow or shrink before a flush, instead of falling back to full reconciliation. It normalizes positions and applies the exact local updates while preserving keyed DOM identity; overlapping or ambiguous updates still use React's existing fallback.

**Verification**

- Prepares every window, binding update, and new row before the first DOM write, then validates identity, duplicate keys, ownership, overlaps, and cross-window movement.
- Adds coverage for source-order variations, empty and adjacent windows, hydration, Strict Mode, cleanup, focus and selection, delegated events, and 1,000 randomized differential updates against React.
- Adds a 10,000-row benchmark with separate performance gates of 4× versus React and 1.5× versus the compiled control.
- Documents the supported operation and safety boundary; no public API changes, compiler-disabled behavior changes, or core runtime size changes are included.
- Increases the optional keyed-window runtime to 14,173 B gzip, a 416 B increase over the previous snapshot.

<sup>Written for commit e7540147b8eb2b9c2fe3ac38b5a189654cf7ee43. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/671?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

