### PR TITLE
fix(storage): retry failed client initialization

### DIFF
--- a/packages/farm/src/__tests__/storage.test.ts
+++ b/packages/farm/src/__tests__/storage.test.ts
@@ -164,6 +164,37 @@ describe("Storage", () => {
     await expect(client.getItem("farewell")).resolves.toBe("goodbye");
   });
 
+  it("retries initialization after a driver factory failure", async () => {
+    const data = new Map<string, string>();
+    let attempts = 0;
+    const client = defineStorageClient(() => {
+      attempts++;
+      if (attempts === 1) throw new Error("temporary storage failure");
+
+      return {
+        name: "retryable",
+        hasItem: (key: string) => data.has(key),
+        getItem: (key: string) => data.get(key) ?? null,
+        setItem: (key: string, value: string) => {
+          data.set(key, value);
+        },
+        removeItem: (key: string) => {
+          data.delete(key);
+        },
+        getKeys: () => [...data.keys()],
+      } as never;
+    });
+
+    const firstAttempts = await Promise.allSettled([client.ready(), client.ready()]);
+    expect(firstAttempts.map((result) => result.status)).toEqual(["rejected", "rejected"]);
+    expect(attempts).toBe(1);
+
+    await client.setItem("status", "ready");
+
+    expect(attempts).toBe(2);
+    await expect(client.getItem("status")).resolves.toBe("ready");
+  });
+
   it("supports mounted local namespaces with shorthand options", async () => {
     const dir = await createTempDir("farm-storage-local-");
     const cacheClient = localStorage({ base: dir });

--- a/packages/farm/src/storage/index.ts
+++ b/packages/farm/src/storage/index.ts
@@ -275,18 +275,33 @@ function createStorageClientFromResolver(resolveDriver: DriverResolver): FarmSto
   let driverPromise: Promise<Driver> | undefined;
   let storagePromise: Promise<Storage> | undefined;
 
-  const ensureDriver = async () => {
-    driverPromise ??= Promise.resolve(resolveDriver());
-    return driverPromise;
+  const ensureDriver = () => {
+    if (driverPromise) return driverPromise;
+
+    const pending = Promise.resolve().then(resolveDriver);
+    driverPromise = pending;
+    void pending.catch(() => {
+      if (driverPromise === pending) {
+        driverPromise = undefined;
+        storagePromise = undefined;
+      }
+    });
+    return pending;
   };
 
-  const ensureStorage = async () => {
-    storagePromise ??= ensureDriver().then((driver) =>
+  const ensureStorage = () => {
+    if (storagePromise) return storagePromise;
+
+    const pending = ensureDriver().then((driver) =>
       createStorage({
         driver,
       }),
     );
-    return storagePromise;
+    storagePromise = pending;
+    void pending.catch(() => {
+      if (storagePromise === pending) storagePromise = undefined;
+    });
+    return pending;
   };
 
   const target = {


### PR DESCRIPTION
## Problem

A transient storage driver initialization failure permanently poisons that storage instance.

## Root cause

Rejected initialization promises stayed cached and were returned by every later access.

## Change

Clear rejected driver and storage promises identity-safely so concurrent attempts still deduplicate and a later call can retry.

## Safety and compatibility

Successful initialization remains cached. Disposal and concurrent initialization semantics are preserved.

## Verification

- pnpm --filter @farm.js/core exec vitest run src/__tests__/storage.test.ts
- pnpm --filter @farm.js/core type-check

## Documentation and release

None.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes storage client initialization so a transient driver failure no longer permanently breaks the storage instance. A rejected initialization promise used to stay cached and make every later access fail; now failed driver and storage promises are cleared so the next call retries, while successful initialization remains cached and concurrent attempts still deduplicate.

Adds a regression test covering retry after the first driver factory failure.

<sup>Written for commit 7975da082356d179a10855ab0157c7ecd31e9224. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/682?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

