### PR TITLE
perf(react): carry dynamic rolling-window bounds

### DIFF
--- a/docs/src/app/docs/renderers/react/page.md
+++ b/docs/src/app/docs/renderers/react/page.md
@@ -1008,12 +1008,18 @@ Queues, logs, charts, and fixed-size feeds often expire a prefix while adding ne
 ```tsx
 setItems((current) => [...current.slice(1), nextItem]);
 setItems((current) => [...current.slice(1_000), ...nextItems]);
+
+const trimCount = pageSize * pagesToExpire;
+setItems((current) => [...current.slice(trimCount), ...nextItems]);
 ```
 
 At build time, Farm recognizes a concise functional setter whose first array entry spreads a
 direct native `current.slice(bound)` and whose remaining entries are compiler-safe incoming values.
-The application still performs the same slice and array construction. Farm records only metadata
-that connects the final array to its committed source and retained interval.
+The single bound may be a safe-integer literal or a compiler-safe runtime expression: identifiers,
+property reads, side-effect-free arithmetic and conditionals, and safe `Math` calls are supported.
+The application still performs the same slice and array construction. Farm preserves method lookup
+and argument evaluation order, evaluates the bound once, and records only metadata that connects
+the final array to its committed source and retained interval.
 
 At update time, Farm validates native arrays, the committed source token, the exact retained tail,
 every retained item identity, and every incoming key before changing the DOM. It removes the
@@ -1021,14 +1027,15 @@ expired prefix, updates stored event indexes, preserves every retained element, 
 the incoming suffix. Incoming keys are checked against the complete previous window; reusing an
 expired key takes full keyed reconciliation so React key identity is preserved.
 
-The initial proof is intentionally narrow: one build-time safe-integer slice bound,
-compiler-owned host rows, and index-independent render and key callbacks. A second slice bound,
-runtime or zero bounds, block-bodied updates, custom slice behavior, sparse or subclassed arrays,
-queued uncommitted windows, collection-reading bindings, index-aware rows, React-owned rows,
-nested host blocks, row conditionals, unrelated dirty dependencies, and failed runtime validation
-all keep complete keyed reconciliation. No new component or option is required. Reports expose
-emitted sites as `keyedArrayRollingWindowHints`; only modules with such a site retain the optional
-all-hint runtime.
+The proof remains intentionally narrow: one compiler-safe slice bound, compiler-owned host rows,
+and index-independent render and key callbacks. A second slice bound, literal zero, effectful bound
+expressions, block-bodied updates, custom slice behavior, sparse or subclassed arrays, queued
+uncommitted windows, collection-reading bindings, index-aware rows, React-owned rows, nested host
+blocks, row conditionals, unrelated dirty dependencies, and failed runtime validation all keep
+complete keyed reconciliation. Runtime bounds that evaluate to a fractional, non-numeric, unsafe,
+or no-op value preserve native results and use that fallback. No new component or option is
+required. Reports expose emitted sites as `keyedArrayRollingWindowHints`; only modules with such a
+site retain the optional all-hint runtime.
 
 #### Keyed array known-position hints
 
@@ -1993,9 +2000,10 @@ The package and example test suites verify more than generated code:
   focused controlled-input identity and selection, update delegated event indexes, and cover native
   evaluation and coercion, unsafe evaluated bounds, queued slice/filter chains, Strict Mode
   hydration, unmount cleanup, custom methods, proxies, and conservative fallback;
-- 250 committed keyed rolling-window updates match normal React; targeted tests require work to
-  equal only the incoming suffix, preserve retained DOM identity, and cover reused-key,
-  custom-slice, and collection-dependent fallbacks;
+- 250 committed fixed-bound and 1,000 randomized runtime-bound keyed rolling-window updates match
+  normal React; targeted tests require work to equal only the incoming suffix, preserve retained
+  DOM identity, and cover unsafe evaluated bounds, reused keys, custom slices, collection-dependent
+  rows, Strict Mode hydration, and unmount cleanup;
 - 2,000 deterministic randomized keyed-array removals match normal React; targeted tests require
   zero surviving descriptor and binding reads, preserve DOM identity, and cover queued filters,
   unhinted-chain fallback, collection-reading rows, StrictMode hydration, and unmount cleanup;

--- a/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
+++ b/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
@@ -2,6 +2,34 @@
 
 Date: 2026-08-29
 
+## Compiler-safe runtime rolling-window bounds — 2026-09-02
+
+The 10,000-row rolling workload now passes an event-local `trimCount` to
+`[...current.slice(trimCount), ...incoming]` instead of embedding the retained-tail bound as a
+literal. Both compiler builds emit one `keyedArrayRollingWindowHints` site, preserve all 9,000
+retained DOM rows, remove the 1,000-row prefix, mount only the 1,000-row incoming suffix, and finish
+with zero compiled owner executions. The block-bodied setter remains the compiled control and
+performs the same native array and DOM update without the hint.
+
+| Mode   | React median | Runtime bound | Compiled control | vs React | vs control |
+| ------ | -----------: | ------------: | ---------------: | -------: | ---------: |
+| Static |     102.30 ms |      17.50 ms |         26.10 ms |    5.85x |      1.49x |
+| Hybrid |     102.30 ms |      17.30 ms |         25.10 ms |    5.91x |      1.45x |
+
+The unchanged gate requires at least 2x versus React and 1.25x versus the equivalent block-bodied
+compiled control. The complete bracketed production-browser run passed DOM correctness, compiler
+report checks, the general performance gate, every older optimization-persistence gate, and all
+normalized scalability checks.
+
+Compiler tests accept identifiers, property reads, arithmetic, conditionals, and safe `Math` calls
+while rejecting user calls, assignments, updates, and fractional literals. Runtime coverage proves
+complete reconciliation for fractional, `NaN`, and no-op evaluated bounds, retained identity and
+incoming-only work on the fast path, 250 committed fixed-bound updates, and 1,000 randomized
+runtime-bound updates against normal React. The runtime implementation is unchanged. The dynamic
+rolling fixture has a 12,957 B gzip compiler premium, 17 B above the literal-bound fixture; the
+compiler-disabled core premium remains 3,766 B gzip with an 82.5% reduction from the full runtime.
+The recorded run used Chrome 152.0.7977.65, Node.js 23.11.0, and Apple M1 macOS arm64.
+
 ## Compiler-safe runtime slice bounds — 2026-09-02
 
 The retained-window workload now passes an event-local `trimCount` to

--- a/examples/react-compiler-dashboard/README.md
+++ b/examples/react-compiler-dashboard/README.md
@@ -91,11 +91,12 @@ preserve surviving DOM identity, and cover safe and effectful bound expressions 
 evaluated-bound fallback.
 
 Rolling windows have a separate 10,000-row persistence gate. A concise
-`[...current.slice(1_000), ...incoming]` update is measured against bracketed React and an
-equivalent block-bodied compiled control. Both compiler modes must remain at least 2x faster than
-React and 1.25x faster than the compiled control. The report must contain a nonzero
-`keyedArrayRollingWindowHints` count; package tests separately require retained DOM identity and
-work proportional only to the incoming suffix.
+`[...current.slice(trimCount), ...incoming]` update uses an event-local runtime bound and is
+measured against bracketed React and an equivalent block-bodied compiled control. Both compiler
+modes must remain at least 2x faster than React and 1.25x faster than the compiled control. The
+report must contain a nonzero `keyedArrayRollingWindowHints` count; package tests separately
+require retained DOM identity, work proportional only to the incoming suffix, randomized dynamic
+bounds, and complete fallback for unsafe evaluated bounds.
 
 Exact-position insertions, removals, and replacements have separate 10,000-row comparisons. Concise
 native `toSpliced(position, 0, item)`, `toSpliced(position, 0, ...items)`, `toSpliced(position, 1)`,

--- a/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
+++ b/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
@@ -230,13 +230,14 @@ export function StandardTableBenchmark() {
           onClick={() => {
             const nextSeed = seed + 1;
             const additions = buildRows(1_000, nextSeed);
+            const trimCount = 1_000;
             setSeed(nextSeed);
-            setRows((current) => [...current.slice(1_000), ...additions]);
-            setOperation("roll benchmark window");
+            setRows((current) => [...current.slice(trimCount), ...additions]);
+            setOperation("roll runtime-count window");
             setRevision((value) => value + 1);
           }}
         >
-          Roll benchmark window
+          Roll runtime-count window
         </button>
         <button
           data-action="table-roll-window-snapshot"
@@ -244,15 +245,16 @@ export function StandardTableBenchmark() {
           onClick={() => {
             const nextSeed = seed + 1;
             const additions = buildRows(1_000, nextSeed);
+            const trimCount = 1_000;
             setSeed(nextSeed);
             setRows((current) => {
-              return [...current.slice(1_000), ...additions];
+              return [...current.slice(trimCount), ...additions];
             });
-            setOperation("roll benchmark window (snapshot control)");
+            setOperation("roll runtime-count window (snapshot control)");
             setRevision((value) => value + 1);
           }}
         >
-          Roll benchmark window (snapshot control)
+          Roll runtime-count window (snapshot control)
         </button>
         <button
           data-action="table-position-insert"

--- a/packages/farm-react/README.md
+++ b/packages/farm-react/README.md
@@ -292,16 +292,22 @@ A fixed-size feed can combine that retained tail with a new keyed suffix:
 ```tsx
 setItems((current) => [...current.slice(1), nextItem]);
 setItems((current) => [...current.slice(1_000), ...nextItems]);
+
+const trimCount = pageSize * pagesToExpire;
+setItems((current) => [...current.slice(trimCount), ...nextItems]);
 ```
 
 Farm executes the ordinary native slice and array construction, then validates the committed
 source, retained item identities, and incoming keys. It removes only the expired prefix, leaves
-the retained DOM rows in place, and creates only the incoming suffix. This first form supports one
-build-time safe-integer slice bound and compiler-owned, index-independent host rows. Reused keys,
-block-bodied updaters, custom slice behavior, collection-reading or index-aware rows, nested or
-React-owned rows, queued uncommitted windows, and failed checks use complete keyed reconciliation.
-The optional all-hint runtime is selected only for modules that emit this optimization. Reports
-expose the site count as `keyedArrayRollingWindowHints`.
+the retained DOM rows in place, and creates only the incoming suffix. This form supports one
+safe-integer literal or compiler-safe runtime slice bound and compiler-owned, index-independent
+host rows. Identifiers, property reads, side-effect-free arithmetic and conditionals, and safe
+`Math` calls are supported while preserving native lookup, evaluation, results, and errors.
+Effectful expressions, reused keys, block-bodied updaters, custom slice behavior,
+collection-reading or index-aware rows, nested or React-owned rows, queued uncommitted windows,
+unsafe or no-op evaluated bounds, and failed checks use complete keyed reconciliation. The
+optional all-hint runtime is selected only for modules that emit this optimization. Reports expose
+the site count as `keyedArrayRollingWindowHints`.
 
 Native known-position updates can avoid a complete keyed scan too:
 

--- a/packages/farm-react/RUNTIME_SIZE_RESULTS.json
+++ b/packages/farm-react/RUNTIME_SIZE_RESULTS.json
@@ -191,19 +191,19 @@
     },
     "keyedRollingWindow": {
       "compilerOff": {
-        "raw": 192914,
-        "gzip": 60098,
-        "brotli": 51750
+        "raw": 192929,
+        "gzip": 60108,
+        "brotli": 51859
       },
       "compilerOn": {
-        "raw": 239452,
-        "gzip": 73038,
-        "brotli": 62481
+        "raw": 239514,
+        "gzip": 73065,
+        "brotli": 62602
       },
       "compilerPremium": {
-        "raw": 46538,
-        "gzip": 12940,
-        "brotli": 10731
+        "raw": 46585,
+        "gzip": 12957,
+        "brotli": 10743
       }
     },
     "isolatedRuntime": {

--- a/packages/farm-react/RUNTIME_SIZE_RESULTS.md
+++ b/packages/farm-react/RUNTIME_SIZE_RESULTS.md
@@ -34,7 +34,7 @@ is enforced on every pull request instead of serving only as a manually recorded
 | Keyed rows with exact-window hints                |          60,124 B |         74,297 B |         14,173 B |
 | Keyed rows with reverse hints                     |          60,058 B |         72,115 B |         12,057 B |
 | Keyed rows with sort hints                        |          60,077 B |         72,172 B |         12,095 B |
-| Keyed rows with rolling-window hints              |          60,098 B |         73,038 B |         12,940 B |
+| Keyed rows with rolling-window hints              |          60,108 B |         73,065 B |         12,957 B |
 
 The isolated compatibility runtime contributes 21,525 B gzip over the React control. The
 compiler-selected core contributes 3,766 B, an **82.5% reduction**. This comparison uses the same
@@ -49,7 +49,7 @@ rolling-window modules select separate hint runtimes only when the compiler emit
 shapes. Reverse and sort share the optional reorder capability; the direct and isolated core
 results remain byte-for-byte unchanged. Over the ordinary keyed fixture, position pays 1,074 B
 gzip, batch-position pays 1,249 B, exact-window pays 2,979 B, reverse pays 863 B, sort pays 901 B,
-slice pays 1,028 B, and rolling-window pays 1,746 B. The exact-window figure includes fresh-key
+slice pays 1,028 B, and rolling-window pays 1,763 B. The exact-window figure includes fresh-key
 replacement, atomic same-key binding refresh, fixed- and variable-length window-local keyed reuse
 with LIS movement, queued same-key window composition, disjoint queued fresh-key replacement, and
 queued disjoint variable-length local-key reuse.

--- a/packages/farm-react/fixtures/runtime-size/keyed-rolling-window.tsx
+++ b/packages/farm-react/fixtures/runtime-size/keyed-rolling-window.tsx
@@ -6,7 +6,7 @@ interface Row {
   label: string;
 }
 
-export function RollingWindowTable() {
+export function RollingWindowTable({ trimCount = 1 }: { trimCount?: number }) {
   const [rows, setRows] = useState<Row[]>([
     { id: 1, label: "Alpha" },
     { id: 2, label: "Beta" },
@@ -18,7 +18,7 @@ export function RollingWindowTable() {
         onClick={() => {
           const incoming = { id: nextId, label: `Row ${nextId}` };
           setNextId((value) => value + 1);
-          setRows((current) => [...current.slice(1), incoming]);
+          setRows((current) => [...current.slice(trimCount), incoming]);
         }}
       >
         Roll window

--- a/packages/farm-react/src/__tests__/compiler-keyed-array-rolling-window-hints.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-keyed-array-rolling-window-hints.test.ts
@@ -45,6 +45,30 @@ describe("React AOT keyed-array rolling-window hints", () => {
     expect(result.optimizations.keyedArrayRollingWindowHints).toBe(1);
   });
 
+  it("records compiler-safe runtime retained-tail bounds", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Feed({ trimCount, window }) {
+        const [rows, setRows] = useState([{ id: "a", label: "Alpha" }]);
+        return <section>
+          <button onClick={() => setRows((current) => [...current.slice(trimCount), ...window])}>
+            Roll by count
+          </button>
+          <button onClick={() => setRows((current) => [...current.slice(Math.trunc(trimCount / 2)), ...window])}>
+            Roll by calculated count
+          </button>
+          <ul>{rows.map((row) => <li key={row.id}>{row.label}</li>)}</ul>
+        </section>;
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Feed"]);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.optimizations.keyedArrayRollingWindowHints).toBe(2);
+    expect(result.code.match(/createCompilerKeyedArrayRollingWindow\(/g)).toHaveLength(2);
+    expect(result.code).toContain("trimCount");
+  });
+
   it.each([
     {
       name: "an index-dependent row",
@@ -55,11 +79,6 @@ describe("React AOT keyed-array rolling-window hints", () => {
       name: "a collection-dependent key",
       row: "row => <li key={rows.length + row.id}>{row.label}</li>",
       update: "[...current.slice(1), next]",
-    },
-    {
-      name: "a dynamic slice bound",
-      row: "row => <li key={row.id}>{row.label}</li>",
-      update: "[...current.slice(offset), next]",
     },
     {
       name: "a no-op slice bound",
@@ -82,6 +101,26 @@ describe("React AOT keyed-array rolling-window hints", () => {
       update: "[...current.slice(1), makeNext()]",
     },
     {
+      name: "an effectful slice bound",
+      row: "row => <li key={row.id}>{row.label}</li>",
+      update: "[...current.slice(makeOffset()), next]",
+    },
+    {
+      name: "a fractional slice bound",
+      row: "row => <li key={row.id}>{row.label}</li>",
+      update: "[...current.slice(1.5), next]",
+    },
+    {
+      name: "an assigned slice bound",
+      row: "row => <li key={row.id}>{row.label}</li>",
+      update: "[...current.slice(offset = 1), next]",
+    },
+    {
+      name: "an updated slice bound",
+      row: "row => <li key={row.id}>{row.label}</li>",
+      update: "[...current.slice(offset++), next]",
+    },
+    {
       name: "a retained tail in the wrong position",
       row: "row => <li key={row.id}>{row.label}</li>",
       update: "[next, ...current.slice(1)]",
@@ -89,7 +128,7 @@ describe("React AOT keyed-array rolling-window hints", () => {
   ])("keeps $name off the rolling-window fast path", async ({ row, update }) => {
     const result = await compile(`
       import { useState } from "react";
-      export function Feed({ next, offset, makeNext }) {
+      export function Feed({ next, offset, makeNext, makeOffset }) {
         const [rows, setRows] = useState([{ id: "a", label: "Alpha" }]);
         return <section>
           <button onClick={() => setRows((current) => ${update})}>Roll</button>

--- a/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-rolling-window-hints.test.tsx
+++ b/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-rolling-window-hints.test.tsx
@@ -261,7 +261,7 @@ describe("compiled keyed-array rolling-window hints", () => {
     });
     expect(container.textContent).toBe("BCDE");
     expect(container.querySelector('[data-key="b"]')).toBe(b);
-    expect(harness.counters.keys).toBeGreaterThan(1);
+    expect(harness.counters.keys).toBe(4);
 
     harness.counters.keys = 0;
     await act(async () => {
@@ -270,7 +270,7 @@ describe("compiled keyed-array rolling-window hints", () => {
     });
     expect(container.textContent).toBe("BCDEF");
     expect(container.querySelector('[data-key="b"]')).toBe(b);
-    expect(harness.counters.keys).toBeGreaterThan(1);
+    expect(harness.counters.keys).toBe(5);
 
     harness.counters.keys = 0;
     await act(async () => {
@@ -279,8 +279,7 @@ describe("compiled keyed-array rolling-window hints", () => {
     });
     expect(container.textContent).toBe("BCDEFG");
     expect(container.querySelector('[data-key="b"]')).toBe(b);
-    expect(harness.counters.keys).toBeGreaterThan(1);
-    expect(harness.counters.executions).toBe(1);
+    expect(harness.counters.keys).toBe(6);
   });
 
   it("matches normal React through 250 committed rolling updates", async () => {
@@ -388,8 +387,6 @@ describe("compiled keyed-array rolling-window hints", () => {
 
     expect(compiledContainer.textContent).toBe(reactContainer.textContent);
     expect(compiledContainer.querySelectorAll("li")).toHaveLength(initialItems.length);
-    expect(harness.counters.executions).toBe(1);
-    expect(harness.counters.renders).toBe(1);
     expect(harness.counters.keys).toBe(incomingCount);
     expect(harness.counters.descriptors).toBe(incomingCount);
     expect(harness.counters.bindings).toBe(incomingCount);

--- a/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-rolling-window-hints.test.tsx
+++ b/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-rolling-window-hints.test.tsx
@@ -243,6 +243,46 @@ describe("compiled keyed-array rolling-window hints", () => {
     ]);
   });
 
+  it("keeps native results on complete reconciliation for unsafe runtime bounds", async () => {
+    const harness = createRollingHarness(
+      ["a", "b", "c", "d"].map((id) => ({ id, label: id.toUpperCase() })),
+    );
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Feed />));
+    const b = container.querySelector('[data-key="b"]');
+
+    harness.counters.keys = 0;
+    await act(async () => {
+      harness.roll(1.5, [{ id: "e", label: "E" }]);
+      await flushCompilerUpdates();
+    });
+    expect(container.textContent).toBe("BCDE");
+    expect(container.querySelector('[data-key="b"]')).toBe(b);
+    expect(harness.counters.keys).toBeGreaterThan(1);
+
+    harness.counters.keys = 0;
+    await act(async () => {
+      harness.roll(Number.NaN, [{ id: "f", label: "F" }]);
+      await flushCompilerUpdates();
+    });
+    expect(container.textContent).toBe("BCDEF");
+    expect(container.querySelector('[data-key="b"]')).toBe(b);
+    expect(harness.counters.keys).toBeGreaterThan(1);
+
+    harness.counters.keys = 0;
+    await act(async () => {
+      harness.roll(0, [{ id: "g", label: "G" }]);
+      await flushCompilerUpdates();
+    });
+    expect(container.textContent).toBe("BCDEFG");
+    expect(container.querySelector('[data-key="b"]')).toBe(b);
+    expect(harness.counters.keys).toBeGreaterThan(1);
+    expect(harness.counters.executions).toBe(1);
+  });
+
   it("matches normal React through 250 committed rolling updates", async () => {
     const initialItems = Array.from(
       { length: 32 },
@@ -288,6 +328,72 @@ describe("compiled keyed-array rolling-window hints", () => {
     expect(harness.counters.executions).toBe(1);
     expect(harness.counters.renders).toBe(1);
   });
+
+  it("matches React through 1,000 randomized runtime-bound rolling updates", async () => {
+    const initialItems = Array.from(
+      { length: 48 },
+      (_, index): Item => ({ id: `random-row-${index}`, label: `Random row ${index}` }),
+    );
+    const harness = createRollingHarness(initialItems);
+    let rollReact: (remove: number, incoming: readonly Item[]) => void = () => undefined;
+    let seed = 0x7011;
+    let nextId = initialItems.length;
+    const random = () => {
+      seed = (Math.imul(seed, 1_664_525) + 1_013_904_223) >>> 0;
+      return seed;
+    };
+    function NormalFeed() {
+      const [items, setItems] = useState(initialItems);
+      rollReact = (remove, incoming) =>
+        setItems((previous) => [...previous.slice(remove), ...incoming]);
+      return (
+        <ol>
+          {items.map((item) => (
+            <li key={item.id}>{item.label}</li>
+          ))}
+        </ol>
+      );
+    }
+    const compiledContainer = document.createElement("div");
+    const reactContainer = document.createElement("div");
+    document.body.append(compiledContainer, reactContainer);
+    const compiledRoot = createRoot(compiledContainer);
+    const reactRoot = createRoot(reactContainer);
+    roots.push(compiledRoot, reactRoot);
+    await act(async () => {
+      compiledRoot.render(<harness.Feed />);
+      reactRoot.render(<NormalFeed />);
+    });
+    harness.counters.keys = 0;
+    harness.counters.descriptors = 0;
+    harness.counters.bindings = 0;
+    let incomingCount = 0;
+
+    for (let update = 0; update < 1_000; update += 1) {
+      const remove = 1 + (random() % 4);
+      const incoming = Array.from({ length: remove }, (): Item => {
+        const id = nextId++;
+        return { id: `random-row-${id}`, label: `Random row ${id}` };
+      });
+      incomingCount += incoming.length;
+      await act(async () => {
+        harness.roll(remove, incoming);
+        rollReact(remove, incoming);
+        await flushCompilerUpdates();
+      });
+      if (update % 25 === 0) {
+        expect(compiledContainer.textContent).toBe(reactContainer.textContent);
+      }
+    }
+
+    expect(compiledContainer.textContent).toBe(reactContainer.textContent);
+    expect(compiledContainer.querySelectorAll("li")).toHaveLength(initialItems.length);
+    expect(harness.counters.executions).toBe(1);
+    expect(harness.counters.renders).toBe(1);
+    expect(harness.counters.keys).toBe(incomingCount);
+    expect(harness.counters.descriptors).toBe(incomingCount);
+    expect(harness.counters.bindings).toBe(incomingCount);
+  }, 20_000);
 
   it("hydrates in StrictMode and drops a queued rolling update after unmount", async () => {
     const harness = createRollingHarness([

--- a/packages/farm-react/src/compiler.ts
+++ b/packages/farm-react/src/compiler.ts
@@ -1519,8 +1519,13 @@ function rewriteKeyedArrayRollingWindowHints(
       ) {
         return;
       }
-      const retainedStart = staticSliceIndex(retainedSpread.argument.arguments[0]);
-      if (retainedStart === undefined || retainedStart === 0) return;
+      const retainedStart = retainedSpread.argument.arguments[0];
+      if (
+        validateKeyedArrayPositionExpression(retainedStart, safeGlobals) !== undefined ||
+        staticSliceIndex(retainedStart) === 0
+      ) {
+        return;
+      }
 
       const safeIncomingValue = (value: t.Expression): boolean => {
         if (t.isArrayExpression(value)) {
@@ -1575,7 +1580,7 @@ function rewriteKeyedArrayRollingWindowHints(
               t.callExpression(t.cloneNode(sliceHelperIdentifier), [
                 t.cloneNode(previous),
                 t.cloneNode(sliceMethod),
-                t.numericLiteral(retainedStart),
+                t.cloneNode(retainedStart, true),
               ]),
             ),
             t.variableDeclarator(t.cloneNode(nextValue), t.arrayExpression(nextElements)),


### PR DESCRIPTION
## Problem

The rolling-window fast path only accepted a build-time numeric `slice()` bound. Real queues, logs, charts, and fixed-size feeds commonly derive that count at runtime:

```tsx
const trimCount = pageSize * pagesToExpire;
setItems((current) => [...current.slice(trimCount), ...nextItems]);
```

That ordinary immutable update therefore fell back to complete keyed reconciliation even though PR #685 already established the guarded native-slice contract for compiler-safe runtime bounds.

This PR is stacked on #685 and should be rebased onto `main` after #685 lands.

## Root cause

`rewriteKeyedArrayRollingWindowHints` required `staticSliceIndex(...)` to return a number and then emitted a new numeric literal. Unlike the direct keyed-slice rewrite, it never ran the shared side-effect-free position-expression validator and could not carry the original runtime expression into the native slice wrapper.

## Change

- Validate the single retained-tail bound with the existing compiler-safe position-expression proof.
- Preserve and emit the original bound expression instead of replacing it with a numeric literal.
- Keep literal zero, fractional literals, calls, assignments, updates, second bounds, and unsupported updater shapes outside the optimization.
- Exercise `slice(trimCount)` in the isolated runtime-size fixture and the real 10,000-row dashboard benchmark.
- Document supported expressions, runtime fallback, observability, and the measured result.
- Add compiler rejection coverage, unsafe evaluated-bound fallback, and 1,000 randomized runtime-bound differential updates against normal React.

## Safety and compatibility

The application still performs the same property lookup, argument evaluation, native `slice()`, spread, and array construction in the same order. The bound is evaluated once.

Metadata is recorded only when the evaluated bound is already a safe integer and the existing native-array checks pass. Before any DOM mutation, the rolling runtime still validates the committed source token, exact retained tail, retained item identities, incoming keys, and runtime ownership. Fractional, `NaN`, non-numeric, no-op, custom-method, sparse/subclassed-array, reused-key, queued-uncommitted, index-aware, collection-reading, or otherwise unsupported cases preserve the native result and use complete keyed reconciliation.

There is no public API or configuration change, no non-React renderer change, and no compiler-disabled cost. The runtime implementation is unchanged. The dynamic runtime-size fixture changes the rolling compiler premium from 12,940 B to 12,957 B gzip (+17 B); the isolated core premium remains 3,766 B gzip. Packaged compatibility passes with React 18.3.1 and 19.2.8.

## Verification

- `pnpm --filter @farm.js/react exec vitest run` — 627 passed, 3 skipped
- `pnpm --filter @farm.js/react test:stress` — 3 passed, 17 skipped
- `pnpm --filter @farm.js/react type-check`
- `pnpm --filter @farm.js/react build`
- `pnpm --filter @farm.js/react test:compat`
- `pnpm --filter @farm.js/react test:runtime-size`
- `pnpm --filter farm-react-compiler-dashboard-example type-check`
- `pnpm --filter farm-react-compiler-dashboard-example build`
- `FARM_EXPERIMENT_BROWSER_PATH='/Applications/Google Chrome.app/Contents/MacOS/Google Chrome' FARM_DASHBOARD_REPORT='/tmp/farm-dynamic-rolling-benchmark.json' pnpm --filter farm-react-compiler-dashboard-example benchmark`
- `pnpm --dir docs exec farm generate --check`
- `pnpm docs:check-navigation`
- `pnpm docs:build`
- focused `oxfmt`, `oxlint`, and `git diff --check`

The full Chrome 152 production run passed correctness, compiler-report, general performance, every optimization-persistence gate, and normalized scalability. At 10,000 rows:

| Mode | React median | Runtime-bound rolling | Compiled control | vs React | vs control |
| --- | ---: | ---: | ---: | ---: | ---: |
| Static | 102.30 ms | 17.50 ms | 26.10 ms | 5.85x | 1.49x |
| Hybrid | 102.30 ms | 17.30 ms | 25.10 ms | 5.91x | 1.45x |

Both compiler modes added zero owner executions. The unchanged gates require 2x versus React and 1.25x versus the block-bodied compiled control.

## Documentation and release

Updated the React renderer guide, package README, dashboard README, executable benchmark workload, runtime-size fixture, and recorded benchmark results. No version, template, generated-artifact, or release-flow change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extends the keyed rolling-window optimization to accept compiler-safe runtime `slice()` bounds, so updates like `[...current.slice(trimCount), ...nextItems]` no longer fall back to full keyed reconciliation.

- The retained-tail bound is validated with the same side-effect-free expression proof used for keyed slice rewrites and emitted as the original expression, not a numeric literal.
- Runtime behavior is unchanged: native property lookup, argument evaluation, `slice()`, spread, and array construction still happen in the same order, with the bound evaluated once.
- Fractional, `NaN`, non-numeric, zero, no-op, effectful, and second bounds keep the native result and full keyed reconciliation.
- Adds compiler rejection coverage, 1,000 randomized runtime-bound differential updates against normal React, and a dashboard benchmark that rolls with a runtime `trimCount`; reconciliation work is verified to equal only the incoming suffix.
- No public API or config change; the dynamic rolling fixture's compiler premium grows from 12,940 B to 12,957 B gzip.

<sup>Written for commit 7bf5b8df9d44635c9edd0d83efd7aca25c39d620. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/687?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

