### PR TITLE
fix(api-client): isolate response observer failures

### DIFF
--- a/docs/src/app/docs/api-client/page.md
+++ b/docs/src/app/docs/api-client/page.md
@@ -274,6 +274,10 @@ while the hydrated fetcher stays on the page.
 - optimistic: update cached query data before the server response returns.
 - onRequest, onResponse, onSuccess, onError, onSettled, and onStatus: observe the full client lifecycle.
 
+`onResponse` is a transport observer. If it throws or returns a rejected promise, Farm reports that
+failure through the platform `reportError` hook (or the console fallback) without retrying or
+changing the completed API result.
+
 Use a structured cache key when an API response intentionally shares data with route data or a [`createServerQuery`](/docs/server-queries):
 
 ```ts

--- a/packages/farm/src/__tests__/api-client.test.ts
+++ b/packages/farm/src/__tests__/api-client.test.ts
@@ -519,6 +519,50 @@ describe("createAPIClient", () => {
     expect(reportError).toHaveBeenCalledWith(observerError);
   });
 
+  it("reports rejected response observers without changing the request result", async () => {
+    const fetchMock = vi.fn(async () => buildResponse({ success: true }));
+    const observerError = new Error("async analytics callback failed");
+    const onResponse = vi.fn(async () => {
+      throw observerError;
+    });
+    const reportError = vi.fn();
+    globalThis.fetch = fetchMock as any;
+    vi.stubGlobal("reportError", reportError);
+    const api = createAPIClient<APIRouter>({ baseURL: "http://example.com" });
+
+    const result = await api.users.post(
+      { body: { name: "Ada", email: "ada@example.com" } },
+      { onResponse },
+    );
+
+    expect(result).toMatchObject({ data: { success: true }, error: null });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(onResponse).toHaveBeenCalledTimes(1);
+    await vi.waitFor(() => expect(reportError).toHaveBeenCalledWith(observerError));
+  });
+
+  it("isolates requests when the response observer console fallback throws", async () => {
+    const fetchMock = vi.fn(async () => buildResponse({ success: true }));
+    const onResponse = vi.fn(() => {
+      throw new Error("analytics callback failed");
+    });
+    vi.spyOn(console, "error").mockImplementation(() => {
+      throw new Error("console unavailable");
+    });
+    vi.stubGlobal("reportError", undefined);
+    globalThis.fetch = fetchMock as any;
+    const api = createAPIClient<APIRouter>({ baseURL: "http://example.com" });
+
+    const result = await api.users.post(
+      { body: { name: "Ada", email: "ada@example.com" } },
+      { onResponse },
+    );
+
+    expect(result).toMatchObject({ data: { success: true }, error: null });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(onResponse).toHaveBeenCalledTimes(1);
+  });
+
   it("invalidates cache entries after mutation", async () => {
     let getCount = 0;
     const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {

--- a/packages/farm/src/__tests__/api-client.test.ts
+++ b/packages/farm/src/__tests__/api-client.test.ts
@@ -497,6 +497,28 @@ describe("createAPIClient", () => {
     expect(responses).toHaveLength(1);
   });
 
+  it("reports response observer failures without changing the request result", async () => {
+    const fetchMock = vi.fn(async () => buildResponse({ success: true }));
+    const observerError = new Error("analytics callback failed");
+    const onResponse = vi.fn(() => {
+      throw observerError;
+    });
+    const reportError = vi.fn();
+    globalThis.fetch = fetchMock as any;
+    vi.stubGlobal("reportError", reportError);
+    const api = createAPIClient<APIRouter>({ baseURL: "http://example.com" });
+
+    const result = await api.users.post(
+      { body: { name: "Ada", email: "ada@example.com" } },
+      { onResponse },
+    );
+
+    expect(result).toMatchObject({ data: { success: true }, error: null });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(onResponse).toHaveBeenCalledTimes(1);
+    expect(reportError).toHaveBeenCalledWith(observerError);
+  });
+
   it("invalidates cache entries after mutation", async () => {
     let getCount = 0;
     const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {

--- a/packages/farm/src/api/client.ts
+++ b/packages/farm/src/api/client.ts
@@ -656,7 +656,12 @@ export function createAPIClient<
               status: response.status,
             };
 
-            clientOptions?.onResponse?.(response.ok ? data : undefined, error, responseEvent);
+            notifyResponseObserver(
+              clientOptions?.onResponse,
+              response.ok ? data : undefined,
+              error,
+              responseEvent,
+            );
 
             if (!error) {
               return { data, error: null, key: cacheKey } as APIResult<any, Error>;
@@ -679,7 +684,7 @@ export function createAPIClient<
               ok: false,
             };
 
-            clientOptions?.onResponse?.(undefined, error, responseEvent);
+            notifyResponseObserver(clientOptions?.onResponse, undefined, error, responseEvent);
 
             if (attempt >= maxRetries) {
               return { data: undefined, error, key: cacheKey } as APIResult<any, Error>;
@@ -1235,6 +1240,38 @@ function normalizeError(error: unknown): Error {
   });
   (normalized as Error & { cause?: unknown }).cause = error;
   return normalized;
+}
+
+function notifyResponseObserver(
+  observer: ClientOptions<any, any>["onResponse"],
+  data: unknown,
+  error: unknown,
+  event: ResponseEvent<any, any>,
+): void {
+  if (!observer) return;
+
+  try {
+    const result = observer(data, error, event) as unknown;
+    if (result && typeof (result as PromiseLike<unknown>).then === "function") {
+      void Promise.resolve(result).catch(reportResponseObserverError);
+    }
+  } catch (observerError) {
+    reportResponseObserverError(observerError);
+  }
+}
+
+function reportResponseObserverError(error: unknown): void {
+  const reportError = (globalThis as typeof globalThis & { reportError?: (error: unknown) => void })
+    .reportError;
+  if (typeof reportError === "function") {
+    try {
+      reportError.call(globalThis, error);
+      return;
+    } catch {
+      // Fall through to the console when the platform reporter itself fails.
+    }
+  }
+  console.error("[Farm.js] API client onResponse callback failed:", error);
 }
 
 function isFormData(value: unknown): value is FormData {

--- a/packages/farm/src/api/client.ts
+++ b/packages/farm/src/api/client.ts
@@ -1271,7 +1271,11 @@ function reportResponseObserverError(error: unknown): void {
       // Fall through to the console when the platform reporter itself fails.
     }
   }
-  console.error("[Farm.js] API client onResponse callback failed:", error);
+  try {
+    console.error("[Farm.js] API client onResponse callback failed:", error);
+  } catch {
+    // Observers and their reporting fallbacks must never affect the request.
+  }
 }
 
 function isFormData(value: unknown): value is FormData {


### PR DESCRIPTION
## Problem

If `onResponse` threw after a successful fetch, the transport catch treated the observer exception as a network failure, invoked `onResponse` a second time, and returned an error result for a mutation the server had already completed.

## Root cause

The observer ran inside the same try/catch that owns fetch and response decoding. Callback failures were therefore indistinguishable from transport failures.

## Change

Invoke `onResponse` through an isolated observer helper. Synchronous throws and rejected promises are reported through `globalThis.reportError` when available, with a console fallback, and cannot enter retry/error classification.

## Safety and compatibility

Observers still receive every real response attempt exactly once. Network and HTTP failures retain existing retry behavior. Observer failures remain visible to platform monitoring without altering the completed API result or duplicating server work.

## Verification

- `pnpm --filter @farm.js/core exec vitest run src/__tests__/api-client.test.ts`
- `pnpm --filter @farm.js/core type-check`
- `pnpm exec oxfmt packages/farm/src/api/client.ts packages/farm/src/__tests__/api-client.test.ts docs/src/app/docs/api-client/page.md`
- `pnpm exec oxlint packages/farm/src/api/client.ts packages/farm/src/__tests__/api-client.test.ts` (passes with one pre-existing unused-parameter warning elsewhere in the test file)

The regression makes a success observer throw and proves the result stays successful, fetch and observer each run once, and the platform reporter receives the original exception.

## Documentation and release

Documented response-observer failure semantics. No manual release changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents response observer failures from being treated as network failures, so a throwing `onResponse` no longer causes retries or converts a successful mutation into an error result.

- Reports observer exceptions through `globalThis.reportError`, falling back to console; a throwing reporter can't affect the request either.
- Observers still receive every real response attempt exactly once.
- Network and HTTP failures keep existing retry behavior.
- Documents that observer failures don't alter the completed API result.

<sup>Written for commit e6de6579587e0c3dcea9834941b2b7ca891f4b89. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/697?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

