### PR TITLE
fix(nitro): secure legacy inline HTML data

### DIFF
--- a/packages/farm/src/__tests__/legacy-nitro-html-safety.test.ts
+++ b/packages/farm/src/__tests__/legacy-nitro-html-safety.test.ts
@@ -1,0 +1,39 @@
+// @vitest-environment node
+
+import { describe, expect, it } from "vitest";
+import {
+  renderFarmLegacyErrorHtml,
+  renderFarmLegacyHtml,
+  serializeFarmInlineValue,
+} from "../nitro/legacy-runtime";
+
+describe("legacy Nitro HTML safety", () => {
+  it("escapes every inline runtime value in rendered HTML", () => {
+    const attack = "</script><script>alert(1)</script>\u2028\u2029";
+    const html = renderFarmLegacyHtml({
+      deploymentId: attack,
+      pageProps: { attack },
+      pathname: attack,
+      html: "<main>safe</main>",
+      clientScript: '/assets/page.js"><img src=x onerror=alert(1)>',
+    });
+
+    expect(html).not.toContain(attack);
+    expect(html).not.toContain("</script><script>alert(1)</script>");
+    expect(html).not.toContain("<img src=x onerror=alert(1)>");
+    expect(html).toContain('src="/assets/page.js&quot;&gt;&lt;img src=x onerror=alert(1)&gt;"');
+    expect(html).not.toContain("\u2028");
+    expect(html).not.toContain("\u2029");
+    expect(html.match(/\\u003c\/script>/g)).toHaveLength(6);
+    expect(html.match(/\\u2028/g)).toHaveLength(3);
+    expect(html.match(/\\u2029/g)).toHaveLength(3);
+    expect(html).toContain(`window.__FARM_DEPLOYMENT_ID__ = ${serializeFarmInlineValue(attack)}`);
+  });
+
+  it("returns a generic production error document", () => {
+    const html = renderFarmLegacyErrorHtml();
+
+    expect(html).toContain("Internal Server Error");
+    expect(html).not.toContain("database password");
+  });
+});

--- a/packages/farm/src/nitro/index.ts
+++ b/packages/farm/src/nitro/index.ts
@@ -269,6 +269,7 @@ import { farmRegistry } from '../farm-registry';
 import React from 'react';
 import { renderToString } from 'react-dom/server';
 import { searchParamsToObject } from '@farm.js/core/internal/production-runtime';
+import { renderFarmLegacyErrorHtml, renderFarmLegacyHtml } from '@farm.js/core/internal/production-runtime';
 
 export default defineEventHandler(async (event: H3Event) => {
   try {
@@ -514,38 +515,28 @@ export default defineEventHandler(async (event: H3Event) => {
       }
       
       // Build full HTML
-      const serializedDeploymentId = JSON.stringify(farmRegistry.deploymentId || '').replace(/</g, '\\u003c');
-      const fullHtml = \`<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="icon" href="data:,">
-  <title>Farm.js App</title>
-  <script>
-    window.__FARM_DEPLOYMENT_ID__ = \${serializedDeploymentId};
-    window.__FARM_PROPS__ = \${JSON.stringify(pageProps)};
-    window.__FARM_PATH__ = \${JSON.stringify(pathname)};
-  </script>
-</head>
-<body>
-  <div id="root">\${html}</div>
-  <script type="module" src="\${clientScript}"></script>
-</body>
-</html>\`;
+      const fullHtml = renderFarmLegacyHtml({
+        deploymentId: farmRegistry.deploymentId || '',
+        pageProps,
+        pathname,
+        html,
+        clientScript,
+      });
       
       setHeader(event, 'Content-Type', 'text/html; charset=utf-8');
       return fullHtml;
       
     } catch (renderError: any) {
+      console.error('SSR render error:', renderError);
       setResponseStatus(event, 500);
       setHeader(event, 'Content-Type', 'text/html; charset=utf-8');
-      return \`<!DOCTYPE html><html><head><title>Error</title></head><body><h1>Error</h1><p>\${renderError.message || 'Internal Server Error'}</p></body></html>\`;
+      return renderFarmLegacyErrorHtml();
     }
   } catch (error: any) {
+    console.error('SSR handler error:', error);
     setResponseStatus(event, 500);
     setHeader(event, 'Content-Type', 'text/html; charset=utf-8');
-    return \`<!DOCTYPE html><html><head><title>Error</title></head><body><h1>Error</h1><p>\${error.message || 'Internal Server Error'}</p></body></html>\`;
+    return renderFarmLegacyErrorHtml();
   }
 });
 `,

--- a/packages/farm/src/nitro/legacy-runtime.ts
+++ b/packages/farm/src/nitro/legacy-runtime.ts
@@ -1,0 +1,48 @@
+const FARM_LEGACY_ERROR_HTML =
+  "<!DOCTYPE html><html><head><title>Error</title></head><body><h1>Error</h1><p>Internal Server Error</p></body></html>";
+
+export function serializeFarmInlineValue(value: unknown): string {
+  return (JSON.stringify(value) ?? "null")
+    .replace(/</g, "\\u003c")
+    .replace(/\u2028/g, "\\u2028")
+    .replace(/\u2029/g, "\\u2029");
+}
+
+function escapeFarmHtmlAttribute(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+export function renderFarmLegacyHtml(options: {
+  deploymentId: unknown;
+  pageProps: unknown;
+  pathname: unknown;
+  html: string;
+  clientScript: string;
+}): string {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="icon" href="data:,">
+  <title>Farm.js App</title>
+  <script>
+    window.__FARM_DEPLOYMENT_ID__ = ${serializeFarmInlineValue(options.deploymentId)};
+    window.__FARM_PROPS__ = ${serializeFarmInlineValue(options.pageProps)};
+    window.__FARM_PATH__ = ${serializeFarmInlineValue(options.pathname)};
+  </script>
+</head>
+<body>
+  <div id="root">${options.html}</div>
+  <script type="module" src="${escapeFarmHtmlAttribute(options.clientScript)}"></script>
+</body>
+</html>`;
+}
+
+export function renderFarmLegacyErrorHtml(): string {
+  return FARM_LEGACY_ERROR_HTML;
+}

--- a/packages/farm/src/nitro/production-runtime.ts
+++ b/packages/farm/src/nitro/production-runtime.ts
@@ -56,6 +56,11 @@ export {
 } from "../preload";
 export { searchParamsToObject } from "../search-params";
 export {
+  renderFarmLegacyErrorHtml,
+  renderFarmLegacyHtml,
+  serializeFarmInlineValue,
+} from "./legacy-runtime";
+export {
   resolveFarmTrailingSlashRedirect,
   setFarmTrailingSlashPreference,
 } from "../trailing-slash";


### PR DESCRIPTION
## Problem

The legacy Nitro SSR handler can interpolate runtime values directly into inline HTML and expose detailed production errors.

## Root cause

The generated compatibility handler used raw template interpolation instead of the framework HTML serialization boundary.

## Change

Serialize deployment IDs, props, and pathnames safely, and return a generic production error while keeping diagnostics in server logs.

## Safety and compatibility

This only changes the legacy Nitro compatibility path. Successful rendering semantics remain unchanged.

## Verification

- pnpm --filter @farm.js/core exec vitest run src/__tests__/legacy-nitro-html-safety.test.ts
- pnpm --filter @farm.js/core type-check

## Documentation and release

None.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the legacy Nitro SSR handler so runtime values can no longer break out of inline HTML and production error documents stop exposing internal error messages.

**Bug Fixes**
- Serializes deployment IDs, page props, and pathnames through a script-safe helper that escapes `<`, U+2028, and U+2029.
- Escapes the client script `src` attribute to block attribute injection.
- Error documents now return a generic message while render and handler errors are logged to the server console.
- Only the legacy Nitro compatibility path changes; successful rendering semantics are unchanged.

<sup>Written for commit a44eea370c7cc2225a72a5a800ea7003d9d65199. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/679?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

