### PR TITLE
fix(create-app): report TypeScript templates accurately

### DIFF
--- a/packages/create-farm-app/README.md
+++ b/packages/create-farm-app/README.md
@@ -5,7 +5,7 @@ Create a new FARMJS application
 FARMJS is currently in beta.
 
 ```bash
-pnpm --config.minimumReleaseAge=0 create @farm.js/app@beta my-app --template basic --typescript
+pnpm --config.minimumReleaseAge=0 create @farm.js/app@beta my-app --template basic
 cd my-app
 pnpm dev
 ```
@@ -19,7 +19,7 @@ within the last 24 hours. Pass `--skip-install` when you only want to generate t
 Choose React, Preact, Solid, Vue, or Svelte for the Basic and Better Auth starters:
 
 ```bash
-pnpm --config.minimumReleaseAge=0 create @farm.js/app@beta my-app --template better-auth --renderer solid --typescript
+pnpm --config.minimumReleaseAge=0 create @farm.js/app@beta my-app --template better-auth --renderer solid
 ```
 
 React remains the default when `--renderer` is omitted. The interactive Basic and Better Auth
@@ -43,7 +43,7 @@ home page, and setup documentation. Better Auth has renderer-native UI for all f
 other integration templates currently use React. For example:
 
 ```bash
-pnpm --config.minimumReleaseAge=0 create @farm.js/app@beta stripe-app --template stripe --typescript
+pnpm --config.minimumReleaseAge=0 create @farm.js/app@beta stripe-app --template stripe
 ```
 
 See the [FARMJS repository](https://github.com/farming-labs/farm.js) for documentation, examples, and support.

--- a/packages/create-farm-app/bin/create-farm-app.js
+++ b/packages/create-farm-app/bin/create-farm-app.js
@@ -15,7 +15,7 @@ program
     "Rendering library to use (react, preact, solid, vue, or svelte)",
   )
   .option("--list-templates", "List all available starter templates")
-  .option("--typescript", "Use TypeScript template")
+  .option("--typescript", "TypeScript is included by default (deprecated)")
   .option("--skip-install", "Skip installing dependencies")
   .action(async (projectName, options) => {
     try {

--- a/packages/create-farm-app/src/index.ts
+++ b/packages/create-farm-app/src/index.ts
@@ -13,6 +13,7 @@ import { logger, showBanner } from "./utils";
 interface CreateAppOptions {
   template?: string;
   renderer?: string;
+  /** @deprecated All maintained templates use TypeScript. */
   typescript?: boolean;
   skipInstall?: boolean;
   listTemplates?: boolean;
@@ -350,23 +351,6 @@ export async function createApp(projectName?: string, options: CreateAppOptions 
     process.exit(1);
   }
 
-  // Check TypeScript preference
-  let useTypeScript = options.typescript;
-  if (useTypeScript === undefined) {
-    const response = await prompts({
-      type: "confirm",
-      name: "typescript",
-      message: "Would you like to use TypeScript?",
-      initial: true,
-    });
-
-    if (response.typescript === undefined) {
-      logger.error("Operation cancelled.");
-      process.exit(1);
-    }
-    useTypeScript = response.typescript;
-  }
-
   const projectPath = path.resolve(process.cwd(), projectName!);
   const packageManager = detectPackageManager();
   const hasExistingFiles = await directoryHasFiles(projectPath);
@@ -388,7 +372,7 @@ export async function createApp(projectName?: string, options: CreateAppOptions 
 
   await fs.mkdir(projectPath, { recursive: true });
 
-  const integrationResult = await copyTemplate(template!, projectPath, useTypeScript!, renderer);
+  const integrationResult = await copyTemplate(template!, projectPath, renderer);
 
   await updatePackageJson(projectPath, projectName!, packageManager);
 
@@ -427,7 +411,7 @@ export async function createApp(projectName?: string, options: CreateAppOptions 
     template,
     renderer,
     packageManager: packageManager.name,
-    typescript: useTypeScript,
+    typescript: true,
     installedDependencies: !options.skipInstall,
   });
 }
@@ -435,7 +419,6 @@ export async function createApp(projectName?: string, options: CreateAppOptions 
 async function copyTemplate(
   template: string,
   projectPath: string,
-  useTypeScript: boolean,
   renderer: RendererName,
 ): Promise<AddFarmIntegrationResult | undefined> {
   const details = templateDetails[template];
@@ -450,14 +433,6 @@ async function copyTemplate(
   await copyDir(templatePath, projectPath);
 
   const basePackageJson = await readPackageJson(projectPath);
-
-  // If TypeScript is requested, copy TS-specific files
-  if (useTypeScript) {
-    const tsTemplatePath = path.join(__dirname, "..", "templates", "_typescript");
-    if (await dirExists(tsTemplatePath)) {
-      await copyDir(tsTemplatePath, projectPath);
-    }
-  }
 
   if (renderer !== "react") {
     await applyRendererTemplate(projectPath, renderer, basePackageJson);

--- a/packages/create-farm-app/templates/auth/README.md
+++ b/packages/create-farm-app/templates/auth/README.md
@@ -20,7 +20,7 @@ This project was generated from the FARMJS Auth template included with `@farm.js
 ## Quick start
 
 ```bash
-pnpm --config.minimumReleaseAge=0 create @farm.js/app@beta my-app --template auth --typescript
+pnpm --config.minimumReleaseAge=0 create @farm.js/app@beta my-app --template auth
 cd my-app
 pnpm dev
 ```

--- a/packages/create-farm-app/templates/better-auth/README.md
+++ b/packages/create-farm-app/templates/better-auth/README.md
@@ -19,7 +19,7 @@ This project was generated from the Better Auth template included with `@farm.js
 ## Quick start
 
 ```bash
-pnpm --config.minimumReleaseAge=0 create @farm.js/app@beta my-app --template better-auth --renderer solid --typescript
+pnpm --config.minimumReleaseAge=0 create @farm.js/app@beta my-app --template better-auth --renderer solid
 cd my-app
 cp .env.example .env.local
 ```

--- a/packages/create-farm-app/templates/react-compiler/README.md
+++ b/packages/create-farm-app/templates/react-compiler/README.md
@@ -10,7 +10,7 @@ update beside ordinary React reconciliation.
 ## Create this starter
 
 ```bash
-pnpm --config.minimumReleaseAge=0 create @farm.js/app@beta my-compiler-app --template react-compiler --typescript
+pnpm --config.minimumReleaseAge=0 create @farm.js/app@beta my-compiler-app --template react-compiler
 cd my-compiler-app
 pnpm dev
 ```

--- a/packages/create-farm-app/test/create-app.test.mjs
+++ b/packages/create-farm-app/test/create-app.test.mjs
@@ -169,7 +169,6 @@ test("generates a buildable starter application", async () => {
         "generated-app",
         "--template",
         "basic",
-        "--typescript",
         "--skip-install",
       ],
       {


### PR DESCRIPTION
## Problem

Create-app asks for a TypeScript choice even though every maintained template is TypeScript, and telemetry can report a choice that does not match the generated project.

## Root cause

The obsolete JavaScript overlay flow remained after the templates became TypeScript-only.

## Change

Remove the misleading prompt and dead overlay, always report TypeScript accurately, and keep the command-line flag as a compatibility alias.

## Safety and compatibility

Existing commands with the TypeScript flag continue to work. Generated maintained starters are unchanged in language.

## Verification

- pnpm --filter @farm.js/create-app test
- pnpm --filter @farm.js/create-app type-check
- pnpm --filter @farm.js/create-app build

## Documentation and release

Updated generator and template README commands.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the TypeScript confirmation prompt from `create-app` since every maintained template is TypeScript-only, so telemetry no longer reports a choice that can mismatch the generated project.

- `--typescript` remains as a deprecated no-op so existing commands keep working.
- Telemetry now always reports `typescript: true`.
- READMEs and tests no longer pass `--typescript`.

<sup>Written for commit 43160b98a1058a8b507701bf3105e9ac88cdb72a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/683?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

