### PR TITLE
fix(hmr): normalize Windows file paths

### DIFF
--- a/packages/farm/src/__tests__/hmr-manager.test.ts
+++ b/packages/farm/src/__tests__/hmr-manager.test.ts
@@ -45,6 +45,15 @@ function sentUpdatePaths(send: ReturnType<typeof vi.fn>): string[] {
 }
 
 describe("HMRManager affected-module traversal", () => {
+  it("reloads Windows page paths as route modules", async () => {
+    const page = createModule({ url: "/src/app/page.tsx" });
+    const { server, send } = createServer(page);
+
+    await new HMRManager(server).handleFileChange("C:\\project\\src\\app\\page.tsx");
+
+    expect(send).toHaveBeenCalledWith({ type: "full-reload", path: "*" });
+  });
+
   it("includes the self-accepting boundary and stops above it", async () => {
     // page -> widget(self-accepting) -> util(changed)
     const util = createModule({ url: "/src/util.ts" });

--- a/packages/farm/src/__tests__/windows-hmr-paths.test.ts
+++ b/packages/farm/src/__tests__/windows-hmr-paths.test.ts
@@ -1,0 +1,71 @@
+// @vitest-environment node
+
+import { describe, expect, it, vi } from "vitest";
+import { farmApiPlugin } from "../api/vite-plugin";
+import { farmPlugin } from "../vite";
+
+describe("Windows HMR paths", () => {
+  it("reloads page modules through the main Farm plugin", async () => {
+    const send = vi.fn();
+    const invalidateModule = vi.fn();
+    const plugin = farmPlugin() as any;
+    const module = { id: "C:\\project\\src\\app\\page.tsx" };
+
+    const result = await plugin.handleHotUpdate({
+      file: "C:\\project\\src\\app\\page.tsx",
+      modules: [module],
+      server: {
+        moduleGraph: {
+          getModuleById: vi.fn(() => null),
+          invalidateModule,
+        },
+        ws: { send },
+      },
+    });
+
+    expect(result).toEqual([]);
+    expect(invalidateModule).toHaveBeenCalledWith(module);
+    expect(send).toHaveBeenCalledWith({ type: "full-reload", path: "*" });
+  });
+
+  it("recognizes root route files through the standalone API plugin", async () => {
+    const ssrLoadModule = vi.fn(async () => ({
+      health: {
+        __path: "/api/health",
+        __method: "GET",
+        handler: async () => new Response("ok"),
+      },
+    }));
+    const plugin = farmApiPlugin() as any;
+
+    const result = await plugin.handleHotUpdate({
+      file: "C:\\project\\src\\routes.ts",
+      modules: [],
+      server: {
+        moduleGraph: { invalidateModule: vi.fn() },
+        ssrLoadModule,
+      },
+    });
+
+    expect(result).toEqual([]);
+    expect(ssrLoadModule).toHaveBeenCalledWith("C:\\project\\src\\routes.ts");
+  });
+
+  it("recognizes file-based API routes through the standalone plugin", async () => {
+    const ssrLoadModule = vi.fn(async () => ({ GET: async () => new Response("ok") }));
+    const plugin = farmApiPlugin() as any;
+
+    const result = await plugin.handleHotUpdate({
+      file: "C:\\project\\src\\api\\users\\route.ts",
+      modules: [],
+      server: {
+        config: { root: "C:\\project" },
+        moduleGraph: { invalidateModule: vi.fn() },
+        ssrLoadModule,
+      },
+    });
+
+    expect(result).toEqual([]);
+    expect(ssrLoadModule).toHaveBeenCalledWith("C:\\project\\src\\api\\users\\route.ts");
+  });
+});

--- a/packages/farm/src/api/vite-plugin.ts
+++ b/packages/farm/src/api/vite-plugin.ts
@@ -28,7 +28,7 @@ import { isFarmAPIRouteFileName } from "./route-files";
 import { _withAfterNodeMiddleware } from "../after";
 import { isProgrammaticRoutesFileName } from "../routes-shared";
 import { findProgrammaticRouteFilesInDir } from "../routes.server";
-import { toViteModuleId } from "../utils";
+import { toPosixPath, toViteModuleId } from "../utils";
 import {
   createFarmRequestBodyErrorResponse,
   readNodeRequestBody,
@@ -423,7 +423,8 @@ export function farmApiPlugin(options: FarmApiPluginOptions = {}): Plugin {
     },
 
     async handleHotUpdate({ file, server, modules }) {
-      const fileName = file.split("/").pop() || "";
+      const normalizedFile = toPosixPath(file);
+      const fileName = normalizedFile.split("/").pop() || "";
 
       // Handle root routes.ts updates
       if (
@@ -485,8 +486,8 @@ export function farmApiPlugin(options: FarmApiPluginOptions = {}): Plugin {
       }
 
       // Handle file-based route updates
-      if (file.includes("/api/") && fileName.startsWith("route.")) {
-        const shortPath = file.split("/api/")[1] || file;
+      if (normalizedFile.includes("/api/") && fileName.startsWith("route.")) {
+        const shortPath = normalizedFile.split("/api/")[1] || normalizedFile;
         log(`API route updated: ${shortPath}`);
 
         for (const mod of modules) {

--- a/packages/farm/src/hmr.ts
+++ b/packages/farm/src/hmr.ts
@@ -1,5 +1,5 @@
 import type { ViteDevServer, ModuleNode } from "vite";
-import { logger } from "./utils";
+import { toPosixPath } from "./utils";
 
 export class HMRManager {
   private server: ViteDevServer;
@@ -30,6 +30,7 @@ export class HMRManager {
    */
   async handleFileChange(file: string) {
     const module = await this.server.moduleGraph.getModuleByUrl(file);
+    const normalizedFile = toPosixPath(file);
 
     if (!module) {
       return;
@@ -45,12 +46,18 @@ export class HMRManager {
       return;
     }
 
-    if (file.includes("/app/") && /\/page\.(?:tsx?|jsx?|vue|svelte)$/.test(file)) {
+    if (
+      normalizedFile.includes("/app/") &&
+      /\/page\.(?:tsx?|jsx?|vue|svelte)$/.test(normalizedFile)
+    ) {
       await this.reloadPage();
       return;
     }
 
-    if (file.includes("/app/") && /\/layout\.(?:tsx?|jsx?|vue|svelte)$/.test(file)) {
+    if (
+      normalizedFile.includes("/app/") &&
+      /\/layout\.(?:tsx?|jsx?|vue|svelte)$/.test(normalizedFile)
+    ) {
       await this.reloadPage();
       return;
     }

--- a/packages/farm/src/vite.ts
+++ b/packages/farm/src/vite.ts
@@ -1,7 +1,7 @@
 import type { ConfigEnv, Plugin, UserConfig, ViteDevServer, HmrContext, Connect } from "vite";
 import type { FarmConfig } from "./types";
 import { FarmApp } from "./app";
-import { logger, toViteModuleId } from "./utils";
+import { logger, toPosixPath, toViteModuleId } from "./utils";
 import { defaultGlobalCSS } from "./default-styles";
 import type { FarmPlugin, FarmPluginRuntimeSession, PluginManager } from "./plugin";
 import { generateFarmClientPluginEntryCode } from "./client-plugin-build";
@@ -878,12 +878,13 @@ export function farmPlugin(
         event: string,
         selection: TypeArtifactSelection,
       ) => {
+        const normalizedFile = toPosixPath(file);
         for (const [artifact, enabled] of Object.entries(selection)) {
           if (enabled) {
             pendingTypeArtifacts[artifact as keyof TypeArtifactSelection] = true;
           }
         }
-        pendingTypeArtifactReason ||= `${event} ${file.split("/app/")[1] || file}`;
+        pendingTypeArtifactReason ||= `${event} ${normalizedFile.split("/app/")[1] || normalizedFile}`;
         if (typeArtifactGenScheduled) return;
         typeArtifactGenScheduled = setTimeout(() => {
           typeArtifactGenScheduled = null;
@@ -3036,9 +3037,9 @@ if (import.meta.hot) {
         return [];
       }
 
-      if (file.includes("/app/")) {
+      if (normalizedFile.includes("/app/")) {
         // Hot reload middleware changes
-        if (file.includes("middleware.")) {
+        if (normalizedFile.includes("middleware.")) {
           if (middlewareManager) {
             await middlewareManager.reload();
             logger.success("✅ Middleware reloaded!");
@@ -3062,8 +3063,8 @@ if (import.meta.hot) {
           server.moduleGraph.invalidateModule(manifestModule);
         }
 
-        if (file.includes("page.") || file.includes("layout.")) {
-          const shortPath = file.split("/app/")[1] || file;
+        if (normalizedFile.includes("page.") || normalizedFile.includes("layout.")) {
+          const shortPath = normalizedFile.split("/app/")[1] || normalizedFile;
           logUpdate("PAGE", `updated ${shortPath}`);
 
           for (const mod of modules) {


### PR DESCRIPTION
## Problem

Windows-style file paths can miss HMR and route matching checks that expect forward slashes.

## Root cause

Several Vite and HMR entry points compared platform paths without normalizing separators first.

## Change

Normalize changed-file paths before framework, API, and HMR route classification.

## Safety and compatibility

POSIX paths are unchanged. The normalization is limited to internal path comparison.

## Verification

- pnpm --filter @farm.js/core exec vitest run src/__tests__/hmr-manager.test.ts src/__tests__/windows-hmr-paths.test.ts
- pnpm --filter @farm.js/core type-check

## Documentation and release

None.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes HMR on Windows by normalizing file paths before route classification, so page, layout, and API route changes now trigger the same reloads as on POSIX systems.

- Normalizes paths in `HMRManager`, `farmApiPlugin`, and `farmPlugin` before route matching and artifact reason strings.
- POSIX paths are unaffected since forward slashes pass through unchanged.
- Adds tests covering Windows page, route file, and API route hot updates.

<sup>Written for commit cc2f678e7ae8ac52b9740f17d7b267e5fb5bb2a9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/676?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

