### PR TITLE
fix(link): preserve native URI schemes

### DIFF
--- a/docs/src/app/docs/routing/page.md
+++ b/docs/src/app/docs/routing/page.md
@@ -117,10 +117,9 @@ Changing only the fragment preserves SPA state, honors push versus replace histo
 request route data again.
 Native anchor behavior still takes precedence: for example, a `Link` with a `download` attribute is
 handled by the browser instead of Farm's SPA router. Absolute URI schemes such as `mailto:`, `tel:`,
-and `sms:` are also passed through unchanged and are never prefetched as app routes.
-For an app-specific scheme, declaration-merge `LinkExternalUriSchemes` from
-`@farm.js/core/client`; the runtime already delegates every syntactically valid URI scheme to the
-browser.
+and `sms:` are also passed through unchanged and are never prefetched as app routes. Literal custom
+schemes such as `customapp:open` are validated from their URI grammar and work without registration.
+For a reusable custom-scheme type, use `ExternalHref<\`customapp:${string}\>`(or declaration-merge`LinkExternalUriSchemes`when the scheme should belong to the default`ExternalHref` union).
 
 **Client navigation**
 

--- a/docs/src/app/docs/routing/page.md
+++ b/docs/src/app/docs/routing/page.md
@@ -116,7 +116,8 @@ Farm writes the route union into the consolidated `src/farm.d.ts` declaration fi
 Changing only the fragment preserves SPA state, honors push versus replace history, and does not
 request route data again.
 Native anchor behavior still takes precedence: for example, a `Link` with a `download` attribute is
-handled by the browser instead of Farm's SPA router.
+handled by the browser instead of Farm's SPA router. Absolute URI schemes such as `mailto:`, `tel:`,
+and `sms:` are also passed through unchanged and are never prefetched as app routes.
 
 **Client navigation**
 

--- a/docs/src/app/docs/routing/page.md
+++ b/docs/src/app/docs/routing/page.md
@@ -118,6 +118,9 @@ request route data again.
 Native anchor behavior still takes precedence: for example, a `Link` with a `download` attribute is
 handled by the browser instead of Farm's SPA router. Absolute URI schemes such as `mailto:`, `tel:`,
 and `sms:` are also passed through unchanged and are never prefetched as app routes.
+For an app-specific scheme, declaration-merge `LinkExternalUriSchemes` from
+`@farm.js/core/client`; the runtime already delegates every syntactically valid URI scheme to the
+browser.
 
 **Client navigation**
 

--- a/packages/farm/src/__tests__/link.test.tsx
+++ b/packages/farm/src/__tests__/link.test.tsx
@@ -368,6 +368,31 @@ describe("Link", () => {
       expect(prefetch).not.toHaveBeenCalled();
       expect(navigate).not.toHaveBeenCalled();
     });
+
+    it("leaves native URI schemes to the browser", () => {
+      const el = render(
+        createElement(Link, { href: "tel:+15551234567", prefetch: "render" }),
+      ) as HTMLAnchorElement;
+      const event = new MouseEvent("click", { bubbles: true, button: 0, cancelable: true });
+      let farmPreventedDefault: boolean | undefined;
+      container.addEventListener(
+        "click",
+        (nativeEvent) => {
+          farmPreventedDefault = nativeEvent.defaultPrevented;
+          nativeEvent.preventDefault();
+        },
+        { once: true },
+      );
+
+      act(() => {
+        el.dispatchEvent(event);
+      });
+
+      expect(el.getAttribute("href")).toBe("tel:+15551234567");
+      expect(farmPreventedDefault).toBe(false);
+      expect(prefetch).not.toHaveBeenCalled();
+      expect(navigate).not.toHaveBeenCalled();
+    });
   });
 
   describe("typed href", () => {
@@ -415,10 +440,8 @@ describe("Link", () => {
         | `/users/${string}?${string}`
         | `/users/${string}#${string}`
         | `/users/${string}?${string}#${string}`
-        | `http://${string}`
-        | `https://${string}`
         | `//${string}`
-        | `mailto:${string}`
+        | `${string}:${string}`
       >();
     });
 

--- a/packages/farm/src/__tests__/link.test.tsx
+++ b/packages/farm/src/__tests__/link.test.tsx
@@ -398,8 +398,23 @@ describe("Link", () => {
       const el = render(
         createElement(Link, { href: "customapp:open/settings", prefetch: "render" }),
       ) as HTMLAnchorElement;
+      const event = new MouseEvent("click", { bubbles: true, button: 0, cancelable: true });
+      let farmPreventedDefault: boolean | undefined;
+      container.addEventListener(
+        "click",
+        (nativeEvent) => {
+          farmPreventedDefault = nativeEvent.defaultPrevented;
+          nativeEvent.preventDefault();
+        },
+        { once: true },
+      );
+
+      act(() => {
+        el.dispatchEvent(event);
+      });
 
       expect(el.getAttribute("href")).toBe("customapp:open/settings");
+      expect(farmPreventedDefault).toBe(false);
       expect(prefetch).not.toHaveBeenCalled();
       expect(navigate).not.toHaveBeenCalled();
     });

--- a/packages/farm/src/__tests__/link.test.tsx
+++ b/packages/farm/src/__tests__/link.test.tsx
@@ -5,7 +5,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { act, createElement } from "react";
 import { expectTypeOf } from "vitest";
 import { createRoot } from "react-dom/client";
-import { Link, type LinkProps, type RouteHref } from "../client/link";
+import { Link, type ExternalHref, type LinkProps, type RouteHref } from "../client/link";
 import { setFarmTrailingSlashPreference } from "../trailing-slash";
 
 const prefetch = vi.fn().mockResolvedValue(undefined);
@@ -441,8 +441,14 @@ describe("Link", () => {
         | `/users/${string}#${string}`
         | `/users/${string}?${string}#${string}`
         | `//${string}`
-        | `${string}:${string}`
+        | ExternalHref
       >();
+
+      expectTypeOf<"/search?q=a:b">().not.toMatchTypeOf<ExternalHref>();
+      expectTypeOf<"/users/:id">().not.toMatchTypeOf<ExternalHref>();
+      expectTypeOf<"/about#sec:1">().not.toMatchTypeOf<ExternalHref>();
+      expectTypeOf<"tel:+15551234567">().toMatchTypeOf<ExternalHref>();
+      expectTypeOf<"web+farm:preview">().toMatchTypeOf<ExternalHref>();
     });
 
     it("accepts a union variable of routes whose params are already resolved", () => {

--- a/packages/farm/src/__tests__/link.test.tsx
+++ b/packages/farm/src/__tests__/link.test.tsx
@@ -393,6 +393,16 @@ describe("Link", () => {
       expect(prefetch).not.toHaveBeenCalled();
       expect(navigate).not.toHaveBeenCalled();
     });
+
+    it("leaves custom URI schemes to the browser", () => {
+      const el = render(
+        createElement(Link, { href: "customapp:open/settings", prefetch: "render" }),
+      ) as HTMLAnchorElement;
+
+      expect(el.getAttribute("href")).toBe("customapp:open/settings");
+      expect(prefetch).not.toHaveBeenCalled();
+      expect(navigate).not.toHaveBeenCalled();
+    });
   });
 
   describe("typed href", () => {
@@ -449,7 +459,17 @@ describe("Link", () => {
       expectTypeOf<"/about#sec:1">().not.toMatchTypeOf<ExternalHref>();
       expectTypeOf<"tel:+15551234567">().toMatchTypeOf<ExternalHref>();
       expectTypeOf<"vscode://file/app.ts">().toMatchTypeOf<ExternalHref>();
+      expectTypeOf<"customapp:open/settings">().toMatchTypeOf<
+        ExternalHref<"customapp:open/settings">
+      >();
+      expectTypeOf<"1custom:value">().not.toMatchTypeOf<ExternalHref<"1custom:value">>();
+      expectTypeOf<"custom app:value">().not.toMatchTypeOf<ExternalHref<"custom app:value">>();
       expectTypeOf<"not a scheme:value">().not.toMatchTypeOf<ExternalHref>();
+
+      const customSchemeProps = {
+        href: "customapp:open/settings",
+      } satisfies LinkProps<"/about", "customapp:open/settings">;
+      expect(customSchemeProps.href).toBe("customapp:open/settings");
     });
 
     it("accepts a union variable of routes whose params are already resolved", () => {

--- a/packages/farm/src/__tests__/link.test.tsx
+++ b/packages/farm/src/__tests__/link.test.tsx
@@ -448,7 +448,8 @@ describe("Link", () => {
       expectTypeOf<"/users/:id">().not.toMatchTypeOf<ExternalHref>();
       expectTypeOf<"/about#sec:1">().not.toMatchTypeOf<ExternalHref>();
       expectTypeOf<"tel:+15551234567">().toMatchTypeOf<ExternalHref>();
-      expectTypeOf<"web+farm:preview">().toMatchTypeOf<ExternalHref>();
+      expectTypeOf<"vscode://file/app.ts">().toMatchTypeOf<ExternalHref>();
+      expectTypeOf<"not a scheme:value">().not.toMatchTypeOf<ExternalHref>();
     });
 
     it("accepts a union variable of routes whose params are already resolved", () => {

--- a/packages/farm/src/client.ts
+++ b/packages/farm/src/client.ts
@@ -133,6 +133,7 @@ export type {
   DefaultRoutePattern,
   DefaultRouteHref,
   ExternalHref,
+  LinkExternalUriSchemes,
   RouteHref,
   RouteParamValue,
   RouteOptionalParamValue,

--- a/packages/farm/src/client/index.ts
+++ b/packages/farm/src/client/index.ts
@@ -14,6 +14,7 @@ export type {
   DefaultRoutePattern,
   DefaultRouteHref,
   ExternalHref,
+  LinkExternalUriSchemes,
   RouteHref,
   RouteParamValue,
   RouteOptionalParamValue,

--- a/packages/farm/src/client/link.tsx
+++ b/packages/farm/src/client/link.tsx
@@ -58,37 +58,39 @@ export type RouteParams<TRoute extends string> = string extends TRoute
   ? FarmRouterPathParams
   : ExtractRouteParams<StripRouteSuffix<TRoute>>;
 
-type LowercaseUriSchemeInitial =
-  | "a"
-  | "b"
-  | "c"
-  | "d"
-  | "e"
-  | "f"
-  | "g"
-  | "h"
-  | "i"
-  | "j"
-  | "k"
-  | "l"
-  | "m"
-  | "n"
-  | "o"
-  | "p"
-  | "q"
-  | "r"
-  | "s"
-  | "t"
-  | "u"
-  | "v"
-  | "w"
-  | "x"
-  | "y"
-  | "z";
-type UriSchemeInitial = LowercaseUriSchemeInitial | Uppercase<LowercaseUriSchemeInitial>;
+/** URI schemes recognized as typed external Link targets. Apps may augment this interface. */
+export interface LinkExternalUriSchemes {
+  about: true;
+  blob: true;
+  data: true;
+  file: true;
+  ftp: true;
+  ftps: true;
+  geo: true;
+  git: true;
+  http: true;
+  https: true;
+  im: true;
+  intent: true;
+  irc: true;
+  ircs: true;
+  magnet: true;
+  mailto: true;
+  market: true;
+  sms: true;
+  ssh: true;
+  tel: true;
+  urn: true;
+  vscode: true;
+  webcal: true;
+  ws: true;
+  wss: true;
+}
+
+type ExternalUriScheme = Extract<keyof LinkExternalUriSchemes, string>;
 
 /** External URLs; these are never type-checked as routes. */
-export type ExternalHref = `//${string}` | `${UriSchemeInitial}${string}:${string}`;
+export type ExternalHref = `//${string}` | `${ExternalUriScheme}:${string}`;
 
 type StripRouteSuffix<TRoute extends string> = TRoute extends `${infer Path}?${string}`
   ? StripRouteSuffix<Path>

--- a/packages/farm/src/client/link.tsx
+++ b/packages/farm/src/client/link.tsx
@@ -89,8 +89,74 @@ export interface LinkExternalUriSchemes {
 
 type ExternalUriScheme = Extract<keyof LinkExternalUriSchemes, string>;
 
+type UriSchemeLetter =
+  | "a"
+  | "b"
+  | "c"
+  | "d"
+  | "e"
+  | "f"
+  | "g"
+  | "h"
+  | "i"
+  | "j"
+  | "k"
+  | "l"
+  | "m"
+  | "n"
+  | "o"
+  | "p"
+  | "q"
+  | "r"
+  | "s"
+  | "t"
+  | "u"
+  | "v"
+  | "w"
+  | "x"
+  | "y"
+  | "z";
+type UriSchemeStart = UriSchemeLetter | Uppercase<UriSchemeLetter>;
+type UriSchemeCharacter =
+  | UriSchemeStart
+  | "0"
+  | "1"
+  | "2"
+  | "3"
+  | "4"
+  | "5"
+  | "6"
+  | "7"
+  | "8"
+  | "9"
+  | "+"
+  | "-"
+  | ".";
+type IsUriSchemeTail<TValue extends string> = TValue extends ""
+  ? true
+  : TValue extends `${infer First}${infer Rest}`
+    ? First extends UriSchemeCharacter
+      ? IsUriSchemeTail<Rest>
+      : false
+    : false;
+type IsUriScheme<TValue extends string> = TValue extends `${infer First}${infer Rest}`
+  ? First extends UriSchemeStart
+    ? IsUriSchemeTail<Rest>
+    : false
+  : false;
+
+type KnownExternalHref = `//${string}` | `${ExternalUriScheme}:${string}`;
+
 /** External URLs; these are never type-checked as routes. */
-export type ExternalHref = `//${string}` | `${ExternalUriScheme}:${string}`;
+export type ExternalHref<THref extends string = string> = string extends THref
+  ? KnownExternalHref
+  : THref extends `//${string}`
+    ? THref
+    : THref extends `${infer Scheme}:${string}`
+      ? IsUriScheme<Scheme> extends true
+        ? THref
+        : never
+      : never;
 
 type StripRouteSuffix<TRoute extends string> = TRoute extends `${infer Path}?${string}`
   ? StripRouteSuffix<Path>
@@ -154,21 +220,21 @@ type LinkRouteTargetProps<TRoute extends string> = [RoutesWithRequiredParams<TRo
       } & LinkRouteParamsProps<TRoute>
     : never;
 
-type LinkExternalTargetProps = {
+type LinkExternalTargetProps<THref extends string = string> = {
   /** External URL; these are never type-checked as app routes. */
-  href: ExternalHref;
+  href: ExternalHref<THref>;
   params?: never;
 };
 
-type LinkTargetProps<TRoute extends string> =
-  | LinkExternalTargetProps
+type LinkTargetProps<TRoute extends string, THref extends string> =
+  | LinkExternalTargetProps<THref>
   | LinkRouteTargetProps<TRoute>;
 
-export type LinkProps<TRoute extends string = DefaultRouteHref> = Omit<
-  AnchorHTMLAttributes<HTMLAnchorElement>,
-  "href"
-> &
-  LinkTargetProps<TRoute> & {
+export type LinkProps<
+  TRoute extends string = DefaultRouteHref,
+  THref extends string = string,
+> = Omit<AnchorHTMLAttributes<HTMLAnchorElement>, "href"> &
+  LinkTargetProps<TRoute, THref> & {
     /**
      * When to prefetch. TanStack-style: "intent" (hover+touch), "viewport", "render", or "none".
      * Legacy: true (intent+viewport), "hover" (intent), "viewport", false/"none".
@@ -241,7 +307,7 @@ function normalizePrefetch(prefetch: LinkProps["prefetch"]): {
   return { intent: false, viewport: false, render: false };
 }
 
-function LinkInner<TRoute extends string = DefaultRouteHref>(
+function LinkInner<TRoute extends string = DefaultRouteHref, THref extends string = string>(
   {
     href,
     params,
@@ -262,7 +328,7 @@ function LinkInner<TRoute extends string = DefaultRouteHref>(
     onBlur,
     onTouchStart,
     ...props
-  }: LinkProps<TRoute>,
+  }: LinkProps<TRoute, THref>,
   ref: React.ForwardedRef<HTMLAnchorElement>,
 ) {
   const elementRef = useRef<HTMLAnchorElement | null>(null);
@@ -459,8 +525,8 @@ function LinkInner<TRoute extends string = DefaultRouteHref>(
 const LinkWithRef = forwardRef(LinkInner);
 LinkWithRef.displayName = "Link";
 
-type LinkComponentType = <TRoute extends string = DefaultRouteHref>(
-  props: LinkProps<TRoute> & { ref?: React.ForwardedRef<HTMLAnchorElement> },
+type LinkComponentType = <TRoute extends string = DefaultRouteHref, THref extends string = string>(
+  props: LinkProps<TRoute, THref> & { ref?: React.ForwardedRef<HTMLAnchorElement> },
 ) => React.ReactElement;
 
 export const Link = LinkWithRef as unknown as LinkComponentType;

--- a/packages/farm/src/client/link.tsx
+++ b/packages/farm/src/client/link.tsx
@@ -58,8 +58,37 @@ export type RouteParams<TRoute extends string> = string extends TRoute
   ? FarmRouterPathParams
   : ExtractRouteParams<StripRouteSuffix<TRoute>>;
 
+type LowercaseUriSchemeInitial =
+  | "a"
+  | "b"
+  | "c"
+  | "d"
+  | "e"
+  | "f"
+  | "g"
+  | "h"
+  | "i"
+  | "j"
+  | "k"
+  | "l"
+  | "m"
+  | "n"
+  | "o"
+  | "p"
+  | "q"
+  | "r"
+  | "s"
+  | "t"
+  | "u"
+  | "v"
+  | "w"
+  | "x"
+  | "y"
+  | "z";
+type UriSchemeInitial = LowercaseUriSchemeInitial | Uppercase<LowercaseUriSchemeInitial>;
+
 /** External URLs; these are never type-checked as routes. */
-export type ExternalHref = `//${string}` | `${string}:${string}`;
+export type ExternalHref = `//${string}` | `${UriSchemeInitial}${string}:${string}`;
 
 type StripRouteSuffix<TRoute extends string> = TRoute extends `${infer Path}?${string}`
   ? StripRouteSuffix<Path>

--- a/packages/farm/src/client/link.tsx
+++ b/packages/farm/src/client/link.tsx
@@ -59,11 +59,7 @@ export type RouteParams<TRoute extends string> = string extends TRoute
   : ExtractRouteParams<StripRouteSuffix<TRoute>>;
 
 /** External URLs; these are never type-checked as routes. */
-export type ExternalHref =
-  | `http://${string}`
-  | `https://${string}`
-  | `//${string}`
-  | `mailto:${string}`;
+export type ExternalHref = `//${string}` | `${string}:${string}`;
 
 type StripRouteSuffix<TRoute extends string> = TRoute extends `${infer Path}?${string}`
   ? StripRouteSuffix<Path>
@@ -170,13 +166,7 @@ function isModifierEvent(e: React.MouseEvent): boolean {
 }
 
 function isExternalUrl(href: string): boolean {
-  const normalizedHref = href.toLowerCase();
-  return (
-    normalizedHref.startsWith("http://") ||
-    normalizedHref.startsWith("https://") ||
-    href.startsWith("//") ||
-    normalizedHref.startsWith("mailto:")
-  );
+  return href.startsWith("//") || /^[a-zA-Z][a-zA-Z\d+.-]*:/.test(href);
 }
 
 function getRouter(): {

--- a/packages/farm/types/client.d.ts
+++ b/packages/farm/types/client.d.ts
@@ -215,37 +215,39 @@ declare module "@farm.js/core/client" {
 
   export type PrefetchBehavior = false | "intent" | "viewport" | "render" | "none";
 
-  type LowercaseUriSchemeInitial =
-    | "a"
-    | "b"
-    | "c"
-    | "d"
-    | "e"
-    | "f"
-    | "g"
-    | "h"
-    | "i"
-    | "j"
-    | "k"
-    | "l"
-    | "m"
-    | "n"
-    | "o"
-    | "p"
-    | "q"
-    | "r"
-    | "s"
-    | "t"
-    | "u"
-    | "v"
-    | "w"
-    | "x"
-    | "y"
-    | "z";
-  type UriSchemeInitial = LowercaseUriSchemeInitial | Uppercase<LowercaseUriSchemeInitial>;
+  /** URI schemes recognized as typed external Link targets. Apps may augment this interface. */
+  export interface LinkExternalUriSchemes {
+    about: true;
+    blob: true;
+    data: true;
+    file: true;
+    ftp: true;
+    ftps: true;
+    geo: true;
+    git: true;
+    http: true;
+    https: true;
+    im: true;
+    intent: true;
+    irc: true;
+    ircs: true;
+    magnet: true;
+    mailto: true;
+    market: true;
+    sms: true;
+    ssh: true;
+    tel: true;
+    urn: true;
+    vscode: true;
+    webcal: true;
+    ws: true;
+    wss: true;
+  }
+
+  type ExternalUriScheme = Extract<keyof LinkExternalUriSchemes, string>;
 
   /** External URLs are never type-checked as routes; use for http/https/mailto etc. */
-  export type ExternalHref = `//${string}` | `${UriSchemeInitial}${string}:${string}`;
+  export type ExternalHref = `//${string}` | `${ExternalUriScheme}:${string}`;
 
   export interface LinkDefaultRoute {}
 

--- a/packages/farm/types/client.d.ts
+++ b/packages/farm/types/client.d.ts
@@ -246,8 +246,74 @@ declare module "@farm.js/core/client" {
 
   type ExternalUriScheme = Extract<keyof LinkExternalUriSchemes, string>;
 
+  type UriSchemeLetter =
+    | "a"
+    | "b"
+    | "c"
+    | "d"
+    | "e"
+    | "f"
+    | "g"
+    | "h"
+    | "i"
+    | "j"
+    | "k"
+    | "l"
+    | "m"
+    | "n"
+    | "o"
+    | "p"
+    | "q"
+    | "r"
+    | "s"
+    | "t"
+    | "u"
+    | "v"
+    | "w"
+    | "x"
+    | "y"
+    | "z";
+  type UriSchemeStart = UriSchemeLetter | Uppercase<UriSchemeLetter>;
+  type UriSchemeCharacter =
+    | UriSchemeStart
+    | "0"
+    | "1"
+    | "2"
+    | "3"
+    | "4"
+    | "5"
+    | "6"
+    | "7"
+    | "8"
+    | "9"
+    | "+"
+    | "-"
+    | ".";
+  type IsUriSchemeTail<TValue extends string> = TValue extends ""
+    ? true
+    : TValue extends `${infer First}${infer Rest}`
+      ? First extends UriSchemeCharacter
+        ? IsUriSchemeTail<Rest>
+        : false
+      : false;
+  type IsUriScheme<TValue extends string> = TValue extends `${infer First}${infer Rest}`
+    ? First extends UriSchemeStart
+      ? IsUriSchemeTail<Rest>
+      : false
+    : false;
+
+  type KnownExternalHref = `//${string}` | `${ExternalUriScheme}:${string}`;
+
   /** External URLs are never type-checked as routes; use for http/https/mailto etc. */
-  export type ExternalHref = `//${string}` | `${ExternalUriScheme}:${string}`;
+  export type ExternalHref<THref extends string = string> = string extends THref
+    ? KnownExternalHref
+    : THref extends `//${string}`
+      ? THref
+      : THref extends `${infer Scheme}:${string}`
+        ? IsUriScheme<Scheme> extends true
+          ? THref
+          : never
+        : never;
 
   export interface LinkDefaultRoute {}
 
@@ -343,16 +409,16 @@ declare module "@farm.js/core/client" {
         } & LinkRouteParamsProps<TRoute>
       : never;
 
-  export type LinkExternalTargetProps = {
-    href: ExternalHref;
+  export type LinkExternalTargetProps<THref extends string = string> = {
+    href: ExternalHref<THref>;
     params?: never;
   };
 
-  export type LinkProps<TRoute extends string = DefaultRouteHref> = Omit<
-    AnchorHTMLAttributes<HTMLAnchorElement>,
-    "href"
-  > &
-    (LinkExternalTargetProps | LinkRouteTargetProps<TRoute>) & {
+  export type LinkProps<
+    TRoute extends string = DefaultRouteHref,
+    THref extends string = string,
+  > = Omit<AnchorHTMLAttributes<HTMLAnchorElement>, "href"> &
+    (LinkExternalTargetProps<THref> | LinkRouteTargetProps<TRoute>) & {
       /** Internal route path (typed when route types are generated) or external URL (never raises route-type errors). */
       prefetch?: PrefetchBehavior | boolean | "hover" | "viewport" | "none";
       query?: URLSearchParams | Record<string, RouteQueryValue>;
@@ -364,8 +430,11 @@ declare module "@farm.js/core/client" {
       viewTransition?: FarmViewTransitionMode;
     };
 
-  export type LinkComponent = <TRoute extends string = DefaultRouteHref>(
-    props: LinkProps<TRoute> & RefAttributes<HTMLAnchorElement>,
+  export type LinkComponent = <
+    TRoute extends string = DefaultRouteHref,
+    THref extends string = string,
+  >(
+    props: LinkProps<TRoute, THref> & RefAttributes<HTMLAnchorElement>,
   ) => ReactElement;
 
   export const Link: LinkComponent;

--- a/packages/farm/types/client.d.ts
+++ b/packages/farm/types/client.d.ts
@@ -215,12 +215,37 @@ declare module "@farm.js/core/client" {
 
   export type PrefetchBehavior = false | "intent" | "viewport" | "render" | "none";
 
+  type LowercaseUriSchemeInitial =
+    | "a"
+    | "b"
+    | "c"
+    | "d"
+    | "e"
+    | "f"
+    | "g"
+    | "h"
+    | "i"
+    | "j"
+    | "k"
+    | "l"
+    | "m"
+    | "n"
+    | "o"
+    | "p"
+    | "q"
+    | "r"
+    | "s"
+    | "t"
+    | "u"
+    | "v"
+    | "w"
+    | "x"
+    | "y"
+    | "z";
+  type UriSchemeInitial = LowercaseUriSchemeInitial | Uppercase<LowercaseUriSchemeInitial>;
+
   /** External URLs are never type-checked as routes; use for http/https/mailto etc. */
-  export type ExternalHref =
-    | `http://${string}`
-    | `https://${string}`
-    | `//${string}`
-    | `mailto:${string}`;
+  export type ExternalHref = `//${string}` | `${UriSchemeInitial}${string}:${string}`;
 
   export interface LinkDefaultRoute {}
 


### PR DESCRIPTION
## Problem

`Link href="tel:+15551234567"` was parsed as an internal Farm route and rendered as an encoded pathname. Other non-HTTP URI schemes could also be prefetched or intercepted incorrectly.

## Root cause

External-link detection was a hard-coded list containing only HTTP(S), protocol-relative, and mailto URLs. The platform URI-scheme grammar was not used.

## Change

Recognize any standards-shaped absolute URI scheme and protocol-relative URL as browser-owned. Extend the external href type accordingly, leaving `tel:`, `sms:`, `geo:`, custom app protocols, and similar anchors unchanged.

## Safety and compatibility

Internal root-relative routes keep typed route construction and SPA behavior. Native schemes are not prefetched, do not call the Farm router, and retain normal anchor click behavior. Existing HTTP(S) and mailto behavior is preserved.

## Verification

- `pnpm --filter @farm.js/core exec vitest run src/__tests__/link.test.tsx`
- `pnpm --filter @farm.js/core type-check`
- `pnpm exec oxlint packages/farm/src/client/link.tsx packages/farm/src/__tests__/link.test.tsx`
- `pnpm exec oxfmt packages/farm/src/client/link.tsx packages/farm/src/__tests__/link.test.tsx docs/src/app/docs/routing/page.md`

The regression proves a `tel:` href remains exact and that Farm neither prevents the click nor invokes prefetch/navigation.

## Documentation and release

Documented native URI-scheme behavior. No manual release changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `Link` handling of native URI schemes like `tel:` as internal Farm routes, which previously encoded them as pathnames and could prefetch or intercept them. Non-HTTP(S) schemes now pass through unchanged to the browser, while internal routing and existing HTTP(S)/mailto behavior stay the same.

**Bug Fixes**
- External URL detection now uses the standard URI-scheme grammar instead of a hard-coded allowlist.
- `ExternalHref` now accepts a curated set of URI schemes (`tel:`, `sms:`, `geo:`, etc.), plus any literal matching the URI-scheme grammar via its type parameter; the curated set can be extended with `LinkExternalUriSchemes` declaration merging.

<sup>Written for commit 70a469df010d4681e21a68dd7b7a63d417b95dd9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/694?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

