### PR TITLE
fix(runtime): close after startup settles

### DIFF
--- a/packages/farm/src/__tests__/node-server-entry.test.ts
+++ b/packages/farm/src/__tests__/node-server-entry.test.ts
@@ -26,7 +26,8 @@ describe("Farm production Node entry", () => {
     expect(source).toContain("startupSignalPromise");
     expect(source).toContain("await Promise.race([");
     expect(source).toContain("() => farmProductionLifecycle.start()");
-    expect(source).toContain("Runtime shutdown during startup timed out");
+    expect(source).toContain("farmProductionLifecycle.forceClose(startupSignal)");
+    expect(source).toContain("Forced runtime shutdown during startup timed out");
     expect(source).toContain("farmProductionLifecycle.beginDrain(signal)");
     expect(source).toContain('nitroApp.hooks.hook("close"');
     expect(source).toContain("process.env.NITRO_SHUTDOWN_TIMEOUT = String");

--- a/packages/farm/src/__tests__/production-lifecycle.test.ts
+++ b/packages/farm/src/__tests__/production-lifecycle.test.ts
@@ -144,6 +144,85 @@ describe("Farm production lifecycle", () => {
     expect(lifecycle.state).toBe("closed");
   });
 
+  it("waits for an in-progress startup before closing its resources", async () => {
+    let finishStartup!: () => void;
+    const startup = new Promise<void>((resolve) => {
+      finishStartup = resolve;
+    });
+    const calls: string[] = [];
+    const lifecycle = createFarmProductionLifecycle({
+      server: resolveFarmServerConfig(undefined),
+      async start() {
+        calls.push("start:begin");
+        await startup;
+        calls.push("start:end");
+      },
+      async close() {
+        calls.push("close");
+      },
+    });
+
+    const starting = lifecycle.start();
+    const closing = lifecycle.close("SIGTERM");
+    await Promise.resolve();
+    expect(calls).toEqual(["start:begin"]);
+
+    finishStartup();
+    await Promise.all([starting, closing]);
+
+    expect(calls).toEqual(["start:begin", "start:end", "close"]);
+    expect(lifecycle.state).toBe("closed");
+  });
+
+  it("deduplicates forced cleanup when startup does not settle", async () => {
+    let finishStartup!: () => void;
+    const startup = new Promise<void>((resolve) => {
+      finishStartup = resolve;
+    });
+    const close = vi.fn(async () => {});
+    const lifecycle = createFarmProductionLifecycle({
+      server: resolveFarmServerConfig(undefined),
+      start: () => startup,
+      close,
+    });
+
+    const starting = lifecycle.start();
+    const closing = lifecycle.close("SIGTERM");
+    await lifecycle.forceClose("SIGTERM");
+    await expect(closing).resolves.toBeUndefined();
+
+    expect(close).toHaveBeenCalledTimes(1);
+    expect(close).toHaveBeenCalledWith("SIGTERM");
+    expect(lifecycle.state).toBe("closed");
+
+    finishStartup();
+    await Promise.all([starting, closing]);
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+
+  it("stays closed when startup rejects after forced cleanup", async () => {
+    let failStartup!: (error: Error) => void;
+    const startup = new Promise<void>((_resolve, reject) => {
+      failStartup = reject;
+    });
+    const lifecycle = createFarmProductionLifecycle({
+      server: resolveFarmServerConfig(undefined),
+      start: () => startup,
+      close: async () => {},
+    });
+
+    const starting = lifecycle.start();
+    await lifecycle.forceClose("SIGTERM");
+    const startupError = new Error("late startup failure");
+    failStartup(startupError);
+
+    await expect(starting).rejects.toBe(startupError);
+    expect(lifecycle.state).toBe("closed");
+    await expect(lifecycle.runRequest(() => new Response("unexpected"))).resolves.toMatchObject({
+      status: 503,
+    });
+  });
+
   it("memoizes synchronous close failures and still reaches closed", async () => {
     const closeError = new Error("synchronous close failed");
     const close = vi.fn(() => {

--- a/packages/farm/src/nitro/node-server-entry.ts
+++ b/packages/farm/src/nitro/node-server-entry.ts
@@ -98,8 +98,31 @@ if (startupSignal) {
   ]);
   clearTimeout(startupCloseTimer);
   if (!startupCloseCompleted) {
-    console.error("[Farm] Runtime shutdown during startup timed out");
-    process.exitCode = 1;
+    console.warn("[Farm] Runtime startup did not settle before shutdown; forcing cleanup");
+    let forcedCloseTimer;
+    const forcedCloseCompleted = await Promise.race([
+      Promise.resolve()
+        .then(() => farmProductionLifecycle.forceClose(startupSignal))
+        .then(
+          () => true,
+          (error) => {
+            console.error("[Farm] Forced runtime shutdown during startup failed:", error);
+            process.exitCode = 1;
+            return true;
+          },
+        ),
+      new Promise((resolve) => {
+        forcedCloseTimer = setTimeout(
+          () => resolve(false),
+          farmServerConfig.gracefulShutdownTimeout,
+        );
+      }),
+    ]);
+    clearTimeout(forcedCloseTimer);
+    if (!forcedCloseCompleted) {
+      console.error("[Farm] Forced runtime shutdown during startup timed out");
+      process.exitCode = 1;
+    }
   }
   process.exit(process.exitCode || 0);
 }

--- a/packages/farm/src/production-lifecycle.ts
+++ b/packages/farm/src/production-lifecycle.ts
@@ -19,6 +19,7 @@ export interface FarmProductionLifecycle {
   beginDrain(reason?: string): void;
   waitForIdle(timeoutMs?: number): Promise<boolean>;
   close(reason?: string): Promise<void>;
+  forceClose(reason?: string): Promise<void>;
   handleHealthRequest(request: Request): Promise<Response | null>;
   runRequest(
     handler: () => Response | Promise<Response>,
@@ -33,6 +34,11 @@ export function createFarmProductionLifecycle(
   let activeRequests = 0;
   let startPromise: Promise<void> | undefined;
   let closePromise: Promise<void> | undefined;
+  let resourceClosePromise: Promise<void> | undefined;
+  let resolveForcedCloseWait!: () => void;
+  const forcedCloseWait = new Promise<void>((resolve) => {
+    resolveForcedCloseWait = resolve;
+  });
   const idleWaiters = new Set<() => void>();
 
   const notifyIdle = () => {
@@ -58,7 +64,7 @@ export function createFarmProductionLifecycle(
           if (state === "starting") state = "ready";
         },
         (error) => {
-          state = "failed";
+          if (state !== "closed") state = "failed";
           throw error;
         },
       );
@@ -91,10 +97,9 @@ export function createFarmProductionLifecycle(
     });
   };
 
-  const close = async (reason = "production-server-closed") => {
-    if (closePromise) return closePromise;
-    beginDrain(reason);
-    closePromise = Promise.resolve()
+  const closeResources = async (reason: string) => {
+    if (resourceClosePromise) return resourceClosePromise;
+    resourceClosePromise = Promise.resolve()
       .then(() => options.close?.(reason))
       .then(
         () => {
@@ -105,7 +110,30 @@ export function createFarmProductionLifecycle(
           throw error;
         },
       );
+    return resourceClosePromise;
+  };
+
+  const close = async (reason = "production-server-closed") => {
+    if (resourceClosePromise) return resourceClosePromise;
+    if (closePromise) return closePromise;
+    beginDrain(reason);
+    closePromise = Promise.race([
+      Promise.resolve(startPromise).catch(() => {
+        // Startup may have partially initialized resources. The close hook
+        // still owns their cleanup, while the original start caller keeps the
+        // startup failure.
+      }),
+      forcedCloseWait,
+    ]).then(() => closeResources(reason));
     return closePromise;
+  };
+
+  const forceClose = async (reason = "production-server-closed") => {
+    beginDrain(reason);
+    resolveForcedCloseWait();
+    const forcedClose = closeResources(reason);
+    closePromise ??= forcedClose;
+    return forcedClose;
   };
 
   const handleHealthRequest = async (request: Request): Promise<Response | null> => {
@@ -178,6 +206,7 @@ export function createFarmProductionLifecycle(
     beginDrain,
     waitForIdle,
     close,
+    forceClose,
     handleHealthRequest,
     runRequest,
   };


### PR DESCRIPTION
## Problem

Production shutdown can run its close hook while an asynchronous startup hook is still in progress.

## Root cause

The lifecycle state allowed close to proceed without awaiting the active startup promise.

## Change

Begin draining immediately, wait for startup to settle, and then run the close hook exactly once.

## Safety and compatibility

Existing successful startup and shutdown ordering is preserved. Startup failures still propagate to their caller while cleanup remains possible.

## Verification

- pnpm --filter @farm.js/core exec vitest run src/__tests__/production-lifecycle.test.ts
- pnpm --filter @farm.js/core type-check

## Documentation and release

None.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race in the Farm production lifecycle where shutdown could run the close hook while an asynchronous startup hook was still in progress. The close hook now waits for startup to settle and still runs exactly once, while startup failures continue to propagate to the caller. If startup doesn't settle before the shutdown timeout, the Node entry now forces cleanup instead of exiting with resources still open.

**Behavior**
- `forceClose` runs the close hook while startup is still pending and deduplicates against a later normal close.
- If startup rejects after forced cleanup, the lifecycle stays closed and requests return 503.
- The Node entry gives forced cleanup its own timeout; if that also times out, it exits with an error.

<sup>Written for commit 2ba4a3739efdb7f61ee147dd9b6478dcf450497d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/673?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

