### PR TITLE
fix(api-client): escape HTTP method path segments

### DIFF
--- a/docs/src/app/docs/api-client/page.md
+++ b/docs/src/app/docs/api-client/page.md
@@ -67,6 +67,19 @@ if (result.error) {
 }
 ```
 
+If a route path contains a lowercase HTTP method segment such as `get`, `post`, or `delete` that
+collides with a method on its parent route, the generated client exposes a leading-slash literal
+alias so the two cannot be confused:
+
+```ts
+// Both src/app/api/users/route.ts and src/app/api/users/get/route.ts export GET.
+const result = await api["/users/get"].get();
+```
+
+The leading slash marks the whole key as a literal API path. This also works when the method-named
+segment is in the middle of a colliding route, for example
+`api["/users/get/profile"].post(...)`. Non-conflicting paths keep their ordinary nested form.
+
 A typed `HEAD` route is called with `.head()`. Its result keeps the same `{ data, error, key }`
 shape, with `data` set to `undefined` because HTTP HEAD responses do not have a body.
 

--- a/packages/farm/src/__tests__/api-client.test.ts
+++ b/packages/farm/src/__tests__/api-client.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { createAPIClient, createServerAPIClient } from "../api/client";
+import { createAPIClient, createServerAPIClient, getAPIRouteRefMetadata } from "../api/client";
 import {
   encodeFarmCacheInvalidations,
   FARM_CACHE_INVALIDATION_HEADER,
@@ -181,6 +181,29 @@ describe("createAPIClient", () => {
 
     expect(fetchMock).toHaveBeenCalledWith(
       "https://api.example.com/gateway/v1/users?limit=5",
+      expect.objectContaining({ method: "GET" }),
+    );
+  });
+
+  it("uses leading-slash aliases for literal HTTP method path segments", async () => {
+    const fetchMock = vi.fn(async () => buildResponse({ ok: true }));
+    globalThis.fetch = fetchMock as any;
+    const api = createAPIClient<{
+      "/users/get": {
+        get: {
+          __types: { body: never; query: never; response: { ok: boolean } };
+        };
+      };
+    }>({ baseURL: "https://api.example.com" });
+
+    await api["/users/get"].get();
+
+    expect(getAPIRouteRefMetadata(api["/users/get"].get)).toMatchObject({
+      path: "/api/users/get",
+      method: "GET",
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.example.com/api/users/get",
       expect.objectContaining({ method: "GET" }),
     );
   });

--- a/packages/farm/src/__tests__/type-generator.test.ts
+++ b/packages/farm/src/__tests__/type-generator.test.ts
@@ -60,6 +60,45 @@ describe("APITypeGenerator", () => {
     expect(new Set(aliases).size).toBe(4);
   });
 
+  it("emits literal aliases only when HTTP method path segments collide", () => {
+    const generator = new APITypeGenerator("/tmp/app");
+
+    const content = generator.generateAPIRouter([
+      {
+        path: "/api/users",
+        methods: ["GET"],
+        filePath: "/tmp/app/api/users/route.ts",
+        relativePath: "api/users/route.ts",
+      },
+      {
+        path: "/api/users/get/profile",
+        methods: ["GET", "POST"],
+        filePath: "/tmp/app/api/users/get/profile/route.ts",
+        relativePath: "api/users/get/profile/route.ts",
+      },
+      {
+        path: "/api/get",
+        methods: ["GET"],
+        filePath: "/tmp/app/api/get/route.ts",
+        relativePath: "api/get/route.ts",
+      },
+      {
+        path: "/api/users/post",
+        methods: ["GET"],
+        filePath: "/tmp/app/api/users/post/route.ts",
+        relativePath: "api/users/post/route.ts",
+      },
+    ]);
+
+    expect(content).toContain("users: {");
+    expect(content).toContain("get: typeof GET_users;");
+    expect(content).toContain('"/users/get/profile": {');
+    expect(content).not.toContain('"/get": {');
+    expect(content).not.toContain('"/users/post": {');
+    expect(content).toContain("post: {");
+    expect(content).not.toMatch(/get: \{\n\s+profile:/);
+  });
+
   it("creates the output directory before writing generated API types", () => {
     const root = mkdtempSync(path.join(os.tmpdir(), "farm-api-types-"));
     const appDir = path.join(root, "src", "app");

--- a/packages/farm/src/api/client.ts
+++ b/packages/farm/src/api/client.ts
@@ -948,7 +948,7 @@ function createNestedProxy(
       if (httpMethods.includes(lastPart)) {
         // Method is explicitly called: api.users.get() or api['auth/login'].post()
         // Remove the method from path and use it as the HTTP method
-        const routePath = "/api/" + path.slice(0, -1).join("/");
+        const routePath = buildProxyRoutePath(path.slice(0, -1));
         const method = lastPart.toUpperCase();
 
         // Extract options from arguments
@@ -959,7 +959,7 @@ function createNestedProxy(
       } else {
         // Direct call without method: api.hello()
         // Use the full path and let the server determine the method (usually GET)
-        const routePath = "/api/" + path.join("/");
+        const routePath = buildProxyRoutePath(path);
 
         // Extract options from arguments
         const [options, clientOptions] = args;
@@ -972,6 +972,10 @@ function createNestedProxy(
 
   routeMeta.set(proxy, { path: [...path], baseURL });
   return proxy;
+}
+
+function buildProxyRoutePath(path: string[]): string {
+  return "/api/" + path.join("/").replace(/^\/+/, "");
 }
 
 export function isAPIRouteRef(value: unknown): value is CallableRouteRef {
@@ -1206,13 +1210,13 @@ function resolveRouteMeta(meta: RouteMeta): { routePath: string; method: string 
   const lastPart = meta.path[meta.path.length - 1];
   if (lastPart && httpMethods.includes(lastPart)) {
     return {
-      routePath: "/api/" + meta.path.slice(0, -1).join("/"),
+      routePath: buildProxyRoutePath(meta.path.slice(0, -1)),
       method: lastPart.toUpperCase(),
     };
   }
 
   return {
-    routePath: "/api/" + meta.path.join("/"),
+    routePath: buildProxyRoutePath(meta.path),
     method: "GET",
   };
 }

--- a/packages/farm/src/type-generator.ts
+++ b/packages/farm/src/type-generator.ts
@@ -3,6 +3,17 @@ import { join, relative, dirname } from "path";
 import { writeFileIfChanged } from "./write-file-if-changed";
 import { isFarmAPIRouteFileName } from "./api/route-files";
 
+const API_CLIENT_METHOD_SEGMENTS = new Set([
+  "get",
+  "head",
+  "query",
+  "post",
+  "put",
+  "delete",
+  "patch",
+  "options",
+]);
+
 export interface APIRouteInfo {
   path: string;
   methods: string[];
@@ -131,6 +142,15 @@ export class APITypeGenerator {
       routeGroups.get(key)!.push(route);
     }
 
+    const routeMethodsByPath = new Map<string, Set<string>>();
+    for (const [routePath, routeList] of routeGroups) {
+      const cleanPath = routePath === "/api" ? "" : routePath.replace(/^\/api\//, "");
+      routeMethodsByPath.set(
+        cleanPath,
+        new Set(routeList.flatMap((route) => route.methods.map((method) => method.toLowerCase()))),
+      );
+    }
+
     // Build nested structure
     const nestedStructure: any = {};
     const usedRouteNames = new Map<string, number>();
@@ -160,11 +180,17 @@ export class APITypeGenerator {
           nestedStructure[methodName] = `typeof ${importName}`;
         }
       } else {
+        const hasMethodCollision = parts.some((part, index) => {
+          if (!API_CLIENT_METHOD_SEGMENTS.has(part)) return false;
+          const parentPath = parts.slice(0, index).join("/");
+          return routeMethodsByPath.get(parentPath)?.has(part) === true;
+        });
+        const typePath = hasMethodCollision ? [`/${cleanPath}`] : parts;
         // Build nested object
         let current = nestedStructure;
-        for (let i = 0; i < parts.length; i++) {
-          const part = parts[i];
-          if (i === parts.length - 1) {
+        for (let i = 0; i < typePath.length; i++) {
+          const part = typePath[i];
+          if (i === typePath.length - 1) {
             // Last part - add methods
             current[part] = {};
             for (const method of allMethods) {


### PR DESCRIPTION
## Problem

An API pathname segment named get, post, or another HTTP method can collide with the generated caller method on its parent object.

## Root cause

Generated types and runtime proxy traversal used the same property name for path segments and terminal HTTP methods.

## Change

Generate leading-slash aliases for method-named path segments and normalize those aliases when building runtime paths and route metadata.

## Safety and compatibility

Existing non-conflicting generated callers remain unchanged. The escaped form is statically typed and only applies where a collision exists.

## Verification

- pnpm --filter @farm.js/core exec vitest run src/__tests__/api-client.test.ts src/__tests__/type-generator.test.ts
- pnpm --filter @farm.js/core type-check
- pnpm docs:build

## Documentation and release

Documented method-named path segment access in the API client guide.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes API client generation so HTTP method path segments such as `get` or `post` no longer collide with method calls on their parent route. Previously, `app/api/users/get/route.ts` generated an ambiguous `users.get`; it now uses `api["/users/get"].get()`, while non-conflicting paths remain unchanged.

- Normalizes leading-slash aliases in runtime paths and route metadata.
- Documents the escaped access pattern and adds type-generation and runtime coverage.

<sup>Written for commit 6f807e6bf5ebe0ad499dce153e604a6d3225e732. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/684?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

