### PR TITLE
fix(api-client): preserve non-JSON responses

### DIFF
--- a/packages/farm/src/__tests__/api-client.test.ts
+++ b/packages/farm/src/__tests__/api-client.test.ts
@@ -228,6 +228,75 @@ describe("createAPIClient", () => {
     expect(result).toMatchObject({ data: undefined, error: null });
   });
 
+  it("preserves non-JSON HTTP errors instead of reporting a network failure", async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response("<h1>Bad Gateway</h1>", {
+          status: 502,
+          statusText: "Bad Gateway",
+          headers: { "content-type": "text/html; charset=utf-8" },
+        }),
+    );
+    globalThis.fetch = fetchMock as any;
+    const api = createAPIClient<APIRouter>({ baseURL: "https://api.example.com" });
+
+    const result = await api.status.get();
+
+    expect(result.data).toBeUndefined();
+    expect(result.error).toMatchObject({
+      code: "http_error",
+      status: 502,
+      data: "<h1>Bad Gateway</h1>",
+    });
+  });
+
+  it("supports empty and binary successful responses", async () => {
+    const responses = [
+      new Response("", { status: 200 }),
+      new Response(Uint8Array.from([1, 2, 3]), {
+        headers: { "content-type": "application/octet-stream" },
+      }),
+    ];
+    globalThis.fetch = vi.fn(async () => responses.shift()!) as any;
+    const api = createAPIClient<APIRouter>({ baseURL: "https://api.example.com" });
+
+    const empty = await api.status.get();
+    const binary = await api.status.get();
+
+    expect(empty).toMatchObject({ data: undefined, error: null });
+    expect(Array.from(new Uint8Array(binary.data as ArrayBuffer))).toEqual([1, 2, 3]);
+    expect(binary.error).toBeNull();
+  });
+
+  it("keeps the legacy JSON fallback when content type is missing", async () => {
+    globalThis.fetch = vi.fn(
+      async () => new Response(new TextEncoder().encode('{"source":"legacy"}')),
+    ) as any;
+    const api = createAPIClient<APIRouter>({ baseURL: "https://api.example.com" });
+
+    await expect(api.status.get()).resolves.toMatchObject({
+      data: { source: "legacy" },
+      error: null,
+    });
+  });
+
+  it("falls back to json for adapters with headers but no binary reader", async () => {
+    globalThis.fetch = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      headers: { get: () => "application/octet-stream" },
+      body: {},
+      json: async () => ({ source: "adapter" }),
+    })) as any;
+    const api = createAPIClient<APIRouter>({ baseURL: "https://api.example.com" });
+
+    await expect(api.status.get()).resolves.toMatchObject({
+      data: { source: "adapter" },
+      error: null,
+    });
+  });
+
   it("applies invalidations declared by the server response", async () => {
     const key = '["products","list"]';
     const cache = getFarmClientDataCache();

--- a/packages/farm/src/api/client.ts
+++ b/packages/farm/src/api/client.ts
@@ -488,10 +488,7 @@ export function createAPIClient<
     applyFarmCacheInvalidations(
       decodeFarmCacheInvalidations(response.headers?.get?.(FARM_CACHE_INVALIDATION_HEADER)),
     );
-    let data: any = undefined;
-    if (method !== "HEAD" && response.status !== 204 && response.status !== 205) {
-      data = isJSONStreamResponse(response) ? readJSONStream(response) : await response.json();
-    }
+    const data = await readAPIResponseData(response, method);
 
     return { response, data };
   };
@@ -812,6 +809,75 @@ export function createAPIClient<
     isSameOriginAPIBaseURL(baseURL),
     rootAliases,
   ) as APIClient<TRouter, TIntegrations>;
+}
+
+async function readAPIResponseData(response: Response, method: string): Promise<unknown> {
+  if (
+    method === "HEAD" ||
+    response.status === 204 ||
+    response.status === 205 ||
+    response.status === 304
+  ) {
+    return undefined;
+  }
+
+  // Keep lightweight fetch-compatible adapters working when they expose the
+  // traditional json() contract without a complete Web Response implementation.
+  if (!response.headers?.get && typeof response.json === "function") {
+    return response.json();
+  }
+
+  if (response.body === null) return undefined;
+
+  if (isJSONStreamResponse(response)) {
+    return readJSONStream(response);
+  }
+
+  const contentType = response.headers.get("content-type")?.split(";", 1)[0]?.trim().toLowerCase();
+  if (typeof response.arrayBuffer === "function") {
+    const data = await response.arrayBuffer();
+    if (data.byteLength === 0) return undefined;
+
+    if (!contentType || contentType === "application/json" || contentType.endsWith("+json")) {
+      return JSON.parse(new TextDecoder().decode(data));
+    }
+
+    if (
+      contentType.startsWith("text/") ||
+      contentType === "application/xml" ||
+      contentType === "application/xhtml+xml" ||
+      contentType === "application/graphql"
+    ) {
+      return new TextDecoder().decode(data);
+    }
+
+    return data;
+  }
+
+  if (
+    (!contentType || contentType === "application/json" || contentType.endsWith("+json")) &&
+    typeof response.json === "function"
+  ) {
+    return response.json();
+  }
+
+  if (
+    (contentType?.startsWith("text/") ||
+      contentType === "application/xml" ||
+      contentType === "application/xhtml+xml" ||
+      contentType === "application/graphql") &&
+    typeof response.text === "function"
+  ) {
+    return response.text();
+  }
+
+  // Some fetch-compatible adapters expose headers but still only implement
+  // the traditional json() reader.
+  if (typeof response.json === "function") {
+    return response.json();
+  }
+
+  return undefined;
 }
 
 /**


### PR DESCRIPTION
## Problem

The typed API client attempts JSON parsing for text, binary, and empty responses.

## Root cause

Response decoding assumed every successful response contained JSON.

## Change

Decode JSON media types as JSON, text media types as text, binary responses as ArrayBuffer, and empty or HEAD responses without parsing.

## Safety and compatibility

JSON behavior remains unchanged, including lightweight fetch adapters that do not provide a complete Headers implementation.

## Verification

- pnpm --filter @farm.js/core exec vitest run src/__tests__/api-client.test.ts
- pnpm --filter @farm.js/core type-check

## Documentation and release

None.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the API client so text, binary, and empty responses are no longer forced through JSON parsing, which previously turned non-JSON bodies into network failures.

- Decodes responses by content type: JSON stays JSON, text and XML become text, binary becomes `ArrayBuffer`, and empty, HEAD, 204, 205, or 304 responses skip parsing.
- Preserves non-JSON HTTP error bodies (for example, an HTML 502 page) in the error object instead of reporting a network failure.
- Keeps JSON behavior unchanged, including when content type is missing and for lightweight fetch adapters that expose `json()` without a full `Headers` implementation or a binary reader.

<sup>Written for commit cf46258c95966c4eeba2929f23a55e5e2833b491. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/681?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

