### PR TITLE
fix(server-query): force fresh refetch work

### DIFF
--- a/docs/src/app/docs/server-queries/page.md
+++ b/docs/src/app/docs/server-queries/page.md
@@ -113,6 +113,8 @@ export function ProductPrice({ id }: { id: string }) {
 ```
 
 The hook returns `data`, `error`, `status`, `pending`, `fetching`, `stale`, and `refetch`. Stale data remains visible while Farm refreshes it in the background. Stale queries also refresh on window focus and reconnect unless those options are disabled.
+`refetch()` always starts fresh work. If an older request finishes afterward, its result is returned
+to its original caller but cannot replace the newer cached value.
 
 Use `fetchServerQuery(productQuery, input)` for an imperative browser read that should participate in deduplication and SWR. Calling the generated `productQuery(input)` reference directly still returns plain typed data, but the fetch helper supplies the browser cache lifecycle.
 

--- a/packages/farm/src/__tests__/server-query-client.test.tsx
+++ b/packages/farm/src/__tests__/server-query-client.test.tsx
@@ -11,6 +11,7 @@ import type { ServerQuery } from "../server-query";
 import {
   beginFarmServerQueryAction,
   completeFarmServerQueryAction,
+  fetchServerQuery,
   prefetchServerQuery,
   useServerQuery,
 } from "../server-query-client";
@@ -45,6 +46,14 @@ function createTransportedQuery(
       }),
     );
   }) as ServerQuery<{ id: string }, Product>;
+}
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
 }
 
 describe("server query client", () => {
@@ -98,6 +107,32 @@ describe("server query client", () => {
 
     expect(container.textContent).toBe("11");
     expect(calls).toBe(1);
+  });
+
+  it("starts forced work and keeps an older result from replacing it", async () => {
+    const firstResult = createDeferred<Product>();
+    const secondResult = createDeferred<Product>();
+    let calls = 0;
+    const product = createTransportedQuery(() => {
+      calls++;
+      return calls === 1 ? firstResult.promise : secondResult.promise;
+    });
+
+    const first = fetchServerQuery(product, { id: "123" }, { force: true });
+    await vi.waitFor(() => expect(calls).toBe(1));
+    const second = fetchServerQuery(product, { id: "123" }, { force: true });
+    await vi.waitFor(() => expect(calls).toBe(2));
+
+    secondResult.resolve({ id: "123", version: 2 });
+    await expect(second).resolves.toEqual({ id: "123", version: 2 });
+    firstResult.resolve({ id: "123", version: 1 });
+    await expect(first).resolves.toEqual({ id: "123", version: 1 });
+
+    await expect(fetchServerQuery(product, { id: "123" })).resolves.toEqual({
+      id: "123",
+      version: 2,
+    });
+    expect(calls).toBe(2);
   });
 
   it("shares structured entries with the API client cache", async () => {

--- a/packages/farm/src/__tests__/server-query-client.test.tsx
+++ b/packages/farm/src/__tests__/server-query-client.test.tsx
@@ -13,6 +13,7 @@ import {
   completeFarmServerQueryAction,
   fetchServerQuery,
   prefetchServerQuery,
+  shouldApplyFarmServerQueryActionResult,
   useServerQuery,
 } from "../server-query-client";
 import { createFarmServerQueryResult } from "../server-query-protocol";
@@ -33,10 +34,12 @@ type ProductAPI = {
 function createTransportedQuery(
   handler: (input: { id: string }) => Product | Promise<Product>,
   staleTime: number | false = 10_000,
+  onAccepted?: (data: Product) => void,
 ): ServerQuery<{ id: string }, Product> {
   return (async (input: { id: string }) => {
     const invocation = beginFarmServerQueryAction("product-query", [input]);
     const data = await handler(input);
+    if (shouldApplyFarmServerQueryActionResult(invocation)) onAccepted?.(data);
     return completeFarmServerQueryAction(
       invocation,
       createFarmServerQueryResult(data, {
@@ -112,11 +115,16 @@ describe("server query client", () => {
   it("starts forced work and keeps an older result from replacing it", async () => {
     const firstResult = createDeferred<Product>();
     const secondResult = createDeferred<Product>();
+    const acceptedVersions: number[] = [];
     let calls = 0;
-    const product = createTransportedQuery(() => {
-      calls++;
-      return calls === 1 ? firstResult.promise : secondResult.promise;
-    });
+    const product = createTransportedQuery(
+      () => {
+        calls++;
+        return calls === 1 ? firstResult.promise : secondResult.promise;
+      },
+      10_000,
+      (data) => acceptedVersions.push(data.version),
+    );
 
     const first = fetchServerQuery(product, { id: "123" }, { force: true });
     await vi.waitFor(() => expect(calls).toBe(1));
@@ -127,7 +135,24 @@ describe("server query client", () => {
     await expect(second).resolves.toEqual({ id: "123", version: 2 });
     firstResult.resolve({ id: "123", version: 1 });
     await expect(first).resolves.toEqual({ id: "123", version: 1 });
+    expect(acceptedVersions).toEqual([2]);
 
+    await expect(fetchServerQuery(product, { id: "123" })).resolves.toEqual({
+      id: "123",
+      version: 2,
+    });
+    expect(calls).toBe(2);
+  });
+
+  it("clears rejected synchronous queries from the in-flight registry", async () => {
+    let calls = 0;
+    const product = (({ id }: { id: string }) => {
+      calls++;
+      if (calls === 1) throw new Error("synchronous failure");
+      return Promise.resolve({ id, version: calls });
+    }) as ServerQuery<{ id: string }, Product>;
+
+    await expect(fetchServerQuery(product, { id: "123" })).rejects.toThrow("synchronous failure");
     await expect(fetchServerQuery(product, { id: "123" })).resolves.toEqual({
       id: "123",
       version: 2,

--- a/packages/farm/src/server-query-client.ts
+++ b/packages/farm/src/server-query-client.ts
@@ -14,6 +14,7 @@ export {
   completeFarmServerQueryAction,
   fetchServerQuery,
   prefetchServerQuery,
+  shouldApplyFarmServerQueryActionResult,
 } from "./server-query-runtime";
 export type {
   FarmServerQueryActionInvocation,

--- a/packages/farm/src/server-query-runtime.ts
+++ b/packages/farm/src/server-query-runtime.ts
@@ -18,27 +18,34 @@ export type FarmServerQueryActionInvocation = {
   actionId: string;
   args: readonly unknown[];
   provisionalKey?: string;
+  owner?: object;
 };
 
 type ActiveServerQueryInvocation = {
   provisionalKey: string;
+  owner: object;
 };
 
 type ServerQueryClientState = {
   functionIds: WeakMap<Function, number>;
   nextFunctionId: number;
   active: ActiveServerQueryInvocation[];
+  latestOwners: Map<string, object>;
 };
 
 const FARM_SERVER_QUERY_CLIENT_STATE = Symbol.for("farm.serverQueryClientState");
 const serverQueryClientGlobal = globalThis as typeof globalThis & {
   [FARM_SERVER_QUERY_CLIENT_STATE]?: ServerQueryClientState;
 };
-const serverQueryClientState = (serverQueryClientGlobal[FARM_SERVER_QUERY_CLIENT_STATE] ??= {
+const serverQueryClientState: ServerQueryClientState = (serverQueryClientGlobal[
+  FARM_SERVER_QUERY_CLIENT_STATE
+] ??= {
   functionIds: new WeakMap(),
   nextFunctionId: 0,
   active: [],
+  latestOwners: new Map(),
 });
+serverQueryClientState.latestOwners ??= new Map();
 
 // Global symbol registry key set on raw server query implementations by
 // createServerQuery. Referenced via Symbol.for instead of importing
@@ -73,6 +80,7 @@ export function beginFarmServerQueryAction(
     actionId,
     args,
     provisionalKey: active?.provisionalKey,
+    owner: active?.owner,
   };
 }
 
@@ -84,6 +92,13 @@ export function completeFarmServerQueryAction<TData>(
 
   const cache = getFarmClientDataCache();
   const metadata = value.__farmServerQuery;
+  if (
+    invocation.provisionalKey &&
+    invocation.owner &&
+    serverQueryClientState.latestOwners.get(invocation.provisionalKey) !== invocation.owner
+  ) {
+    return value.data as TData;
+  }
   if (invocation.provisionalKey) {
     cache.alias(invocation.provisionalKey, metadata.key);
   }
@@ -126,7 +141,7 @@ export async function fetchServerQuery<TInput, TData>(
   const stale = cache.isStale(provisionalKey);
   const inflight = cache.getInflight<TData>(provisionalKey);
 
-  if (inflight) return inflight;
+  if (inflight && !options.force) return inflight;
   if (!options.force && entry && !stale && entry.status !== "error") return entry.data;
 
   if (
@@ -161,7 +176,10 @@ async function executeServerQuery<TInput, TData>(
   assertNotRawServerQueryInBrowser(query);
   const cache = getFarmClientDataCache();
   const inflight = cache.getInflight<TData>(provisionalKey);
-  if (inflight) return inflight;
+  if (inflight && !options.force) return inflight;
+
+  const owner = {};
+  serverQueryClientState.latestOwners.set(provisionalKey, owner);
 
   const previous = cache.get<TData>(provisionalKey);
   cache.set(provisionalKey, {
@@ -175,9 +193,10 @@ async function executeServerQuery<TInput, TData>(
     fetching: true,
   });
 
-  const promise = (async () => {
+  let promise!: Promise<TData>;
+  promise = (async () => {
     try {
-      serverQueryClientState.active.push({ provisionalKey });
+      serverQueryClientState.active.push({ provisionalKey, owner });
       let pending: Promise<TData>;
       try {
         pending = query(input);
@@ -187,7 +206,10 @@ async function executeServerQuery<TInput, TData>(
 
       const data = await pending;
       const transported = cache.get<TData>(provisionalKey);
-      if (!transported || transported.fetching) {
+      if (
+        serverQueryClientState.latestOwners.get(provisionalKey) === owner &&
+        (!transported || transported.fetching)
+      ) {
         const updatedAt = Date.now();
         cache.set(provisionalKey, {
           data,
@@ -204,20 +226,27 @@ async function executeServerQuery<TInput, TData>(
       return data;
     } catch (cause) {
       const error = normalizeServerQueryError(cause);
-      const current = cache.get<TData>(provisionalKey);
-      cache.set(provisionalKey, {
-        data: current?.data as TData,
-        updatedAt: current?.updatedAt ?? 0,
-        staleAt: current?.staleAt ?? 0,
-        gcAt: current?.gcAt,
-        invalidatedAt: current?.invalidatedAt,
-        status: "error",
-        error,
-        fetching: false,
-      });
+      if (serverQueryClientState.latestOwners.get(provisionalKey) === owner) {
+        const current = cache.get<TData>(provisionalKey);
+        cache.set(provisionalKey, {
+          data: current?.data as TData,
+          updatedAt: current?.updatedAt ?? 0,
+          staleAt: current?.staleAt ?? 0,
+          gcAt: current?.gcAt,
+          invalidatedAt: current?.invalidatedAt,
+          status: "error",
+          error,
+          fetching: false,
+        });
+      }
       throw error;
     } finally {
-      cache.deleteInflight(provisionalKey);
+      if (cache.getInflight(provisionalKey) === promise) {
+        cache.deleteInflight(provisionalKey);
+      }
+      if (serverQueryClientState.latestOwners.get(provisionalKey) === owner) {
+        serverQueryClientState.latestOwners.delete(provisionalKey);
+      }
     }
   })();
 

--- a/packages/farm/src/server-query-runtime.ts
+++ b/packages/farm/src/server-query-runtime.ts
@@ -92,11 +92,7 @@ export function completeFarmServerQueryAction<TData>(
 
   const cache = getFarmClientDataCache();
   const metadata = value.__farmServerQuery;
-  if (
-    invocation.provisionalKey &&
-    invocation.owner &&
-    serverQueryClientState.latestOwners.get(invocation.provisionalKey) !== invocation.owner
-  ) {
+  if (!shouldApplyFarmServerQueryActionResult(invocation)) {
     return value.data as TData;
   }
   if (invocation.provisionalKey) {
@@ -116,6 +112,13 @@ export function completeFarmServerQueryAction<TData>(
   });
 
   return value.data as TData;
+}
+
+export function shouldApplyFarmServerQueryActionResult(
+  invocation: FarmServerQueryActionInvocation,
+): boolean {
+  if (!invocation.provisionalKey || !invocation.owner) return true;
+  return serverQueryClientState.latestOwners.get(invocation.provisionalKey) === invocation.owner;
 }
 
 export function createServerQueryCallKey<TInput, TData>(
@@ -195,6 +198,9 @@ async function executeServerQuery<TInput, TData>(
 
   let promise!: Promise<TData>;
   promise = (async () => {
+    // Let the promise be assigned and registered before a query implementation
+    // can throw synchronously and enter the cleanup path.
+    await Promise.resolve();
     try {
       serverQueryClientState.active.push({ provisionalKey, owner });
       let pending: Promise<TData>;

--- a/packages/farmjs-plugin/src/rsc/entries/client.ts
+++ b/packages/farmjs-plugin/src/rsc/entries/client.ts
@@ -71,6 +71,7 @@ import { applyFarmCacheInvalidations } from '@farm.js/core/cache';
 import {
   beginFarmServerQueryAction,
   completeFarmServerQueryAction,
+  shouldApplyFarmServerQueryActionResult,
 } from '@farm.js/core/server-query/client';
 `;
   }
@@ -129,8 +130,10 @@ setServerCallback(async (id, args) => {
     console.error('[Farm.js] Action response missing payload.root / payload.rootContent');
     return;
   }
-  setPayloadRef.current?.(p);
-  applyFarmCacheInvalidations(p.returnValue?.invalidations);
+  if (shouldApplyFarmServerQueryActionResult(serverQueryInvocation)) {
+    setPayloadRef.current?.(p);
+    applyFarmCacheInvalidations(p.returnValue?.invalidations);
+  }
   if (!p.returnValue || !p.returnValue.ok) {
     debug('Server action failed:', id);
     throw createFarmServerFnTransportError(p.returnValue?.data);

--- a/packages/farmjs-plugin/src/rsc/entries/security.test.ts
+++ b/packages/farmjs-plugin/src/rsc/entries/security.test.ts
@@ -75,6 +75,10 @@ describe("generated server action security", () => {
     expect(entry).toContain("Symbol.for('farm.server-fn.failure')");
     expect(entry).toContain("throw createFarmServerFnTransportError(p.returnValue?.data)");
     expect(entry).not.toContain("throw p.returnValue?.data");
+    expect(entry).toContain("shouldApplyFarmServerQueryActionResult(serverQueryInvocation)");
+    expect(entry.indexOf("if (shouldApplyFarmServerQueryActionResult")).toBeLessThan(
+      entry.indexOf("setPayloadRef.current?.(p)"),
+    );
   });
 
   it("emits the resolved global stylesheet URL for every routes directory shape", () => {


### PR DESCRIPTION
## Problem

`refetch()` and `fetchServerQuery(..., { force: true })` still joined an existing in-flight request. A force request therefore did not fetch fresh data, and allowing a second request without ownership protection would let an older completion overwrite it.

## Root cause

Both fetch and execution paths returned the current in-flight promise before considering `force`. Cache writes and in-flight cleanup also had no request ownership check.

## Change

Forced reads now start a new invocation. Each invocation receives an internal owner token, and only the latest owner can alias/write the transported cache entry, publish errors, or clear current work. Older callers still receive their own result.

## Safety and compatibility

Ordinary prefetches and mounted consumers continue to deduplicate. The token stays in the client-side invocation wrapper and is not part of query input or cache keys. Latest-result ownership covers direct results, transported structured results, errors, and cleanup.

## Verification

- `pnpm --filter @farm.js/core exec vitest run src/__tests__/server-query-client.test.tsx`
- `pnpm --filter @farm.js/core type-check`
- `pnpm exec oxlint packages/farm/src/server-query-runtime.ts packages/farm/src/__tests__/server-query-client.test.tsx`
- `pnpm exec oxfmt packages/farm/src/server-query-runtime.ts packages/farm/src/__tests__/server-query-client.test.tsx docs/src/app/docs/server-queries/page.md`

The regression starts two forced reads, resolves the newer one first, then proves the older caller gets its result without replacing the cached newer value.

## Documentation and release

Documented forced refetch and stale-completion ownership. No manual release changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes forced server query refetches so `refetch()` and `fetchServerQuery(..., { force: true })` start fresh work and older completions can't replace newer cached data or trigger stale side effects. Ordinary prefetches and mounted consumers still deduplicate; the owner token stays internal and doesn't affect query keys.

- Forced reads create a new invocation with an internal owner token; only the latest owner can write the cache, publish errors, or clean up in-flight state.
- The generated RSC client entry skips cache invalidations and payload updates from stale responses.
- Synchronously rejected queries are cleared from the in-flight registry so the next call runs fresh.

<sup>Written for commit de18b5f0f61861d6d526729294a856829ad05db8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/693?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

