### PR TITLE
test(hmr): make Windows path coverage deterministic

### DIFF
--- a/packages/farm/src/__tests__/windows-hmr-paths.test.ts
+++ b/packages/farm/src/__tests__/windows-hmr-paths.test.ts
@@ -4,6 +4,14 @@ import { describe, expect, it, vi } from "vitest";
 import { farmApiPlugin } from "../api/vite-plugin";
 import { farmPlugin } from "../vite";
 
+const { existsSync } = vi.hoisted(() => ({ existsSync: vi.fn() }));
+
+vi.mock("fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("fs")>();
+  existsSync.mockImplementation(actual.existsSync);
+  return { ...actual, existsSync };
+});
+
 describe("Windows HMR paths", () => {
   it("reloads page modules through the main Farm plugin", async () => {
     const send = vi.fn();
@@ -52,6 +60,7 @@ describe("Windows HMR paths", () => {
   });
 
   it("recognizes file-based API routes through the standalone plugin", async () => {
+    existsSync.mockReturnValueOnce(true);
     const ssrLoadModule = vi.fn(async () => ({ GET: async () => new Response("ok") }));
     const plugin = farmApiPlugin() as any;
 


### PR DESCRIPTION
## Problem

The Windows file-based API HMR regression test uses a synthetic `C:\\project` path. The standalone plugin checks whether that route file still exists before loading it, so the test fails on non-Windows release runs even though its purpose is to exercise Windows path classification.

## Root cause

The test assumed the synthetic absolute path existed and accidentally coupled path normalization coverage to the host filesystem.

## Change

Mock `fs.existsSync` for the single file-based route case while preserving its real implementation for the rest of the test file.

## Safety and compatibility

Test-only change. Runtime HMR and deletion behavior are unchanged.

## Verification

- `pnpm --filter @farm.js/core exec vitest run src/__tests__/windows-hmr-paths.test.ts --reporter=dot`
- `pnpm --filter @farm.js/core type-check`
- `pnpm exec oxlint packages/farm/src/__tests__/windows-hmr-paths.test.ts`

The focused regression fails before this change and passes with it.

## Documentation and release

None.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the Windows HMR regression test deterministic by mocking `fs.existsSync` for the synthetic `C:\project` route path, so the test no longer fails on non-Windows systems. This is a test-only change; runtime HMR and deletion behavior are unchanged.

<sup>Written for commit da9492ba79eb0f85464f466bc7b05f28c1f900f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/686?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

