### PR TITLE
perf(react): carry dynamic keyed slice bounds

### DIFF
--- a/docs/src/app/docs/renderers/react/page.md
+++ b/docs/src/app/docs/renderers/react/page.md
@@ -370,8 +370,8 @@ module.
 and can hand the appended suffix to the runtime. `keyedArrayFilterHints` counts concise keyed-array
 filter sites that can report removed positions. `keyedArrayPrependHints` counts setter sites where
 the compiler proved a direct keyed array prepend and can hand the new prefix to the runtime.
-`keyedArraySliceHints` counts direct keyed-array slices whose build-time bounds identify one exact
-retained interval.
+`keyedArraySliceHints` counts direct keyed-array slices whose compiler-safe bounds identify one
+exact retained interval after runtime validation.
 `keyedArrayPositionHints` counts compiler-proven native keyed-array insertions, single or
 contiguous-range removals, single-row replacements, and exact-window replacements with a guarded
 position.
@@ -968,12 +968,20 @@ setItems((current) => current.slice(1_000));
 setItems((current) => current.slice(0, -1_000));
 setItems((current) => current.slice(2, 8));
 setItems((current) => current.slice(-5));
+
+const trimCount = pageSize * pagesToDiscard;
+setItems((current) => current.slice(trimCount));
+setItems((current) => current.slice(visible.start, visible.end));
 ```
 
 At build time, Farm recognizes a concise functional setter that directly calls native `slice()`
-with one or two safe-integer bounds known by the compiler. The application still executes its
-ordinary `slice()`. Generated metadata records the normalized retained interval and links multiple
-slice or filter updates queued before one compiler flush.
+with one or two safe-integer literals or compiler-safe runtime expressions. Identifiers, property
+reads, side-effect-free arithmetic and conditionals, and safe `Math` calls are supported.
+User-defined calls, assignments, update expressions, and other effectful forms are not transformed.
+Farm preserves the original method lookup and argument evaluation order, evaluates each bound once,
+and preserves the native call, coercion, return value, and thrown errors. Generated metadata records
+the normalized retained interval only when every evaluated bound is already a safe integer, and
+links multiple slice or filter updates queued before one compiler flush.
 
 At update time, Farm validates the native arrays, committed source, queued lengths, interval, and
 surviving item identities before changing the DOM. It removes only rows outside the interval,
@@ -982,12 +990,14 @@ slice-only chain does not reread surviving keys, descriptors, or bindings, and t
 does not rerun.
 
 The proof requires compiler-owned host rows whose render callback and key do not observe the row
-index. Runtime or fractional bounds, `slice()` without a bound, a no-op `slice(0)`, block-bodied or
-chained updaters, custom slice methods, sparse or subclassed arrays, collection-derived keys,
+index. Effectful bound expressions, evaluated bounds that are fractional, non-numeric, or otherwise
+not safe integers, `slice()` without a bound, a literal no-op `slice(0)`, block-bodied or chained
+updaters, custom slice methods, sparse or subclassed arrays, collection-derived keys,
 collection-reading bindings, React-owned row structures, nested host blocks, row conditionals,
 unrelated dirty dependencies, and failed runtime validation keep complete keyed reconciliation.
-These checks make the metadata an optional optimization rather than a new behavior contract. No
-configuration or component primitive is added. Reports expose emitted sites as
+A runtime bound that evaluates to a no-op still preserves the native result and uses complete
+reconciliation. These checks make the metadata an optional optimization rather than a new behavior
+contract. No configuration or component primitive is added. Reports expose emitted sites as
 `keyedArraySliceHints`; slice reuses the existing removal-hint runtime so it does not add another
 structural runtime combination.
 
@@ -1977,10 +1987,12 @@ The package and example test suites verify more than generated code:
   descriptor, and binding reads to equal only the inserted prefix, preserve every existing DOM
   row, update delegated event indexes, and cover queued updates, StrictMode hydration, unmount,
   invalid metadata, custom arrays, and conservative fallback;
-- 2,000 deterministic queued keyed-array slices match normal React; targeted tests require zero
-  surviving key, descriptor, and binding reads, preserve focused controlled-input identity and
-  selection, update delegated event indexes, and cover native bounds, queued slice/filter chains,
-  Strict Mode hydration, unmount cleanup, custom methods, proxies, and conservative fallback;
+- 2,000 deterministic queued keyed-array slices and 1,000 randomized runtime-bound slices match
+  normal React; compiler tests cover literal and compiler-safe runtime bounds while rejecting calls
+  and mutations; targeted tests require zero surviving key, descriptor, and binding reads, preserve
+  focused controlled-input identity and selection, update delegated event indexes, and cover native
+  evaluation and coercion, unsafe evaluated bounds, queued slice/filter chains, Strict Mode
+  hydration, unmount cleanup, custom methods, proxies, and conservative fallback;
 - 250 committed keyed rolling-window updates match normal React; targeted tests require work to
   equal only the incoming suffix, preserve retained DOM identity, and cover reused-key,
   custom-slice, and collection-dependent fallbacks;

--- a/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
+++ b/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
@@ -2,6 +2,34 @@
 
 Date: 2026-08-29
 
+## Compiler-safe runtime slice bounds — 2026-09-02
+
+The retained-window workload now passes an event-local `trimCount` to
+`current.slice(trimCount)` instead of embedding the value as a literal. Both compiler builds emit
+one `keyedArraySliceHints` site, preserve every surviving DOM row, remove the exact prefix, and
+finish with zero compiled owner executions. The equivalent block-bodied setter remains the
+compiled control and performs the same native array and DOM work without the hint.
+
+| Mode   | React median | Runtime bound | Compiled control | vs React | vs control | 21k vs React |
+| ------ | -----------: | ------------: | ---------------: | -------: | ---------: | -----------: |
+| Static |      64.00 ms |       5.40 ms |         17.10 ms |   11.85x |      3.17x |       13.65x |
+| Hybrid |      64.00 ms |       7.00 ms |         18.70 ms |    9.14x |      2.67x |       15.53x |
+
+The unchanged gate requires at least 3x versus React at both 10,000 and 21,000 rows and 1.25x
+versus the compiled control. Three complete bracketed production-browser runs all passed the slice
+gate: 5.82x–13.37x versus React at 10,000 rows, 9.00x–15.53x at 21,000 rows, and 2.67x–4.64x versus
+the control. Each run also passed DOM correctness, compiler-report, owner-execution, general
+optimization-persistence, and normalized scalability checks for this path.
+
+Compiler tests accept identifiers, property reads, arithmetic, conditionals, and safe `Math` calls
+while rejecting user calls, assignments, updates, and fractional literals. Runtime coverage proves
+native bound coercion order, complete fallback for fractional, `NaN`, and no-op evaluated bounds,
+2,000 queued slices, and 1,000 randomized runtime-bound slices against normal React. The runtime is
+unchanged: the keyed-slice fixture remains a 12,222 B gzip compiler premium, the optional
+keyed-window fixture remains 14,173 B gzip, and the compiler-disabled core premium remains 3,766 B
+gzip with an 82.5% reduction from the full compatibility runtime. The recorded run used Chrome
+152.0.7977.65, Node.js 23.11.0, and Apple M1 macOS arm64.
+
 ## Runtime delete-count exact-window follow-up — 2026-09-02
 
 The full bracketed production-browser run changed the existing 10,000-row exact-window workload

--- a/examples/react-compiler-dashboard/README.md
+++ b/examples/react-compiler-dashboard/README.md
@@ -81,12 +81,14 @@ least 1.25x faster than the compiled control at 10,000 rows. The report must con
 `keyedArrayPrependHints` count; deterministic package tests separately require key, descriptor, and
 binding work to equal only the new prefix while preserving every existing DOM row.
 
-Keyed array slices have an independent retained-window comparison. A concise `slice(1_000)` is
-measured against bracketed React and an equivalent block-bodied compiled snapshot control. Both
-compiler modes must remain at least 3x faster than React while trimming 10,000- and 21,000-row
-arrays, and at least 1.25x faster than the compiled control at 10,000 rows. The report must contain
-a nonzero `keyedArraySliceHints` count; deterministic package tests separately require zero
-surviving key, descriptor, and binding reads while preserving surviving DOM identity.
+Keyed array slices have an independent retained-window comparison. A concise
+`slice(trimCount)` uses an event-local runtime bound and is measured against bracketed React and an
+equivalent block-bodied compiled snapshot control. Both compiler modes must remain at least 3x
+faster than React while trimming 10,000- and 21,000-row arrays, and at least 1.25x faster than the
+compiled control at 10,000 rows. The report must contain a nonzero `keyedArraySliceHints` count;
+deterministic package tests separately require zero surviving key, descriptor, and binding reads,
+preserve surviving DOM identity, and cover safe and effectful bound expressions plus unsafe
+evaluated-bound fallback.
 
 Rolling windows have a separate 10,000-row persistence gate. A concise
 `[...current.slice(1_000), ...incoming]` update is measured against bracketed React and an

--- a/examples/react-compiler-dashboard/scripts/benchmark.mjs
+++ b/examples/react-compiler-dashboard/scripts/benchmark.mjs
@@ -1927,9 +1927,10 @@ const keyedPrependRegressions = keyedPrependResults.filter(
     !Number.isFinite(snapshotSpeedup) ||
     snapshotSpeedup < keyedPrependMinimumSnapshotSpeedup,
 );
-// A compiler-proven native slice identifies one exact retained interval. Reuse those row instances
-// without rescanning their keys, descriptors, or bindings. Compare it with React and a block-bodied
-// compiled control, and preserve the same advantage after trimming a 21,000-row list.
+// A compiler-proven native slice with an event-local runtime bound identifies one exact retained
+// interval after runtime validation. Reuse those row instances without rescanning their keys,
+// descriptors, or bindings. Compare it with React and a block-bodied compiled control, and
+// preserve the same advantage after trimming a 21,000-row list.
 const keyedSliceMinimumSpeedup = 3;
 const keyedSliceMinimumSnapshotSpeedup = 1.25;
 const keyedSliceResults = ["static", "hybrid"].map((mode) => {

--- a/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
+++ b/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
@@ -202,25 +202,27 @@ export function StandardTableBenchmark() {
           data-action="table-drop-prefix"
           type="button"
           onClick={() => {
-            setRows((current) => current.slice(1_000));
-            setOperation("drop benchmark prefix");
+            const trimCount = 1_000;
+            setRows((current) => current.slice(trimCount));
+            setOperation("drop runtime-count prefix");
             setRevision((value) => value + 1);
           }}
         >
-          Drop benchmark prefix
+          Drop runtime-count prefix
         </button>
         <button
           data-action="table-drop-prefix-snapshot"
           type="button"
           onClick={() => {
+            const trimCount = 1_000;
             setRows((current) => {
-              return current.slice(1_000);
+              return current.slice(trimCount);
             });
-            setOperation("drop benchmark prefix (snapshot control)");
+            setOperation("drop runtime-count prefix (snapshot control)");
             setRevision((value) => value + 1);
           }}
         >
-          Drop benchmark prefix (snapshot control)
+          Drop runtime-count prefix (snapshot control)
         </button>
         <button
           data-action="table-roll-window"

--- a/packages/farm-react/README.md
+++ b/packages/farm-react/README.md
@@ -264,22 +264,28 @@ keys, React-owned row structures, middle insertion, direct replacement, duplicat
 sparse arrays, and failed validation use complete keyed reconciliation. The compiler report
 exposes the emitted-site count as `keyedArrayPrependHints`.
 
-Literal native slices can carry their exact retained interval into the same removal runtime:
+Native slices with compiler-safe bounds can carry their exact retained interval into the same
+removal runtime:
 
 ```tsx
 setItems((current) => current.slice(1_000));
 setItems((current) => current.slice(0, -1_000));
 setItems((current) => current.slice(2, 8));
+setItems((current) => current.slice(trimCount));
+setItems((current) => current.slice(visible.start, visible.end));
 ```
 
 For compiler-owned host rows whose render and key do not read the row index, Farm validates the
 committed source and queued slice chain, preserves every surviving DOM row, and removes only rows
 outside the retained interval. A slice-only chain does not reread surviving keys, descriptors, or
-bindings. One or two build-time safe-integer bounds are required. Runtime bounds, block-bodied or
-chained updates, custom slice methods, sparse or subclassed arrays, index-aware or
-collection-reading rows, React-owned structures, and failed validation keep complete keyed
-reconciliation. No option or component is added. The compiler report exposes the emitted-site
-count as `keyedArraySliceHints`.
+bindings. One or two safe-integer literals or compiler-safe runtime expressions are required.
+Identifiers, property reads, side-effect-free arithmetic and conditionals, and safe `Math` calls
+are supported. Farm preserves native method lookup, argument evaluation, coercion, results, and
+errors, then records metadata only when the evaluated bounds are already safe integers. Calls,
+assignments, updates, unsafe evaluated bounds, block-bodied or chained updates, custom slice
+methods, sparse or subclassed arrays, index-aware or collection-reading rows, React-owned
+structures, and failed validation keep complete keyed reconciliation. No option or component is
+added. The compiler report exposes the emitted-site count as `keyedArraySliceHints`.
 
 A fixed-size feed can combine that retained tail with a new keyed suffix:
 
@@ -702,8 +708,8 @@ and
 `keyedArraySortHints`, the number of compiler-proven direct native keyed-array sort sites; and
 `keyedArrayRollingWindowHints`, the number of compiler-proven retained-tail plus incoming-suffix
 sites; and
-`keyedArraySliceHints`, the number of compiler-proven direct keyed-array slice sites. A custom
-project-relative `reportFile` also enables reporting.
+`keyedArraySliceHints`, the number of compiler-proven direct keyed-array slice sites with literal or
+guarded compiler-safe runtime bounds. A custom project-relative `reportFile` also enables reporting.
 
 The runtime test compares the same counter interaction on both paths: ordinary React performs a
 second component render and commit, while the compiled component remains at one render and one

--- a/packages/farm-react/src/__tests__/compiler-keyed-array-slice-hints.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-keyed-array-slice-hints.test.ts
@@ -65,6 +65,28 @@ describe("React AOT keyed-array slice hints", () => {
     expect(result.code).not.toContain("keyedRowsFilterPrependHintedRuntimeFeature");
   });
 
+  it("records compiler-safe runtime slice bounds", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Feed({ offset, bounds, trimTail }) {
+        const [rows, setRows] = useState([{ id: "a", label: "Alpha" }]);
+        return <main>
+          <button onClick={() => setRows((current) => current.slice(offset))}>Drop prefix</button>
+          <button onClick={() => setRows((current) => current.slice(bounds.start, bounds.end))}>Keep window</button>
+          <button onClick={() => setRows((current) => current.slice(Math.trunc(offset / 2)))}>Drop calculated prefix</button>
+          <button onClick={() => setRows((current) => current.slice(0, trimTail ? -trimTail : current.length))}>Drop suffix</button>
+          <ul>{rows.map((row) => <li key={row.id}>{row.label}</li>)}</ul>
+        </main>;
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Feed"]);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.optimizations.keyedArraySliceHints).toBe(4);
+    expect(result.code.match(/createCompilerKeyedArraySlice\(/g)).toHaveLength(4);
+    expect(result.code).toContain("keyedRowsFilterHintedRuntimeFeature");
+  });
+
   it.each([
     {
       name: "an index-sensitive row",
@@ -82,14 +104,24 @@ describe("React AOT keyed-array slice hints", () => {
       update: "{ return current.slice(1); }",
     },
     {
-      name: "a dynamic start",
-      row: "(row) => <li key={row.id}>{row.label}</li>",
-      update: "current.slice(offset)",
-    },
-    {
       name: "a fractional start",
       row: "(row) => <li key={row.id}>{row.label}</li>",
       update: "current.slice(1.5)",
+    },
+    {
+      name: "a bound call",
+      row: "(row) => <li key={row.id}>{row.label}</li>",
+      update: "current.slice(getOffset())",
+    },
+    {
+      name: "a bound assignment",
+      row: "(row) => <li key={row.id}>{row.label}</li>",
+      update: "current.slice(offset = 1)",
+    },
+    {
+      name: "a bound update expression",
+      row: "(row) => <li key={row.id}>{row.label}</li>",
+      update: "current.slice(offset++)",
     },
     {
       name: "an unbounded copy",
@@ -109,7 +141,7 @@ describe("React AOT keyed-array slice hints", () => {
   ])("keeps $name off the slice fast path", async ({ row, update }) => {
     const result = await compile(`
       import { useState } from "react";
-      export function Feed({ offset = 1 }: { offset?: number }) {
+      export function Feed({ offset = 1, getOffset }: { offset?: number; getOffset?: () => number }) {
         const [rows, setRows] = useState([{ id: "a", label: "Alpha" }]);
         return <main>
           <button onClick={() => setRows((current) => ${update})}>Trim</button>

--- a/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-slice-hints.test.tsx
+++ b/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-slice-hints.test.tsx
@@ -165,6 +165,81 @@ function createSliceHarness(initialItems: Item[], readsCollection = false) {
 }
 
 describe("compiled keyed-array slice hints", () => {
+  it("preserves native runtime-bound coercion exactly once and in order", () => {
+    const source = [
+      { id: "a", label: "Alpha" },
+      { id: "b", label: "Beta" },
+      { id: "c", label: "Gamma" },
+      { id: "d", label: "Delta" },
+    ];
+    const coercions: string[] = [];
+    const start = {
+      valueOf() {
+        coercions.push("start");
+        return 1;
+      },
+    };
+    const end = {
+      valueOf() {
+        coercions.push("end");
+        return 3;
+      },
+    };
+
+    const result = createCompilerKeyedArraySlice(
+      source,
+      source.slice,
+      start as unknown as number,
+      end as unknown as number,
+    );
+
+    expect(result).toEqual([source[1], source[2]]);
+    expect(coercions).toEqual(["start", "end"]);
+  });
+
+  it("keeps native results on complete reconciliation for unsafe or no-op runtime bounds", async () => {
+    const harness = createSliceHarness(
+      ["a", "b", "c", "d"].map((id) => ({ id, label: id.toUpperCase() })),
+    );
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Feed />));
+    const b = container.querySelector('[data-key="b"]');
+
+    harness.counters.keyReads = 0;
+    await act(async () => {
+      harness.slice(1.5);
+      await flushCompilerUpdates();
+    });
+
+    expect(container.textContent).toBe("BCD");
+    expect(container.querySelector('[data-key="b"]')).toBe(b);
+    expect(harness.counters.keyReads).toBeGreaterThan(0);
+
+    harness.counters.keyReads = 0;
+    await act(async () => {
+      harness.slice(Number.NaN);
+      await flushCompilerUpdates();
+    });
+
+    expect(container.textContent).toBe("BCD");
+    expect(container.querySelector('[data-key="b"]')).toBe(b);
+    expect(harness.counters.keyReads).toBeGreaterThan(0);
+
+    harness.counters.keyReads = 0;
+    await act(async () => {
+      harness.slice(0);
+      await flushCompilerUpdates();
+    });
+
+    expect(container.textContent).toBe("BCD");
+    expect(container.querySelector('[data-key="b"]')).toBe(b);
+    expect(harness.counters.keyReads).toBeGreaterThan(0);
+    expect(harness.counters.executions).toBe(1);
+  });
+
   it("removes a prefix without reading or rebuilding surviving rows", async () => {
     const initialItems = Array.from(
       { length: 2_048 },
@@ -499,6 +574,76 @@ describe("compiled keyed-array slice hints", () => {
         [...container.querySelectorAll('[data-owner="compiled"] li')].map((row) => row.outerHTML),
       ).toEqual(
         [...container.querySelectorAll('[data-owner="react"] li')].map((row) => row.outerHTML),
+      );
+    }
+    expect(harness.counters.executions).toBe(1);
+  }, 20_000);
+
+  it("matches React through 1,000 randomized runtime-bound slices", async () => {
+    const initialItems = Array.from(
+      { length: 5_000 },
+      (_, index): Item => ({ id: `random-row-${index}`, label: `Random row ${index}` }),
+    );
+    const harness = createSliceHarness(initialItems);
+    let sliceReact: (start: number, end?: number) => void = () => undefined;
+    let seed = 0x51ce;
+    const random = () => {
+      seed = (Math.imul(seed, 1_664_525) + 1_013_904_223) >>> 0;
+      return seed;
+    };
+    function Normal() {
+      const [items, setItems] = useState(initialItems);
+      sliceReact = (start, end) =>
+        setItems((previous) =>
+          end === undefined ? previous.slice(start) : previous.slice(start, end),
+        );
+      return (
+        <ol data-owner="random-react">
+          {items.map((item) => (
+            <li data-key={item.id} key={item.id}>
+              {item.label}
+            </li>
+          ))}
+        </ol>
+      );
+    }
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () =>
+      root.render(
+        <>
+          <div data-owner="random-compiled">
+            <harness.Feed />
+          </div>
+          <Normal />
+        </>,
+      ),
+    );
+
+    for (let batch = 0; batch < 100; batch += 1) {
+      await act(async () => {
+        for (let update = 0; update < 10; update += 1) {
+          const removal = 1 + (random() % 3);
+          if (random() % 2 === 0) {
+            harness.slice(removal);
+            sliceReact(removal);
+          } else {
+            harness.slice(0, -removal);
+            sliceReact(0, -removal);
+          }
+        }
+        await flushCompilerUpdates();
+      });
+      expect(
+        [...container.querySelectorAll('[data-owner="random-compiled"] li')].map(
+          (row) => row.outerHTML,
+        ),
+      ).toEqual(
+        [...container.querySelectorAll('[data-owner="random-react"] li')].map(
+          (row) => row.outerHTML,
+        ),
       );
     }
     expect(harness.counters.executions).toBe(1);

--- a/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-slice-hints.test.tsx
+++ b/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-slice-hints.test.tsx
@@ -622,9 +622,9 @@ describe("compiled keyed-array slice hints", () => {
       ),
     );
 
-    for (let batch = 0; batch < 100; batch += 1) {
+    for (let batch = 0; batch < 20; batch += 1) {
       await act(async () => {
-        for (let update = 0; update < 10; update += 1) {
+        for (let update = 0; update < 50; update += 1) {
           const removal = 1 + (random() % 3);
           if (random() % 2 === 0) {
             harness.slice(removal);
@@ -636,14 +636,8 @@ describe("compiled keyed-array slice hints", () => {
         }
         await flushCompilerUpdates();
       });
-      expect(
-        [...container.querySelectorAll('[data-owner="random-compiled"] li')].map(
-          (row) => row.outerHTML,
-        ),
-      ).toEqual(
-        [...container.querySelectorAll('[data-owner="random-react"] li')].map(
-          (row) => row.outerHTML,
-        ),
+      expect(container.querySelector('[data-owner="random-compiled"]')?.textContent).toBe(
+        container.querySelector('[data-owner="random-react"]')?.textContent,
       );
     }
     expect(harness.counters.executions).toBe(1);

--- a/packages/farm-react/src/compiler.ts
+++ b/packages/farm-react/src/compiler.ts
@@ -1960,6 +1960,7 @@ function rewriteKeyedArraySliceHints(
   hintedStateIndices: ReadonlySet<number>,
   statesBySetter: ReadonlyMap<string, StateBinding>,
   helperIdentifier: t.Identifier,
+  safeGlobals: ReadonlySet<string>,
 ): { root: t.JSXElement; count: number; stateIndices: ReadonlySet<number> } {
   if (hintedStateIndices.size === 0) {
     return { root: t.cloneNode(root, true), count: 0, stateIndices: new Set() };
@@ -1992,14 +1993,13 @@ function rewriteKeyedArraySliceHints(
       ) {
         return;
       }
-      const indexes: number[] = [];
+      const bounds: t.Expression[] = [];
       for (const argument of updater.body.arguments) {
         if (!t.isExpression(argument)) return;
-        const value = staticSliceIndex(argument);
-        if (value === undefined) return;
-        indexes.push(value);
+        if (validateKeyedArrayPositionExpression(argument, safeGlobals) !== undefined) return;
+        bounds.push(argument);
       }
-      if (indexes.length === 1 && indexes[0] === 0) return;
+      if (bounds.length === 1 && staticSliceIndex(bounds[0]) === 0) return;
 
       const previous = t.cloneNode(updater.params[0]);
       const sliceMethod = path.scope.generateUidIdentifier("farmSlice");
@@ -2016,7 +2016,7 @@ function rewriteKeyedArraySliceHints(
             t.callExpression(t.cloneNode(helperIdentifier), [
               t.cloneNode(previous),
               t.cloneNode(sliceMethod),
-              ...indexes.map((value) => t.numericLiteral(value)),
+              ...bounds.map((bound) => t.cloneNode(bound, true)),
             ]),
           ),
         ]),
@@ -7413,6 +7413,7 @@ function compileCandidate(
     shiftedIndexIndependentStateIndices,
     statesBySetter,
     keyedArraySliceIdentifier,
+    safeGlobals,
   );
   let appliedKeyedArraySliceHints = 0;
   let appliedSliceHintedStateIndices: ReadonlySet<number> = new Set();


### PR DESCRIPTION
## Problem

Farm's keyed-array slice fast path only accepted bounds that were safe-integer literals at build time. Real retained-window updates such as `current.slice(trimCount)` and `current.slice(bounds.start, bounds.end)` therefore performed complete keyed reconciliation even though the existing runtime can validate their evaluated bounds and retained interval safely.

## Root cause

The slice-hint rewrite converted every bound through `staticSliceIndex()` and abandoned the optimization when any bound was not a literal. This compiler restriction was narrower than the runtime contract, which already checks the native method, ordinary arrays, raw safe-integer bounds, normalized interval, result length, committed source, and surviving identities before publishing metadata.

## Change

- Validate slice bounds with the existing compiler-safe position-expression rules used by dynamic keyed positions.
- Preserve the original bound expressions in generated code instead of replacing them with numeric literals.
- Keep method lookup before bound evaluation and reuse `createCompilerKeyedArraySlice()` unchanged for native execution and guarded metadata.
- Exercise an event-local `trimCount` in the maintained 10,000/21,000-row production benchmark.
- Document supported expressions, native semantics, runtime validation, fallbacks, compiler reporting, and measured results.
- Add compiler, runtime, no-op/unsafe fallback, native coercion-order, and 1,000-update randomized differential coverage.

## Safety and compatibility

- Scope remains concise functional setters for compiler-owned, index-independent keyed host rows.
- User calls, assignments, update expressions, fractional literals, block-bodied/chained updaters, custom methods, sparse/subclassed arrays, React-owned structures, and failed validation keep complete reconciliation.
- Evaluated bounds must already be safe integers before metadata is recorded. Fractional, `NaN`, non-numeric, and runtime no-op bounds preserve the native result and use complete reconciliation.
- Native method lookup, argument evaluation order, coercion, return values, and errors are preserved.
- The runtime implementation, public API, configuration, compiler-disabled path, and other renderers are unchanged.

## Verification

- `pnpm --filter @farm.js/react exec vitest run --maxWorkers=1` — 621 passed, 3 expected skips across 68 files.
- `pnpm --filter @farm.js/react exec vitest run --config vitest.stress.config.ts --maxWorkers=1` — 3 stress controls passed, 17 expected skips.
- Focused slice suites — 26 passed, including 2,000 queued slices and 1,000 randomized runtime-bound slices against normal React.
- `pnpm --filter @farm.js/react type-check`
- `pnpm --filter @farm.js/react build`
- `pnpm --filter @farm.js/react test:compat` — React 18.3.1 and 19.2.8 passed.
- `pnpm --filter @farm.js/react test:runtime-size` — unchanged: keyed-slice premium 12,222 B gzip; keyed-window premium 14,173 B gzip; compiler-disabled core premium 3,766 B gzip; 82.5% reduction from the full runtime.
- `pnpm --filter farm-react-compiler-dashboard-example type-check`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter farm-react-compiler-dashboard-example build`
- `pnpm docs:check-navigation`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm docs:build`
- Focused `oxfmt`, `oxlint`, and `git diff --check` passed.
- Three complete bracketed production-browser runs all passed correctness, compiler-report, zero-owner-execution, optimization-persistence, scalability, and the unchanged slice gate. The recorded Chrome 152 run measured:

| Mode | React | Runtime bound | Compiled control | vs React | vs control | 21k vs React |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| Static | 64.00 ms | 5.40 ms | 17.10 ms | 11.85x | 3.17x | 13.65x |
| Hybrid | 64.00 ms | 7.00 ms | 18.70 ms | 9.14x | 2.67x | 15.53x |

  Across all three runs the slice path remained 5.82x–13.37x faster than React at 10,000 rows, 9.00x–15.53x at 21,000 rows, and 2.67x–4.64x faster than the compiled control. The aggregate command remained sensitive to unrelated window gates on this shared workstation as background indexing and other test workers spiked; the failing gate varied by run, the affected runtime code is unchanged, and a clean current-main report from earlier the same day passes those gates. No threshold was lowered.

## Documentation and release

Updated the React renderer docs, package README, maintained dashboard example, benchmark description, and benchmark results. No templates, generated routes, versions, or release flow changed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The keyed-array slice fast path now accepts compiler-safe dynamic bounds like `current.slice(trimCount)` and `current.slice(bounds.start, bounds.end)`, instead of only build-time literal integers. Previously these updates fell back to complete keyed reconciliation; now they keep the optimization after runtime validation of the evaluated bounds.

**Safety and compatibility**
- Bounds follow the same compiler-safe position-expression rules as dynamic keyed positions, and generated code preserves the original expressions.
- Evaluated bounds must be safe integers; fractional, `NaN`, no-op, and other unsafe values keep the native result and fall back to complete reconciliation.
- Native method lookup, argument evaluation order, coercion, return values, and errors are unchanged.
- Added compiler, runtime, fallback, coercion-order, and 1,000-update randomized differential coverage, and the maintained benchmark now uses an event-local `trimCount`.

<sup>Written for commit c0886cf81e2194b6911dd07ed4328b683c076f45. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/685?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

