### PR TITLE
fix(api-client): invalidate cache after successful mutations

### DIFF
--- a/docs/src/app/docs/api-client/page.md
+++ b/docs/src/app/docs/api-client/page.md
@@ -345,8 +345,8 @@ response type, so `current` is inferred from `api.products.get`. You can also ta
 route directly with `[api.products.get, { query: { category } }, updater]`.
 
 With `rollbackOnError: true`, Farm restores the exact previous cache entry when the mutation fails.
-After the request settles, invalidation marks the key stale so mounted consumers or the next read
-can load the canonical server result.
+After a successful mutation, invalidation marks the key stale so mounted consumers or the next read
+can load the canonical server result. Failed mutations do not invalidate known-good cached reads.
 
 ## Result shape
 

--- a/docs/src/app/docs/api-client/page.md
+++ b/docs/src/app/docs/api-client/page.md
@@ -346,7 +346,9 @@ route directly with `[api.products.get, { query: { category } }, updater]`.
 
 With `rollbackOnError: true`, Farm restores the exact previous cache entry when the mutation fails.
 After a successful mutation, invalidation marks the key stale so mounted consumers or the next read
-can load the canonical server result. Failed mutations do not invalidate known-good cached reads.
+can load the canonical server result. Failed mutations do not invalidate known-good cached reads;
+when rollback is disabled, only cache entries changed optimistically are marked stale so the next
+read loads canonical data.
 
 ## Result shape
 

--- a/packages/farm/src/__tests__/api-client.test.ts
+++ b/packages/farm/src/__tests__/api-client.test.ts
@@ -677,6 +677,56 @@ describe("createAPIClient", () => {
     expect(getCount).toBe(2);
   });
 
+  it("does not invalidate newer canonical data after an optimistic mutation fails", async () => {
+    const postDeferred = createDeferred<ReturnType<typeof buildResponse>>();
+    let getCount = 0;
+    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+      if ((init?.method ?? "GET").toUpperCase() === "POST") {
+        return postDeferred.promise;
+      }
+
+      getCount += 1;
+      return buildResponse({
+        users: [{ id: String(getCount), name: `User ${getCount}` }],
+        total: getCount,
+        limit: 5,
+        offset: 0,
+      });
+    });
+    globalThis.fetch = fetchMock as any;
+
+    type UsersData = APIRouter["users"]["get"]["__types"]["response"];
+    const usersKey = defineCacheKey<UsersData>()(() => ["users", "list"] as const)();
+    const api = createAPIClient<APIRouter>({ baseURL: "http://example.com" });
+    const cache = { key: usersKey, policy: "cache-first" as const, staleTime: 10_000 };
+
+    await api.users.get({}, { cache });
+    const mutation = api.users.post(
+      { body: { name: "Ada", email: "ada@example.com" } },
+      {
+        optimistic: {
+          update: [
+            [
+              usersKey,
+              (current) => ({
+                ...current!,
+                users: [{ id: "optimistic", name: "Ada" }, ...(current?.users ?? [])],
+              }),
+            ],
+          ],
+        },
+      },
+    );
+    const refreshed = await api.users.get({}, { cache: { ...cache, policy: "network-only" } });
+    postDeferred.resolve(buildResponse({ message: "fail" }, false, 500));
+    await mutation;
+    const cached = await api.users.get({}, { cache });
+
+    expect(refreshed.data?.users[0]?.id).toBe("2");
+    expect(cached.data?.users[0]?.id).toBe("2");
+    expect(getCount).toBe(2);
+  });
+
   it("applies optimistic updates immediately while the mutation is still pending", async () => {
     const postDeferred = createDeferred<ReturnType<typeof buildResponse>>();
     let getCount = 0;

--- a/packages/farm/src/__tests__/api-client.test.ts
+++ b/packages/farm/src/__tests__/api-client.test.ts
@@ -436,6 +436,39 @@ describe("createAPIClient", () => {
     expect(getCount).toBe(2);
   });
 
+  it("keeps cached reads fresh when a mutation fails", async () => {
+    let getCount = 0;
+    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+      if ((init?.method ?? "GET").toUpperCase() === "POST") {
+        return buildResponse({ error: "Write failed" }, false, 500);
+      }
+
+      getCount += 1;
+      return buildResponse({
+        users: [{ id: String(getCount), name: `User ${getCount}` }],
+        total: getCount,
+        limit: 5,
+        offset: 0,
+      });
+    });
+    globalThis.fetch = fetchMock as any;
+    const api = createAPIClient<APIRouter>({ baseURL: "http://example.com" });
+    const usersKey = ["users", "list"] as const;
+    const cache = { key: usersKey, policy: "cache-first" as const, staleTime: 10_000 };
+
+    const initial = await api.users.get({}, { cache });
+    const mutation = await api.users.post(
+      { body: { name: "Ada", email: "ada@example.com" } },
+      { invalidate: [usersKey] },
+    );
+    const cached = await api.users.get({}, { cache });
+
+    expect(mutation.error).toBeTruthy();
+    expect(initial.data?.users[0]?.id).toBe("1");
+    expect(cached.data?.users[0]?.id).toBe("1");
+    expect(getCount).toBe(1);
+  });
+
   it("keeps default cache keys isolated by API origin", async () => {
     const fetchMock = vi.fn(async (url: string) => buildResponse({ origin: new URL(url).origin }));
     globalThis.fetch = fetchMock as any;

--- a/packages/farm/src/__tests__/api-client.test.ts
+++ b/packages/farm/src/__tests__/api-client.test.ts
@@ -631,6 +631,65 @@ describe("createAPIClient", () => {
     expect(afterRollback.data?.users).toHaveLength(1);
   });
 
+  it("removes every failed overlapping optimistic update", async () => {
+    const postDeferreds = [
+      createDeferred<ReturnType<typeof buildResponse>>(),
+      createDeferred<ReturnType<typeof buildResponse>>(),
+    ];
+    let postCount = 0;
+    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+      if ((init?.method ?? "GET").toUpperCase() === "POST") {
+        return postDeferreds[postCount++]!.promise;
+      }
+
+      return buildResponse({
+        users: [{ id: "1", name: "Alice" }],
+        total: 1,
+        limit: 5,
+        offset: 0,
+      });
+    });
+    globalThis.fetch = fetchMock as any;
+
+    type UsersData = APIRouter["users"]["get"]["__types"]["response"];
+    const usersKey = defineCacheKey<UsersData>()(() => ["users", "list"] as const)();
+    const api = createAPIClient<APIRouter>({ baseURL: "http://example.com" });
+    const secondApi = createAPIClient<APIRouter>({ baseURL: "http://example.com" });
+    const cache = { key: usersKey, policy: "cache-first" as const, staleTime: 10_000 };
+    const optimisticMutation = (client: typeof api, id: string) =>
+      client.users.post(
+        { body: { name: id, email: `${id}@example.com` } },
+        {
+          optimistic: {
+            update: [
+              [
+                usersKey,
+                (current) => ({
+                  ...current!,
+                  users: [{ id, name: id }, ...(current?.users ?? [])],
+                }),
+              ],
+            ],
+            rollbackOnError: true,
+          },
+        },
+      );
+
+    await api.users.get({}, { cache });
+    const firstMutation = optimisticMutation(api, "first");
+    const secondMutation = optimisticMutation(secondApi, "second");
+
+    postDeferreds[0]!.resolve(buildResponse({ message: "fail" }, false, 500));
+    await firstMutation;
+    const afterFirstFailure = await api.users.get({}, { cache });
+    expect(afterFirstFailure.data?.users.map(({ id }) => id)).toEqual(["second", "1"]);
+
+    postDeferreds[1]!.resolve(buildResponse({ message: "fail" }, false, 500));
+    await secondMutation;
+    const afterBothFailures = await api.users.get({}, { cache });
+    expect(afterBothFailures.data?.users.map(({ id }) => id)).toEqual(["1"]);
+  });
+
   it("marks uncommitted optimistic data stale when rollback is disabled", async () => {
     let getCount = 0;
     const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
@@ -704,6 +763,7 @@ describe("createAPIClient", () => {
     const mutation = api.users.post(
       { body: { name: "Ada", email: "ada@example.com" } },
       {
+        invalidate: [usersKey],
         optimistic: {
           update: [
             [

--- a/packages/farm/src/__tests__/api-client.test.ts
+++ b/packages/farm/src/__tests__/api-client.test.ts
@@ -631,6 +631,52 @@ describe("createAPIClient", () => {
     expect(afterRollback.data?.users).toHaveLength(1);
   });
 
+  it("marks uncommitted optimistic data stale when rollback is disabled", async () => {
+    let getCount = 0;
+    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+      if ((init?.method ?? "GET").toUpperCase() === "POST") {
+        return buildResponse({ message: "fail" }, false, 500);
+      }
+
+      getCount += 1;
+      return buildResponse({
+        users: [{ id: String(getCount), name: `User ${getCount}` }],
+        total: getCount,
+        limit: 5,
+        offset: 0,
+      });
+    });
+    globalThis.fetch = fetchMock as any;
+
+    type UsersData = APIRouter["users"]["get"]["__types"]["response"];
+    const usersKey = defineCacheKey<UsersData>()(() => ["users", "list"] as const)();
+    const api = createAPIClient<APIRouter>({ baseURL: "http://example.com" });
+    const cache = { key: usersKey, policy: "cache-first" as const, staleTime: 10_000 };
+
+    await api.users.get({}, { cache });
+    const mutation = await api.users.post(
+      { body: { name: "Ada", email: "ada@example.com" } },
+      {
+        optimistic: {
+          update: [
+            [
+              usersKey,
+              (current) => ({
+                ...current!,
+                users: [{ id: "optimistic", name: "Ada" }, ...(current?.users ?? [])],
+              }),
+            ],
+          ],
+        },
+      },
+    );
+    const canonical = await api.users.get({}, { cache });
+
+    expect(mutation.error).toBeTruthy();
+    expect(canonical.data?.users[0]?.id).toBe("2");
+    expect(getCount).toBe(2);
+  });
+
   it("applies optimistic updates immediately while the mutation is still pending", async () => {
     const postDeferred = createDeferred<ReturnType<typeof buildResponse>>();
     let getCount = 0;

--- a/packages/farm/src/__tests__/api-client.test.ts
+++ b/packages/farm/src/__tests__/api-client.test.ts
@@ -5,7 +5,7 @@ import {
   FARM_CACHE_INVALIDATION_HEADER,
 } from "../cache-invalidation";
 import { defineCacheKey } from "../cache";
-import { getFarmClientDataCache } from "../client-cache";
+import { getFarmClientDataCache, normalizeFarmClientCacheKey } from "../client-cache";
 import { endpoint } from "../integration-api";
 import { defineIntegration, integrationRoute, resolveIntegrationPlugins } from "../integrations";
 import { PluginManager } from "../plugin";
@@ -629,6 +629,53 @@ describe("createAPIClient", () => {
     );
 
     expect(afterRollback.data?.users).toHaveLength(1);
+  });
+
+  it("rolls back optimistic data after another request invalidates it", async () => {
+    const postDeferred = createDeferred<ReturnType<typeof buildResponse>>();
+    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+      if ((init?.method ?? "GET").toUpperCase() === "POST") return postDeferred.promise;
+      return buildResponse({
+        users: [{ id: "1", name: "Alice" }],
+        total: 1,
+        limit: 5,
+        offset: 0,
+      });
+    });
+    globalThis.fetch = fetchMock as any;
+
+    type UsersData = APIRouter["users"]["get"]["__types"]["response"];
+    const usersKey = defineCacheKey<UsersData>()(() => ["users", "list"] as const)();
+    const normalizedUsersKey = normalizeFarmClientCacheKey(usersKey);
+    const api = createAPIClient<APIRouter>({ baseURL: "http://example.com" });
+    const cache = { key: usersKey, policy: "cache-first" as const, staleTime: 10_000 };
+
+    await api.users.get({}, { cache });
+    const mutation = api.users.post(
+      { body: { name: "Ada", email: "ada@example.com" } },
+      {
+        optimistic: {
+          update: [
+            [
+              usersKey,
+              (current) => ({
+                ...current!,
+                users: [{ id: "optimistic", name: "Ada" }, ...(current?.users ?? [])],
+              }),
+            ],
+          ],
+          rollbackOnError: true,
+        },
+      },
+    );
+
+    getFarmClientDataCache().invalidate(normalizedUsersKey);
+    postDeferred.resolve(buildResponse({ message: "fail" }, false, 500));
+    await mutation;
+
+    const rolledBack = getFarmClientDataCache().get<UsersData>(normalizedUsersKey);
+    expect(rolledBack?.data.users.map(({ id }) => id)).toEqual(["1"]);
+    expect(getFarmClientDataCache().isStale(normalizedUsersKey)).toBe(true);
   });
 
   it("removes every failed overlapping optimistic update", async () => {

--- a/packages/farm/src/api/client.ts
+++ b/packages/farm/src/api/client.ts
@@ -539,7 +539,7 @@ export function createAPIClient<
     const applyOptimisticUpdates = () => {
       if (!clientOptions?.optimistic?.update?.length) return [] as OptimisticSnapshot[];
 
-      const snapshots: OptimisticSnapshot[] = [];
+      const snapshots = new Map<string, OptimisticSnapshot>();
       for (const update of clientOptions.optimistic.update) {
         const [target, targetInput, updater] =
           update.length === 2
@@ -555,7 +555,14 @@ export function createAPIClient<
         if (!targetKey) continue;
 
         const targetEntry = getValidCacheEntry(cacheState, targetKey, now);
-        const previousEntry = targetEntry ? { ...targetEntry } : undefined;
+        let snapshot = snapshots.get(targetKey);
+        if (!snapshot) {
+          snapshot = {
+            key: targetKey,
+            entry: targetEntry ? { ...targetEntry } : undefined,
+          };
+          snapshots.set(targetKey, snapshot);
+        }
         const previousData = targetEntry?.data;
         const nextData = updater(previousData);
         cacheState.set(targetKey, {
@@ -569,17 +576,17 @@ export function createAPIClient<
             getGcAt(now, cacheOptions?.gcTime ?? options.cacheDefaults?.gcTime),
           invalidatedAt: targetEntry?.invalidatedAt,
         });
-
-        snapshots.push({ key: targetKey, entry: previousEntry });
+        snapshot.optimisticEntry = cacheState.get(targetKey);
       }
 
-      return snapshots;
+      return Array.from(snapshots.values());
     };
 
     const rollbackOptimisticUpdates = (snapshots: OptimisticSnapshot[]) => {
       if (!clientOptions?.optimistic?.rollbackOnError) return;
 
       for (const snapshot of snapshots) {
+        if (cacheState.get(snapshot.key) !== snapshot.optimisticEntry) continue;
         if (!snapshot.entry) {
           cacheState.delete(snapshot.key);
           continue;
@@ -593,18 +600,10 @@ export function createAPIClient<
       if (clientOptions?.optimistic?.rollbackOnError) return;
 
       const invalidatedAt = Date.now();
-      const invalidatedKeys = new Set<string>();
       for (const snapshot of snapshots) {
-        if (invalidatedKeys.has(snapshot.key)) continue;
-        invalidatedKeys.add(snapshot.key);
-
         const current = cacheState.get(snapshot.key);
-        if (!current) continue;
-        cacheState.set(snapshot.key, {
-          ...current,
-          staleAt: 0,
-          invalidatedAt,
-        });
+        if (!current || current !== snapshot.optimisticEntry) continue;
+        cacheState.invalidate(snapshot.key, invalidatedAt);
         emitStatus("invalidated", { key: snapshot.key });
       }
     };
@@ -1103,6 +1102,7 @@ type RouteMeta = {
 type OptimisticSnapshot = {
   key: string;
   entry?: CacheEntry;
+  optimisticEntry?: CacheEntry;
 };
 
 function buildCacheKey(

--- a/packages/farm/src/api/client.ts
+++ b/packages/farm/src/api/client.ts
@@ -442,8 +442,80 @@ export function createAPIClient<
 
   const cacheState = getFarmClientDataCache();
   const inflightState = new Map<string, InflightEntry>();
+  const optimisticState = getOptimisticState(cacheState);
   const routeMeta = new WeakMap<AnyRouteRef, RouteMeta>();
   let requestCounter = 0;
+
+  const applyOptimisticLayer = (
+    entry: CacheEntry | undefined,
+    layer: OptimisticLayer,
+  ): CacheEntry => {
+    let data = entry?.data;
+    for (const updater of layer.updaters) data = updater(data);
+
+    return {
+      data,
+      updatedAt: layer.updatedAt,
+      staleAt: entry?.staleAt ?? layer.staleAt,
+      gcAt: entry?.gcAt ?? layer.gcAt,
+      invalidatedAt: entry?.invalidatedAt,
+    };
+  };
+
+  const storeOptimisticEntry = (
+    key: string,
+    stack: OptimisticStack,
+    entry: CacheEntry | undefined,
+  ) => {
+    if (!entry) {
+      cacheState.delete(key);
+      stack.renderedEntry = undefined;
+      return;
+    }
+
+    cacheState.set(key, entry);
+    if (stack.invalidatedAt !== undefined) {
+      cacheState.invalidate(key, stack.invalidatedAt);
+    }
+    stack.renderedEntry = cacheState.get(key);
+  };
+
+  const renderOptimisticStack = (key: string, stack: OptimisticStack) => {
+    let entry = stack.entry ? { ...stack.entry } : undefined;
+    for (const layer of stack.layers) entry = applyOptimisticLayer(entry, layer);
+    storeOptimisticEntry(key, stack, entry);
+  };
+
+  const settleOptimisticUpdates = (
+    snapshots: OptimisticSnapshot[],
+    outcome: "commit" | "rollback" | "invalidate",
+  ) => {
+    const settledKeys: string[] = [];
+    for (const snapshot of snapshots) {
+      const stack = optimisticState.get(snapshot.key);
+      if (stack !== snapshot.stack) continue;
+      if (cacheState.get(snapshot.key) !== stack.renderedEntry) {
+        optimisticState.delete(snapshot.key);
+        continue;
+      }
+
+      if (outcome === "rollback") {
+        stack.layers = stack.layers.filter((layer) => layer !== snapshot.layer);
+      } else {
+        snapshot.layer.committed = true;
+        if (outcome === "invalidate") stack.invalidatedAt = Date.now();
+      }
+
+      while (stack.layers[0]?.committed) {
+        stack.entry = applyOptimisticLayer(stack.entry, stack.layers.shift()!);
+      }
+
+      renderOptimisticStack(snapshot.key, stack);
+      if (stack.layers.length === 0) optimisticState.delete(snapshot.key);
+      settledKeys.push(snapshot.key);
+    }
+    return settledKeys;
+  };
 
   // Create a simple fetch-based client (browser compatible)
   const fetchClient = async (path: string, requestOptions: any = {}) => {
@@ -555,28 +627,51 @@ export function createAPIClient<
         if (!targetKey) continue;
 
         const targetEntry = getValidCacheEntry(cacheState, targetKey, now);
+        const currentEntry = cacheState.get(targetKey);
+        let stack = optimisticState.get(targetKey);
+        if (!stack || currentEntry !== stack.renderedEntry) {
+          stack = {
+            entry: targetEntry ? { ...targetEntry } : undefined,
+            layers: [],
+            renderedEntry: currentEntry,
+          };
+          optimisticState.set(targetKey, stack);
+        }
+
         let snapshot = snapshots.get(targetKey);
         if (!snapshot) {
+          const previousEntry = stack.layers.length === 0 ? stack.entry : stack.renderedEntry;
+          const layer: OptimisticLayer = {
+            updaters: [],
+            updatedAt: now,
+            staleAt:
+              targetEntry?.staleAt ??
+              now + (cacheOptions?.staleTime ?? options.cacheDefaults?.staleTime ?? 0),
+            gcAt:
+              targetEntry?.gcAt ??
+              getGcAt(now, cacheOptions?.gcTime ?? options.cacheDefaults?.gcTime),
+          };
+          stack.layers.push(layer);
           snapshot = {
             key: targetKey,
-            entry: targetEntry ? { ...targetEntry } : undefined,
+            stack,
+            layer,
           };
           snapshots.set(targetKey, snapshot);
+          snapshot.layer.updaters.push(updater);
+          const nextEntry = applyOptimisticLayer(previousEntry, {
+            ...snapshot.layer,
+            updaters: [updater],
+          });
+          storeOptimisticEntry(targetKey, stack, nextEntry);
+          continue;
         }
-        const previousData = targetEntry?.data;
-        const nextData = updater(previousData);
-        cacheState.set(targetKey, {
-          data: nextData,
-          updatedAt: now,
-          staleAt:
-            targetEntry?.staleAt ??
-            now + (cacheOptions?.staleTime ?? options.cacheDefaults?.staleTime ?? 0),
-          gcAt:
-            targetEntry?.gcAt ??
-            getGcAt(now, cacheOptions?.gcTime ?? options.cacheDefaults?.gcTime),
-          invalidatedAt: targetEntry?.invalidatedAt,
+        snapshot.layer.updaters.push(updater);
+        const nextEntry = applyOptimisticLayer(stack.renderedEntry, {
+          ...snapshot.layer,
+          updaters: [updater],
         });
-        snapshot.optimisticEntry = cacheState.get(targetKey);
+        storeOptimisticEntry(targetKey, stack, nextEntry);
       }
 
       return Array.from(snapshots.values());
@@ -584,27 +679,13 @@ export function createAPIClient<
 
     const rollbackOptimisticUpdates = (snapshots: OptimisticSnapshot[]) => {
       if (!clientOptions?.optimistic?.rollbackOnError) return;
-
-      for (const snapshot of snapshots) {
-        if (cacheState.get(snapshot.key) !== snapshot.optimisticEntry) continue;
-        if (!snapshot.entry) {
-          cacheState.delete(snapshot.key);
-          continue;
-        }
-
-        cacheState.set(snapshot.key, { ...snapshot.entry });
-      }
+      settleOptimisticUpdates(snapshots, "rollback");
     };
 
     const invalidateUncommittedOptimisticUpdates = (snapshots: OptimisticSnapshot[]) => {
       if (clientOptions?.optimistic?.rollbackOnError) return;
-
-      const invalidatedAt = Date.now();
-      for (const snapshot of snapshots) {
-        const current = cacheState.get(snapshot.key);
-        if (!current || current !== snapshot.optimisticEntry) continue;
-        cacheState.invalidate(snapshot.key, invalidatedAt);
-        emitStatus("invalidated", { key: snapshot.key });
+      for (const key of settleOptimisticUpdates(snapshots, "invalidate")) {
+        emitStatus("invalidated", { key });
       }
     };
 
@@ -775,11 +856,13 @@ export function createAPIClient<
 
         const existing = cacheState.get(targetKey);
         if (existing) {
-          cacheState.set(targetKey, {
-            ...existing,
-            staleAt: 0,
-            invalidatedAt: Date.now(),
-          });
+          const invalidatedAt = Date.now();
+          const stack = optimisticState.get(targetKey);
+          cacheState.invalidate(targetKey, invalidatedAt);
+          if (stack?.renderedEntry === existing) {
+            stack.invalidatedAt = invalidatedAt;
+            stack.renderedEntry = cacheState.get(targetKey);
+          }
         }
 
         emitStatus("invalidated", { key: targetKey });
@@ -815,6 +898,7 @@ export function createAPIClient<
       rollbackOptimisticUpdates(optimisticSnapshots);
       invalidateUncommittedOptimisticUpdates(optimisticSnapshots);
     } else {
+      settleOptimisticUpdates(optimisticSnapshots, "commit");
       await invalidateTargets();
     }
     clientOptions?.onSettled?.(result.data, result.error);
@@ -1101,9 +1185,35 @@ type RouteMeta = {
 
 type OptimisticSnapshot = {
   key: string;
-  entry?: CacheEntry;
-  optimisticEntry?: CacheEntry;
+  stack: OptimisticStack;
+  layer: OptimisticLayer;
 };
+
+type OptimisticStack = {
+  entry?: CacheEntry;
+  layers: OptimisticLayer[];
+  renderedEntry?: CacheEntry;
+  invalidatedAt?: number;
+};
+
+type OptimisticLayer = {
+  updaters: Array<(prev: any) => any>;
+  updatedAt: number;
+  staleAt: number;
+  gcAt?: number;
+  committed?: boolean;
+};
+
+const optimisticStates = new WeakMap<FarmClientDataCache, Map<string, OptimisticStack>>();
+
+function getOptimisticState(cache: FarmClientDataCache): Map<string, OptimisticStack> {
+  let state = optimisticStates.get(cache);
+  if (!state) {
+    state = new Map();
+    optimisticStates.set(cache, state);
+  }
+  return state;
+}
 
 function buildCacheKey(
   method: string,

--- a/packages/farm/src/api/client.ts
+++ b/packages/farm/src/api/client.ts
@@ -794,8 +794,9 @@ export function createAPIClient<
     const result = await executeNetwork();
     if (result.error) {
       rollbackOptimisticUpdates(optimisticSnapshots);
+    } else {
+      await invalidateTargets();
     }
-    await invalidateTargets();
     clientOptions?.onSettled?.(result.data, result.error);
     return result;
   };

--- a/packages/farm/src/api/client.ts
+++ b/packages/farm/src/api/client.ts
@@ -589,6 +589,26 @@ export function createAPIClient<
       }
     };
 
+    const invalidateUncommittedOptimisticUpdates = (snapshots: OptimisticSnapshot[]) => {
+      if (clientOptions?.optimistic?.rollbackOnError) return;
+
+      const invalidatedAt = Date.now();
+      const invalidatedKeys = new Set<string>();
+      for (const snapshot of snapshots) {
+        if (invalidatedKeys.has(snapshot.key)) continue;
+        invalidatedKeys.add(snapshot.key);
+
+        const current = cacheState.get(snapshot.key);
+        if (!current) continue;
+        cacheState.set(snapshot.key, {
+          ...current,
+          staleAt: 0,
+          invalidatedAt,
+        });
+        emitStatus("invalidated", { key: snapshot.key });
+      }
+    };
+
     const executeNetwork = async (opts?: { isBackground?: boolean; callCallbacks?: boolean }) => {
       const dedupeMs = cacheOptions?.dedupeMs ?? 0;
       const inflight = inflightState.get(cacheKey);
@@ -794,6 +814,7 @@ export function createAPIClient<
     const result = await executeNetwork();
     if (result.error) {
       rollbackOptimisticUpdates(optimisticSnapshots);
+      invalidateUncommittedOptimisticUpdates(optimisticSnapshots);
     } else {
       await invalidateTargets();
     }

--- a/packages/farm/src/api/client.ts
+++ b/packages/farm/src/api/client.ts
@@ -480,6 +480,30 @@ export function createAPIClient<
     stack.renderedEntry = cacheState.get(key);
   };
 
+  const reconcileOptimisticInvalidation = (key: string, stack: OptimisticStack) => {
+    const current = cacheState.get(key);
+    const rendered = stack.renderedEntry;
+    if (current === rendered) return true;
+    if (
+      !current ||
+      !rendered ||
+      current.data !== rendered.data ||
+      current.updatedAt !== rendered.updatedAt ||
+      current.gcAt !== rendered.gcAt ||
+      current.status !== rendered.status ||
+      current.error !== rendered.error ||
+      current.fetching !== rendered.fetching ||
+      current.staleAt !== 0 ||
+      current.invalidatedAt === undefined
+    ) {
+      return false;
+    }
+
+    stack.invalidatedAt = current.invalidatedAt;
+    stack.renderedEntry = current;
+    return true;
+  };
+
   const renderOptimisticStack = (key: string, stack: OptimisticStack) => {
     let entry = stack.entry ? { ...stack.entry } : undefined;
     for (const layer of stack.layers) entry = applyOptimisticLayer(entry, layer);
@@ -494,7 +518,7 @@ export function createAPIClient<
     for (const snapshot of snapshots) {
       const stack = optimisticState.get(snapshot.key);
       if (stack !== snapshot.stack) continue;
-      if (cacheState.get(snapshot.key) !== stack.renderedEntry) {
+      if (!reconcileOptimisticInvalidation(snapshot.key, stack)) {
         optimisticState.delete(snapshot.key);
         continue;
       }
@@ -629,7 +653,8 @@ export function createAPIClient<
         const targetEntry = getValidCacheEntry(cacheState, targetKey, now);
         const currentEntry = cacheState.get(targetKey);
         let stack = optimisticState.get(targetKey);
-        if (!stack || currentEntry !== stack.renderedEntry) {
+        if (stack && !reconcileOptimisticInvalidation(targetKey, stack)) stack = undefined;
+        if (!stack) {
           stack = {
             entry: targetEntry ? { ...targetEntry } : undefined,
             layers: [],


### PR DESCRIPTION
## Problem

A failed mutation still invalidated every configured target. The next cache-first read discarded known-good data and fetched again even though the write never succeeded.

## Root cause

The request lifecycle rolled back optimistic updates on error but called `invalidateTargets()` unconditionally afterward.

## Change

Run mutation target invalidation only when the network result has no error. Error paths continue to roll back optimistic snapshots and invoke settled/error callbacks.

## Safety and compatibility

Successful mutation invalidation and optional refetch behavior are unchanged. Server-declared response invalidations remain authoritative because they are processed directly from response headers. Failed writes preserve the previous cache freshness.

## Verification

- `pnpm --filter @farm.js/core exec vitest run src/__tests__/api-client.test.ts`
- `pnpm --filter @farm.js/core type-check`
- `pnpm exec oxfmt packages/farm/src/api/client.ts packages/farm/src/__tests__/api-client.test.ts docs/src/app/docs/api-client/page.md`
- `pnpm exec oxlint packages/farm/src/api/client.ts packages/farm/src/__tests__/api-client.test.ts` (passes with one pre-existing unused-parameter warning elsewhere in the test file)

The regression primes a structured cache key, fails a POST, then proves the next cache-first GET returns the original entry without another fetch.

## Documentation and release

Clarified that client-declared invalidation follows successful mutations only. No manual release changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the API client's mutation invalidation so failed writes no longer discard known-good cached reads, and keeps overlapping optimistic updates consistent when some writes fail.

**Bug Fixes**
- Mutations invalidate configured targets only when the network result has no error.
- Error paths still run settled/error callbacks and roll back optimistic updates only when rollback is enabled.
- Overlapping optimistic updates are layered, so a failed mutation removes only its own changes.
- With rollback disabled, failed mutations mark optimistically written keys stale unless a newer canonical write replaced the entry.
- Server-declared response invalidations remain authoritative from response headers.
- Documentation now states client-declared invalidation follows successful mutations only.

<sup>Written for commit 75ab7eef9e661df898c7f1d56bb9088440af996e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/696?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

