### PR TITLE
fix(routing): reject ambiguous dynamic route shapes

### DIFF
--- a/packages/farm/src/__tests__/api-route-manager.test.ts
+++ b/packages/farm/src/__tests__/api-route-manager.test.ts
@@ -40,6 +40,88 @@ describe("APIRouteManager", () => {
     expect(manager.getRoutes().get("/api/jsx")?.methods).toEqual(["GET"]);
   });
 
+  it("rejects dynamic API routes that match the same URL shape", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "farm-api-route-"));
+    tempDirs.push(root);
+    const firstDir = path.join(root, "api", "users", "[id]");
+    const secondDir = path.join(root, "api", "users", "[slug]");
+    fs.mkdirSync(firstDir, { recursive: true });
+    fs.mkdirSync(secondDir, { recursive: true });
+    fs.writeFileSync(path.join(firstDir, "route.ts"), "export const GET = () => new Response();\n");
+    fs.writeFileSync(
+      path.join(secondDir, "route.ts"),
+      "export const GET = () => new Response();\n",
+    );
+
+    const manager = new APIRouteManager(root, {
+      ssrLoadModule: async () => ({ GET: async () => new Response() }),
+    } as any);
+
+    const error = await manager.discoverRoutes().catch((cause) => cause);
+    expect(error).toBeInstanceOf(Error);
+    expect(error.message).toContain("Ambiguous API routes");
+    expect(error.message).toContain("/api/users/[id]");
+    expect(error.message).toContain("/api/users/[slug]");
+  });
+
+  it("ignores empty programmatic routes and preserves API-literal syntax", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "farm-api-route-"));
+    tempDirs.push(root);
+    const srcDir = path.join(root, "src");
+    const appDir = path.join(srcDir, "app");
+    const routesFile = path.join(srcDir, "farm.routes.js");
+    fs.mkdirSync(appDir, { recursive: true });
+    fs.writeFileSync(routesFile, "export {};\n");
+
+    const handler = async () => new Response("ok");
+    const manager = new APIRouteManager(appDir, {
+      ssrLoadModule: async () => ({
+        default: defineRoutes(({ api }) => [
+          api("/api/items/[id]", {}),
+          api("/api/items/[slug]", { GET: handler }),
+          api("/api/literal/:id", { GET: handler }),
+          api("/api/literal/[id]", { GET: handler }),
+          api("/api/(group)/items", { GET: handler }),
+          api("/api/items", { GET: handler }),
+        ]),
+      }),
+    } as any);
+
+    await manager.discoverRoutes();
+
+    expect(manager.getRoutes().has("/api/items/[id]")).toBe(false);
+    expect(manager.getRoutes().has("/api/items/[slug]")).toBe(true);
+    expect(manager.getRoutes().has("/api/literal/:id")).toBe(true);
+    expect(manager.getRoutes().has("/api/literal/[id]")).toBe(true);
+    expect(manager.getRoutes().has("/api/(group)/items")).toBe(true);
+    expect(manager.getRoutes().has("/api/items")).toBe(true);
+  });
+
+  it("does not let an invalid route config reserve a dynamic URL shape", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "farm-api-route-"));
+    tempDirs.push(root);
+    const idDir = path.join(root, "api", "users", "[id]");
+    const slugDir = path.join(root, "api", "users", "[slug]");
+    const idFile = path.join(idDir, "route.ts");
+    const slugFile = path.join(slugDir, "route.ts");
+    fs.mkdirSync(idDir, { recursive: true });
+    fs.mkdirSync(slugDir, { recursive: true });
+    fs.writeFileSync(idFile, "export {};\n");
+    fs.writeFileSync(slugFile, "export {};\n");
+
+    const manager = new APIRouteManager(root, {
+      ssrLoadModule: async (filePath: string) => ({
+        GET: async () => new Response("ok"),
+        ...(filePath === idFile ? { runtime: "invalid" } : {}),
+      }),
+    } as any);
+
+    await manager.discoverRoutes();
+
+    expect(manager.getRoutes().has("/api/users/[id]")).toBe(false);
+    expect(manager.getRoutes().has("/api/users/[slug]")).toBe(true);
+  });
+
   it("rejects duplicate methods for the same API path in one app source", async () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), "farm-api-route-"));
     tempDirs.push(root);

--- a/packages/farm/src/__tests__/api-vite-plugin-rewrite.test.ts
+++ b/packages/farm/src/__tests__/api-vite-plugin-rewrite.test.ts
@@ -129,6 +129,61 @@ async function createDevHarness(
 }
 
 describe("dev API dispatch after middleware rewrites", () => {
+  it("rejects dynamic routes that have the same URL shape", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await expect(
+      createDevHarness({
+        "users/[id]": `export const GET = async () => new Response("id");\n`,
+        "users/[slug]": `export const GET = async () => new Response("slug");\n`,
+      }),
+    ).rejects.toThrow("Ambiguous API routes");
+  });
+
+  it("reports ambiguous routes introduced by HMR", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "farm-api-ambiguous-hmr-"));
+    tempDirs.add(root);
+    const idDir = path.join(root, "src", "api", "users", "[id]");
+    const slugDir = path.join(root, "src", "api", "users", "[slug]");
+    const idFile = path.join(idDir, "route.ts");
+    const slugFile = path.join(slugDir, "route.ts");
+    const routesFile = path.join(root, "src", "routes.ts");
+    await mkdir(idDir, { recursive: true });
+    await writeFile(idFile, "export {};\n");
+    await writeFile(routesFile, "export {};\n");
+
+    let rootModule: Record<string, unknown> = {};
+    const server: any = {
+      config: { root },
+      ssrLoadModule: async (filePath: string) =>
+        filePath === routesFile ? rootModule : { GET: async () => new Response("ok") },
+      moduleGraph: { invalidateModule() {} },
+      middlewares: { use() {} },
+      watcher: { on() {} },
+    };
+    const plugin = farmApiPlugin() as any;
+    await plugin.configureServer(server);
+    await server.__farmApi__.waitForDiscovery();
+
+    rootModule = {
+      slug: {
+        __path: "/api/users/[slug]",
+        __method: "GET",
+        handler: async () => new Response("slug"),
+      },
+    };
+    await expect(plugin.handleHotUpdate({ file: routesFile, modules: [], server })).rejects.toThrow(
+      "Ambiguous API routes",
+    );
+
+    rootModule = {};
+    await mkdir(slugDir, { recursive: true });
+    await writeFile(slugFile, "export {};\n");
+    await expect(plugin.handleHotUpdate({ file: slugFile, modules: [], server })).rejects.toThrow(
+      "Ambiguous API routes",
+    );
+  });
+
   it("reports duplicate methods across file and explicit routes", async () => {
     const root = await mkdtemp(path.join(tmpdir(), "farm-api-conflict-"));
     tempDirs.add(root);

--- a/packages/farm/src/__tests__/layers.test.ts
+++ b/packages/farm/src/__tests__/layers.test.ts
@@ -237,7 +237,10 @@ describe("Farm layers", () => {
     writeSource(baseRoot, "src/app/products/page.tsx");
     writeSource(baseRoot, "src/app/admin/page.tsx");
     writeSource(baseRoot, "src/app/products/loading.tsx");
+    writeSource(baseRoot, "src/app/users/[id]/page.tsx");
+    writeSource(baseRoot, "src/app/@modal/(.)users/[id]/page.tsx");
     writeSource(root, "src/app/products/page.tsx");
+    writeSource(root, "src/app/users/[slug]/page.tsx");
 
     const config = await resolveConfig({ root, extends: ["./layers/base"] }, "development");
     const manager = new RouteManager(config as any);
@@ -255,6 +258,15 @@ describe("Farm layers", () => {
     expect(manager.getLoadings().get("/products")?.modulePath).toBe(
       path.join(baseRoot, "src/app/products/loading.tsx"),
     );
+    expect(manager.getRoutes().has("/users/[id]")).toBe(false);
+    expect(manager.getRoutes().get("/users/[slug]")?.modulePath).toBe(
+      path.join(root, "src/app/users/[slug]/page.tsx"),
+    );
+    expect(
+      [...manager.getRouteSlots().values()].some(
+        (slot) => slot.interception && slot.pattern === "/users/[id]",
+      ),
+    ).toBe(true);
     expect(
       manager.generateClientManifest(root).routes.find((route) => route.pattern === "/admin")
         ?.modulePath,

--- a/packages/farm/src/__tests__/route-manager.test.ts
+++ b/packages/farm/src/__tests__/route-manager.test.ts
@@ -349,6 +349,35 @@ describe("RouteManager", () => {
       await expect(routeManager.discoverRoutes()).rejects.toThrow('Duplicate page route "/about"');
     });
 
+    it("rejects dynamic page routes that match the same URL shape", async () => {
+      const { globFiles } = await import("../utils");
+      vi.mocked(globFiles).mockImplementation(async (pattern: string) => {
+        if (pattern.includes("page")) {
+          return ["users/[id]/page.tsx", "users/[slug]/page.tsx"];
+        }
+        return [];
+      });
+
+      await expect(routeManager.discoverRoutes()).rejects.toThrow(
+        'Ambiguous page routes "/users/[id]" and "/users/[slug]" match the same URLs.',
+      );
+    });
+
+    it("keeps colon and star page segments literal", async () => {
+      const { globFiles } = await import("../utils");
+      vi.mocked(globFiles).mockImplementation(async (pattern: string) => {
+        if (pattern.includes("page")) {
+          return ["users/:id/page.tsx", "users/[id]/page.tsx", "files/*path/page.tsx"];
+        }
+        return [];
+      });
+
+      await expect(routeManager.discoverRoutes()).resolves.toBeUndefined();
+      expect(Array.from(routeManager.getRoutes().keys())).toEqual(
+        expect.arrayContaining(["/users/:id", "/users/[id]", "/files/*path"]),
+      );
+    });
+
     it("rejects ambiguous markdown representations for one page", async () => {
       const { globFiles } = await import("../utils");
       vi.mocked(globFiles).mockImplementation(async (pattern: string) => {

--- a/packages/farm/src/__tests__/router.test.ts
+++ b/packages/farm/src/__tests__/router.test.ts
@@ -34,6 +34,25 @@ describe("createFarmRouter", () => {
       slug: "getting-started",
     });
   });
+
+  it("rejects routes that differ only by parameter names", () => {
+    expect(() => createFarmRouter(["/users/[id]", "/users/[slug]"])).toThrow(
+      'Ambiguous route patterns "/users/[id]" and "/users/[slug]" match the same URLs.',
+    );
+  });
+
+  it("keeps literal bracket syntax and encoded segment boundaries distinct", () => {
+    const router = createFarmRouter([
+      "/docs/[not.valid]",
+      "/docs/[id]",
+      "/files/a%2Fb",
+      "/files/a/b",
+    ]);
+
+    expect(router.match("/docs/%5Bnot.valid%5D")?.route.path).toBe("/docs/[not.valid]");
+    expect(router.match("/files/a%2Fb")?.route.path).toBe("/files/a%2Fb");
+    expect(router.match("/files/a/b")?.route.path).toBe("/files/a/b");
+  });
 });
 
 describe("route helpers", () => {

--- a/packages/farm/src/api/route-manager.ts
+++ b/packages/farm/src/api/route-manager.ts
@@ -20,6 +20,7 @@ import {
   type APIRouteMatch,
 } from "./runtime";
 import { isFarmAPIRouteFileName } from "./route-files";
+import { AmbiguousRouteError, getRoutePatternShape } from "../routing/specificity";
 
 export interface APIRoute extends FarmRouteRuntimeConfig {
   path: string;
@@ -65,6 +66,7 @@ export class APIRouteManager {
   private routes: Map<string, APIRoute> = new Map();
   private endpointSources: Map<string, Map<string, { appDir: string; filePath: string }>> =
     new Map();
+  private routeShapes = new Map<string, { routePath: string; appDir: string; filePath: string }>();
   private viteServer?: ViteDevServer;
   private appDirs: string[];
   private throwOnLoadError: boolean;
@@ -91,8 +93,10 @@ export class APIRouteManager {
   async discoverRoutes(): Promise<void> {
     const previousRoutes = this.routes;
     const previousEndpointSources = this.endpointSources;
+    const previousRouteShapes = this.routeShapes;
     this.routes = new Map();
     this.endpointSources = new Map();
+    this.routeShapes = new Map();
 
     try {
       for (const appDir of this.appDirs) {
@@ -113,6 +117,7 @@ export class APIRouteManager {
     } catch (error) {
       this.routes = previousRoutes;
       this.endpointSources = previousEndpointSources;
+      this.routeShapes = previousRouteShapes;
       throw error;
     }
 
@@ -182,11 +187,11 @@ export class APIRouteManager {
             }
           }
         }
-
         const runtimeConfig = normalizeFarmRouteRuntimeConfig(
           getFarmRouteRuntimeConfig(routeModule),
           `API route "${routePath}"`,
         );
+        this.registerRouteShape(routePath, filePath, appDir);
         const existingRoute = this.routes.get(routePath);
         const mergedMethods = existingRoute ? [...existingRoute.methods] : [];
         for (const method of availableMethods) {
@@ -230,6 +235,7 @@ export class APIRouteManager {
         }
 
         const method = String(endpoint.__method || "GET").toUpperCase();
+        this.registerRouteShape(endpoint.__path, routesFile, appDir);
         this.addEndpoint(endpoint.__path, routesFile, method, endpoint, appDir);
       }
     } catch (error) {
@@ -254,6 +260,7 @@ export class APIRouteManager {
 
         for (const definition of manifest.routes) {
           if (definition.kind !== "api") continue;
+          if (!Object.values(definition.methods).some(Boolean)) continue;
           this.addProgrammaticApiRoute(routeFile, definition, appDir);
         }
       } catch (error) {
@@ -264,7 +271,11 @@ export class APIRouteManager {
 
   private handleLoadError(message: string, error: unknown): void {
     logger.error(`${message}: ${error}`);
-    if (this.throwOnLoadError || error instanceof APIRouteConflictError) {
+    if (
+      this.throwOnLoadError ||
+      error instanceof APIRouteConflictError ||
+      error instanceof AmbiguousRouteError
+    ) {
       throw error;
     }
   }
@@ -355,6 +366,23 @@ export class APIRouteManager {
         this.addEndpoint(route.path, modulePath, method, endpoint, appDir, runtimeConfig);
       }
     }
+  }
+
+  private registerRouteShape(routePath: string, filePath: string, appDir: string): void {
+    const shape = getRoutePatternShape(routePath, "api");
+    const existing = this.routeShapes.get(shape);
+
+    if (existing && existing.routePath !== routePath) {
+      if (existing.appDir === appDir) {
+        throw new AmbiguousRouteError(
+          `Ambiguous API routes "${existing.routePath}" and "${routePath}" match the same URLs. Found ${existing.filePath} and ${filePath}. Keep only one route for this URL shape.`,
+        );
+      }
+      this.routes.delete(existing.routePath);
+      this.endpointSources.delete(existing.routePath);
+    }
+
+    this.routeShapes.set(shape, { routePath, appDir, filePath });
   }
 
   /**

--- a/packages/farm/src/api/vite-plugin.ts
+++ b/packages/farm/src/api/vite-plugin.ts
@@ -36,6 +36,7 @@ import {
   resolveFarmServerConfig,
 } from "../server-http";
 import { createCliColors } from "../cli-colors";
+import { AmbiguousRouteError, getRoutePatternShape } from "../routing/specificity";
 
 export interface FarmApiPluginOptions {
   /** Source directory containing the api folder (default: 'src') */
@@ -74,6 +75,7 @@ export function farmApiPlugin(options: FarmApiPluginOptions = {}): Plugin {
   let discoveryError: unknown;
   let recoverFailedDiscovery: (() => Promise<boolean>) | undefined;
   const endpointSources = new Map<string, Map<string, string>>();
+  const routeShapes = new Map<string, { routePath: string; filePath: string }>();
 
   const log = (_message: string) => {};
   const logResponse = (method: string, urlPath: string, status: number, duration: number) => {
@@ -95,12 +97,24 @@ export function farmApiPlugin(options: FarmApiPluginOptions = {}): Plugin {
     console.log(logMsg);
   };
 
+  const registerRouteShape = (routePath: string, filePath: string): void => {
+    const shape = getRoutePatternShape(routePath, "api");
+    const existing = routeShapes.get(shape);
+    if (existing && existing.routePath !== routePath) {
+      throw new AmbiguousRouteError(
+        `Ambiguous API routes "${existing.routePath}" and "${routePath}" match the same URLs. Found ${existing.filePath} and ${filePath}. Keep only one route for this URL shape.`,
+      );
+    }
+    routeShapes.set(shape, { routePath, filePath });
+  };
+
   const addEndpoint = (
     routePath: string,
     filePath: string,
     method: string,
     endpoint: any,
   ): void => {
+    registerRouteShape(routePath, filePath);
     const normalizedMethod = method.toUpperCase();
     const existing = apiRoutesCache.get(routePath);
     const existingFile = endpointSources.get(routePath)?.get(normalizedMethod);
@@ -144,8 +158,16 @@ export function farmApiPlugin(options: FarmApiPluginOptions = {}): Plugin {
       if (route.methods.length === 0) {
         apiRoutesCache.delete(routePath);
         endpointSources.delete(routePath);
-      } else if (route.filePath === filePath) {
-        route.filePath = sources.values().next().value ?? route.filePath;
+        routeShapes.delete(getRoutePatternShape(routePath, "api"));
+      } else {
+        const currentSource = sources.values().next().value;
+        if (route.filePath === filePath && currentSource) {
+          route.filePath = currentSource;
+        }
+        routeShapes.set(getRoutePatternShape(routePath, "api"), {
+          routePath,
+          filePath: currentSource ?? route.filePath,
+        });
       }
     }
   };
@@ -164,6 +186,7 @@ export function farmApiPlugin(options: FarmApiPluginOptions = {}): Plugin {
     sources: new Map(
       [...endpointSources].map(([routePath, sources]) => [routePath, new Map(sources)]),
     ),
+    shapes: new Map(routeShapes),
   });
 
   const restoreRouteState = (snapshot: ReturnType<typeof snapshotRouteState>): void => {
@@ -171,6 +194,10 @@ export function farmApiPlugin(options: FarmApiPluginOptions = {}): Plugin {
     endpointSources.clear();
     for (const [routePath, sources] of snapshot.sources) {
       endpointSources.set(routePath, sources);
+    }
+    routeShapes.clear();
+    for (const [shape, route] of snapshot.shapes) {
+      routeShapes.set(shape, route);
     }
   };
 
@@ -257,6 +284,7 @@ export function farmApiPlugin(options: FarmApiPluginOptions = {}): Plugin {
         const routeFiles = findRouteFiles(apiDir);
         apiRoutesCache.clear();
         endpointSources.clear();
+        routeShapes.clear();
 
         for (const filePath of routeFiles) {
           try {
@@ -282,7 +310,7 @@ export function farmApiPlugin(options: FarmApiPluginOptions = {}): Plugin {
               log(`API route discovered: ${availableMethods.join(", ")} ${routePath}`);
             }
           } catch (e: any) {
-            if (e instanceof APIRouteConflictError) throw e;
+            if (e instanceof APIRouteConflictError || e instanceof AmbiguousRouteError) throw e;
             log(`API route load failed at ${filePath}: ${e.message}`);
           }
         }
@@ -316,7 +344,7 @@ export function farmApiPlugin(options: FarmApiPluginOptions = {}): Plugin {
                 }
               }
             } catch (e: any) {
-              if (e instanceof APIRouteConflictError) throw e;
+              if (e instanceof APIRouteConflictError || e instanceof AmbiguousRouteError) throw e;
               log(`Root routes.ts load failed: ${e.message}`);
             }
             break;
@@ -350,7 +378,7 @@ export function farmApiPlugin(options: FarmApiPluginOptions = {}): Plugin {
               }
             }
           } catch (e: any) {
-            if (e instanceof APIRouteConflictError) throw e;
+            if (e instanceof APIRouteConflictError || e instanceof AmbiguousRouteError) throw e;
             log(`Programmatic routes file load failed at ${routeFile}: ${e.message}`);
           }
         }
@@ -560,7 +588,7 @@ export function farmApiPlugin(options: FarmApiPluginOptions = {}): Plugin {
           log(`API router recreated`);
         } catch (e: any) {
           restoreRouteState(previousState);
-          if (e instanceof APIRouteConflictError) throw e;
+          if (e instanceof APIRouteConflictError || e instanceof AmbiguousRouteError) throw e;
           log(`Root routes.ts HMR failed: ${e.message}`);
         }
 
@@ -600,7 +628,7 @@ export function farmApiPlugin(options: FarmApiPluginOptions = {}): Plugin {
           log(`API router recreated`);
         } catch (e: any) {
           restoreRouteState(previousState);
-          if (e instanceof APIRouteConflictError) throw e;
+          if (e instanceof APIRouteConflictError || e instanceof AmbiguousRouteError) throw e;
           log(`API route HMR failed: ${e.message}`);
         }
 

--- a/packages/farm/src/router.ts
+++ b/packages/farm/src/router.ts
@@ -1,4 +1,9 @@
-import { compareRouteSpecificity, type RouteSegmentSpecificity } from "./routing/specificity";
+import {
+  AmbiguousRouteError,
+  compareRouteSpecificity,
+  getRoutePatternShape,
+  type RouteSegmentSpecificity,
+} from "./routing/specificity";
 
 export type FarmRouterPrimitiveParam = string | number | boolean;
 export type FarmRouterPathParam =
@@ -68,7 +73,19 @@ interface NormalizedRouterRoute<TMeta> {
 export function createFarmRouter<TMeta = unknown>(
   routes: FarmRouterRouteInput<TMeta>[],
 ): FarmRouter<TMeta> {
-  const normalizedRoutes = routes.map(normalizeRouteInput).sort(compareRoutes);
+  const normalizedRoutes = routes.map(normalizeRouteInput);
+  const patternsByShape = new Map<string, string>();
+  for (const entry of normalizedRoutes) {
+    const shape = getRoutePatternShape(entry.route.path, "router");
+    const existingPattern = patternsByShape.get(shape);
+    if (existingPattern) {
+      throw new AmbiguousRouteError(
+        `Ambiguous route patterns "${existingPattern}" and "${entry.route.path}" match the same URLs. Keep only one route for this URL shape.`,
+      );
+    }
+    patternsByShape.set(shape, entry.route.path);
+  }
+  normalizedRoutes.sort(compareRoutes);
 
   return {
     routes: normalizedRoutes.map((entry) => entry.route),

--- a/packages/farm/src/routing/route-manager.ts
+++ b/packages/farm/src/routing/route-manager.ts
@@ -69,7 +69,12 @@ import type { ResolvedFarmI18nConfig } from "../i18n/types";
 import { createRouteSlotContainerId, parseRouteSlotFile } from "./route-slots";
 import { getFarmRendererComponentExtensions } from "../renderer";
 import type { ApplicationMetadataRouteKind } from "../metadata-route";
-import { compareRouteSpecificity, type RouteSegmentSpecificity } from "./specificity";
+import {
+  AmbiguousRouteError,
+  compareRouteSpecificity,
+  getRoutePatternShape,
+  type RouteSegmentSpecificity,
+} from "./specificity";
 
 interface RouteEntry {
   route: ParsedRoute;
@@ -187,6 +192,7 @@ function compareRouteEntries(left: RouteEntry, right: RouteEntry): number {
 export class RouteManager {
   private config: Required<FarmConfig>;
   private routes: Map<string, RouteEntry> = new Map();
+  private pageRouteShapes: Map<string, RouteEntry> = new Map();
   private layouts: Map<string, RouteEntry> = new Map();
   private routeSlots: Map<string, RouteSlotEntry> = new Map();
   private loadings: Map<string, RouteEntry> = new Map();
@@ -218,6 +224,7 @@ export class RouteManager {
   async discoverRoutes(): Promise<void> {
     this.invalidateClientManifest();
     this.routes.clear();
+    this.pageRouteShapes.clear();
     this.layouts.clear();
     this.routeSlots.clear();
     this.loadings.clear();
@@ -234,8 +241,8 @@ export class RouteManager {
     }
 
     for (const slot of this.routeSlots.values()) {
-      if (slot.interception && !this.routes.has(slot.pattern)) {
-        throw new Error(
+      if (slot.interception && !this.pageRouteShapes.has(getRoutePatternShape(slot.pattern))) {
+        throw new AmbiguousRouteError(
           `Intercepting route slot "${slot.name}" targets "${slot.pattern}", but no canonical page exists for that URL`,
         );
       }
@@ -807,6 +814,23 @@ export class RouteManager {
     );
   }
 
+  private registerPageRoute(entry: RouteEntry): void {
+    const shape = getRoutePatternShape(entry.pattern);
+    const existing = this.pageRouteShapes.get(shape);
+
+    if (existing && existing.pattern !== entry.pattern) {
+      if (existing.sourceRoot === entry.sourceRoot) {
+        throw new Error(
+          `Ambiguous page routes "${existing.pattern}" and "${entry.pattern}" match the same URLs. Found ${existing.modulePath} and ${entry.modulePath}. Keep only one route for this URL shape.`,
+        );
+      }
+      this.routes.delete(existing.pattern);
+    }
+
+    this.routes.set(entry.pattern, entry);
+    this.pageRouteShapes.set(shape, entry);
+  }
+
   private async discoverFileRoutes(source: FarmSourceRoot): Promise<void> {
     const appDir = resolveAppPath(source.root, source.srcDir, "app");
     const componentExtensions = getFarmRendererComponentExtensions(this.config.renderer).map(
@@ -875,7 +899,7 @@ export class RouteManager {
           `Duplicate page route "${pattern}". Found both ${existing.modulePath} and ${modulePath}.`,
         );
       }
-      this.routes.set(pattern, {
+      this.registerPageRoute({
         route: group.route,
         modulePath,
         ...(markdownFile
@@ -1028,7 +1052,7 @@ export class RouteManager {
 
           const modulePath = createProgrammaticRouteModuleId(filePath, "page", definition.path);
           this.programmaticPages.set(modulePath, definition);
-          this.routes.set(pattern, {
+          this.registerPageRoute({
             route,
             modulePath,
             pattern,

--- a/packages/farm/src/routing/specificity.ts
+++ b/packages/farm/src/routing/specificity.ts
@@ -1,5 +1,12 @@
 export type RouteSegmentSpecificity = "static" | "dynamic" | "catch-all" | "optional-catch-all";
 
+export class AmbiguousRouteError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "AmbiguousRouteError";
+  }
+}
+
 const SEGMENT_RANK: Record<RouteSegmentSpecificity, number> = {
   static: 4,
   dynamic: 3,
@@ -25,4 +32,46 @@ export function compareRouteSpecificity(
   }
 
   return 0;
+}
+
+export type RoutePatternSyntax = "page" | "router" | "api";
+
+const ROUTER_PARAMETER_NAME = "[A-Za-z0-9_$-]+";
+
+/** Return the URL-matching shape of a route without its parameter names. */
+export function getRoutePatternShape(pattern: string, syntax: RoutePatternSyntax = "page"): string {
+  const segments = pattern
+    .split("/")
+    .filter(Boolean)
+    .filter((segment) => syntax === "api" || !/^\([^/]+\)$/.test(segment))
+    .map((segment) => {
+      const parameterName = syntax === "router" ? ROUTER_PARAMETER_NAME : ".+";
+      const supportsColonAndStar = syntax === "router";
+      if (
+        new RegExp(`^\\[\\[\\.\\.\\.${parameterName}\\]\\]$`).test(segment) ||
+        (supportsColonAndStar && new RegExp(`^\\*${parameterName}\\?$`).test(segment))
+      ) {
+        return "optional-catch-all";
+      }
+      if (
+        new RegExp(`^\\[\\.\\.\\.${parameterName}\\]$`).test(segment) ||
+        (supportsColonAndStar && new RegExp(`^\\*${parameterName}$`).test(segment))
+      ) {
+        return "catch-all";
+      }
+      if (
+        new RegExp(`^\\[${parameterName}\\]$`).test(segment) ||
+        (supportsColonAndStar && new RegExp(`^:${parameterName}$`).test(segment))
+      ) {
+        return "dynamic";
+      }
+
+      try {
+        return `static:${decodeURIComponent(segment)}`;
+      } catch {
+        return `static:${segment}`;
+      }
+    });
+
+  return segments.length === 0 ? "/" : JSON.stringify(segments);
 }


### PR DESCRIPTION
## Problem

Routes such as /users/[id] and /users/[slug] match the same URLs but can both be accepted.

## Root cause

Routing compared source path strings instead of their normalized matching shape.

## Change

Introduce a shared route-pattern shape and reject ambiguous page and API registrations while preserving layer precedence.

## Safety and compatibility

Distinct static, catch-all, and method routes keep their existing behavior. Earlier layers may still be replaced by application routes.

## Verification

- pnpm --filter @farm.js/core exec vitest run src/__tests__/route-manager.test.ts src/__tests__/router.test.ts src/__tests__/api-route-manager.test.ts src/__tests__/api-vite-plugin-rewrite.test.ts
- pnpm --filter @farm.js/core type-check

## Documentation and release

None.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects ambiguous dynamic routes that match the same URLs, so `/users/[id]` and `/users/[slug]` now fail loudly instead of silently both being accepted.

- Compares routes by a normalized URL-matching shape that ignores parameter names and route group segments.
- Throws for page routes, API routes, and router registrations that collide on the same URL shape.
- Keeps API literal syntax distinct (`:id`, `[id]`, `(group)`) and ignores empty programmatic API routes.
- Preserves existing behavior for static, catch-all, and method-specific routes; earlier layers can still be replaced by application routes.
- Surfaces API discovery errors through `waitForDiscovery` so dev servers report ambiguous route failures.

<sup>Written for commit 551d6c07565908a1d7c42e764348f9e2f452b842. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/677?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

