### PR TITLE
fix(api-client): preserve HTTP errors after decode failures

### DIFF
--- a/docs/src/app/docs/api-client/page.md
+++ b/docs/src/app/docs/api-client/page.md
@@ -368,6 +368,8 @@ console.log(result.data.message);
 ```
 
 This makes client components easier to write because failed responses do not need to be caught with `try/catch` unless you want that behavior.
+If an HTTP error body is malformed, Farm still returns an `http_error` with the real status and
+`Response`; the decoding failure is available as `error.cause`.
 
 ## Server callers
 

--- a/packages/farm/src/__tests__/api-client.test.ts
+++ b/packages/farm/src/__tests__/api-client.test.ts
@@ -273,6 +273,26 @@ describe("createAPIClient", () => {
     });
   });
 
+  it("preserves the HTTP response when an error body cannot be decoded", async () => {
+    const response = new Response("{broken", {
+      status: 500,
+      statusText: "Internal Server Error",
+      headers: { "content-type": "application/json" },
+    });
+    globalThis.fetch = vi.fn(async () => response) as any;
+    const api = createAPIClient<APIRouter>({ baseURL: "https://api.example.com" });
+
+    const result = await api.status.get();
+
+    expect(result.error).toMatchObject({
+      code: "http_error",
+      status: 500,
+      response,
+      cause: expect.any(SyntaxError),
+    });
+    expect(result.error).not.toMatchObject({ code: "network_error", status: 0 });
+  });
+
   it("supports empty and binary successful responses", async () => {
     const responses = [
       new Response("", { status: 200 }),

--- a/packages/farm/src/__tests__/api-client.test.ts
+++ b/packages/farm/src/__tests__/api-client.test.ts
@@ -293,6 +293,29 @@ describe("createAPIClient", () => {
     expect(result.error).not.toMatchObject({ code: "network_error", status: 0 });
   });
 
+  it("keeps transport failures while reading error bodies classified as network errors", async () => {
+    const transportError = new TypeError("connection closed while reading the body");
+    const response = {
+      ok: false,
+      status: 502,
+      statusText: "Bad Gateway",
+      headers: new Headers({ "content-type": "application/json" }),
+      body: {},
+      arrayBuffer: vi.fn().mockRejectedValue(transportError),
+    } as unknown as Response;
+    globalThis.fetch = vi.fn(async () => response) as any;
+    const api = createAPIClient<APIRouter>({ baseURL: "https://api.example.com" });
+
+    const result = await api.status.get();
+
+    expect(result.error).toMatchObject({
+      code: "network_error",
+      status: 0,
+      cause: transportError,
+    });
+    expect(result.error).not.toMatchObject({ code: "http_error", status: 502 });
+  });
+
   it("supports empty and binary successful responses", async () => {
     const responses = [
       new Response("", { status: 200 }),

--- a/packages/farm/src/api/client.ts
+++ b/packages/farm/src/api/client.ts
@@ -488,7 +488,13 @@ export function createAPIClient<
     applyFarmCacheInvalidations(
       decodeFarmCacheInvalidations(response.headers?.get?.(FARM_CACHE_INVALIDATION_HEADER)),
     );
-    const data = await readAPIResponseData(response, method);
+    let data: unknown;
+    try {
+      data = await readAPIResponseData(response, method);
+    } catch (decodeError) {
+      if (response.ok) throw decodeError;
+      return { response, data: undefined, decodeError };
+    }
 
     return { response, data };
   };
@@ -634,12 +640,12 @@ export function createAPIClient<
           });
 
           try {
-            const { response, data } = await fetchClient(path, {
+            const { response, data, decodeError } = await fetchClient(path, {
               ...input,
               method: methodUpper,
             });
 
-            const error = response.ok ? null : createResponseError(response, data);
+            const error = response.ok ? null : createResponseError(response, data, decodeError);
 
             const responseEvent: ResponseEvent<any, Error> = {
               requestId,
@@ -1254,7 +1260,7 @@ function deleteHeader(headers: Record<string, string>, name: string): void {
   }
 }
 
-function createResponseError(response: Response, data: any): Error {
+function createResponseError(response: Response, data: any, cause?: unknown): Error {
   const expected = readEndpointErrorEnvelope(data);
   if (expected) {
     return new APIClientError(expected.code, expected.data, {
@@ -1264,11 +1270,13 @@ function createResponseError(response: Response, data: any): Error {
     });
   }
 
-  return new APIClientError("http_error", data, {
+  const error = new APIClientError("http_error", data, {
     status: response.status,
     message: `HTTP ${response.status}: ${response.statusText}`,
     response,
   });
+  if (cause !== undefined) (error as Error & { cause?: unknown }).cause = cause;
+  return error;
 }
 
 function readEndpointErrorEnvelope(data: unknown): {

--- a/packages/farm/src/api/client.ts
+++ b/packages/farm/src/api/client.ts
@@ -492,8 +492,9 @@ export function createAPIClient<
     try {
       data = await readAPIResponseData(response, method);
     } catch (decodeError) {
-      if (response.ok) throw decodeError;
-      return { response, data: undefined, decodeError };
+      if (!(decodeError instanceof APIResponseDecodeError)) throw decodeError;
+      if (response.ok) throw decodeError.cause;
+      return { response, data: undefined, decodeError: decodeError.cause };
     }
 
     return { response, data };
@@ -830,7 +831,7 @@ async function readAPIResponseData(response: Response, method: string): Promise<
   // Keep lightweight fetch-compatible adapters working when they expose the
   // traditional json() contract without a complete Web Response implementation.
   if (!response.headers?.get && typeof response.json === "function") {
-    return response.json();
+    return readResponseJSON(response);
   }
 
   if (response.body === null) return undefined;
@@ -845,7 +846,7 @@ async function readAPIResponseData(response: Response, method: string): Promise<
     if (data.byteLength === 0) return undefined;
 
     if (!contentType || contentType === "application/json" || contentType.endsWith("+json")) {
-      return JSON.parse(new TextDecoder().decode(data));
+      return parseResponseJSON(new TextDecoder().decode(data));
     }
 
     if (
@@ -864,7 +865,7 @@ async function readAPIResponseData(response: Response, method: string): Promise<
     (!contentType || contentType === "application/json" || contentType.endsWith("+json")) &&
     typeof response.json === "function"
   ) {
-    return response.json();
+    return readResponseJSON(response);
   }
 
   if (
@@ -880,10 +881,37 @@ async function readAPIResponseData(response: Response, method: string): Promise<
   // Some fetch-compatible adapters expose headers but still only implement
   // the traditional json() reader.
   if (typeof response.json === "function") {
-    return response.json();
+    return readResponseJSON(response);
   }
 
   return undefined;
+}
+
+class APIResponseDecodeError extends Error {
+  readonly cause: unknown;
+
+  constructor(cause: unknown) {
+    super(cause instanceof Error ? cause.message : "Failed to decode JSON response");
+    this.name = "APIResponseDecodeError";
+    this.cause = cause;
+  }
+}
+
+function parseResponseJSON(value: string): unknown {
+  try {
+    return JSON.parse(value);
+  } catch (error) {
+    throw new APIResponseDecodeError(error);
+  }
+}
+
+async function readResponseJSON(response: Pick<Response, "json">): Promise<unknown> {
+  try {
+    return await response.json();
+  } catch (error) {
+    if (error instanceof SyntaxError) throw new APIResponseDecodeError(error);
+    throw error;
+  }
 }
 
 /**


### PR DESCRIPTION
## Problem

A non-2xx response with malformed JSON was reported as `network_error` with status `0`. Callers lost the actual HTTP status and `Response`, making server failures look like connectivity failures.

## Root cause

The response body was decoded before the response reached HTTP error classification. A JSON parser exception escaped into the outer fetch catch and was normalized as a network error.

## Change

Keep decoding failures attached to non-successful responses, create the normal `http_error` from the real response, and expose the parser failure as `error.cause`. Successful responses with malformed payloads retain the existing decode-failure behavior.

## Safety and compatibility

Valid endpoint error envelopes and non-JSON errors are unchanged. Retry and response lifecycle hooks now see the correct HTTP status for malformed error bodies. The public error code union does not change.

## Verification

- `pnpm --filter @farm.js/core exec vitest run src/__tests__/api-client.test.ts`
- `pnpm --filter @farm.js/core type-check`
- `pnpm exec oxfmt packages/farm/src/api/client.ts packages/farm/src/__tests__/api-client.test.ts docs/src/app/docs/api-client/page.md`
- `pnpm exec oxlint packages/farm/src/api/client.ts packages/farm/src/__tests__/api-client.test.ts` (passes with one pre-existing unused-parameter warning elsewhere in the test file)

The regression uses a real `Response` with status 500 and malformed JSON; before the fix it returns status 0.

## Documentation and release

Documented malformed HTTP error-body behavior. No manual release changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves HTTP errors when a non-2xx response body fails to decode: the client now returns `http_error` with the actual status and `Response`, while exposing the decode failure as `error.cause`. Transport failures while reading the body remain `network_error` with status `0`, and successful-response decode behavior is unchanged.

**Bug Fixes**

- Keeps retry and response lifecycle hooks aligned with the actual HTTP status.
- Adds regression tests and documents malformed error-body behavior without changing the public error code union.

<sup>Written for commit c7a4a01f33f0c07a50f8fe2e490d9ebc0d83218a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/691?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

