### PR TITLE
fix(api-client): normalize outgoing request headers

### DIFF
--- a/docs/src/app/docs/api-client/page.md
+++ b/docs/src/app/docs/api-client/page.md
@@ -125,6 +125,10 @@ path, URL query parameters, request body, `Content-Type`, and `Content-Encoding`
 requests need an explicit cache key because a generated multipart boundary cannot be represented
 reliably before `fetch` sends the request.
 
+Farm adds `Content-Type: application/json` when it serializes a JSON request body. Bodyless
+requests do not receive that header, and an explicitly configured content type takes precedence
+regardless of header casing.
+
 ## Upload files and consume progress streams
 
 `toFormData()` retains the endpoint's body shape while sending files as real multipart fields. When

--- a/packages/farm/src/__tests__/api-client.test.ts
+++ b/packages/farm/src/__tests__/api-client.test.ts
@@ -248,6 +248,31 @@ describe("createAPIClient", () => {
     expect(new Headers(init.headers).has("content-type")).toBe(false);
   });
 
+  it("keeps the JSON content type on bodyless QUERY requests", async () => {
+    const fetchMock = vi.fn(async () => buildResponse({ results: [] }));
+    globalThis.fetch = fetchMock as any;
+    const api = createAPIClient<APIRouter>({ baseURL: "https://api.example.com" });
+
+    await (api.search.query as any)();
+
+    const init = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    expect(new Headers(init.headers).get("content-type")).toBe("application/json");
+  });
+
+  it("lets fetch set the multipart boundary for FormData QUERY bodies", async () => {
+    const fetchMock = vi.fn(async () => buildResponse({ results: [] }));
+    globalThis.fetch = fetchMock as any;
+    const api = createAPIClient<APIRouter>({ baseURL: "https://api.example.com" });
+    const body = new FormData();
+    body.set("filter", "tools");
+
+    await (api.search.query as any)({ body });
+
+    const init = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    expect(init.body).toBe(body);
+    expect(new Headers(init.headers).has("content-type")).toBe(false);
+  });
+
   it("normalizes header overrides without combining duplicate casing", async () => {
     const fetchMock = vi.fn(async () => buildResponse({ success: true }));
     globalThis.fetch = fetchMock as any;

--- a/packages/farm/src/__tests__/api-client.test.ts
+++ b/packages/farm/src/__tests__/api-client.test.ts
@@ -237,6 +237,45 @@ describe("createAPIClient", () => {
     );
   });
 
+  it("does not add a JSON content type to bodyless requests", async () => {
+    const fetchMock = vi.fn(async () => buildResponse({ users: [], total: 0 }));
+    globalThis.fetch = fetchMock as any;
+    const api = createAPIClient<APIRouter>({ baseURL: "https://api.example.com" });
+
+    await api.users.get({ query: { limit: "5" } });
+
+    const init = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    expect(new Headers(init.headers).has("content-type")).toBe(false);
+  });
+
+  it("normalizes header overrides without combining duplicate casing", async () => {
+    const fetchMock = vi.fn(async () => buildResponse({ success: true }));
+    globalThis.fetch = fetchMock as any;
+    const api = createAPIClient<APIRouter>({
+      baseURL: "https://api.example.com",
+      headers: { "Content-Type": "application/json" },
+    });
+
+    await api.users.post({
+      body: { name: "Ada", email: "ada@example.com" },
+      headers: { "content-type": "application/problem+json" },
+    });
+
+    const init = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    expect(new Headers(init.headers).get("content-type")).toBe("application/problem+json");
+  });
+
+  it("adds JSON content type when serializing a request body", async () => {
+    const fetchMock = vi.fn(async () => buildResponse({ success: true }));
+    globalThis.fetch = fetchMock as any;
+    const api = createAPIClient<APIRouter>({ baseURL: "https://api.example.com" });
+
+    await api.users.post({ body: { name: "Ada", email: "ada@example.com" } });
+
+    const init = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    expect(new Headers(init.headers).get("content-type")).toBe("application/json");
+  });
+
   it("does not parse an empty HEAD response as JSON", async () => {
     const fetchMock = vi.fn(async () => new Response(null, { status: 200 }));
     globalThis.fetch = fetchMock as any;

--- a/packages/farm/src/api/client.ts
+++ b/packages/farm/src/api/client.ts
@@ -463,11 +463,8 @@ export function createAPIClient<
     }
 
     // Prepare fetch options
-    const headers: Record<string, string> = {
-      "Content-Type": "application/json",
-      ...options.headers,
-      ...requestOptions.headers,
-    };
+    const headers = new Headers(options.headers);
+    new Headers(requestOptions.headers).forEach((value, key) => headers.set(key, value));
     const fetchOptions: RequestInit = {
       method,
       headers,
@@ -477,9 +474,10 @@ export function createAPIClient<
     // Handle body
     if (requestOptions.body !== undefined) {
       if (isFormData(requestOptions.body)) {
-        deleteHeader(headers, "content-type");
+        headers.delete("content-type");
         fetchOptions.body = requestOptions.body;
       } else {
+        if (!headers.has("content-type")) headers.set("content-type", "application/json");
         fetchOptions.body = JSON.stringify(requestOptions.body);
       }
     }
@@ -1245,13 +1243,6 @@ function isFormData(value: unknown): value is FormData {
       (Object.prototype.toString.call(value) === "[object FormData]" &&
         typeof (value as { entries?: unknown }).entries === "function"))
   );
-}
-
-function deleteHeader(headers: Record<string, string>, name: string): void {
-  const normalized = name.toLowerCase();
-  for (const key of Object.keys(headers)) {
-    if (key.toLowerCase() === normalized) delete headers[key];
-  }
 }
 
 function createResponseError(response: Response, data: any): Error {

--- a/packages/farm/src/api/client.ts
+++ b/packages/farm/src/api/client.ts
@@ -470,6 +470,9 @@ export function createAPIClient<
       headers,
       credentials: options.credentials,
     };
+    if (method === "QUERY" && !headers.has("content-type")) {
+      headers.set("content-type", "application/json");
+    }
 
     // Handle body
     if (requestOptions.body !== undefined) {


### PR DESCRIPTION
## Problem

The generated API client added `Content-Type: application/json` to bodyless requests and merged configured/request headers as plain objects. A differently cased override could therefore produce two content-type values on the wire.

## Root cause

Header construction used object spread with a default JSON header before Farm knew whether a body existed. Plain object keys are case-sensitive even though HTTP header names are not.

## Change

Construct outgoing headers with the platform `Headers` API, apply request overrides case-insensitively, and add the JSON content type only when Farm serializes a non-FormData body. Explicit content types continue to win, and FormData continues to let fetch create its multipart boundary.

## Safety and compatibility

JSON POST/PUT/PATCH/QUERY bodies keep their existing default media type. Bodyless requests avoid unnecessary CORS preflights caused by the non-simple header. User-supplied header casing no longer changes override semantics.

## Verification

- `pnpm --filter @farm.js/core exec vitest run src/__tests__/api-client.test.ts`
- `pnpm --filter @farm.js/core type-check`
- `pnpm exec oxfmt packages/farm/src/api/client.ts packages/farm/src/__tests__/api-client.test.ts docs/src/app/docs/api-client/page.md`
- `pnpm exec oxlint packages/farm/src/api/client.ts packages/farm/src/__tests__/api-client.test.ts` (passes with one pre-existing unused-parameter warning elsewhere in the test file)

The regressions assert that GET has no content type, JSON bodies still do, and a lowercase request override replaces an uppercase configured value.

## Documentation and release

Updated the API client request-header behavior. No manual release changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalizes outgoing request headers in the generated API client so differently cased `Content-Type` overrides no longer produce duplicate headers on the wire. Bodyless GET requests no longer get a default JSON content type, avoiding unnecessary CORS preflights; bodyless QUERY requests keep it.

- Constructs headers with the platform `Headers` API and applies request overrides case-insensitively.
- Explicit content types and FormData behavior are unchanged.
- Updates the API client docs and adds regression tests for GET, QUERY, JSON bodies, FormData, and casing overrides.

<sup>Written for commit 2bd43b6e7acea716bba1c00068c8cb7d49fc3859. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/690?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

