### PR TITLE
fix(integrations): decode structured JSON responses

### DIFF
--- a/docs/src/app/docs/integrations/custom/page.md
+++ b/docs/src/app/docs/integrations/custom/page.md
@@ -176,6 +176,8 @@ export async function startCheckoutOnServer() {
 
 Both calls have typed input, typed `data`, and typed `error`. The Zod body schema also validates the
 incoming request at runtime.
+Integration clients decode both `application/json` and structured JSON media types such as
+`application/problem+json`, so structured success and error payloads remain available to callers.
 
 ### 2. `endpoints`: grouped owned handlers
 

--- a/packages/farm/src/__tests__/integration-client.test.ts
+++ b/packages/farm/src/__tests__/integration-client.test.ts
@@ -124,6 +124,43 @@ describe("integration client", () => {
     } satisfies Partial<IntegrationClientError>);
   });
 
+  it("decodes structured JSON media types", async () => {
+    stubBrowser();
+
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ authenticated: true }), {
+          headers: { "content-type": "application/vnd.farm.session+json; charset=utf-8" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ error: "Session expired", code: "expired" }), {
+          status: 401,
+          headers: { "content-type": "application/problem+json" },
+        }),
+      );
+
+    const api = createIntegrationClient({
+      auth: {
+        session: endpoint.get<{ authenticated: boolean }>("/auth/session", {
+          responseFormat: "json",
+        }),
+      },
+    });
+
+    await expect(api.auth.session()).resolves.toMatchObject({
+      data: { authenticated: true },
+      error: null,
+    });
+    const failed = await api.auth.session();
+    expect(failed.error).toMatchObject({
+      name: "IntegrationClientError",
+      status: 401,
+      message: "Session expired",
+      data: { error: "Session expired", code: "expired" },
+    });
+  });
+
   it("supports nesting namespaces under an integrations key", async () => {
     stubBrowser();
 

--- a/packages/farm/src/integration-client.ts
+++ b/packages/farm/src/integration-client.ts
@@ -631,11 +631,16 @@ async function parseResponseData(response: Response): Promise<unknown> {
 
   const contentType = response.headers.get("content-type") || "";
 
-  if (contentType.includes("application/json")) {
+  if (isJSONMediaType(contentType)) {
     return await response.json();
   }
 
   return await response.text();
+}
+
+function isJSONMediaType(contentType: string): boolean {
+  const mediaType = contentType.split(";", 1)[0].trim().toLowerCase();
+  return mediaType === "application/json" || mediaType.endsWith("+json");
 }
 
 async function safeParseResponseData(response: Response): Promise<unknown> {


### PR DESCRIPTION
## Problem

Integration responses using standard structured JSON media types such as `application/problem+json` were decoded as text. Typed success data became a string, while errors lost their structured fields and used the entire JSON document as the message.

## Root cause

The client only recognized content types containing the literal `application/json`; it did not recognize the registered `+json` structured syntax suffix.

## Change

Normalize the response media type and decode exact `application/json` or any media type ending in `+json` with `response.json()`.

## Safety and compatibility

Parameters and casing are normalized. Text and other media types keep their previous behavior. Both successful responses and `IntegrationClientError.data` now preserve structured JSON payloads.

## Verification

- `pnpm --filter @farm.js/core exec vitest run src/__tests__/integration-client.test.ts`
- `pnpm --filter @farm.js/core type-check`
- `pnpm exec oxfmt packages/farm/src/integration-client.ts packages/farm/src/__tests__/integration-client.test.ts docs/src/app/docs/integrations/custom/page.md`
- `pnpm exec oxlint packages/farm/src/integration-client.ts packages/farm/src/__tests__/integration-client.test.ts` (0 errors; 4 pre-existing warnings in these files)

The regression covers a vendor `+json` success and an `application/problem+json` 401 error.

## Documentation and release

Documented structured JSON integration responses. No manual release changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes integration client parsing so structured JSON media types (anything ending in `+json`, like `application/problem+json`) are decoded with `response.json()` instead of as text. Previously only content types containing the literal `application/json` were parsed as JSON, so success data became strings and error responses lost their structured fields. The media type is now normalized by trimming, lowercasing, and stripping parameters before matching. Text and other media types behave as before, and `IntegrationClientError.data` now carries structured error payloads.

<sup>Written for commit 55f6cd5555d457de29b08b29a063f53696c9c935. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/695?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

