### PR TITLE
fix(types): detect annotated API handlers

### DIFF
--- a/packages/farm/src/__tests__/type-generator.test.ts
+++ b/packages/farm/src/__tests__/type-generator.test.ts
@@ -105,6 +105,34 @@ describe("APITypeGenerator", () => {
     expect(content).toContain("query: typeof QUERY_profile;");
   });
 
+  it("detects typed variable handlers", () => {
+    const root = mkdtempSync(path.join(os.tmpdir(), "farm-api-types-"));
+    const appDir = path.join(root, "src", "app");
+    const routeDir = path.join(appDir, "api", "typed");
+    const similarlyNamedRouteDir = path.join(appDir, "api", "similarly-named");
+    mkdirSync(routeDir, { recursive: true });
+    mkdirSync(similarlyNamedRouteDir, { recursive: true });
+
+    writeFileSync(
+      path.join(routeDir, "route.ts"),
+      [
+        "type Handler = () => Response;",
+        "export const GET: Handler = () => Response.json({ ok: true });",
+        "export let POST: Handler = () => Response.json({ ok: true });",
+      ].join("\n"),
+    );
+    writeFileSync(
+      path.join(similarlyNamedRouteDir, "route.ts"),
+      "export const GET$ = () => Response.json({ ok: true });\n",
+    );
+
+    const generator = new APITypeGenerator(appDir);
+    const routes = generator.scanAPIRoutes();
+
+    expect(routes).toHaveLength(1);
+    expect(routes[0]?.methods).toEqual(["GET", "POST"]);
+  });
+
   it("detects the HTTP names exposed by export lists", () => {
     const root = mkdtempSync(path.join(os.tmpdir(), "farm-api-types-"));
     const appDir = path.join(root, "src", "app");

--- a/packages/farm/src/type-generator.ts
+++ b/packages/farm/src/type-generator.ts
@@ -102,7 +102,7 @@ export class APITypeGenerator {
     for (const method of httpMethods) {
       // Look for a direct declaration or the name exposed by an export list.
       const patterns = [
-        new RegExp(`export\\s+const\\s+${method}\\s*=`, "g"),
+        new RegExp(`export\\s+(?:const|let|var)\\s+${method}\\s*(?::|=)`, "g"),
         new RegExp(`export\\s+(?:async\\s+)?function\\s+${method}\\s*\\(`, "g"),
       ];
 


### PR DESCRIPTION
## Problem

Generated API types can omit HTTP handlers declared with an explicit TypeScript annotation.

## Root cause

Handler discovery recognized inferred const exports but not annotated const declarations.

## Change

Recognize annotated exported HTTP handler declarations during type generation.

## Safety and compatibility

The existing inferred and function declaration forms remain supported. This only broadens static detection.

## Verification

- pnpm --filter @farm.js/core exec vitest run src/__tests__/type-generator.test.ts
- pnpm --filter @farm.js/core type-check

## Documentation and release

None.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Generated API types now detect HTTP handlers declared with explicit TypeScript annotations (e.g., `export const GET: Handler = ...`), which were previously omitted. Inferred const exports and function declarations remain supported; the change only broadens detection to also cover `let` and `var` handlers.

<sup>Written for commit e31c96c2510915fcb4e6208db9807941d99b3f32. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/674?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

