### PR TITLE
fix(api-client): isolate authenticated response caches

### DIFF
--- a/docs/src/app/docs/api-client/page.md
+++ b/docs/src/app/docs/api-client/page.md
@@ -289,7 +289,12 @@ const product = await api.products.get(
 );
 ```
 
-Structured keys use Farm's route-data key contract. Default API cache keys include the API origin and remain isolated from other clients.
+Structured keys use Farm's route-data key contract. Default API cache keys include the API origin.
+Clients that configure headers or non-default credentials keep their cache private to that client,
+and changing that request context clears the private cache. This prevents an authenticated response
+from being reused by a client with a different identity without placing credential values in a
+public cache key. Clients using the default same-origin request context can still share structured
+keys with Farm's route-data cache.
 
 Set `cache.dedupeMs` to join identical requests started within that window. If an older request is
 still running after the window expires, the newer request becomes the cache owner; the older result

--- a/packages/farm/src/__tests__/api-client.test.ts
+++ b/packages/farm/src/__tests__/api-client.test.ts
@@ -392,6 +392,36 @@ describe("createAPIClient", () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
+  it("isolates credentialed caches between client instances", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(buildResponse({ users: [{ id: "a" }], total: 1, limit: 5, offset: 0 }))
+      .mockResolvedValueOnce(
+        buildResponse({ users: [{ id: "b" }], total: 1, limit: 5, offset: 0 }),
+      );
+    globalThis.fetch = fetchMock as any;
+    const first = createAPIClient<APIRouter>({
+      baseURL: "http://example.com",
+      credentials: "include",
+    });
+    const second = createAPIClient<APIRouter>({
+      baseURL: "http://example.com",
+      credentials: "include",
+    });
+    const cache = { policy: "cache-first" as const, staleTime: 10_000 };
+
+    const firstResult = await first.users.get({}, { cache });
+    const secondResult = await second.users.get({}, { cache });
+    const cachedFirst = await first.users.get({}, { cache });
+    const cachedSecond = await second.users.get({}, { cache });
+
+    expect(firstResult.data?.users[0]?.id).toBe("a");
+    expect(secondResult.data?.users[0]?.id).toBe("b");
+    expect(cachedFirst.data?.users[0]?.id).toBe("a");
+    expect(cachedSecond.data?.users[0]?.id).toBe("b");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
   it("drops a client cache when its request context changes", async () => {
     const headers = { Authorization: "Bearer user-a" };
     const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
@@ -409,6 +439,66 @@ describe("createAPIClient", () => {
     expect(first.data).toEqual({ user: "Bearer user-a" });
     expect(second.data).toEqual({ user: "Bearer user-b" });
     expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not dedupe a new request context against an older in-flight request", async () => {
+    const headers = { Authorization: "Bearer user-a" };
+    const firstResponse = createDeferred<ReturnType<typeof buildResponse>>();
+    const secondResponse = createDeferred<ReturnType<typeof buildResponse>>();
+    const fetchMock = vi
+      .fn()
+      .mockImplementationOnce(() => firstResponse.promise)
+      .mockImplementationOnce(() => secondResponse.promise);
+    globalThis.fetch = fetchMock as any;
+    const api = createAPIClient<APIRouter>({ baseURL: "http://example.com", headers });
+    const cache = { policy: "cache-first" as const, staleTime: 10_000, dedupeMs: 10_000 };
+
+    const first = api.users.get({}, { cache });
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    headers.Authorization = "Bearer user-b";
+    const second = api.users.get({}, { cache });
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+
+    secondResponse.resolve(buildResponse({ users: [{ id: "b" }], total: 1, limit: 5, offset: 0 }));
+    await expect(second).resolves.toMatchObject({ data: { users: [{ id: "b" }] } });
+    await expect(api.users.get({}, { cache })).resolves.toMatchObject({
+      data: { users: [{ id: "b" }] },
+    });
+
+    firstResponse.resolve(buildResponse({ users: [{ id: "a" }], total: 1, limit: 5, offset: 0 }));
+    await expect(first).resolves.toMatchObject({ data: { users: [{ id: "a" }] } });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("reports malformed cache-context headers through the result lifecycle", async () => {
+    const fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as any;
+    const onRequest = vi.fn();
+    const onResponse = vi.fn();
+    const onError = vi.fn();
+    const onSettled = vi.fn();
+    const api = createAPIClient<APIRouter>({
+      baseURL: "http://example.com",
+      headers: { "invalid\nheader": "value" },
+    });
+
+    const result = await api.users.get(
+      {},
+      {
+        cache: { policy: "cache-first", staleTime: 10_000 },
+        onRequest,
+        onResponse,
+        onError,
+        onSettled,
+      },
+    );
+
+    expect(result.error).toMatchObject({ code: "network_error", status: 0 });
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(onRequest).toHaveBeenCalledTimes(1);
+    expect(onResponse).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onSettled).toHaveBeenCalledTimes(1);
   });
 
   it("uses defined structured keys directly for optimistic updates and invalidation", async () => {

--- a/packages/farm/src/__tests__/api-client.test.ts
+++ b/packages/farm/src/__tests__/api-client.test.ts
@@ -367,6 +367,50 @@ describe("createAPIClient", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
+  it("isolates cached responses between clients with different request contexts", async () => {
+    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+      const authorization = (init?.headers as Record<string, string>)?.Authorization;
+      return buildResponse({ user: authorization });
+    });
+    globalThis.fetch = fetchMock as any;
+
+    const first = createAPIClient<APIRouter>({
+      baseURL: "http://example.com",
+      headers: { Authorization: "Bearer user-a" },
+    });
+    const second = createAPIClient<APIRouter>({
+      baseURL: "http://example.com",
+      headers: { Authorization: "Bearer user-b" },
+    });
+    const cache = { policy: "cache-first" as const, staleTime: 10_000 };
+
+    const firstResult = await first.users.get({}, { cache });
+    const secondResult = await second.users.get({}, { cache });
+
+    expect(firstResult.data).toEqual({ user: "Bearer user-a" });
+    expect(secondResult.data).toEqual({ user: "Bearer user-b" });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("drops a client cache when its request context changes", async () => {
+    const headers = { Authorization: "Bearer user-a" };
+    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+      const authorization = (init?.headers as Record<string, string>)?.Authorization;
+      return buildResponse({ user: authorization });
+    });
+    globalThis.fetch = fetchMock as any;
+    const api = createAPIClient<APIRouter>({ baseURL: "http://example.com", headers });
+    const cache = { policy: "cache-first" as const, staleTime: 10_000 };
+
+    const first = await api.users.get({}, { cache });
+    headers.Authorization = "Bearer user-b";
+    const second = await api.users.get({}, { cache });
+
+    expect(first.data).toEqual({ user: "Bearer user-a" });
+    expect(second.data).toEqual({ user: "Bearer user-b" });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
   it("uses defined structured keys directly for optimistic updates and invalidation", async () => {
     let getCount = 0;
     const mutationResponse = createDeferred<any>();

--- a/packages/farm/src/__tests__/client-cache.test.ts
+++ b/packages/farm/src/__tests__/client-cache.test.ts
@@ -1,6 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createRouteDataCacheKey } from "../cache";
-import { getFarmClientDataCache, normalizeFarmClientCacheKey } from "../client-cache";
+import {
+  FarmClientDataCache,
+  getFarmClientDataCache,
+  normalizeFarmClientCacheKey,
+} from "../client-cache";
 import { notifyFarmCacheInvalidation } from "../cache-invalidation";
 
 describe("Farm client data cache", () => {
@@ -31,6 +35,20 @@ describe("Farm client data cache", () => {
     expect(cache.get(key)?.invalidatedAt).toEqual(expect.any(Number));
     expect(listener).toHaveBeenCalledTimes(2);
     unsubscribe();
+  });
+
+  it("unsubscribes disposed cache instances from shared invalidations", () => {
+    const cache = new FarmClientDataCache();
+    cache.dispose();
+    cache.set("private", {
+      data: { id: "private" },
+      updatedAt: 1,
+      staleAt: Number.POSITIVE_INFINITY,
+    });
+
+    notifyFarmCacheInvalidation("private");
+
+    expect(cache.isStale("private")).toBe(false);
   });
 
   it("resolves aliases to one cache entry", () => {

--- a/packages/farm/src/api/client.ts
+++ b/packages/farm/src/api/client.ts
@@ -7,11 +7,11 @@ import {
   type IntegrationServerClientRoot,
 } from "../integration-client";
 import {
+  FarmClientDataCache,
   getFarmClientDataCache,
   normalizeFarmClientCacheKey,
   type FarmClientCacheEntry,
   type FarmClientCacheKey,
-  type FarmClientDataCache,
 } from "../client-cache";
 import {
   applyFarmCacheInvalidations,
@@ -440,7 +440,9 @@ export function createAPIClient<
           integrations: integrationsClient<TIntegrations>(integrationOptions),
         };
 
-  const cacheState = getFarmClientDataCache();
+  const sharedCacheState = getFarmClientDataCache();
+  let scopedCacheState: FarmClientDataCache | undefined;
+  let scopedCacheContext: string | undefined;
   const inflightState = new Map<string, InflightEntry>();
   const routeMeta = new WeakMap<AnyRouteRef, RouteMeta>();
   let requestCounter = 0;
@@ -499,6 +501,17 @@ export function createAPIClient<
     input: any = {},
     clientOptions?: ClientOptions<any, any>,
   ): Promise<APIResult<any, Error>> => {
+    const requestCacheContext = getRequestCacheContext(options, input);
+    let cacheState = sharedCacheState;
+    if (requestCacheContext !== undefined) {
+      scopedCacheState ??= new FarmClientDataCache();
+      if (scopedCacheContext !== requestCacheContext) {
+        scopedCacheState.clear();
+        scopedCacheContext = requestCacheContext;
+      }
+      cacheState = scopedCacheState;
+    }
+
     const methodUpper = method.toUpperCase() as StatusEvent["method"];
     const requestId = `${Date.now()}-${++requestCounter}`;
     const cacheOptions = clientOptions?.cache
@@ -1139,6 +1152,27 @@ function getHeader(headers: unknown, name: string): string | undefined {
 
   const entry = Object.entries(headers).find(([key]) => key.toLowerCase() === name);
   return entry?.[1] === undefined ? undefined : String(entry[1]);
+}
+
+function getRequestCacheContext(
+  options: Pick<APIClientOptions, "headers" | "credentials">,
+  input: unknown,
+): string | undefined {
+  const credentials = options.credentials ?? "same-origin";
+  const headers = new Headers(options.headers);
+  const requestHeaders =
+    input && typeof input === "object" && "headers" in input ? input.headers : undefined;
+
+  if (requestHeaders) {
+    new Headers(requestHeaders as HeadersInit).forEach((value, key) => headers.set(key, value));
+  }
+
+  if (credentials === "same-origin" && [...headers].length === 0) return undefined;
+
+  return stableStringify({
+    credentials,
+    headers: [...headers].sort(([left], [right]) => left.localeCompare(right)),
+  });
 }
 
 function getGcAt(now: number, gcTime?: number): number | undefined {

--- a/packages/farm/src/api/client.ts
+++ b/packages/farm/src/api/client.ts
@@ -441,9 +441,8 @@ export function createAPIClient<
         };
 
   const sharedCacheState = getFarmClientDataCache();
-  let scopedCacheState: FarmClientDataCache | undefined;
-  let scopedCacheContext: string | undefined;
-  const inflightState = new Map<string, InflightEntry>();
+  const sharedInflightState = new Map<string, InflightEntry>();
+  let scopedRequestState: ScopedRequestState | undefined;
   const routeMeta = new WeakMap<AnyRouteRef, RouteMeta>();
   let requestCounter = 0;
 
@@ -501,17 +500,6 @@ export function createAPIClient<
     input: any = {},
     clientOptions?: ClientOptions<any, any>,
   ): Promise<APIResult<any, Error>> => {
-    const requestCacheContext = getRequestCacheContext(options, input);
-    let cacheState = sharedCacheState;
-    if (requestCacheContext !== undefined) {
-      scopedCacheState ??= new FarmClientDataCache();
-      if (scopedCacheContext !== requestCacheContext) {
-        scopedCacheState.clear();
-        scopedCacheContext = requestCacheContext;
-      }
-      cacheState = scopedCacheState;
-    }
-
     const methodUpper = method.toUpperCase() as StatusEvent["method"];
     const requestId = `${Date.now()}-${++requestCounter}`;
     const cacheOptions = clientOptions?.cache
@@ -538,7 +526,6 @@ export function createAPIClient<
       });
     };
 
-    const entry = getValidCacheEntry(cacheState, cacheKey, now);
     const policy = cacheOptions?.policy ?? (cacheOptions ? "cache-first" : "network-only");
     const staleTime = cacheOptions?.staleTime ?? 0;
     const hasReliableDefaultCacheKey =
@@ -547,6 +534,42 @@ export function createAPIClient<
       Boolean(cacheOptions) &&
       (methodUpper === "GET" || methodUpper === "QUERY") &&
       hasReliableDefaultCacheKey;
+    const needsCacheState =
+      isCacheEnabled ||
+      Boolean(clientOptions?.optimistic?.update?.length) ||
+      Boolean(clientOptions?.invalidate);
+    let requestCacheContext: string | undefined;
+    let requestContextError: Error | undefined;
+    if (needsCacheState) {
+      try {
+        requestCacheContext = getRequestCacheContext(options, input);
+      } catch (error) {
+        requestCacheContext = `invalid:${requestId}`;
+        requestContextError = normalizeError(error);
+      }
+    }
+
+    let cacheState = sharedCacheState;
+    let inflightState = sharedInflightState;
+    let requestScopedState: ScopedRequestState | undefined;
+    if (requestCacheContext !== undefined) {
+      if (scopedRequestState && scopedRequestState.context !== requestCacheContext) {
+        scopedRequestState.retired = true;
+        if (scopedRequestState.inflight.size === 0) scopedRequestState.cache.dispose();
+        scopedRequestState = undefined;
+      }
+      scopedRequestState ??= {
+        context: requestCacheContext,
+        cache: new FarmClientDataCache(),
+        inflight: new Map(),
+        retired: false,
+      };
+      requestScopedState = scopedRequestState;
+      cacheState = requestScopedState.cache;
+      inflightState = requestScopedState.inflight;
+    }
+
+    const entry = getValidCacheEntry(cacheState, cacheKey, now);
     const isStale = entry ? isEntryStale(entry, now) : true;
 
     const applyOptimisticUpdates = () => {
@@ -647,6 +670,7 @@ export function createAPIClient<
           });
 
           try {
+            if (requestContextError) throw requestContextError;
             const { response, data } = await fetchClient(path, {
               ...input,
               method: methodUpper,
@@ -749,6 +773,13 @@ export function createAPIClient<
       } finally {
         if (inflightState.get(cacheKey) === inflightEntry) {
           inflightState.delete(cacheKey);
+        }
+        if (requestContextError && requestScopedState) {
+          requestScopedState.retired = true;
+          if (scopedRequestState === requestScopedState) scopedRequestState = undefined;
+        }
+        if (requestScopedState?.retired && requestScopedState.inflight.size === 0) {
+          requestScopedState.cache.dispose();
         }
       }
     };
@@ -1084,6 +1115,13 @@ type CacheEntry = FarmClientCacheEntry<any>;
 type InflightEntry = {
   promise: Promise<APIResult<any, Error>>;
   startedAt: number;
+};
+
+type ScopedRequestState = {
+  context: string;
+  cache: FarmClientDataCache;
+  inflight: Map<string, InflightEntry>;
+  retired: boolean;
 };
 
 type RouteMeta = {

--- a/packages/farm/src/client-cache.ts
+++ b/packages/farm/src/client-cache.ts
@@ -24,9 +24,10 @@ export class FarmClientDataCache {
   private invalidatedAt = new Map<string, number>();
   private listeners = new Map<string, Set<FarmClientCacheListener>>();
   private inflight = new Map<string, Promise<unknown>>();
+  private unsubscribeInvalidation: (() => void) | undefined;
 
   constructor() {
-    subscribeFarmCacheInvalidation((key) => this.invalidate(key));
+    this.unsubscribeInvalidation = subscribeFarmCacheInvalidation((key) => this.invalidate(key));
   }
 
   get size(): number {
@@ -91,6 +92,12 @@ export class FarmClientDataCache {
     this.invalidatedAt.clear();
     this.inflight.clear();
     for (const key of keys) this.emit(key);
+  }
+
+  dispose(): void {
+    this.unsubscribeInvalidation?.();
+    this.unsubscribeInvalidation = undefined;
+    this.clear();
   }
 
   isStale(key: string, now = Date.now()): boolean {


### PR DESCRIPTION
## Problem

API clients using the shared cache could reuse a response produced with another client's headers when the method, URL, and input matched. This could surface data from the wrong authenticated request context.

## Root cause

The cache key intentionally excludes header values, but every client used the same global data cache. Nothing separated clients configured with different headers or credential modes.

## Change

Clients with configured headers or non-default credentials now use a private cache. If that client's effective request headers change, Farm clears the private cache before reading it. Default same-origin clients still use the shared cache and keep route-data interoperability.

## Safety and compatibility

Credential values are not placed in public cache keys. Existing unauthenticated structured-key sharing is preserved. Request-context caches still receive Farm cache-invalidation events.

## Verification

- `pnpm --filter @farm.js/core exec vitest run src/__tests__/api-client.test.ts`
- `pnpm --filter @farm.js/core type-check`
- `pnpm exec oxfmt packages/farm/src/api/client.ts packages/farm/src/__tests__/api-client.test.ts docs/src/app/docs/api-client/page.md`
- `pnpm exec oxlint packages/farm/src/api/client.ts packages/farm/src/__tests__/api-client.test.ts` (passes with one pre-existing unused-parameter warning elsewhere in the test file)

The new regression tests reproduce cross-client cache reuse and same-client identity changes before the fix.

## Documentation and release

Updated the API client caching documentation. No manual release changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
API clients no longer reuse cached responses across different authenticated request contexts. Previously, all clients shared a cache when the method, URL, and input matched; now clients with configured headers or non-default credentials use a private cache, and changing the effective request context clears it. Default same-origin clients continue sharing route-data cache entries.

- Credential values stay out of public cache keys.
- Private caches still receive Farm cache-invalidation events.
- Added regression coverage and updated the API client caching documentation.

<sup>Written for commit c0355f4e0c2323983e8ca585cb84aa94bdf6694b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/688?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

