### PR TITLE
fix(api): remove stale routes during HMR

### DIFF
--- a/packages/farm/src/__tests__/api-vite-plugin-hmr.test.ts
+++ b/packages/farm/src/__tests__/api-vite-plugin-hmr.test.ts
@@ -1,0 +1,144 @@
+// @vitest-environment node
+
+import { mkdir, mkdtemp, rm, unlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { farmApiPlugin } from "../api/vite-plugin";
+
+const tempDirs = new Set<string>();
+
+afterEach(async () => {
+  await Promise.all(
+    [...tempDirs].map(async (dir) => {
+      await rm(dir, { recursive: true, force: true });
+      tempDirs.delete(dir);
+    }),
+  );
+});
+
+async function createHMRHarness(options: { withRootPost?: boolean } = {}) {
+  const root = await mkdtemp(path.join(tmpdir(), "farm-api-hmr-"));
+  tempDirs.add(root);
+  const routeDir = path.join(root, "src", "api", "users");
+  const routeFile = path.join(routeDir, "route.ts");
+  const rootRoutesFile = path.join(root, "src", "routes.ts");
+  await mkdir(routeDir, { recursive: true });
+  await writeFile(routeFile, "export {};\n");
+  if (options.withRootPost) await writeFile(rootRoutesFile, "export {};\n");
+
+  let routeModule: Record<string, unknown> = {
+    GET: async () => new Response("users"),
+  };
+  const rootPostEndpoint = {
+    __path: "/api/users",
+    __method: "POST",
+    handler: async () => new Response("root-post"),
+  };
+  const ssrLoadModule = vi.fn(async (filePath: string) =>
+    filePath === routeFile ? routeModule : { users: rootPostEndpoint },
+  );
+  const plugin = farmApiPlugin() as any;
+  const server: any = {
+    config: { root },
+    ssrLoadModule,
+    moduleGraph: { invalidateModule: vi.fn() },
+    middlewares: { use() {} },
+    watcher: { on() {} },
+  };
+
+  await plugin.configureServer(server);
+  await server.__farmApi__.waitForDiscovery();
+
+  return {
+    plugin,
+    rootPostEndpoint,
+    routeFile,
+    server,
+    ssrLoadModule,
+    failNextLoad(error: Error) {
+      ssrLoadModule.mockRejectedValueOnce(error);
+    },
+    setRouteModule(next: Record<string, unknown>) {
+      routeModule = next;
+    },
+  };
+}
+
+describe("standalone API route HMR", () => {
+  it("removes a cached route after its last method export is deleted", async () => {
+    const harness = await createHMRHarness();
+    expect(harness.server.__farmApi__.getRoutes().has("/api/users")).toBe(true);
+    harness.setRouteModule({});
+
+    await harness.plugin.handleHotUpdate({
+      file: harness.routeFile,
+      modules: [],
+      server: harness.server,
+    });
+
+    expect(harness.server.__farmApi__.getRoutes().has("/api/users")).toBe(false);
+    expect(harness.server.__farmApi__.getHandler()).toBeNull();
+  });
+
+  it("removes a cached route when its file disappears", async () => {
+    const harness = await createHMRHarness();
+    await unlink(harness.routeFile);
+
+    await harness.plugin.handleHotUpdate({
+      file: harness.routeFile,
+      modules: [],
+      server: harness.server,
+    });
+
+    expect(harness.server.__farmApi__.getRoutes().has("/api/users")).toBe(false);
+    expect(harness.server.__farmApi__.getHandler()).toBeNull();
+    expect(harness.ssrLoadModule).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the last-good route when the updated module fails to load", async () => {
+    const harness = await createHMRHarness();
+    harness.failNextLoad(new Error("syntax error"));
+
+    await harness.plugin.handleHotUpdate({
+      file: harness.routeFile,
+      modules: [],
+      server: harness.server,
+    });
+
+    expect(harness.server.__farmApi__.getRoutes().has("/api/users")).toBe(true);
+    expect(harness.server.__farmApi__.getHandler()).not.toBeNull();
+  });
+
+  it("preserves handlers from another source when the last file export is deleted", async () => {
+    const harness = await createHMRHarness({ withRootPost: true });
+    harness.setRouteModule({});
+
+    await harness.plugin.handleHotUpdate({
+      file: harness.routeFile,
+      modules: [],
+      server: harness.server,
+    });
+
+    const route = harness.server.__farmApi__.getRoutes().get("/api/users");
+    expect(route?.methods).toEqual(["POST"]);
+    expect(route?.endpoints.POST).toBe(harness.rootPostEndpoint);
+    expect(harness.server.__farmApi__.getHandler()).not.toBeNull();
+  });
+
+  it("preserves handlers from another source when the route file disappears", async () => {
+    const harness = await createHMRHarness({ withRootPost: true });
+    await unlink(harness.routeFile);
+
+    await harness.plugin.handleHotUpdate({
+      file: harness.routeFile,
+      modules: [],
+      server: harness.server,
+    });
+
+    const route = harness.server.__farmApi__.getRoutes().get("/api/users");
+    expect(route?.methods).toEqual(["POST"]);
+    expect(route?.endpoints.POST).toBe(harness.rootPostEndpoint);
+    expect(harness.server.__farmApi__.getHandler()).not.toBeNull();
+  });
+});

--- a/packages/farm/src/api/vite-plugin.ts
+++ b/packages/farm/src/api/vite-plugin.ts
@@ -613,6 +613,13 @@ export function farmApiPlugin(options: FarmApiPluginOptions = {}): Plugin {
           const relativePath = path.relative(apiDir, path.dirname(file));
           const routePath =
             "/api/" + (relativePath === "." ? "" : relativePath.replace(/\\/g, "/"));
+          const fs = await import("fs");
+          if (!fs.existsSync(file)) {
+            removeEndpointsFromFile(file);
+            await createRouter();
+            log(`API route file removed: ${routePath}`);
+            return [];
+          }
           const routeModule = await server.ssrLoadModule(file);
 
           removeEndpointsFromFile(file);


### PR DESCRIPTION
## Problem

Removing an API method export or deleting its route file can leave the old handler active in development.

## Root cause

API HMR updated successful module loads but did not remove routes that no longer existed.

## Change

Remove the cached route and rebuild the router when the final method disappears or a file is deleted, while retaining the last-good route after transient load errors.

## Safety and compatibility

Normal updates keep their current behavior. Syntax errors continue to preserve the last working handler.

## Verification

- pnpm --filter @farm.js/core exec vitest run src/__tests__/api-vite-plugin-hmr.test.ts
- pnpm --filter @farm.js/core type-check

## Documentation and release

None.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes API HMR keeping deleted or emptied route handlers active. Removed files and exports now disappear from the router without discarding handlers from other sources or transient load failures.

- Rebuilds routes from remaining sources after a file deletion or final method removal.
- Adds coverage for cleanup, source merging, and last-good handler preservation.

<sup>Written for commit 2fc00ecb9afc3f472dfa3a623ab68410111b4892. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/680?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

