### PR TITLE
fix(link): honor the configured app base path

### DIFF
--- a/docs/src/app/docs/routing/page.md
+++ b/docs/src/app/docs/routing/page.md
@@ -117,6 +117,8 @@ Changing only the fragment preserves SPA state, honors push versus replace histo
 request route data again.
 Native anchor behavior still takes precedence: for example, a `Link` with a `download` attribute is
 handled by the browser instead of Farm's SPA router.
+Internal `Link` hrefs stay app-relative: when `basePath: "/console"` is configured, `href="/about"`
+renders and navigates to `/console/about`. Do not add the base path to route hrefs yourself.
 
 **Client navigation**
 

--- a/packages/farm/src/__tests__/link.test.tsx
+++ b/packages/farm/src/__tests__/link.test.tsx
@@ -7,6 +7,8 @@ import { expectTypeOf } from "vitest";
 import { createRoot } from "react-dom/client";
 import { Link, type LinkProps, type RouteHref } from "../client/link";
 import { setFarmTrailingSlashPreference } from "../trailing-slash";
+import { setFarmBasePath } from "../base-path";
+import { FarmProvider } from "../provider";
 
 const prefetch = vi.fn().mockResolvedValue(undefined);
 const navigate = vi.fn();
@@ -46,6 +48,7 @@ describe("Link", () => {
     delete (window as any).__FARM_SPA_ROUTER__;
     delete (window as any).__FARM_MANIFEST__;
     setFarmTrailingSlashPreference(false);
+    setFarmBasePath("/");
   });
 
   function render(ui: React.ReactElement) {
@@ -176,6 +179,26 @@ describe("Link", () => {
   });
 
   describe("navigation", () => {
+    it("prefixes internal links with the configured app base path", () => {
+      setFarmBasePath("/console");
+      const el = render(createElement(Link, { href: "/dashboard", prefetch: "render" }));
+
+      expect(el?.getAttribute("href")).toBe("/console/dashboard");
+      expect(prefetch).toHaveBeenCalledWith("/console/dashboard");
+    });
+
+    it("uses an explicit FarmProvider base path without prefixing it twice", () => {
+      const el = render(
+        createElement(
+          FarmProvider,
+          { config: { basePath: "/workspace" } as any },
+          createElement(Link, { href: "/workspace/settings" }),
+        ),
+      );
+
+      expect(el?.getAttribute("href")).toBe("/workspace/settings");
+    });
+
     it("inherits the app trailing-slash preference", () => {
       setFarmTrailingSlashPreference(true);
       const el = render(

--- a/packages/farm/src/__tests__/link.test.tsx
+++ b/packages/farm/src/__tests__/link.test.tsx
@@ -187,7 +187,19 @@ describe("Link", () => {
       expect(prefetch).toHaveBeenCalledWith("/console/dashboard");
     });
 
-    it("uses an explicit FarmProvider base path without prefixing it twice", () => {
+    it("normalizes and uses an explicit FarmProvider base path", () => {
+      const el = render(
+        createElement(
+          FarmProvider,
+          { config: { basePath: "workspace/" } as any },
+          createElement(Link, { href: "/settings" }),
+        ),
+      );
+
+      expect(el?.getAttribute("href")).toBe("/workspace/settings");
+    });
+
+    it("does not prefix an already-prefixed FarmProvider link twice", () => {
       const el = render(
         createElement(
           FarmProvider,
@@ -197,6 +209,28 @@ describe("Link", () => {
       );
 
       expect(el?.getAttribute("href")).toBe("/workspace/settings");
+    });
+
+    it("treats a root FarmProvider base path as unprefixed", () => {
+      const el = render(
+        createElement(
+          FarmProvider,
+          { config: { basePath: "/" } as any },
+          createElement(Link, { href: "/about" }),
+        ),
+      );
+
+      expect(el?.getAttribute("href")).toBe("/about");
+    });
+
+    it("recognizes an already-prefixed base path before a query or hash", () => {
+      setFarmBasePath("/console");
+      const queryLink = render(createElement(Link, { href: "/console?tab=activity" }));
+      expect(queryLink?.getAttribute("href")).toBe("/console?tab=activity");
+
+      act(() => root.unmount());
+      const hashLink = render(createElement(Link, { href: "/console#activity" }));
+      expect(hashLink?.getAttribute("href")).toBe("/console#activity");
     });
 
     it("inherits the app trailing-slash preference", () => {

--- a/packages/farm/src/__tests__/searchparams.test.ts
+++ b/packages/farm/src/__tests__/searchparams.test.ts
@@ -226,7 +226,7 @@ describe("SearchParams in the production runtime", () => {
     const source = readSource("nitro", "universal-build.ts");
 
     expect(source).toContain(
-      'import { createClientPluginManager, installChunkErrorRecovery, scheduleFarmIslandHydration, searchParamsToObject, setFarmTrailingSlashPreference } from "@farm.js/core/internal/client-runtime";',
+      'import { createClientPluginManager, installChunkErrorRecovery, scheduleFarmIslandHydration, searchParamsToObject, setFarmBasePath, setFarmTrailingSlashPreference } from "@farm.js/core/internal/client-runtime";',
     );
     expect(source).toContain(
       "const searchParams = searchParamsToObject(new URLSearchParams(window.location.search));",

--- a/packages/farm/src/__tests__/server-renderer-route-states.test.tsx
+++ b/packages/farm/src/__tests__/server-renderer-route-states.test.tsx
@@ -9,6 +9,7 @@ import { ServerRenderer } from "../server/renderer";
 import type { FarmConfig, FarmRequest, FarmResponse, LoadingProps, ErrorProps } from "../types";
 import { logger } from "../utils";
 import { defer } from "../deferred";
+import { Link } from "../client/link";
 
 type MockResponse = FarmResponse & {
   body: string;
@@ -538,6 +539,23 @@ describe("file route loading.tsx and error.tsx", () => {
     expect(html).toContain('data-farm-client="false"');
     expect(html).toContain("Settings fragment");
   });
+
+  it("applies the app base path while rendering navigation fragments", async () => {
+    const renderer = createRenderer({}, { basePath: "/console" });
+    const html = await renderer.renderNavigationFragment({
+      PageComponent: function SettingsPage() {
+        return React.createElement(Link, { href: "/settings" }, "Settings");
+      },
+      pageProps: {},
+      params: {},
+      layouts: [],
+      pageShouldHydrate: false,
+      layoutShouldHydrate: false,
+      islandStrategy: null,
+    });
+
+    expect(html).toContain('href="/console/settings"');
+  });
 });
 
 describe("custom not-found rendering", () => {
@@ -613,6 +631,7 @@ function createRenderer(
       islandStrategy?: string;
     };
     onGenerateClientManifest?: () => void;
+    basePath?: string;
   } = {},
 ) {
   const metadataImageEntry = {
@@ -785,7 +804,10 @@ function createRenderer(
     },
   };
 
-  return new ServerRenderer(createConfig(), routeManager as any);
+  return new ServerRenderer(
+    { ...createConfig(), basePath: options.basePath ?? "/" },
+    routeManager as any,
+  );
 }
 
 function createConfig(): Required<FarmConfig> {

--- a/packages/farm/src/base-path.ts
+++ b/packages/farm/src/base-path.ts
@@ -15,12 +15,20 @@ export function getFarmBasePath(): string {
 }
 
 export function applyFarmBasePath(href: string, basePath = getFarmBasePath()): string {
-  if (!basePath || !href.startsWith("/")) return href;
-  if (href === basePath || href.startsWith(`${basePath}/`)) return href;
-  return `${basePath}${href}`;
+  const normalizedBasePath = normalizeFarmBasePath(basePath);
+  if (!normalizedBasePath || !href.startsWith("/")) return href;
+  if (
+    href === normalizedBasePath ||
+    href.startsWith(`${normalizedBasePath}/`) ||
+    href.startsWith(`${normalizedBasePath}?`) ||
+    href.startsWith(`${normalizedBasePath}#`)
+  ) {
+    return href;
+  }
+  return `${normalizedBasePath}${href}`;
 }
 
-function normalizeFarmBasePath(basePath: string | undefined): string {
+export function normalizeFarmBasePath(basePath: string | undefined): string {
   if (!basePath || basePath === "/") return "";
   return `/${basePath}`.replace(/\/{2,}/g, "/").replace(/\/+$/, "");
 }

--- a/packages/farm/src/base-path.ts
+++ b/packages/farm/src/base-path.ts
@@ -1,0 +1,26 @@
+const FARM_BASE_PATH = Symbol.for("farm.basePath");
+
+function getFarmGlobalState(): Record<PropertyKey, unknown> {
+  return globalThis as unknown as Record<PropertyKey, unknown>;
+}
+
+/** @internal Configure the app-wide base path for framework link rendering. */
+export function setFarmBasePath(basePath: string | undefined): void {
+  getFarmGlobalState()[FARM_BASE_PATH] = normalizeFarmBasePath(basePath);
+}
+
+/** @internal Read the app-wide base path used by framework links. */
+export function getFarmBasePath(): string {
+  return (getFarmGlobalState()[FARM_BASE_PATH] as string | undefined) ?? "";
+}
+
+export function applyFarmBasePath(href: string, basePath = getFarmBasePath()): string {
+  if (!basePath || !href.startsWith("/")) return href;
+  if (href === basePath || href.startsWith(`${basePath}/`)) return href;
+  return `${basePath}${href}`;
+}
+
+function normalizeFarmBasePath(basePath: string | undefined): string {
+  if (!basePath || basePath === "/") return "";
+  return `/${basePath}`.replace(/\/{2,}/g, "/").replace(/\/+$/, "");
+}

--- a/packages/farm/src/client/link.tsx
+++ b/packages/farm/src/client/link.tsx
@@ -12,6 +12,8 @@ import type { FarmViewTransitionMode } from "./spa-router";
 import { isFarmLocaleChangeHref, localizeActiveFarmHref } from "../i18n/client-runtime";
 import type { FarmI18nLocale } from "../i18n/types";
 import { getFarmTrailingSlashPreference } from "../trailing-slash";
+import { applyFarmBasePath, getFarmBasePath } from "../base-path";
+import { useOptionalFarm } from "../provider";
 
 /**
  * Prefetch strategy (TanStack Router–style):
@@ -247,6 +249,7 @@ function LinkInner<TRoute extends string = DefaultRouteHref>(
   const elementRef = useRef<HTMLAnchorElement | null>(null);
   const intentTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const hasPrefetched = useRef(false);
+  const farm = useOptionalFarm();
 
   const { intent, viewport, render } = normalizePrefetch(prefetch);
   const baseHref = resolveLinkHref(href, params, {
@@ -254,7 +257,10 @@ function LinkInner<TRoute extends string = DefaultRouteHref>(
     hash,
     trailingSlash: trailingSlash ?? getFarmTrailingSlashPreference(),
   });
-  const resolvedHref = localizeActiveFarmHref(baseHref, locale);
+  const localizedHref = localizeActiveFarmHref(baseHref, locale);
+  const resolvedHref = isExternalUrl(localizedHref)
+    ? localizedHref
+    : applyFarmBasePath(localizedHref, farm?.basePath ?? getFarmBasePath());
   const isExternal = isExternalUrl(resolvedHref);
 
   const doPrefetch = useCallback(() => {
@@ -388,7 +394,7 @@ function LinkInner<TRoute extends string = DefaultRouteHref>(
 
       if (typeof window !== "undefined") {
         event.preventDefault();
-        if (isFarmLocaleChangeHref(resolvedHref)) {
+        if (isFarmLocaleChangeHref(localizedHref)) {
           window.location.assign(resolvedHref);
           return;
         }
@@ -401,7 +407,7 @@ function LinkInner<TRoute extends string = DefaultRouteHref>(
         }
       }
     },
-    [resolvedHref, replace, scroll, viewTransition, target, isExternal, onClick],
+    [localizedHref, resolvedHref, replace, scroll, viewTransition, target, isExternal, onClick],
   );
 
   const setRefs = useCallback(

--- a/packages/farm/src/client/production-runtime.ts
+++ b/packages/farm/src/client/production-runtime.ts
@@ -3,3 +3,4 @@ export { scheduleFarmIslandHydration } from "./island-runtime";
 export { createClientPluginManager } from "./plugin";
 export { searchParamsToObject } from "../search-params";
 export { setFarmTrailingSlashPreference } from "../trailing-slash";
+export { setFarmBasePath } from "../base-path";

--- a/packages/farm/src/nitro/production-runtime.ts
+++ b/packages/farm/src/nitro/production-runtime.ts
@@ -65,6 +65,7 @@ export {
   resolveFarmTrailingSlashRedirect,
   setFarmTrailingSlashPreference,
 } from "../trailing-slash";
+export { setFarmBasePath } from "../base-path";
 
 export function appendFarmLinkHeader(headers: Headers, value: string): void {
   const current = headers.get("Link");

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -1338,6 +1338,7 @@ async function buildClient(
     config.renderer,
     config.publicRuntimeConfig,
     config.trailingSlash,
+    config.basePath,
   );
 
   // Write the client entry to a temporary file
@@ -1853,6 +1854,7 @@ function generateClientHydrationEntry(
   renderer: FarmRenderer = REACT_RENDERER,
   publicRuntimeConfig: Record<string, unknown> | undefined = undefined,
   trailingSlash = false,
+  basePath = "/",
 ): string {
   const toImportPath = (targetPath: string) => targetPath.replace(/\\/g, "/");
   const clientPluginEntry: FarmClientPluginEntryCode = generateFarmClientPluginEntryCode(
@@ -1961,13 +1963,14 @@ async function hydrateFarmDocsAdapterRuntime() {
 // Farm.js Client Runtime (no client components)
 ${cssImport}
 ${layoutImports}
-import { createClientPluginManager, installChunkErrorRecovery, setFarmTrailingSlashPreference } from "@farm.js/core/internal/client-runtime";
+import { createClientPluginManager, installChunkErrorRecovery, setFarmBasePath, setFarmTrailingSlashPreference } from "@farm.js/core/internal/client-runtime";
 ${clientPluginEntry.imports}
 ${i18nClientRuntime}
 ${docsNavigationRuntime}
 ${docsAdapterRuntime}
 ${generateFarmDocsSearchClientRuntime(docsSearchEnabled, docsSearchModuleId)}
 
+setFarmBasePath(${JSON.stringify(basePath)});
 setFarmTrailingSlashPreference(${JSON.stringify(trailingSlash)});
 installChunkErrorRecovery();
 mountFarmDocsSearch();
@@ -2347,7 +2350,7 @@ async function hydrateFarmIsolatedClientBoundaries(scope = document) {
 ${cssImport}
 ${layoutImports}
 ${rendererClientImports}
-import { createClientPluginManager, installChunkErrorRecovery, scheduleFarmIslandHydration, searchParamsToObject, setFarmTrailingSlashPreference } from "@farm.js/core/internal/client-runtime";
+import { createClientPluginManager, installChunkErrorRecovery, scheduleFarmIslandHydration, searchParamsToObject, setFarmBasePath, setFarmTrailingSlashPreference } from "@farm.js/core/internal/client-runtime";
 import { matchFarmRoute } from "@farm.js/core/router";
 ${clientPluginEntry.imports}
 ${i18nClientRuntime}
@@ -2357,6 +2360,7 @@ ${docsAdapterRuntime}
 ${imports.join("\n")}
 ${generateFarmDocsSearchClientRuntime(docsSearchEnabled, docsSearchModuleId)}
 
+setFarmBasePath(${JSON.stringify(basePath)});
 setFarmTrailingSlashPreference(${JSON.stringify(trailingSlash)});
 installChunkErrorRecovery();
 
@@ -3982,6 +3986,7 @@ function generateVirtualEntryCode(
   resolveFarmInstrumentationRuntime,
   runWithFarmRequestSpan,
   searchParamsToObject,
+  setFarmBasePath,
   setFarmTrailingSlashPreference,
   stripFarmLocaleFromPathname,
   withFarmRouteContext,
@@ -4219,6 +4224,7 @@ const farmUserConfig = ${
   };
 const farmRuntimeConfigs = [${[...layerConfigValues, "farmUserConfig"].join(", ")}].filter(Boolean);
 const farmResolvedRuntimeConfig = Object.assign({}, ...farmRuntimeConfigs);
+setFarmBasePath(${JSON.stringify(config.basePath)});
 setFarmTrailingSlashPreference(${JSON.stringify(config.trailingSlash)});
 const hasConfiguredRouteContext = typeof farmResolvedRuntimeConfig.context === "function";
 const configuredIntegrations = Object.assign(

--- a/packages/farm/src/provider.tsx
+++ b/packages/farm/src/provider.tsx
@@ -38,6 +38,11 @@ export function useFarm(): FarmContextValue {
   return context;
 }
 
+/** @internal Read Farm context when a component can also use a runtime fallback. */
+export function useOptionalFarm(): FarmContextValue | null {
+  return useContext(FarmContext);
+}
+
 /**
  * Hook to get the current base path
  */

--- a/packages/farm/src/provider.tsx
+++ b/packages/farm/src/provider.tsx
@@ -1,5 +1,6 @@
 import React, { createContext, useContext, type ReactNode } from "react";
 import type { FarmConfig } from "./types";
+import { normalizeFarmBasePath } from "./base-path";
 
 interface FarmContextValue {
   config: FarmConfig;
@@ -19,7 +20,7 @@ interface FarmProviderProps {
 export function FarmProvider({ children, config }: FarmProviderProps) {
   const value: FarmContextValue = {
     config,
-    basePath: config.basePath || "/",
+    basePath: normalizeFarmBasePath(config.basePath),
   };
 
   return <FarmContext.Provider value={value}>{children}</FarmContext.Provider>;

--- a/packages/farm/src/server/renderer.ts
+++ b/packages/farm/src/server/renderer.ts
@@ -628,6 +628,8 @@ export class ServerRenderer {
    */
   async renderNavigationFragment(input: FarmNavigationFragmentInput): Promise<string> {
     await this.initialize();
+    setFarmBasePath(this.config.basePath);
+    setFarmTrailingSlashPreference(this.config.trailingSlash);
     let element = this.rendererRuntime.createElement(input.PageComponent, input.pageProps);
     if (input.LoadingComponent) {
       element = this.rendererRuntime.createElement(

--- a/packages/farm/src/server/renderer.ts
+++ b/packages/farm/src/server/renderer.ts
@@ -66,6 +66,7 @@ import {
   resolveFarmTrailingSlashRedirect,
   setFarmTrailingSlashPreference,
 } from "../trailing-slash";
+import { setFarmBasePath } from "../base-path";
 import { DEFAULT_NOT_FOUND_STYLES } from "../components/not-found-styles";
 import {
   createDefaultErrorMarkup,
@@ -987,6 +988,7 @@ export class ServerRenderer {
 
   async renderPage(req: FarmRequest, res: FarmResponse): Promise<void> {
     await this.initialize();
+    setFarmBasePath(this.config.basePath);
     setFarmTrailingSlashPreference(this.config.trailingSlash);
     const request = createWebRequestFromFarmRequest(req);
     const runtime = this.i18nRuntime;

--- a/packages/farm/src/vite.ts
+++ b/packages/farm/src/vite.ts
@@ -2621,6 +2621,7 @@ window.__FARM_MANIFEST__ = ${inlineValue({
           renderer,
           resolvedConfig?.experimental?.isolatedClientHydration === "enabled",
           resolvedConfig?.trailingSlash ?? false,
+          resolvedConfig?.basePath ?? "/",
         );
       }
 
@@ -3481,6 +3482,7 @@ function generateClientCode(
   renderer: FarmRenderer = REACT_RENDERER,
   isolatedHydrationEnabled = false,
   trailingSlash = false,
+  basePath = "/",
 ): string {
   const hasClerkProvider = integrationProviders.some((provider) => provider.type === "clerk");
   const providerImportBlock = hasClerkProvider
@@ -3565,7 +3567,7 @@ async function hydrateFarmIsolatedClientBoundaries(scope = document) {
 ${rendererClientImports}
 import { installChunkErrorRecovery, SPARouter } from '@farm.js/core/client'
 import { createClientPluginManager } from '@farm.js/core/plugin/client'
-import { scheduleFarmIslandHydration, searchParamsToObject, setFarmTrailingSlashPreference } from '@farm.js/core/internal/client-runtime'
+import { scheduleFarmIslandHydration, searchParamsToObject, setFarmBasePath, setFarmTrailingSlashPreference } from '@farm.js/core/internal/client-runtime'
 import { reviveDeferredData } from '@farm.js/core/deferred'
 import {
   createFarmDeploymentMismatchError,
@@ -3587,6 +3589,7 @@ window.__FARM_REACT__ = React;
 const integrationProviders = ${JSON.stringify(integrationProviders)};
 const integrationDocumentNavigationMatchers = ${JSON.stringify(documentNavigationMatchers)};
 
+setFarmBasePath(${JSON.stringify(basePath)});
 setFarmTrailingSlashPreference(${JSON.stringify(trailingSlash)});
 installChunkErrorRecovery();
 


### PR DESCRIPTION
## Problem

`Link` rendered root-relative hrefs even when the app was mounted under a configured `basePath`. The browser, prefetcher, and SPA router therefore targeted `/about` instead of paths such as `/console/about`.

## Root cause

The resolved app base path reached the routers but was not part of the shared link-rendering preference used during SSR and hydration. `FarmProvider` also exposed `basePath`, but `Link` never read it.

## Change

Added a normalized app-wide base-path preference, initialized it in Vite development, production client entries, and both server render paths, and applied it to internal `Link` hrefs. An explicit `FarmProvider` value takes precedence. Already-prefixed hrefs are left unchanged.

## Safety and compatibility

External URLs remain untouched. Route typing and app-relative href inputs do not change. Locale detection still runs against the route-relative href before the mount path is added. Both hydratable and server-rendered-only production clients initialize the same preference.

## Verification

- `pnpm --filter @farm.js/core exec vitest run src/__tests__/link.test.tsx src/__tests__/searchparams.test.ts src/__tests__/trailing-slash.test.ts`
- `pnpm --filter @farm.js/core type-check`
- `pnpm exec oxlint <changed TypeScript files>` (passes with one pre-existing unused-variable warning in `universal-build.ts`)
- `pnpm exec oxfmt <changed files>`

The link regression test fails before this change because the rendered and prefetched href remains `/dashboard`.

## Documentation and release

Updated the routing documentation with app-relative `Link` behavior under `basePath`. No manual release changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `Link` so internal hrefs honor the configured app base path, rendering and navigating to `/console/about` instead of `/about` when the app is mounted at `/console`.

**Bug Fixes**
- Adds a normalized app-wide base-path preference, initialized in Vite dev, both production client entries, and the server renderer; normalization strips trailing slashes and treats `/` as no base path.
- Applies the base path only to internal links; external URLs and hrefs already prefixed with the base path (including before a query or hash) are unchanged.
- An explicit `FarmProvider` `basePath` takes precedence over the app-wide value and is normalized the same way.
- Locale detection still runs against the route-relative href before the base path is added.

<sup>Written for commit 293e9340c7c94a608fc0d4e76b66c93ac2e4ec6b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/689?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

