### PR TITLE
perf(react): carry dynamic keyed-window counts

### DIFF
--- a/docs/src/app/docs/renderers/react/page.md
+++ b/docs/src/app/docs/renderers/react/page.md
@@ -1034,28 +1034,32 @@ setItems((current) => current.toSpliced(selectedIndex, 1, replacement));
 setItems((current) => current.toSpliced(selectedIndex, 25, ...replacements));
 setItems((current) => current.with(selectedIndex, replacement));
 
+const deleteCount = visibleRows.length;
+setItems((current) => current.toSpliced(selectedIndex, deleteCount, ...replacements));
+
 // Two same-key windows may be queued before one compiler flush.
 setItems((current) => current.toSpliced(firstIndex, 25, ...firstRefresh));
 setItems((current) => current.toSpliced(secondIndex, 25, ...secondRefresh));
 ```
 
-At build time, Farm recognizes only concise functional setters whose position is either a
-safe-integer literal or a compiler-safe runtime expression. Identifiers, property reads,
+At build time, Farm recognizes only concise functional setters whose position—and, for
+`toSpliced()`, delete count—is a safe-integer literal or compiler-safe runtime expression.
+Identifiers, property reads,
 side-effect-free arithmetic and conditionals, and safe `Math` calls are supported. User-defined
 calls, assignments, update expressions, and other effectful forms are not transformed.
-`toSpliced()` must insert compiler-safe items with a zero delete count, remove one item or a
-contiguous range using a positive safe-integer literal delete count, replace exactly one item with
-a delete count of one, or replace a positive safe-integer literal window with compiler-safe
-explicit items or a safe spread; `with()` must replace exactly one item. A zero delete count with
-an explicit pair or a safe spread such as `...incomingItems` selects the batch insertion path when
-at least two items are produced at runtime. A delete count above one with any incoming item, or a
-positive delete count with multiple items or a spread, selects exact-window replacement; the spread
-may evaluate to zero, one, or many items. Farm
+`toSpliced()` may insert compiler-safe items with a literal zero delete count, remove one item or a
+contiguous range, replace exactly one item, or replace a positive window with compiler-safe
+explicit items or a safe spread; `with()` must replace exactly one item. A literal zero delete count
+with an explicit pair or a safe spread such as `...incomingItems` selects the batch insertion path
+when at least two items are produced at runtime. A literal delete count above one with any incoming
+item, a positive literal count with multiple items or a spread, or any compiler-safe runtime delete
+count selects exact-window replacement; the spread may evaluate to zero, one, or many items. Farm
 preserves the original method lookup,
 evaluates every argument once in its original order, and preserves the native call, return value,
-coercion, and thrown errors. If the method is not native, the evaluated position is not already a
-safe integer, or the removal count is dynamic or unsafe, the update still runs normally but no
-metadata is recorded.
+coercion, and thrown errors. The runtime records metadata only after the native call proves that the
+evaluated position is already a safe integer and the evaluated delete count is already a positive
+safe integer. A custom method or a count that is zero, negative, fractional, non-numeric, or
+otherwise unsafe still runs normally but takes complete keyed reconciliation.
 
 At update time, Farm validates the committed native source, result length, source token, normalized
 position, clamped removal count, and any incoming key before changing the DOM. For a batch, Farm
@@ -1096,9 +1100,10 @@ and swaps one host row. The owner component does not rerun, and surviving row ke
 and bindings are not reread.
 
 The proof requires compiler-owned host rows whose render and key do not observe the row index.
-Effectful position expressions, runtime values that are fractional or otherwise not safe integers,
-dynamic, zero, negative, or fractional removal counts, other `toSpliced()` shapes, block-bodied
-updaters, unsafe incoming expressions, custom methods, overlapping queued structural windows,
+Effectful position or delete-count expressions, runtime positions that are fractional or otherwise
+not safe integers, runtime delete counts that are zero, negative, fractional, non-numeric, or
+otherwise not positive safe integers, other `toSpliced()` shapes, block-bodied updaters, unsafe
+incoming expressions, custom methods, overlapping queued structural windows,
 unhinted intermediate updates, an existing key moved from outside its local removed interval or
 between queued windows, duplicate final keys, collection-reading bindings, React-owned rows,
 nested host blocks, row conditionals, unrelated dirty dependencies, and failed runtime checks keep
@@ -1983,8 +1988,9 @@ The package and example test suites verify more than generated code:
   zero surviving descriptor and binding reads, preserve DOM identity, and cover queued filters,
   unhinted-chain fallback, collection-reading rows, StrictMode hydration, and unmount cleanup;
 - 1,000 deterministic exact-position insertions, single and contiguous-range removals, single-row
-  replacements, and exact-window replacements match normal React; compiler tests cover literal counts and guarded runtime
-  positions, while targeted removal tests require zero surviving key, descriptor, or binding reads,
+  replacements, and exact-window replacements match normal React; compiler tests cover guarded
+  runtime positions plus literal and compiler-safe runtime delete counts, while targeted removal
+  tests require zero surviving key, descriptor, or binding reads,
   preserve focused input and surrounding DOM identity, and cover native evaluation and coercion,
   clamping, unsafe runtime positions and counts, custom methods, queued updates,
   collection-reading rows, StrictMode hydration, and cleanup; targeted window tests additionally

--- a/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
+++ b/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
@@ -2,6 +2,35 @@
 
 Date: 2026-08-29
 
+## Runtime delete-count exact-window follow-up — 2026-09-02
+
+The full bracketed production-browser run changed the existing 10,000-row exact-window workload
+from a literal delete count to `deleteCount = replacements.length`. The concise setter passes that
+runtime value to `toSpliced(position, deleteCount, ...replacements)`, while the block-bodied
+compiled control performs the same native array and DOM work without the hint. Both compiler builds
+emitted all 15 expected `keyedArrayPositionHints` sites, preserved both surrounding DOM anchors,
+disconnected the complete removed interval, mounted the 64 replacement rows, and produced zero
+owner executions.
+
+| Mode   | React median | Runtime count | Compiled control | vs React | vs control |
+| ------ | -----------: | ------------: | ---------------: | -------: | ---------: |
+| Static |     110.95 ms |       7.60 ms |         19.90 ms |   14.60x |      2.62x |
+| Hybrid |     110.95 ms |       7.80 ms |         18.90 ms |   14.22x |      2.42x |
+
+The unchanged gate requires at least 4x versus React and 1.5x versus the equivalent block-bodied
+compiled control. Every correctness, performance, persistence, and scalability gate passed. The
+stacked queued grow/shrink workload also remained above its existing floors: 7.27x/7.78x versus
+React and 2.03x/2.05x versus its control in static/hybrid modes.
+
+Compiler tests accept identifiers, property reads, arithmetic, conditionals, and safe `Math` calls
+as count expressions while rejecting calls, assignments, and update expressions. Runtime coverage
+proves native count coercion occurs exactly once and that zero or fractional evaluated counts keep
+their native result through complete reconciliation. The full 615-test ordinary suite and all
+three isolated stress controls pass, as do packaged React 18.3.1 and 19.2.8 compatibility. The
+optional keyed-window runtime remains unchanged at a 14,173 B gzip compiler premium, and the
+compiler-disabled core premium remains 3,766 B gzip. The measured environment was Chrome
+145.0.7632.6, Node.js 23.11.0, and Apple M1 macOS arm64.
+
 ## Queued disjoint variable-length window follow-up — 2026-09-02
 
 The full bracketed production-browser run added a 10,000-row workload that queues two disjoint

--- a/examples/react-compiler-dashboard/README.md
+++ b/examples/react-compiler-dashboard/README.md
@@ -98,9 +98,10 @@ work proportional only to the incoming suffix.
 Exact-position insertions, removals, and replacements have separate 10,000-row comparisons. Concise
 native `toSpliced(position, 0, item)`, `toSpliced(position, 0, ...items)`, `toSpliced(position, 1)`,
 `toSpliced(position, 64)`, `toSpliced(position, 1, replacement)`, and
-`toSpliced(position, 64, ...replacements)` and `with(position, replacement)` updates use event-local
-runtime position variables and are measured against bracketed React and equivalent block-bodied
-compiled controls. The compiler report must contain every dashboard `keyedArrayPositionHints` site;
+`toSpliced(position, runtimeCount, ...replacements)` and `with(position, replacement)` updates use
+event-local runtime position and count variables and are measured against bracketed React and
+equivalent block-bodied compiled controls. The compiler report must contain every dashboard
+`keyedArrayPositionHints` site;
 package tests separately require zero
 surviving key/descriptor/binding reads for removal, surrounding DOM identity, randomized
 differential correctness, runtime-position and count fallback, hydration, and cleanup. Both the
@@ -112,13 +113,15 @@ both surrounding DOM nodes, add no owner executions, remain at least 4x faster t
 at least 1.5x faster than the equivalent block-bodied compiled control. This gate is independent of
 the older single-row position gates, so a batch regression cannot hide inside their aggregate.
 
-The exact-window replacement case swaps 64 rows in the middle of a 10,000-row table. It must
+The exact-window replacement case derives its delete count from the 64-row replacement array and
+swaps that window in the middle of a 10,000-row table. It must
 preserve both retained boundary nodes, disconnect both removed boundaries, add no owner
 executions, remain at least 4x faster than React, and stay at least 1.5x faster than the equivalent
 block-bodied compiled control. Package tests require work proportional only to the 64 incoming
 rows and cover empty spreads, negative positions, clamped counts, reused and duplicate keys,
 native custom-method behavior, queued fallback, controlled-input focus and selection, delegated
-events, 1,000 differential replacements, hydration, Strict Mode, and unmount cleanup.
+events, compiler-safe and effectful count expressions, unsafe evaluated-count fallback, 1,000
+differential replacements, hydration, Strict Mode, and unmount cleanup.
 
 Mixed local-key exact-window replacement has its own 10,000-row gate. The benchmark reverses 48
 keys from inside one 64-row removed interval, changes their visible data, and adds 16 globally new
@@ -247,7 +250,7 @@ The default JSON report is `/tmp/farm-react-dashboard-benchmark.json`; change it
   saved suffix scan while the hinted path still creates and inserts every required new DOM row.
 - The slice snapshot control retains the same 9,000-row suffix through an unsupported block-bodied
   updater. It isolates the saved survivor scan while both paths remove the same 1,000 DOM rows.
-- The exact-position controls pass event-local runtime variables to concise native
+- The exact-position controls pass event-local runtime position and delete-count variables to concise native
   `toSpliced()` updates and compare them with equivalent block-bodied compiled controls. Package
   tests cover the equivalent `with()` replacement path too.
   They verify surrounding DOM identity and isolate the saved full keyed scan for one insertion,

--- a/examples/react-compiler-dashboard/scripts/benchmark.mjs
+++ b/examples/react-compiler-dashboard/scripts/benchmark.mjs
@@ -1999,9 +1999,10 @@ const keyedBatchInsertRegressions = keyedBatchInsertResults.filter(
     !Number.isFinite(snapshotSpeedup) ||
     snapshotSpeedup < keyedBatchInsertMinimumSnapshotSpeedup,
 );
-// A compiler-proven toSpliced(position, count, ...items) replacement can validate the retained
-// prefix and suffix, prepare the incoming rows, and swap only that exact DOM window. Keep this
-// 10,000-row/64-row workload independent from the insertion and single-position gates.
+// A compiler-proven toSpliced(position, runtimeCount, ...items) replacement can validate the
+// evaluated count, retained prefix and suffix, prepare the incoming rows, and swap only that exact
+// DOM window. Keep this 10,000-row/64-row workload independent from the literal-count, insertion,
+// and single-position gates.
 const keyedWindowReplaceMinimumSpeedup = 4;
 const keyedWindowReplaceMinimumSnapshotSpeedup = 1.5;
 const keyedWindowReplaceResults = ["static", "hybrid"].map((mode) => {

--- a/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
+++ b/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
@@ -323,13 +323,14 @@ export function StandardTableBenchmark() {
             const nextSeed = seed + 1;
             const replacements = buildRows(64, nextSeed);
             const position = 5_000;
+            const deleteCount = replacements.length;
             setSeed(nextSeed);
-            setRows((current) => current.toSpliced(position, 64, ...replacements));
-            setOperation("replace 64-row runtime window");
+            setRows((current) => current.toSpliced(position, deleteCount, ...replacements));
+            setOperation("replace dynamic-count runtime window");
             setRevision((value) => value + 1);
           }}
         >
-          Replace 64-row runtime window
+          Replace dynamic-count runtime window
         </button>
         <button
           data-action="table-position-window-replace-snapshot"
@@ -338,15 +339,16 @@ export function StandardTableBenchmark() {
             const nextSeed = seed + 1;
             const replacements = buildRows(64, nextSeed);
             const position = 5_000;
+            const deleteCount = replacements.length;
             setSeed(nextSeed);
             setRows((current) => {
-              return current.toSpliced(position, 64, ...replacements);
+              return current.toSpliced(position, deleteCount, ...replacements);
             });
-            setOperation("replace 64-row runtime window (snapshot control)");
+            setOperation("replace dynamic-count runtime window (snapshot control)");
             setRevision((value) => value + 1);
           }}
         >
-          Replace 64-row runtime window (snapshot control)
+          Replace dynamic-count runtime window (snapshot control)
         </button>
         <button
           data-action="table-position-window-reuse"

--- a/packages/farm-react/src/__tests__/compiler-keyed-array-position-hints.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-keyed-array-position-hints.test.ts
@@ -139,6 +139,30 @@ describe("React AOT keyed-array position hints", () => {
     expect(result.code).toContain("current.length - 1");
   });
 
+  it("records compiler-safe runtime delete-count expressions", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Table({ next, incoming, offset, deleteCount, counts }) {
+        const [rows, setRows] = useState([
+          { id: "a", label: "Alpha" },
+          { id: "b", label: "Beta" },
+          { id: "c", label: "Gamma" },
+        ]);
+        return <section>
+          <button onClick={() => setRows((current) => current.toSpliced(offset, deleteCount))}>Remove</button>
+          <button onClick={() => setRows((current) => current.toSpliced(offset, counts.window, next))}>Replace</button>
+          <button onClick={() => setRows((current) => current.toSpliced(offset, Math.trunc(deleteCount), ...incoming))}>Replace window</button>
+          <ul>{rows.map((row) => <li key={row.id}>{row.label}</li>)}</ul>
+        </section>;
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Table"]);
+    expect(result.optimizations.keyedArrayPositionHints).toBe(3);
+    expect(result.code.match(/createCompilerKeyedArrayWindowReplace\(/g)).toHaveLength(3);
+    expect(result.code).toContain("keyedRowsWindowPositionHintedRuntimeFeature");
+  });
+
   it.each([
     {
       name: "an index-dependent row",
@@ -176,11 +200,6 @@ describe("React AOT keyed-array position hints", () => {
       update: "current.toSpliced(0, 1.5)",
     },
     {
-      name: "a dynamic removal count",
-      row: "row => <li key={row.id}>{row.label}</li>",
-      update: "current.toSpliced(0, deleteCount)",
-    },
-    {
       name: "a computed removal method",
       row: "row => <li key={row.id}>{row.label}</li>",
       update: 'current["toSpliced"](0, 1)',
@@ -191,9 +210,19 @@ describe("React AOT keyed-array position hints", () => {
       update: "current.slice().toSpliced(0, 1)",
     },
     {
-      name: "a dynamic replacement count",
+      name: "a delete-count call",
       row: "row => <li key={row.id}>{row.label}</li>",
-      update: "current.toSpliced(0, deleteCount, next, next)",
+      update: "current.toSpliced(0, getDeleteCount(), next, next)",
+    },
+    {
+      name: "a delete-count assignment",
+      row: "row => <li key={row.id}>{row.label}</li>",
+      update: "current.toSpliced(0, deleteCount = 2, next, next)",
+    },
+    {
+      name: "a delete-count update expression",
+      row: "row => <li key={row.id}>{row.label}</li>",
+      update: "current.toSpliced(0, deleteCount++, next, next)",
     },
     {
       name: "an unsafe incoming spread call",
@@ -223,7 +252,7 @@ describe("React AOT keyed-array position hints", () => {
   ])("keeps $name off the position fast path", async ({ row, update }) => {
     const result = await compile(`
       import { useState } from "react";
-      export function Table({ next, offset, deleteCount, makeNext, getOffset }) {
+      export function Table({ next, offset, deleteCount, makeNext, getOffset, getDeleteCount }) {
         const [rows, setRows] = useState([{ id: "a", label: "Alpha" }]);
         return <section>
           <button onClick={() => setRows((current) => ${update})}>Change</button>

--- a/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-window-replace-hints.test.tsx
+++ b/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-window-replace-hints.test.tsx
@@ -276,6 +276,33 @@ describe("compiled keyed-array window replacement hints", () => {
     ).toThrow(error);
   });
 
+  it("preserves native runtime count coercion exactly once", () => {
+    const source = [
+      { id: "a", label: "Alpha" },
+      { id: "b", label: "Beta" },
+      { id: "c", label: "Gamma" },
+    ] as WindowArray;
+    const replacement = { id: "x", label: "Xi" };
+    const coercions: string[] = [];
+    const runtimeCount = {
+      valueOf() {
+        coercions.push("count");
+        return 2;
+      },
+    };
+
+    const result = createCompilerKeyedArrayWindowReplace(
+      source,
+      source.toSpliced,
+      1,
+      runtimeCount as unknown as number,
+      replacement,
+    ) as Item[];
+
+    expect(result).toEqual([source[0], replacement]);
+    expect(coercions).toEqual(["count"]);
+  });
+
   it("replaces one exact window without reading or replacing retained rows", async () => {
     const initialItems = Array.from(
       { length: 4_096 },
@@ -661,6 +688,46 @@ describe("compiled keyed-array window replacement hints", () => {
     expect(harness.counters.keys).toBe(0);
     expect(harness.counters.descriptors).toBe(0);
     expect(harness.counters.bindings).toBe(0);
+  });
+
+  it("falls back without changing native results for unsafe runtime counts", async () => {
+    const harness = createWindowHarness([
+      { id: "a", label: "Alpha" },
+      { id: "b", label: "Beta" },
+      { id: "c", label: "Gamma" },
+      { id: "d", label: "Delta" },
+    ]);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Table />));
+    const alpha = container.querySelector('[data-key="a"]');
+    const gamma = container.querySelector('[data-key="c"]');
+    harness.counters.keys = 0;
+
+    await act(async () => {
+      harness.replace(1, 1.5, [{ id: "x", label: "Xi" }]);
+      await flushCompilerUpdates();
+    });
+
+    expect(container.textContent).toBe("AlphaXiGammaDelta");
+    expect(container.querySelector('[data-key="a"]')).toBe(alpha);
+    expect(container.querySelector('[data-key="c"]')).toBe(gamma);
+    expect(harness.counters.keys).toBeGreaterThan(1);
+
+    harness.counters.keys = 0;
+    await act(async () => {
+      harness.replace(1, 0, [{ id: "y", label: "Upsilon" }]);
+      await flushCompilerUpdates();
+    });
+
+    expect(container.textContent).toBe("AlphaUpsilonXiGammaDelta");
+    expect(container.querySelector('[data-key="a"]')).toBe(alpha);
+    expect(container.querySelector('[data-key="c"]')).toBe(gamma);
+    expect(harness.counters.keys).toBeGreaterThan(1);
+    expect(harness.counters.executions).toBe(1);
+    expect(harness.counters.renders).toBe(1);
   });
 
   it("reuses, reorders, and creates only rows inside one fixed-length window", async () => {

--- a/packages/farm-react/src/compiler.ts
+++ b/packages/farm-react/src/compiler.ts
@@ -1687,10 +1687,17 @@ function rewriteKeyedArrayPositionHints(
 
       const methodName = updater.body.callee.property.name;
       const args = updater.body.arguments;
-      const toSplicedDeleteCount =
-        methodName === "toSpliced" && args.length >= 2 && t.isNumericLiteral(args[1])
-          ? args[1].value
+      const deleteCountExpression =
+        methodName === "toSpliced" && args.length >= 2 && t.isExpression(args[1])
+          ? args[1]
           : undefined;
+      const toSplicedDeleteCount = deleteCountExpression
+        ? staticSliceIndex(deleteCountExpression)
+        : undefined;
+      const hasRuntimeDeleteCount =
+        deleteCountExpression !== undefined &&
+        toSplicedDeleteCount === undefined &&
+        validateKeyedArrayPositionExpression(deleteCountExpression, safeGlobals) === undefined;
       const isBatchInsert =
         methodName === "toSpliced" &&
         args.length >= 3 &&
@@ -1698,11 +1705,12 @@ function rewriteKeyedArrayPositionHints(
         (args.length > 3 || t.isSpreadElement(args[2]));
       const isWindowReplace =
         methodName === "toSpliced" &&
-        args.length >= 3 &&
-        toSplicedDeleteCount !== undefined &&
-        Number.isSafeInteger(toSplicedDeleteCount) &&
-        toSplicedDeleteCount > 0 &&
-        (toSplicedDeleteCount !== 1 || args.length > 3 || t.isSpreadElement(args[2]));
+        ((args.length >= 3 &&
+          toSplicedDeleteCount !== undefined &&
+          Number.isSafeInteger(toSplicedDeleteCount) &&
+          toSplicedDeleteCount > 0 &&
+          (toSplicedDeleteCount !== 1 || args.length > 3 || t.isSpreadElement(args[2]))) ||
+          hasRuntimeDeleteCount);
       const kind = isBatchInsert
         ? "batch-insert"
         : isWindowReplace
@@ -1729,6 +1737,10 @@ function rewriteKeyedArrayPositionHints(
         kind === "batch-insert" || kind === "window-replace" ? args.slice(2) : [args.at(-1)];
       if (
         validateKeyedArrayPositionExpression(position, safeGlobals) !== undefined ||
+        (kind === "window-replace" &&
+          (!deleteCountExpression ||
+            validateKeyedArrayPositionExpression(deleteCountExpression, safeGlobals) !==
+              undefined)) ||
         (kind !== "remove" &&
           incoming.some((item) => {
             const expression = t.isSpreadElement(item) ? item.argument : item;


### PR DESCRIPTION
## Problem

The keyed exact-window fast path recognizes concise `toSpliced(position, literalCount, ...items)` updates, but real window sizes are often derived at event time from pagination, virtualization, or the replacement collection itself. A safe update such as `toSpliced(position, replacements.length, ...replacements)` therefore fell back to complete keyed reconciliation and lost the bounded-window performance win.

This PR builds on the now-merged #671 and contains only runtime delete-count support.

## Root cause

The compiler classified exact-window replacement only when the second `toSpliced()` argument was a positive safe-integer literal. The existing runtime helper already calls the native method first and can validate whether the evaluated count is eligible, but the compiler never emitted that helper for a compiler-safe runtime count expression.

## Change

- Accept identifiers, property reads, side-effect-free arithmetic and conditionals, and safe `Math` calls as delete-count expressions in concise keyed `toSpliced()` setters.
- Route both runtime-count removals and replacements through the existing exact-window helper.
- Keep calls, assignments, updates, and other effectful count expressions uncompiled.
- Change the existing 10,000-row exact-window benchmark to derive its count from `replacements.length` while retaining the same React and block-bodied compiled controls and performance floors.
- Document the supported syntax, runtime proof, native semantics, and fallback behavior.
- Add compiler and runtime coverage for supported expressions, removals, native coercion, and unsafe evaluated counts.

## Safety and compatibility

The transform preserves method lookup and argument evaluation order and evaluates each source expression once. The native `toSpliced()` call still owns coercion, return values, and thrown errors. Fast-path metadata is recorded only after runtime validation proves a native dense array/method, a safe-integer position, a positive safe-integer delete count, a consistent result length, and valid keys.

Zero, negative, fractional, non-numeric, or otherwise unsafe evaluated counts still produce the native result and use complete keyed reconciliation. Custom methods, effectful expressions, sparse or subclassed arrays, failed ownership checks, and unsupported syntax retain the existing fallback. There is no new public API, option, disabled-path cost, or runtime byte contribution. React 18 and React 19 compatibility remains covered.

## Verification

- `pnpm --filter @farm.js/react exec vitest run src/__tests__/compiler-keyed-array-position-hints.test.ts src/__tests__/compiler-runtime-keyed-array-window-replace-hints.test.tsx --maxWorkers=1` — 61 passed
- `pnpm --filter @farm.js/react exec vitest run --maxWorkers=1` — 615 passed, 3 intentionally skipped
- `pnpm --filter @farm.js/react exec vitest run --config vitest.stress.config.ts --maxWorkers=1` — 3 heavy controls passed
- `pnpm --filter @farm.js/react type-check`
- `pnpm --filter @farm.js/react test:compat` — React 18.3.1 and 19.2.8 passed
- `pnpm --filter @farm.js/react test:runtime-size` — unchanged: 14,173 B gzip keyed-window premium, 3,766 B gzip compiler-disabled core premium, 82.5% isolated-runtime reduction
- `pnpm --filter farm-react-compiler-dashboard-example type-check`
- `pnpm --filter farm-react-compiler-dashboard-example build` — production compiler report emitted all 15 expected position hints
- `FARM_DASHBOARD_REPORT=/tmp/farm-react-dynamic-count-benchmark.json pnpm --filter farm-react-compiler-dashboard-example benchmark` — all correctness, performance, persistence, and scalability gates passed in Chrome 145 on Apple M1 macOS arm64
- `pnpm docs:check-navigation` — 74 pages passed
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm docs:build`
- focused `oxfmt`, `oxlint`, and `git diff --check`

| Mode | React median | Runtime count | Compiled control | vs React | vs control |
| --- | ---: | ---: | ---: | ---: | ---: |
| Static | 110.95 ms | 7.60 ms | 19.90 ms | 14.60x | 2.62x |
| Hybrid | 110.95 ms | 7.80 ms | 18.90 ms | 14.22x | 2.42x |

The existing floors remain 4x versus React and 1.5x versus the equivalent compiled control. The queued grow/shrink workload from #671 also remained above its existing floors.

## Documentation and release

Updated the experimental React compiler documentation and the maintained compiler-dashboard example, benchmark description, and measured results. No configuration, template, package version, generated artifact, or release-flow change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extends the keyed `toSpliced()` window-replacement fast path to accept runtime delete counts, so real window sizes derived from pagination, virtualization, or the replacement collection itself keep the bounded-window optimization instead of falling back to full keyed reconciliation.

**Details**
- Accepts identifiers, property reads, side-effect-free arithmetic and conditionals, and safe `Math` calls as delete-count expressions; effectful expressions keep the native fallback.
- The runtime validates the evaluated count after the native call, so zero, negative, fractional, or unsafe counts still produce native results through complete reconciliation.
- Updates the 10,000-row benchmark to derive its count from `replacements.length` and adds compiler and runtime coverage for dynamic counts.

<sup>Written for commit 9b3c7bfb3d916a82865d3d5fdc51acaf8e56feff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/672?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

