### PR TITLE
fix(query): resync hooks when inputs change

### DIFF
--- a/docs/src/app/docs/query/page.md
+++ b/docs/src/app/docs/query/page.md
@@ -45,10 +45,13 @@ export function SearchControls() {
 
 `throttleMs` coalesces rapid writes to the same query key. Updates to different keys are
 composed against the latest URL, and returning a value to the current URL cancels its queued write.
+If a component changes the key or parser it passes to the hook, the returned value is immediately
+re-read from the current URL.
 
 ## Multiple query values
 
 Use `useQueryStates` when several controls should update together. This keeps the browser URL as the source of shareable state for filters, pagination, and tabs.
+Changing the parser map replaces the returned object with exactly the newly declared keys.
 
 **src/components/product-filters.tsx**
 

--- a/packages/farm/src/__tests__/query-client-shallow.test.tsx
+++ b/packages/farm/src/__tests__/query-client-shallow.test.tsx
@@ -329,6 +329,36 @@ describe("useQueryState shallow routing", () => {
     expect(renders).toBe(1);
   });
 
+  it("compares self-referential array values without recursing forever", () => {
+    type CyclicValue = Array<string | CyclicValue>;
+    const parser = createParser({
+      parse: (value): CyclicValue => {
+        const parsed: CyclicValue = [value];
+        parsed.push(parsed);
+        return parsed;
+      },
+      serialize: (value) => String(value[0]),
+    });
+    let renders = 0;
+
+    function App() {
+      renders += 1;
+      useQueryState("value", parser);
+      return null;
+    }
+
+    window.history.replaceState(null, "", "/?value=one");
+    root = createRoot(container);
+    act(() => {
+      root?.render(createElement(App));
+    });
+    act(() => {
+      window.dispatchEvent(new PopStateEvent("popstate"));
+    });
+
+    expect(renders).toBe(1);
+  });
+
   it("resynchronizes primitive state when a default changes its serialized value", () => {
     vi.useFakeTimers();
     let value: string | null = null;
@@ -375,19 +405,23 @@ describe("useQueryState shallow routing", () => {
     expect(value).not.toBe(firstValue);
   });
 
-  it("replaces useQueryStates values when parser semantics change", () => {
+  it("replaces useQueryStates values when parser-visible hidden state changes", () => {
     window.history.replaceState(null, "", "/?item=one");
+    type ParsedItem = { value: string; mode: string };
+    const parseItem = (value: string, mode: string): ParsedItem => {
+      const item = { value } as ParsedItem;
+      Object.defineProperty(item, "mode", { value: mode, configurable: true });
+      return item;
+    };
     const oldParser = createParser({
-      parse: (value) => ({ value }),
-      serialize: (value) => value.value,
+      parse: (value) => parseItem(value, "old"),
+      serialize: (value) => `${value.value}:${value.mode}`,
     });
     const nextParser = createParser({
-      parse: (value) => {
-        return { value };
-      },
-      serialize: (value) => value.value,
+      parse: (value) => parseItem(value, "next"),
+      serialize: (value) => `${value.value}:${value.mode}`,
     });
-    let values: { item: { value: string } | null } = { item: null };
+    let values: { item: ParsedItem | null } = { item: null };
 
     function App({ parser }: { parser: typeof oldParser }) {
       [values] = useQueryStates({ item: parser });
@@ -399,12 +433,12 @@ describe("useQueryState shallow routing", () => {
       root?.render(createElement(App, { parser: oldParser }));
     });
     const oldValue = values.item;
-    expect(oldValue).toEqual({ value: "one" });
+    expect(oldValue?.mode).toBe("old");
 
     act(() => {
       root?.render(createElement(App, { parser: nextParser }));
     });
-    expect(values.item).toEqual({ value: "one" });
+    expect(values.item?.mode).toBe("next");
     expect(values.item).not.toBe(oldValue);
   });
 

--- a/packages/farm/src/__tests__/query-client-shallow.test.tsx
+++ b/packages/farm/src/__tests__/query-client-shallow.test.tsx
@@ -251,6 +251,48 @@ describe("useQueryState shallow routing", () => {
     expect(historyChange).toHaveBeenCalledTimes(1);
   });
 
+  it("reads the current URL when a useQueryState key changes", () => {
+    window.history.replaceState(null, "", "/?first=one&second=two");
+    let value: string | null = null;
+
+    function App({ queryKey }: { queryKey: string }) {
+      [value] = useQueryState(queryKey, asString);
+      return null;
+    }
+
+    root = createRoot(container);
+    act(() => {
+      root?.render(createElement(App, { queryKey: "first" }));
+    });
+    expect(value).toBe("one");
+
+    act(() => {
+      root?.render(createElement(App, { queryKey: "second" }));
+    });
+    expect(value).toBe("two");
+  });
+
+  it("replaces useQueryStates output when its parser keys change", () => {
+    window.history.replaceState(null, "", "/?first=one&second=two");
+    let value: Record<string, string | null> = {};
+
+    function App({ queryKey }: { queryKey: "first" | "second" }) {
+      [value] = useQueryStates({ [queryKey]: asString });
+      return null;
+    }
+
+    root = createRoot(container);
+    act(() => {
+      root?.render(createElement(App, { queryKey: "first" }));
+    });
+    expect(value).toEqual({ first: "one" });
+
+    act(() => {
+      root?.render(createElement(App, { queryKey: "second" }));
+    });
+    expect(value).toEqual({ second: "two" });
+  });
+
   it("composes throttled updates for different query keys", () => {
     vi.useFakeTimers();
 

--- a/packages/farm/src/__tests__/query-client-shallow.test.tsx
+++ b/packages/farm/src/__tests__/query-client-shallow.test.tsx
@@ -8,7 +8,7 @@ import { useSearchParams } from "../navigation";
 import { pushState as pushFarmPageState, readPageState, SPARouter } from "../client/spa-router";
 import { usePageState } from "../client/router";
 import { FARM_HISTORY_CHANGE_EVENT, notifyHistoryChange } from "../client/history-sync";
-import { asJson, asString, useQueryState, useQueryStates } from "../query/client";
+import { asJson, asString, createParser, useQueryState, useQueryStates } from "../query/client";
 
 describe("useQueryState shallow routing", () => {
   let container: HTMLDivElement;
@@ -327,6 +327,85 @@ describe("useQueryState shallow routing", () => {
     });
 
     expect(renders).toBe(1);
+  });
+
+  it("resynchronizes primitive state when a default changes its serialized value", () => {
+    vi.useFakeTimers();
+    let value: string | null = null;
+    let setValue!: (next: string | null) => void;
+
+    function App() {
+      [value, setValue] = useQueryState("q", asString.withDefault!("fallback"));
+      return null;
+    }
+
+    root = createRoot(container);
+    act(() => {
+      root?.render(createElement(App));
+    });
+    act(() => {
+      setValue("");
+      vi.runAllTimers();
+    });
+
+    expect(window.location.search).toBe("?q=fallback");
+    expect(value).toBe("fallback");
+  });
+
+  it("replaces object state when the useQueryState key changes", () => {
+    window.history.replaceState(null, "", '/?first={"id":1}&second={"id":1}');
+    const parser = asJson<{ id: number }>();
+    let value: { id: number } | null = null;
+
+    function App({ queryKey }: { queryKey: "first" | "second" }) {
+      [value] = useQueryState(queryKey, parser);
+      return null;
+    }
+
+    root = createRoot(container);
+    act(() => {
+      root?.render(createElement(App, { queryKey: "first" }));
+    });
+    const firstValue = value;
+    act(() => {
+      root?.render(createElement(App, { queryKey: "second" }));
+    });
+
+    expect(value).toEqual({ id: 1 });
+    expect(value).not.toBe(firstValue);
+  });
+
+  it("replaces useQueryStates values when parser semantics change", () => {
+    window.history.replaceState(null, "", "/?item=one");
+    const oldParser = createParser({
+      parse: (value) => ({ value }),
+      serialize: (value) => value.value,
+    });
+    const nextParser = createParser({
+      parse: (value) => {
+        return { value };
+      },
+      serialize: (value) => value.value,
+    });
+    let values: { item: { value: string } | null } = { item: null };
+
+    function App({ parser }: { parser: typeof oldParser }) {
+      [values] = useQueryStates({ item: parser });
+      return null;
+    }
+
+    root = createRoot(container);
+    act(() => {
+      root?.render(createElement(App, { parser: oldParser }));
+    });
+    const oldValue = values.item;
+    expect(oldValue).toEqual({ value: "one" });
+
+    act(() => {
+      root?.render(createElement(App, { parser: nextParser }));
+    });
+    expect(values.item).toEqual({ value: "one" });
+    expect(values.item).not.toBe(oldValue);
   });
 
   it("composes throttled updates for different query keys", () => {

--- a/packages/farm/src/__tests__/query-client-shallow.test.tsx
+++ b/packages/farm/src/__tests__/query-client-shallow.test.tsx
@@ -8,7 +8,7 @@ import { useSearchParams } from "../navigation";
 import { pushState as pushFarmPageState, readPageState, SPARouter } from "../client/spa-router";
 import { usePageState } from "../client/router";
 import { FARM_HISTORY_CHANGE_EVENT, notifyHistoryChange } from "../client/history-sync";
-import { asString, useQueryState, useQueryStates } from "../query/client";
+import { asJson, asString, useQueryState, useQueryStates } from "../query/client";
 
 describe("useQueryState shallow routing", () => {
   let container: HTMLDivElement;
@@ -291,6 +291,42 @@ describe("useQueryState shallow routing", () => {
       root?.render(createElement(App, { queryKey: "second" }));
     });
     expect(value).toEqual({ second: "two" });
+  });
+
+  it("does not loop when useQueryState receives an inline parser returning objects", () => {
+    window.history.replaceState(null, "", '/?filters={"status":"open"}');
+    let renders = 0;
+
+    function App() {
+      renders += 1;
+      useQueryState("filters", asJson<{ status: string }>());
+      return null;
+    }
+
+    root = createRoot(container);
+    act(() => {
+      root?.render(createElement(App));
+    });
+
+    expect(renders).toBe(1);
+  });
+
+  it("does not loop when useQueryStates receives an inline parser map", () => {
+    window.history.replaceState(null, "", '/?filters={"status":"open"}');
+    let renders = 0;
+
+    function App() {
+      renders += 1;
+      useQueryStates({ filters: asJson<{ status: string }>() });
+      return null;
+    }
+
+    root = createRoot(container);
+    act(() => {
+      root?.render(createElement(App));
+    });
+
+    expect(renders).toBe(1);
   });
 
   it("composes throttled updates for different query keys", () => {

--- a/packages/farm/src/query/client.ts
+++ b/packages/farm/src/query/client.ts
@@ -242,6 +242,7 @@ export function useQueryState<TParser extends Parser<any>>(
     // popstate, so listen through the shared history channel (real
     // back/forward events included). Self-updates no-op via the Object.is
     // comparison above.
+    onPopState();
     const unsubscribeHistory = subscribeHistoryChange(onPopState);
     emitter.on("update", onEmitterUpdate);
     emitter.onKey(key, onKeyUpdate);
@@ -312,9 +313,12 @@ export function useQueryStates<T extends Record<string, Parser<any>>>(
   useEffect(() => {
     if (typeof window === "undefined") return;
 
-    const applyChange = (searchParams: URLSearchParams, fromEmitter = false) => {
+    const applyChange = (searchParams: URLSearchParams) => {
       const result = {} as { [K in keyof T]: ReturnType<T[K]["parse"]> };
-      let hasChanged = false;
+      const currentKeys = Object.keys(stateRef.current);
+      let hasChanged =
+        currentKeys.length !== keys.length ||
+        currentKeys.some((key) => !Object.prototype.hasOwnProperty.call(parsers, key));
 
       Object.entries(parsers).forEach(([key, parser]) => {
         const value = searchParams.get(key);
@@ -335,13 +339,14 @@ export function useQueryStates<T extends Record<string, Parser<any>>>(
 
     const onPopState = () => {
       const searchParams = getCurrentSearchParams();
-      applyChange(searchParams, false);
+      applyChange(searchParams);
     };
 
     const onEmitterUpdate = (searchParams: URLSearchParams) => {
-      applyChange(searchParams, true);
+      applyChange(searchParams);
     };
 
+    applyChange(getCurrentSearchParams());
     const unsubscribeHistory = subscribeHistoryChange(onPopState);
     emitter.on("update", onEmitterUpdate);
 

--- a/packages/farm/src/query/client.ts
+++ b/packages/farm/src/query/client.ts
@@ -70,6 +70,9 @@ const compareStructuredValues = (
     if (!Array.isArray(current) || !Array.isArray(next) || current.length !== next.length) {
       return false;
     }
+    const knownNext = seen.get(current);
+    if (knownNext) return knownNext === next;
+    seen.set(current, next);
     for (let index = 0; index < current.length; index++) {
       const equal = compareStructuredValues(current[index], next[index], seen);
       if (equal !== true) return equal;
@@ -106,22 +109,15 @@ const compareStructuredValues = (
 };
 
 const areParsedValuesEqual = <T>(parser: Parser<T>, current: T | null, next: T | null) => {
+  if (Object.is(current, next)) return true;
   const structuredResult = compareStructuredValues(current, next);
-  if (structuredResult !== undefined) return structuredResult;
+  if (structuredResult === false) return false;
   if (current === null || next === null) return false;
 
   try {
     return parser.serialize(current) === parser.serialize(next);
   } catch {
-    return false;
-  }
-};
-
-const getParserSignature = (parser: Parser<unknown>): string => {
-  try {
-    return `${Function.prototype.toString.call(parser.parse)}\0${Function.prototype.toString.call(parser.serialize)}`;
-  } catch {
-    return "";
+    return structuredResult === true;
   }
 };
 
@@ -249,7 +245,6 @@ export function useQueryState<TParser extends Parser<any>>(
 
   const stateRef = useRef(state);
   const stateKeyRef = useRef(key);
-  const stateParserSignatureRef = useRef(getParserSignature(parser));
   const isInternalUpdateRef = useRef(false);
   stateRef.current = state;
 
@@ -280,11 +275,8 @@ export function useQueryState<TParser extends Parser<any>>(
       const searchParams = getCurrentSearchParams();
       const value = searchParams.get(key);
       const parsed = parser.parse(value ?? "");
-      const parserSignature = getParserSignature(parser);
-      const sourceChanged =
-        stateKeyRef.current !== key || stateParserSignatureRef.current !== parserSignature;
+      const sourceChanged = stateKeyRef.current !== key;
       stateKeyRef.current = key;
-      stateParserSignatureRef.current = parserSignature;
       if (sourceChanged || !areParsedValuesEqual(parser, stateRef.current, parsed)) {
         setState(parsed);
         stateRef.current = parsed;
@@ -357,11 +349,6 @@ export function useQueryStates<T extends Record<string, Parser<any>>>(
   });
 
   const stateRef = useRef(state);
-  const stateParserSignaturesRef = useRef(
-    Object.fromEntries(
-      Object.entries(parsers).map(([key, parser]) => [key, getParserSignature(parser)]),
-    ),
-  );
   stateRef.current = state;
 
   const setValues = useCallback(
@@ -406,15 +393,10 @@ export function useQueryStates<T extends Record<string, Parser<any>>>(
         const value = searchParams.get(key);
         const parsed = parser.parse(value ?? "");
         const currentValue = stateRef.current[key as keyof T];
-        const parserSignature = getParserSignature(parser);
 
-        if (
-          stateParserSignaturesRef.current[key] !== parserSignature ||
-          !areParsedValuesEqual(parser, currentValue, parsed)
-        ) {
+        if (!areParsedValuesEqual(parser, currentValue, parsed)) {
           hasChanged = true;
         }
-        stateParserSignaturesRef.current[key] = parserSignature;
         result[key as keyof T] = parsed;
       });
 

--- a/packages/farm/src/query/client.ts
+++ b/packages/farm/src/query/client.ts
@@ -55,6 +55,19 @@ const getCurrentSearchParams = (): URLSearchParams => {
 
 const throttleTimers = new Map<string, ReturnType<typeof setTimeout>>();
 
+const areParsedValuesEqual = <T>(parser: Parser<T>, current: T | null, next: T | null) => {
+  if (Object.is(current, next)) return true;
+  if (current === null || next === null || typeof current !== typeof next) return false;
+  if (Array.isArray(current) !== Array.isArray(next)) return false;
+  if (current instanceof Date !== next instanceof Date) return false;
+
+  try {
+    return parser.serialize(current) === parser.serialize(next);
+  } catch {
+    return false;
+  }
+};
+
 const applyChange = (
   searchParams: URLSearchParams,
   updates: Record<string, string | null>,
@@ -208,7 +221,7 @@ export function useQueryState<TParser extends Parser<any>>(
       const searchParams = getCurrentSearchParams();
       const value = searchParams.get(key);
       const parsed = parser.parse(value ?? "");
-      if (!Object.is(stateRef.current, parsed)) {
+      if (!areParsedValuesEqual(parser, stateRef.current, parsed)) {
         setState(parsed);
         stateRef.current = parsed;
       }
@@ -221,7 +234,7 @@ export function useQueryState<TParser extends Parser<any>>(
 
       const value = searchParams.get(key);
       const parsed = parser.parse(value ?? "");
-      if (!Object.is(stateRef.current, parsed)) {
+      if (!areParsedValuesEqual(parser, stateRef.current, parsed)) {
         setState(parsed);
         stateRef.current = parsed;
       }
@@ -232,7 +245,7 @@ export function useQueryState<TParser extends Parser<any>>(
         return;
       }
 
-      if (!Object.is(stateRef.current, payload.state)) {
+      if (!areParsedValuesEqual(parser, stateRef.current, payload.state)) {
         setState(payload.state);
         stateRef.current = payload.state;
       }
@@ -265,7 +278,7 @@ export function useQueryStates<T extends Record<string, Parser<any>>>(
   (updates: Partial<{ [K in keyof T]: ReturnType<T[K]["parse"]> | null }>) => void,
 ] {
   const keys = Object.keys(parsers);
-  const watchKeys = keys.join("&");
+  const watchKeys = JSON.stringify(keys);
 
   const [state, setState] = useState<{ [K in keyof T]: ReturnType<T[K]["parse"]> }>(() => {
     const searchParams = getCurrentSearchParams();
@@ -325,7 +338,7 @@ export function useQueryStates<T extends Record<string, Parser<any>>>(
         const parsed = parser.parse(value ?? "");
         const currentValue = stateRef.current[key as keyof T];
 
-        if (!Object.is(currentValue, parsed)) {
+        if (!areParsedValuesEqual(parser, currentValue, parsed)) {
           hasChanged = true;
         }
         result[key as keyof T] = parsed;

--- a/packages/farm/src/query/client.ts
+++ b/packages/farm/src/query/client.ts
@@ -55,16 +55,73 @@ const getCurrentSearchParams = (): URLSearchParams => {
 
 const throttleTimers = new Map<string, ReturnType<typeof setTimeout>>();
 
-const areParsedValuesEqual = <T>(parser: Parser<T>, current: T | null, next: T | null) => {
+const compareStructuredValues = (
+  current: unknown,
+  next: unknown,
+  seen = new WeakMap<object, object>(),
+): boolean | undefined => {
   if (Object.is(current, next)) return true;
   if (current === null || next === null || typeof current !== typeof next) return false;
-  if (Array.isArray(current) !== Array.isArray(next)) return false;
-  if (current instanceof Date !== next instanceof Date) return false;
+  if (typeof current !== "object" || typeof next !== "object") return false;
+  if (current instanceof Date || next instanceof Date) {
+    return current instanceof Date && next instanceof Date && current.getTime() === next.getTime();
+  }
+  if (Array.isArray(current) || Array.isArray(next)) {
+    if (!Array.isArray(current) || !Array.isArray(next) || current.length !== next.length) {
+      return false;
+    }
+    for (let index = 0; index < current.length; index++) {
+      const equal = compareStructuredValues(current[index], next[index], seen);
+      if (equal !== true) return equal;
+    }
+    return true;
+  }
+
+  const currentPrototype = Object.getPrototypeOf(current);
+  const nextPrototype = Object.getPrototypeOf(next);
+  if (currentPrototype !== nextPrototype) return false;
+  if (currentPrototype !== Object.prototype && currentPrototype !== null) return undefined;
+
+  const knownNext = seen.get(current);
+  if (knownNext) return knownNext === next;
+  seen.set(current, next);
+
+  const currentKeys = Object.keys(current);
+  const nextKeys = Object.keys(next);
+  if (
+    currentKeys.length !== nextKeys.length ||
+    currentKeys.some((key) => !Object.prototype.hasOwnProperty.call(next, key))
+  ) {
+    return false;
+  }
+  for (const key of currentKeys) {
+    const equal = compareStructuredValues(
+      (current as Record<string, unknown>)[key],
+      (next as Record<string, unknown>)[key],
+      seen,
+    );
+    if (equal !== true) return equal;
+  }
+  return true;
+};
+
+const areParsedValuesEqual = <T>(parser: Parser<T>, current: T | null, next: T | null) => {
+  const structuredResult = compareStructuredValues(current, next);
+  if (structuredResult !== undefined) return structuredResult;
+  if (current === null || next === null) return false;
 
   try {
     return parser.serialize(current) === parser.serialize(next);
   } catch {
     return false;
+  }
+};
+
+const getParserSignature = (parser: Parser<unknown>): string => {
+  try {
+    return `${Function.prototype.toString.call(parser.parse)}\0${Function.prototype.toString.call(parser.serialize)}`;
+  } catch {
+    return "";
   }
 };
 
@@ -191,6 +248,8 @@ export function useQueryState<TParser extends Parser<any>>(
   });
 
   const stateRef = useRef(state);
+  const stateKeyRef = useRef(key);
+  const stateParserSignatureRef = useRef(getParserSignature(parser));
   const isInternalUpdateRef = useRef(false);
   stateRef.current = state;
 
@@ -221,7 +280,12 @@ export function useQueryState<TParser extends Parser<any>>(
       const searchParams = getCurrentSearchParams();
       const value = searchParams.get(key);
       const parsed = parser.parse(value ?? "");
-      if (!areParsedValuesEqual(parser, stateRef.current, parsed)) {
+      const parserSignature = getParserSignature(parser);
+      const sourceChanged =
+        stateKeyRef.current !== key || stateParserSignatureRef.current !== parserSignature;
+      stateKeyRef.current = key;
+      stateParserSignatureRef.current = parserSignature;
+      if (sourceChanged || !areParsedValuesEqual(parser, stateRef.current, parsed)) {
         setState(parsed);
         stateRef.current = parsed;
       }
@@ -293,6 +357,11 @@ export function useQueryStates<T extends Record<string, Parser<any>>>(
   });
 
   const stateRef = useRef(state);
+  const stateParserSignaturesRef = useRef(
+    Object.fromEntries(
+      Object.entries(parsers).map(([key, parser]) => [key, getParserSignature(parser)]),
+    ),
+  );
   stateRef.current = state;
 
   const setValues = useCallback(
@@ -337,10 +406,15 @@ export function useQueryStates<T extends Record<string, Parser<any>>>(
         const value = searchParams.get(key);
         const parsed = parser.parse(value ?? "");
         const currentValue = stateRef.current[key as keyof T];
+        const parserSignature = getParserSignature(parser);
 
-        if (!areParsedValuesEqual(parser, currentValue, parsed)) {
+        if (
+          stateParserSignaturesRef.current[key] !== parserSignature ||
+          !areParsedValuesEqual(parser, currentValue, parsed)
+        ) {
           hasChanged = true;
         }
+        stateParserSignaturesRef.current[key] = parserSignature;
         result[key as keyof T] = parsed;
       });
 


### PR DESCRIPTION
## Problem

`useQueryState` kept the previous value when its key changed, and `useQueryStates` could retain keys from the previous parser map. Components rendered stale URL state until another history or emitter event happened.

## Root cause

Both hooks subscribed again when their inputs changed, but their state initializer only ran on the first mount. The multi-key equality check also compared values without checking that the object shape still matched the parser map.

## Change

Re-read the current URL as each subscription effect is installed and treat added or removed parser keys as a state change. `useQueryStates` now replaces its result with exactly the active parser keys.

## Safety and compatibility

Normal history/emitter synchronization and shallow updates are unchanged. Object identity is retained when both the declared keys and parsed values are unchanged, avoiding unnecessary state updates.

## Verification

- `pnpm --filter @farm.js/core exec vitest run src/__tests__/query-client-shallow.test.tsx`
- `pnpm --filter @farm.js/core type-check`
- `pnpm exec oxlint packages/farm/src/query/client.ts packages/farm/src/__tests__/query-client-shallow.test.tsx`
- `pnpm exec oxfmt packages/farm/src/query/client.ts packages/farm/src/__tests__/query-client-shallow.test.tsx docs/src/app/docs/query/page.md`

The new tests rerender one mounted component with a different single key and a different parser-map shape; both fail before the fix.

## Documentation and release

Documented dynamic key and parser-map behavior. No manual release changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `useQueryState` and `useQueryStates` so they re-read the current URL when their key or parser inputs change, instead of rendering stale values.

**Bug Fixes**
- Changing the key or parser now re-reads the URL and replaces the value, even when the serialized output is unchanged.
- `useQueryStates` now returns exactly the keys declared in the parser map.
- Parsed values are compared by serialized output, so inline parsers returning fresh objects no longer loop and cyclic values are handled safely.
- Added regression tests for key changes, parser-map shape changes, parser identity changes, inline parser objects, and cyclic values.

<sup>Written for commit 2b68ddbd83ae3ea3c6b00f1db40e5c40d351bd3a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/692?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

