### PR TITLE
fix(api): reject duplicate route methods

### DIFF
--- a/packages/farm/src/__tests__/api-route-manager.test.ts
+++ b/packages/farm/src/__tests__/api-route-manager.test.ts
@@ -40,6 +40,113 @@ describe("APIRouteManager", () => {
     expect(manager.getRoutes().get("/api/jsx")?.methods).toEqual(["GET"]);
   });
 
+  it("rejects duplicate methods for the same API path in one app source", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "farm-api-route-"));
+    tempDirs.push(root);
+
+    const routeDir = path.join(root, "api", "health");
+    const routeFile = path.join(routeDir, "route.ts");
+    const routesFile = path.join(root, "routes.ts");
+    fs.mkdirSync(routeDir, { recursive: true });
+    fs.writeFileSync(routeFile, "export const GET = () => new Response('file');\n");
+    fs.writeFileSync(routesFile, "export {};\n");
+
+    const manager = new APIRouteManager(root, {
+      ssrLoadModule: async (filePath: string) => {
+        if (filePath === routeFile) return { GET: async () => new Response("file") };
+        return {
+          health: createEndpoint("/api/health", { method: "GET" }, async () => ({ ok: true })),
+        };
+      },
+    } as any);
+
+    await expect(manager.discoverRoutes()).rejects.toThrow(
+      `Duplicate API route for GET /api/health: ${routeFile} conflicts with ${routesFile}`,
+    );
+  });
+
+  it("combines different methods for the same API path", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "farm-api-route-"));
+    tempDirs.push(root);
+
+    const routeDir = path.join(root, "api", "health");
+    const routeFile = path.join(routeDir, "route.ts");
+    const routesFile = path.join(root, "routes.ts");
+    fs.mkdirSync(routeDir, { recursive: true });
+    fs.writeFileSync(routeFile, "export const GET = () => new Response('file');\n");
+    fs.writeFileSync(routesFile, "export {};\n");
+
+    const manager = new APIRouteManager(root, {
+      ssrLoadModule: async (filePath: string) => {
+        if (filePath === routeFile) return { GET: async () => new Response("file") };
+        return {
+          update: createEndpoint("/api/health", { method: "POST" }, async () => ({ ok: true })),
+        };
+      },
+    } as any);
+
+    await manager.discoverRoutes();
+
+    expect(manager.getRoutes().get("/api/health")?.methods).toEqual(["GET", "POST"]);
+  });
+
+  it("keeps the last complete route registry when refresh finds a conflict", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "farm-api-route-"));
+    tempDirs.push(root);
+
+    const routeDir = path.join(root, "api", "health");
+    const routeFile = path.join(routeDir, "route.ts");
+    const routesFile = path.join(root, "routes.ts");
+    fs.mkdirSync(routeDir, { recursive: true });
+    fs.writeFileSync(routeFile, "export const GET = () => new Response('file');\n");
+    fs.writeFileSync(routesFile, "export {};\n");
+
+    let rootMethod = "POST";
+    const rootEndpoint = createEndpoint("/api/health", { method: rootMethod }, async () => ({
+      ok: true,
+    }));
+    const manager = new APIRouteManager(root, {
+      ssrLoadModule: async (filePath: string) => {
+        if (filePath === routeFile) return { GET: async () => new Response("file") };
+        rootEndpoint.__method = rootMethod;
+        return { health: rootEndpoint };
+      },
+    } as any);
+
+    await manager.discoverRoutes();
+    expect(manager.getRoutes().get("/api/health")?.methods.sort()).toEqual(["GET", "POST"]);
+
+    rootMethod = "GET";
+    await expect(manager.discoverRoutes()).rejects.toThrow(
+      `Duplicate API route for GET /api/health: ${routeFile} conflicts with ${routesFile}`,
+    );
+    expect(manager.getRoutes().get("/api/health")?.methods.sort()).toEqual(["GET", "POST"]);
+    expect(manager.getRoutes().get("/api/health")?.endpoints.POST).toBe(rootEndpoint);
+  });
+
+  it("combines disjoint methods from supported route files in one directory", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "farm-api-route-"));
+    tempDirs.push(root);
+
+    const routeDir = path.join(root, "api", "health");
+    const tsRouteFile = path.join(routeDir, "route.ts");
+    const jsRouteFile = path.join(routeDir, "route.js");
+    fs.mkdirSync(routeDir, { recursive: true });
+    fs.writeFileSync(tsRouteFile, "export const GET = () => new Response('get');\n");
+    fs.writeFileSync(jsRouteFile, "export const POST = () => new Response('post');\n");
+
+    const manager = new APIRouteManager(root, {
+      ssrLoadModule: async (filePath: string) =>
+        filePath === tsRouteFile
+          ? { GET: async () => new Response("get") }
+          : { POST: async () => new Response("post") },
+    } as any);
+
+    await manager.discoverRoutes();
+
+    expect(manager.getRoutes().get("/api/health")?.methods.sort()).toEqual(["GET", "POST"]);
+  });
+
   it("serves canonical routes through a custom same-origin API path", async () => {
     const manager = new APIRouteManager("/tmp/farm-api-base-path-test", undefined, {
       basePath: "/v2/api",

--- a/packages/farm/src/__tests__/api-vite-plugin-collision-hmr.test.ts
+++ b/packages/farm/src/__tests__/api-vite-plugin-collision-hmr.test.ts
@@ -1,0 +1,75 @@
+// @vitest-environment node
+
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { farmApiPlugin } from "../api/vite-plugin";
+
+const tempDirs = new Set<string>();
+
+afterEach(async () => {
+  await Promise.all([...tempDirs].map((dir) => rm(dir, { recursive: true, force: true })));
+  tempDirs.clear();
+});
+
+describe("standalone API collision handling during HMR", () => {
+  it("preserves composed endpoints and rolls back a conflicting reload", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "farm-api-collision-hmr-"));
+    tempDirs.add(root);
+    const routeDir = path.join(root, "src", "api", "health");
+    const routeFile = path.join(routeDir, "route.ts");
+    const rootRoutesFile = path.join(root, "src", "routes.ts");
+    await mkdir(routeDir, { recursive: true });
+    await writeFile(routeFile, "export {};\n");
+    await writeFile(rootRoutesFile, "export {};\n");
+
+    let fileModule: Record<string, unknown> = {
+      GET: async () => new Response("file-get"),
+    };
+    const rootPost = async () => new Response("root-post");
+    const rootEndpoint = {
+      __path: "/api/health",
+      __method: "POST",
+      handler: rootPost,
+    };
+    const server: any = {
+      config: { root },
+      ssrLoadModule: vi.fn(async (filePath: string) =>
+        filePath === routeFile
+          ? fileModule
+          : {
+              health: rootEndpoint,
+            },
+      ),
+      moduleGraph: { invalidateModule: vi.fn() },
+      middlewares: { use() {} },
+      watcher: { on() {} },
+    };
+    const plugin = farmApiPlugin() as any;
+
+    await plugin.configureServer(server);
+    await server.__farmApi__.waitForDiscovery();
+    expect(server.__farmApi__.getRoutes().get("/api/health")?.methods.sort()).toEqual([
+      "GET",
+      "POST",
+    ]);
+
+    fileModule = { PUT: async () => new Response("file-put") };
+    await plugin.handleHotUpdate({ file: routeFile, modules: [], server });
+    expect(server.__farmApi__.getRoutes().get("/api/health")?.methods.sort()).toEqual([
+      "POST",
+      "PUT",
+    ]);
+
+    fileModule = { POST: async () => new Response("file-post") };
+    await expect(plugin.handleHotUpdate({ file: routeFile, modules: [], server })).rejects.toThrow(
+      `Duplicate API route for POST /api/health`,
+    );
+    expect(server.__farmApi__.getRoutes().get("/api/health")?.methods.sort()).toEqual([
+      "POST",
+      "PUT",
+    ]);
+    expect(server.__farmApi__.getRoutes().get("/api/health")?.endpoints.POST).toBe(rootEndpoint);
+  });
+});

--- a/packages/farm/src/__tests__/api-vite-plugin-rewrite.test.ts
+++ b/packages/farm/src/__tests__/api-vite-plugin-rewrite.test.ts
@@ -4,7 +4,7 @@ import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { farmApiPlugin } from "../api/vite-plugin";
 
 const tempDirs = new Set<string>();
@@ -16,6 +16,7 @@ function decodeChunk(chunk: unknown): string {
 }
 
 afterEach(async () => {
+  vi.restoreAllMocks();
   await Promise.all(
     [...tempDirs].map(async (dir) => {
       await rm(dir, { recursive: true, force: true });
@@ -128,6 +129,70 @@ async function createDevHarness(
 }
 
 describe("dev API dispatch after middleware rewrites", () => {
+  it("reports duplicate methods across file and explicit routes", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "farm-api-conflict-"));
+    tempDirs.add(root);
+    const routeDir = path.join(root, "src", "api", "health");
+    const routeFile = path.join(routeDir, "route.js");
+    const routesFile = path.join(root, "src", "routes.js");
+    await mkdir(routeDir, { recursive: true });
+    await writeFile(routeFile, "export {};\n");
+    await writeFile(routesFile, "export {};\n");
+
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const plugin = farmApiPlugin() as any;
+    let apiMiddleware: ((req: any, res: any, next: () => void) => Promise<void>) | undefined;
+    let rootMethod = "GET";
+    const server = {
+      config: { root },
+      ssrLoadModule: async (filePath: string) =>
+        filePath === routeFile
+          ? { GET: async () => new Response("file") }
+          : {
+              health: {
+                __path: "/api/health",
+                __method: rootMethod,
+                handler: async () => new Response("explicit"),
+              },
+            },
+      middlewares: {
+        use(handler: typeof apiMiddleware) {
+          apiMiddleware = handler;
+        },
+      },
+      moduleGraph: { invalidateModule: vi.fn() },
+      watcher: { on() {} },
+    };
+
+    const register = await plugin.configureServer(server);
+    register?.();
+
+    await expect((server as any).__farmApi__.waitForDiscovery()).rejects.toThrow(
+      `Duplicate API route for GET /api/health: ${routeFile} conflicts with ${routesFile}`,
+    );
+    expect(consoleError).toHaveBeenCalledWith(
+      "[FARM] API discovery error:",
+      expect.objectContaining({ name: "APIRouteConflictError" }),
+    );
+
+    await expect(
+      apiMiddleware!(
+        { url: "/api/health", method: "GET", headers: {} },
+        { once() {}, writableEnded: false },
+        vi.fn(),
+      ),
+    ).rejects.toThrow("Duplicate API route for GET /api/health");
+
+    rootMethod = "POST";
+    await plugin.handleHotUpdate({ file: routesFile, modules: [], server });
+    await expect((server as any).__farmApi__.waitForDiscovery()).resolves.toBeUndefined();
+    expect((server as any).__farmApi__.isReady()).toBe(true);
+    expect((server as any).__farmApi__.getRoutes().get("/api/health")?.methods.sort()).toEqual([
+      "GET",
+      "POST",
+    ]);
+  });
+
   it("serves canonical routes through the configured local base path", async () => {
     const harness = await createDevHarness(
       {

--- a/packages/farm/src/api/route-manager.ts
+++ b/packages/farm/src/api/route-manager.ts
@@ -41,6 +41,15 @@ export interface APIRouteHandlerOptions {
   throwOnError?: boolean;
 }
 
+export class APIRouteConflictError extends Error {
+  constructor(routePath: string, method: string, existingFile: string, conflictingFile: string) {
+    super(
+      `Duplicate API route for ${method.toUpperCase()} ${routePath}: ${existingFile} conflicts with ${conflictingFile}`,
+    );
+    this.name = "APIRouteConflictError";
+  }
+}
+
 export const API_ROUTE_METHODS = [
   "GET",
   "HEAD",
@@ -54,6 +63,8 @@ export const API_ROUTE_METHODS = [
 
 export class APIRouteManager {
   private routes: Map<string, APIRoute> = new Map();
+  private endpointSources: Map<string, Map<string, { appDir: string; filePath: string }>> =
+    new Map();
   private viteServer?: ViteDevServer;
   private appDirs: string[];
   private throwOnLoadError: boolean;
@@ -78,22 +89,31 @@ export class APIRouteManager {
    * Discover route.ts files in /app/api and explicit endpoints in root routes.ts
    */
   async discoverRoutes(): Promise<void> {
-    this.routes.clear();
+    const previousRoutes = this.routes;
+    const previousEndpointSources = this.endpointSources;
+    this.routes = new Map();
+    this.endpointSources = new Map();
 
-    for (const appDir of this.appDirs) {
-      const apiDir = path.join(appDir, "api");
-      let routeFiles: string[] = [];
+    try {
+      for (const appDir of this.appDirs) {
+        const apiDir = path.join(appDir, "api");
+        let routeFiles: string[] = [];
 
-      if (fs.existsSync(apiDir)) {
-        routeFiles = this.findRouteFiles(apiDir);
+        if (fs.existsSync(apiDir)) {
+          routeFiles = this.findRouteFiles(apiDir);
+        }
+
+        for (const filePath of routeFiles) {
+          await this.loadRoute(filePath, appDir);
+        }
+
+        await this.loadRootRoutes(appDir);
+        await this.loadProgrammaticApiRoutes(appDir);
       }
-
-      for (const filePath of routeFiles) {
-        await this.loadRoute(filePath, appDir);
-      }
-
-      await this.loadRootRoutes(appDir);
-      await this.loadProgrammaticApiRoutes(appDir);
+    } catch (error) {
+      this.routes = previousRoutes;
+      this.endpointSources = previousEndpointSources;
+      throw error;
     }
 
     if (process.env.FARM_VERBOSE) {
@@ -153,17 +173,38 @@ export class APIRouteManager {
       }
 
       if (availableMethods.length > 0) {
+        const existingSources = this.endpointSources.get(routePath);
+        if (existingSources) {
+          for (const method of availableMethods) {
+            const existingSource = existingSources.get(method);
+            if (existingSource?.appDir === appDir) {
+              throw new APIRouteConflictError(routePath, method, existingSource.filePath, filePath);
+            }
+          }
+        }
+
         const runtimeConfig = normalizeFarmRouteRuntimeConfig(
           getFarmRouteRuntimeConfig(routeModule),
           `API route "${routePath}"`,
         );
+        const existingRoute = this.routes.get(routePath);
+        const mergedMethods = existingRoute ? [...existingRoute.methods] : [];
+        for (const method of availableMethods) {
+          if (!mergedMethods.includes(method)) mergedMethods.push(method);
+        }
         this.routes.set(routePath, {
+          ...existingRoute,
           path: routePath,
           filePath,
-          methods: availableMethods,
-          endpoints,
+          methods: mergedMethods,
+          endpoints: { ...existingRoute?.endpoints, ...endpoints },
           ...runtimeConfig,
         });
+        const nextSources = new Map(existingSources);
+        for (const method of availableMethods) {
+          nextSources.set(method, { appDir, filePath });
+        }
+        this.endpointSources.set(routePath, nextSources);
       }
     } catch (error) {
       this.handleLoadError(`Error loading route ${filePath}`, error);
@@ -189,7 +230,7 @@ export class APIRouteManager {
         }
 
         const method = String(endpoint.__method || "GET").toUpperCase();
-        this.addEndpoint(endpoint.__path, routesFile, method, endpoint);
+        this.addEndpoint(endpoint.__path, routesFile, method, endpoint, appDir);
       }
     } catch (error) {
       this.handleLoadError(`Error loading root API routes ${routesFile}`, error);
@@ -213,7 +254,7 @@ export class APIRouteManager {
 
         for (const definition of manifest.routes) {
           if (definition.kind !== "api") continue;
-          this.addProgrammaticApiRoute(routeFile, definition);
+          this.addProgrammaticApiRoute(routeFile, definition, appDir);
         }
       } catch (error) {
         this.handleLoadError(`Error loading programmatic API routes ${routeFile}`, error);
@@ -223,7 +264,7 @@ export class APIRouteManager {
 
   private handleLoadError(message: string, error: unknown): void {
     logger.error(`${message}: ${error}`);
-    if (this.throwOnLoadError) {
+    if (this.throwOnLoadError || error instanceof APIRouteConflictError) {
       throw error;
     }
   }
@@ -264,10 +305,21 @@ export class APIRouteManager {
     filePath: string,
     method: string,
     endpoint: any,
+    appDir: string,
     runtimeConfig: FarmRouteRuntimeConfig = {},
   ): void {
     const normalizedMethod = method.toUpperCase();
     const existingRoute = this.routes.get(routePath);
+    const existingSource = this.endpointSources.get(routePath)?.get(normalizedMethod);
+
+    if (existingSource?.appDir === appDir) {
+      throw new APIRouteConflictError(
+        routePath,
+        normalizedMethod,
+        existingSource.filePath,
+        filePath,
+      );
+    }
 
     if (existingRoute) {
       if (!existingRoute.methods.includes(normalizedMethod)) {
@@ -275,6 +327,9 @@ export class APIRouteManager {
       }
       existingRoute.endpoints[normalizedMethod] = endpoint;
       Object.assign(existingRoute, runtimeConfig);
+      const sources = this.endpointSources.get(routePath) ?? new Map();
+      sources.set(normalizedMethod, { appDir, filePath });
+      this.endpointSources.set(routePath, sources);
       return;
     }
 
@@ -285,14 +340,19 @@ export class APIRouteManager {
       endpoints: { [normalizedMethod]: endpoint },
       ...runtimeConfig,
     });
+    this.endpointSources.set(routePath, new Map([[normalizedMethod, { appDir, filePath }]]));
   }
 
-  private addProgrammaticApiRoute(filePath: string, route: ProgrammaticApiRoute): void {
+  private addProgrammaticApiRoute(
+    filePath: string,
+    route: ProgrammaticApiRoute,
+    appDir: string,
+  ): void {
     const modulePath = createProgrammaticRouteModuleId(filePath, "api", route.path);
     const runtimeConfig = normalizeFarmRouteRuntimeConfig(route, `API route "${route.path}"`);
     for (const [method, endpoint] of Object.entries(route.methods)) {
       if (endpoint) {
-        this.addEndpoint(route.path, modulePath, method, endpoint, runtimeConfig);
+        this.addEndpoint(route.path, modulePath, method, endpoint, appDir, runtimeConfig);
       }
     }
   }

--- a/packages/farm/src/api/vite-plugin.ts
+++ b/packages/farm/src/api/vite-plugin.ts
@@ -17,6 +17,7 @@
 
 import type { Plugin, ViteDevServer } from "vite";
 import {
+  APIRouteConflictError,
   API_ROUTE_METHODS,
   getAllowedAPIRouteMethods,
   invokeAPIRouteEndpoint,
@@ -70,6 +71,9 @@ export function farmApiPlugin(options: FarmApiPluginOptions = {}): Plugin {
   let apiRouterHandler: ((req: Request) => Promise<Response>) | null = null;
   let discoveryComplete = false;
   let discoveryPromise: Promise<void> | null = null;
+  let discoveryError: unknown;
+  let recoverFailedDiscovery: (() => Promise<boolean>) | undefined;
+  const endpointSources = new Map<string, Map<string, string>>();
 
   const log = (_message: string) => {};
   const logResponse = (method: string, urlPath: string, status: number, duration: number) => {
@@ -99,12 +103,20 @@ export function farmApiPlugin(options: FarmApiPluginOptions = {}): Plugin {
   ): void => {
     const normalizedMethod = method.toUpperCase();
     const existing = apiRoutesCache.get(routePath);
+    const existingFile = endpointSources.get(routePath)?.get(normalizedMethod);
+
+    if (existingFile) {
+      throw new APIRouteConflictError(routePath, normalizedMethod, existingFile, filePath);
+    }
 
     if (existing) {
       if (!existing.methods.includes(normalizedMethod)) {
         existing.methods.push(normalizedMethod);
       }
       existing.endpoints[normalizedMethod] = endpoint;
+      const sources = endpointSources.get(routePath) ?? new Map();
+      sources.set(normalizedMethod, filePath);
+      endpointSources.set(routePath, sources);
       return;
     }
 
@@ -114,6 +126,52 @@ export function farmApiPlugin(options: FarmApiPluginOptions = {}): Plugin {
       methods: [normalizedMethod],
       endpoints: { [normalizedMethod]: endpoint },
     });
+    endpointSources.set(routePath, new Map([[normalizedMethod, filePath]]));
+  };
+
+  const removeEndpointsFromFile = (filePath: string): void => {
+    for (const [routePath, sources] of endpointSources) {
+      const route = apiRoutesCache.get(routePath);
+      if (!route) continue;
+
+      for (const [method, sourceFile] of sources) {
+        if (sourceFile !== filePath) continue;
+        sources.delete(method);
+        route.methods = route.methods.filter((candidate) => candidate !== method);
+        delete route.endpoints[method];
+      }
+
+      if (route.methods.length === 0) {
+        apiRoutesCache.delete(routePath);
+        endpointSources.delete(routePath);
+      } else if (route.filePath === filePath) {
+        route.filePath = sources.values().next().value ?? route.filePath;
+      }
+    }
+  };
+
+  const snapshotRouteState = () => ({
+    routes: new Map(
+      [...apiRoutesCache].map(([routePath, route]) => [
+        routePath,
+        {
+          ...route,
+          methods: [...route.methods],
+          endpoints: { ...route.endpoints },
+        },
+      ]),
+    ),
+    sources: new Map(
+      [...endpointSources].map(([routePath, sources]) => [routePath, new Map(sources)]),
+    ),
+  });
+
+  const restoreRouteState = (snapshot: ReturnType<typeof snapshotRouteState>): void => {
+    apiRoutesCache = snapshot.routes;
+    endpointSources.clear();
+    for (const [routePath, sources] of snapshot.sources) {
+      endpointSources.set(routePath, sources);
+    }
   };
 
   // Create API router handler
@@ -198,6 +256,7 @@ export function farmApiPlugin(options: FarmApiPluginOptions = {}): Plugin {
 
         const routeFiles = findRouteFiles(apiDir);
         apiRoutesCache.clear();
+        endpointSources.clear();
 
         for (const filePath of routeFiles) {
           try {
@@ -217,15 +276,13 @@ export function farmApiPlugin(options: FarmApiPluginOptions = {}): Plugin {
             }
 
             if (availableMethods.length > 0) {
-              apiRoutesCache.set(routePath, {
-                path: routePath,
-                filePath,
-                methods: availableMethods,
-                endpoints,
-              });
+              for (const method of availableMethods) {
+                addEndpoint(routePath, filePath, method, endpoints[method]);
+              }
               log(`API route discovered: ${availableMethods.join(", ")} ${routePath}`);
             }
           } catch (e: any) {
+            if (e instanceof APIRouteConflictError) throw e;
             log(`API route load failed at ${filePath}: ${e.message}`);
           }
         }
@@ -259,6 +316,7 @@ export function farmApiPlugin(options: FarmApiPluginOptions = {}): Plugin {
                 }
               }
             } catch (e: any) {
+              if (e instanceof APIRouteConflictError) throw e;
               log(`Root routes.ts load failed: ${e.message}`);
             }
             break;
@@ -292,6 +350,7 @@ export function farmApiPlugin(options: FarmApiPluginOptions = {}): Plugin {
               }
             }
           } catch (e: any) {
+            if (e instanceof APIRouteConflictError) throw e;
             log(`Programmatic routes file load failed at ${routeFile}: ${e.message}`);
           }
         }
@@ -313,15 +372,40 @@ export function farmApiPlugin(options: FarmApiPluginOptions = {}): Plugin {
       };
 
       discoveryPromise = initializeDiscovery().catch((e) => {
+        discoveryError = e;
         console.error("[FARM] API discovery error:", e);
       });
+
+      const waitForDiscovery = async () => {
+        await discoveryPromise;
+        if (discoveryError) throw discoveryError;
+      };
+
+      recoverFailedDiscovery = async (): Promise<boolean> => {
+        if (!discoveryError) return false;
+
+        const previousState = snapshotRouteState();
+        try {
+          await initializeDiscovery();
+          discoveryError = undefined;
+          discoveryPromise = Promise.resolve();
+        } catch (error) {
+          restoreRouteState(previousState);
+          discoveryError = error;
+          discoveryComplete = false;
+          discoveryPromise = Promise.resolve();
+          throw error;
+        }
+
+        return true;
+      };
 
       // Expose API router for other plugins
       (server as any).__farmApi__ = {
         getHandler: () => apiRouterHandler,
         getRoutes: () => apiRoutesCache,
         isReady: () => discoveryComplete,
-        waitForDiscovery: () => discoveryPromise,
+        waitForDiscovery,
       };
 
       // Add middleware to handle API requests
@@ -332,9 +416,7 @@ export function farmApiPlugin(options: FarmApiPluginOptions = {}): Plugin {
             const pathname = url.split("?")[0];
             const method = req.method || "GET";
 
-            if (discoveryPromise && !discoveryComplete) {
-              await discoveryPromise;
-            }
+            if (discoveryPromise) await waitForDiscovery();
 
             if (!matchAPIRouteAtBasePath(apiRoutesCache, pathname, basePath)) {
               return next();
@@ -439,15 +521,13 @@ export function farmApiPlugin(options: FarmApiPluginOptions = {}): Plugin {
           server.moduleGraph.invalidateModule(mod);
         }
 
-        // Clear routes from this file
-        for (const [routePath, route] of apiRoutesCache) {
-          if (route.filePath === file) {
-            apiRoutesCache.delete(routePath);
-          }
-        }
+        if (await recoverFailedDiscovery?.()) return [];
+
+        const previousState = snapshotRouteState();
 
         try {
           const routesModule = await server.ssrLoadModule(file);
+          removeEndpointsFromFile(file);
 
           for (const [exportName, exportValue] of Object.entries(routesModule)) {
             const endpoint = exportValue as any;
@@ -479,6 +559,8 @@ export function farmApiPlugin(options: FarmApiPluginOptions = {}): Plugin {
           await createRouter();
           log(`API router recreated`);
         } catch (e: any) {
+          restoreRouteState(previousState);
+          if (e instanceof APIRouteConflictError) throw e;
           log(`Root routes.ts HMR failed: ${e.message}`);
         }
 
@@ -494,74 +576,32 @@ export function farmApiPlugin(options: FarmApiPluginOptions = {}): Plugin {
           server.moduleGraph.invalidateModule(mod);
         }
 
-        let routePathToUpdate: string | null = null;
-        for (const [routePath, route] of apiRoutesCache) {
-          if (route.filePath === file) {
-            routePathToUpdate = routePath;
-            break;
+        if (await recoverFailedDiscovery?.()) return [];
+
+        const previousState = snapshotRouteState();
+        try {
+          const path = await import("path");
+          const apiDir = path.join(server.config.root, srcDir, "api");
+          const relativePath = path.relative(apiDir, path.dirname(file));
+          const routePath =
+            "/api/" + (relativePath === "." ? "" : relativePath.replace(/\\/g, "/"));
+          const routeModule = await server.ssrLoadModule(file);
+
+          removeEndpointsFromFile(file);
+          const availableMethods: string[] = [];
+          for (const method of API_ROUTE_METHODS) {
+            if (!routeModule[method]) continue;
+            availableMethods.push(method);
+            addEndpoint(routePath, file, method, routeModule[method]);
           }
-        }
 
-        if (routePathToUpdate) {
-          try {
-            const routeModule = await server.ssrLoadModule(file);
-            const endpoints: Record<string, any> = {};
-            const availableMethods: string[] = [];
-
-            for (const method of API_ROUTE_METHODS) {
-              if (routeModule[method]) {
-                availableMethods.push(method);
-                endpoints[method] = routeModule[method];
-              }
-            }
-
-            if (availableMethods.length > 0) {
-              apiRoutesCache.set(routePathToUpdate, {
-                path: routePathToUpdate,
-                filePath: file,
-                methods: availableMethods,
-                endpoints,
-              });
-              log(`API route reloaded: ${routePathToUpdate}`);
-              await createRouter();
-              log(`API router recreated`);
-            }
-          } catch (e: any) {
-            log(`API route HMR failed: ${e.message}`);
-          }
-        } else {
-          // New route file
-          try {
-            const path = await import("path");
-            const apiDir = path.join(server.config.root, srcDir, "api");
-            const relativePath = path.relative(apiDir, path.dirname(file));
-            const routePath =
-              "/api/" + (relativePath === "." ? "" : relativePath.replace(/\\/g, "/"));
-
-            const routeModule = await server.ssrLoadModule(file);
-            const endpoints: Record<string, any> = {};
-            const availableMethods: string[] = [];
-
-            for (const method of API_ROUTE_METHODS) {
-              if (routeModule[method]) {
-                availableMethods.push(method);
-                endpoints[method] = routeModule[method];
-              }
-            }
-
-            if (availableMethods.length > 0) {
-              apiRoutesCache.set(routePath, {
-                path: routePath,
-                filePath: file,
-                methods: availableMethods,
-                endpoints,
-              });
-              log(`New API route discovered: ${routePath}`);
-              await createRouter();
-            }
-          } catch (e: any) {
-            log(`New API route load failed: ${e.message}`);
-          }
+          await createRouter();
+          log(`API route reloaded: ${availableMethods.join(", ")} ${routePath}`);
+          log(`API router recreated`);
+        } catch (e: any) {
+          restoreRouteState(previousState);
+          if (e instanceof APIRouteConflictError) throw e;
+          log(`API route HMR failed: ${e.message}`);
         }
 
         return [];


### PR DESCRIPTION
## Problem

Two API files can register the same HTTP method and pathname, leaving the selected handler dependent on discovery order.

## Root cause

Route registration merged handlers without tracking their source provenance.

## Change

Track endpoint ownership and reject duplicate method/path registrations in both the framework route manager and standalone Vite API plugin.

## Safety and compatibility

Different methods still compose on one pathname, and application routes still override layer routes according to existing precedence.

## Verification

- pnpm --filter @farm.js/core exec vitest run src/__tests__/api-route-manager.test.ts src/__tests__/api-vite-plugin-rewrite.test.ts
- pnpm --filter @farm.js/core type-check

## Documentation and release

None.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects duplicate API route methods so the winning handler no longer depends on file discovery order. The route manager and the Vite API plugin now track which file owns each method/pathname pair and throw an `APIRouteConflictError` when two files register the same combination. On hot reload, a conflicting update is rejected and the previous route state is restored.

**Compatibility**
- Different HTTP methods on the same pathname still merge into one route.
- Application routes still override layer routes according to existing precedence.
- Existing apps with duplicate method/pathname registrations will now fail at discovery time.
- After a failed discovery, the next hot update retries discovery and recovers once the conflict is resolved.

<sup>Written for commit 6db014cd1dd487f4472ed64cabc1c99e82d82905. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/675?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

