### PR TITLE
fix(integrations): render custom provider components

### DIFF
--- a/docs/src/app/docs/integrations/custom/page.md
+++ b/docs/src/app/docs/integrations/custom/page.md
@@ -908,9 +908,9 @@ Farm statically imports the component into development and production client ent
 the same provider during server rendering. Use the standard `@/` source alias, a relative path, or
 a package specifier; `export` defaults to `default`. Keep the provider module client-safe and
 provider props public-safe. Secrets belong in server config and lifecycle hooks. Passing an opaque
-function directly is retained for server compatibility, but client generation reports an
-actionable error because Farm cannot trace that function's imports without also exposing the
-server configuration module.
+function directly remains available to development and custom server-renderer callers, but a full
+production build reports an actionable error because Farm cannot trace that function's imports
+without also exposing the server configuration module.
 
 ## Logging
 

--- a/docs/src/app/docs/integrations/custom/page.md
+++ b/docs/src/app/docs/integrations/custom/page.md
@@ -869,11 +869,20 @@ The integration code still uses `ctx.args.db`, not SQLite-specific APIs. If the 
 Use `providers` for client SDKs, context providers, or integration metadata that the app shell can compose.
 
 ```tsx
+// src/components/acme-provider.tsx
+"use client";
+
 import type { FarmIntegrationProviderProps } from "@farm.js/core";
 
-function AcmeProvider({ children }: FarmIntegrationProviderProps) {
+export function AcmeProvider({ children }: FarmIntegrationProviderProps) {
   return <>{children}</>;
 }
+```
+
+Reference that client-safe module from the integration definition:
+
+```ts
+// farm.config.ts
 
 export const acme = defineIntegration({
   category: "custom",
@@ -886,13 +895,22 @@ export const acme = defineIntegration({
       props: {
         publishableKey: process.env.ACME_PUBLISHABLE_KEY,
       },
-      component: AcmeProvider,
+      component: {
+        module: "@/components/acme-provider",
+        export: "AcmeProvider",
+      },
     },
   ],
 });
 ```
 
-Keep provider props public-safe. Secrets belong in server config and lifecycle hooks.
+Farm statically imports the component into development and production client entries and composes
+the same provider during server rendering. Use the standard `@/` source alias, a relative path, or
+a package specifier; `export` defaults to `default`. Keep the provider module client-safe and
+provider props public-safe. Secrets belong in server config and lifecycle hooks. Passing an opaque
+function directly is retained for server compatibility, but client generation reports an
+actionable error because Farm cannot trace that function's imports without also exposing the
+server configuration module.
 
 ## Logging
 

--- a/packages/farm/src/__tests__/integration-provider.test.tsx
+++ b/packages/farm/src/__tests__/integration-provider.test.tsx
@@ -1,7 +1,10 @@
 import { createElement, type ReactNode } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
-import { describe, expect, it } from "vitest";
-import { generateFarmIntegrationProviderClientCode } from "../integration-provider-build";
+import { describe, expect, it, vi } from "vitest";
+import {
+  generateFarmIntegrationProviderClientCode,
+  generateFarmIntegrationProviderServerModules,
+} from "../integration-provider-build";
 import { defineIntegration, getIntegrationProviders } from "../integrations";
 import { REACT_RENDERER } from "../renderer";
 import { ServerRenderer } from "../server/renderer";
@@ -76,6 +79,59 @@ describe("integration providers", () => {
     expect(generated.imports).toContain(
       'import * as FarmIntegrationProviderModule0 from "/src/components/acme-provider";',
     );
+  });
+
+  it("resolves relative provider modules from the app root in development", async () => {
+    function AcmeProvider({ children }: { children: ReactNode }) {
+      return createElement("section", { "data-acme-provider": "" }, children);
+    }
+    const ssrLoadModule = vi.fn(async () => ({ default: AcmeProvider }));
+    const acme = defineIntegration({
+      category: "custom",
+      type: "acme",
+      instance: {},
+      providers: [
+        {
+          name: "acme",
+          type: "client",
+          component: { module: "./src/components/acme-provider" },
+        },
+      ],
+    });
+    const renderer = new ServerRenderer(
+      {
+        root: "/app",
+        outDir: ".farm-integration-provider-test",
+        integrations: { acme },
+        renderer: REACT_RENDERER,
+      } as any,
+      {} as any,
+    );
+    (renderer as any).viteServer = { ssrLoadModule };
+    (renderer as any).rendererRuntime = { createElement };
+
+    const wrapped = await (renderer as any).wrapWithIntegrationProviders(
+      createElement("span", null, "inside"),
+    );
+
+    expect(ssrLoadModule).toHaveBeenCalledWith("/src/components/acme-provider");
+    expect(renderToStaticMarkup(wrapped)).toContain("data-acme-provider");
+  });
+
+  it("does not import Clerk when a Clerk provider configures its own component", () => {
+    const providers = [
+      {
+        name: "custom-clerk",
+        type: "clerk",
+        component: { module: "@/components/custom-clerk-provider" },
+      },
+    ];
+    const client = generateFarmIntegrationProviderClientCode(providers, "/app");
+    const server = generateFarmIntegrationProviderServerModules(providers, "/app");
+
+    expect(client.imports).not.toContain("@clerk/react");
+    expect(server.hasClerkProvider).toBe(false);
+    expect(server.imports).not.toContain("@clerk/react");
   });
 
   it("rejects opaque function components from client generation", () => {

--- a/packages/farm/src/__tests__/integration-provider.test.tsx
+++ b/packages/farm/src/__tests__/integration-provider.test.tsx
@@ -1,0 +1,106 @@
+import { createElement, type ReactNode } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { generateFarmIntegrationProviderClientCode } from "../integration-provider-build";
+import { defineIntegration, getIntegrationProviders } from "../integrations";
+import { REACT_RENDERER } from "../renderer";
+import { ServerRenderer } from "../server/renderer";
+
+describe("integration providers", () => {
+  it("carries and renders a configured provider component on the server", async () => {
+    function AcmeProvider({ children }: { children: ReactNode }) {
+      return createElement("section", { "data-acme-provider": "" }, children);
+    }
+
+    const acme = defineIntegration({
+      category: "custom",
+      type: "acme",
+      instance: {},
+      providers: [{ name: "acme", type: "client", component: AcmeProvider }],
+    });
+    const providers = getIntegrationProviders({ acme });
+    expect(providers[0]?.component).toBe(AcmeProvider);
+
+    const renderer = new ServerRenderer(
+      {
+        root: process.cwd(),
+        outDir: ".farm-integration-provider-test",
+        integrations: { acme },
+        renderer: REACT_RENDERER,
+      } as any,
+      {} as any,
+    );
+    (renderer as any).rendererRuntime = { createElement };
+    const wrapped = await (renderer as any).wrapWithIntegrationProviders(
+      createElement("span", null, "inside"),
+    );
+
+    expect(renderToStaticMarkup(wrapped)).toBe(
+      '<section data-acme-provider=""><span>inside</span></section>',
+    );
+  });
+
+  it("generates statically traceable client imports for provider modules", () => {
+    const generated = generateFarmIntegrationProviderClientCode(
+      [
+        {
+          name: "acme",
+          type: "client",
+          props: { publishableKey: "pk_test" },
+          component: { module: "@/components/acme-provider", export: "AcmeProvider" },
+        },
+      ],
+      "/app",
+    );
+
+    expect(generated.imports).toContain(
+      'import * as FarmIntegrationProviderModule0 from "@/components/acme-provider";',
+    );
+    expect(generated.runtime).toContain('name: "acme"');
+    expect(generated.runtime).toContain('FarmIntegrationProviderModule0["AcmeProvider"]');
+    expect(generated.runtime).toContain("React.createElement(provider.Component");
+  });
+
+  it("resolves provider paths relative to the app root", () => {
+    const generated = generateFarmIntegrationProviderClientCode(
+      [
+        {
+          name: "acme",
+          type: "client",
+          component: { module: "./src/components/acme-provider" },
+        },
+      ],
+      "/app",
+    );
+
+    expect(generated.imports).toContain(
+      'import * as FarmIntegrationProviderModule0 from "/src/components/acme-provider";',
+    );
+  });
+
+  it("rejects opaque function components from client generation", () => {
+    expect(() =>
+      generateFarmIntegrationProviderClientCode(
+        [
+          {
+            name: "acme",
+            type: "client",
+            component: ({ children }) => children,
+          },
+        ],
+        "/app",
+      ),
+    ).toThrow(/importable component reference/);
+  });
+
+  it("ignores integration metadata providers without renderable components", () => {
+    const generated = generateFarmIntegrationProviderClientCode(
+      [{ name: "metadata", type: "client", props: { mode: "test" } }],
+      "/app",
+    );
+
+    expect(generated.hasProviders).toBe(false);
+    expect(generated.imports).toBe("");
+    expect(generated.runtime).not.toContain('name: "metadata"');
+  });
+});

--- a/packages/farm/src/__tests__/production-async-page.test.ts
+++ b/packages/farm/src/__tests__/production-async-page.test.ts
@@ -39,6 +39,7 @@ async function runRenderPageElement(
     "params",
     "renderFarmElement",
     "ReactDOMServer",
+    "wrapWithFarmIntegrationProviders",
     `${extractRenderPageElement(source)}\nreturn renderPageElement();`,
   );
   await run(
@@ -58,6 +59,7 @@ async function runRenderPageElement(
       return { html: "" };
     },
     {},
+    (element: unknown) => element,
   );
   return { pageTree };
 }

--- a/packages/farm/src/__tests__/production-prebuilt-ssr.test.ts
+++ b/packages/farm/src/__tests__/production-prebuilt-ssr.test.ts
@@ -294,21 +294,91 @@ describe("production prebuilt SSR output", () => {
     }
   }, 120_000);
 
-  it("renders custom integration providers in production and ships them for hydration", async () => {
-    const root = await createProductionFixture();
+  it.each([
+    { label: "from programmatic config", runtimeConfigWithoutProviders: false },
+    { label: "when runtime config omits providers", runtimeConfigWithoutProviders: true },
+  ])(
+    "renders custom integration providers in production $label",
+    async ({ runtimeConfigWithoutProviders }) => {
+      const root = await createProductionFixture();
 
-    try {
-      await fs.mkdir(path.join(root, "src", "components"), { recursive: true });
-      await fs.writeFile(
-        path.join(root, "src", "components", "acme-provider.tsx"),
-        `
+      try {
+        await fs.mkdir(path.join(root, "src", "components"), { recursive: true });
+        await fs.writeFile(
+          path.join(root, "src", "components", "acme-provider.tsx"),
+          `
 "use client";
 
 export function AcmeProvider({ children, label }) {
   return <section data-acme-provider={label}>{children}</section>;
 }
 `.trim(),
-      );
+        );
+        if (runtimeConfigWithoutProviders) {
+          await fs.writeFile(
+            path.join(root, "farm.config.ts"),
+            `
+import { defineConfig, defineIntegration } from "@farm.js/core";
+
+const acme = defineIntegration({
+  category: "custom",
+  type: "acme",
+  instance: {},
+});
+
+export default defineConfig({ integrations: { acme } });
+`.trim(),
+          );
+        }
+        const acme = defineIntegration({
+          category: "custom",
+          type: "acme",
+          instance: {},
+          providers: [
+            {
+              name: "acme",
+              type: "client",
+              props: { label: "production-provider" },
+              component: { module: "@/components/acme-provider", export: "AcmeProvider" },
+            },
+          ],
+        });
+        const config = await resolveConfig(
+          {
+            root,
+            srcDir: "src",
+            images: { provider: "none" },
+            telemetry: false,
+            integrations: { acme },
+            generateBuildId: () => "programmatic-integration-provider-test",
+          },
+          "production",
+        );
+
+        await build(config, { root, preset: "node-server" });
+
+        const clientJavaScript = await readAllClientJavaScript(root);
+        expect(clientJavaScript).toContain("data-acme-provider");
+        await runProductionRequest(
+          path.join(root, ".farm", ".output", "server"),
+          async (response) => {
+            expect(response.status).toBe(200);
+            await expect(response.text()).resolves.toContain(
+              'data-acme-provider="production-provider"',
+            );
+          },
+        );
+      } finally {
+        await fs.rm(root, { recursive: true, force: true });
+      }
+    },
+    120_000,
+  );
+
+  it("rejects opaque integration provider components in production", async () => {
+    const root = await createProductionFixture();
+
+    try {
       const acme = defineIntegration({
         category: "custom",
         type: "acme",
@@ -317,8 +387,7 @@ export function AcmeProvider({ children, label }) {
           {
             name: "acme",
             type: "client",
-            props: { label: "production-provider" },
-            component: { module: "@/components/acme-provider", export: "AcmeProvider" },
+            component: ({ children }) => children,
           },
         ],
       });
@@ -329,28 +398,18 @@ export function AcmeProvider({ children, label }) {
           images: { provider: "none" },
           telemetry: false,
           integrations: { acme },
-          generateBuildId: () => "programmatic-integration-provider-test",
+          generateBuildId: () => "opaque-integration-provider-test",
         },
         "production",
       );
 
-      await build(config, { root, preset: "node-server" });
-
-      const clientJavaScript = await readAllClientJavaScript(root);
-      expect(clientJavaScript).toContain("data-acme-provider");
-      await runProductionRequest(
-        path.join(root, ".farm", ".output", "server"),
-        async (response) => {
-          expect(response.status).toBe(200);
-          await expect(response.text()).resolves.toContain(
-            'data-acme-provider="production-provider"',
-          );
-        },
+      await expect(build(config, { root, preset: "node-server" })).rejects.toThrow(
+        "Integration provider components in production must use an importable component reference",
       );
     } finally {
       await fs.rm(root, { recursive: true, force: true });
     }
-  }, 120_000);
+  });
 
   it("isolates a client leaf without shipping its server layout", async () => {
     const root = await createProductionFixture();

--- a/packages/farm/src/__tests__/production-prebuilt-ssr.test.ts
+++ b/packages/farm/src/__tests__/production-prebuilt-ssr.test.ts
@@ -309,27 +309,6 @@ export function AcmeProvider({ children, label }) {
 }
 `.trim(),
       );
-      await fs.writeFile(
-        path.join(root, "farm.config.ts"),
-        `
-import { defineConfig, defineIntegration } from "@farm.js/core";
-
-const acme = defineIntegration({
-  category: "custom",
-  type: "acme",
-  instance: {},
-  providers: [{
-    name: "acme",
-    type: "client",
-    props: { label: "production-provider" },
-    component: { module: "@/components/acme-provider", export: "AcmeProvider" },
-  }],
-});
-
-export default defineConfig({ integrations: { acme } });
-`.trim(),
-      );
-
       const acme = defineIntegration({
         category: "custom",
         type: "acme",
@@ -350,7 +329,7 @@ export default defineConfig({ integrations: { acme } });
           images: { provider: "none" },
           telemetry: false,
           integrations: { acme },
-          generateBuildId: () => "custom-integration-provider-test",
+          generateBuildId: () => "programmatic-integration-provider-test",
         },
         "production",
       );

--- a/packages/farm/src/__tests__/production-prebuilt-ssr.test.ts
+++ b/packages/farm/src/__tests__/production-prebuilt-ssr.test.ts
@@ -294,6 +294,85 @@ describe("production prebuilt SSR output", () => {
     }
   }, 120_000);
 
+  it("renders custom integration providers in production and ships them for hydration", async () => {
+    const root = await createProductionFixture();
+
+    try {
+      await fs.mkdir(path.join(root, "src", "components"), { recursive: true });
+      await fs.writeFile(
+        path.join(root, "src", "components", "acme-provider.tsx"),
+        `
+"use client";
+
+export function AcmeProvider({ children, label }) {
+  return <section data-acme-provider={label}>{children}</section>;
+}
+`.trim(),
+      );
+      await fs.writeFile(
+        path.join(root, "farm.config.ts"),
+        `
+import { defineConfig, defineIntegration } from "@farm.js/core";
+
+const acme = defineIntegration({
+  category: "custom",
+  type: "acme",
+  instance: {},
+  providers: [{
+    name: "acme",
+    type: "client",
+    props: { label: "production-provider" },
+    component: { module: "@/components/acme-provider", export: "AcmeProvider" },
+  }],
+});
+
+export default defineConfig({ integrations: { acme } });
+`.trim(),
+      );
+
+      const acme = defineIntegration({
+        category: "custom",
+        type: "acme",
+        instance: {},
+        providers: [
+          {
+            name: "acme",
+            type: "client",
+            props: { label: "production-provider" },
+            component: { module: "@/components/acme-provider", export: "AcmeProvider" },
+          },
+        ],
+      });
+      const config = await resolveConfig(
+        {
+          root,
+          srcDir: "src",
+          images: { provider: "none" },
+          telemetry: false,
+          integrations: { acme },
+          generateBuildId: () => "custom-integration-provider-test",
+        },
+        "production",
+      );
+
+      await build(config, { root, preset: "node-server" });
+
+      const clientJavaScript = await readAllClientJavaScript(root);
+      expect(clientJavaScript).toContain("data-acme-provider");
+      await runProductionRequest(
+        path.join(root, ".farm", ".output", "server"),
+        async (response) => {
+          expect(response.status).toBe(200);
+          await expect(response.text()).resolves.toContain(
+            'data-acme-provider="production-provider"',
+          );
+        },
+      );
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  }, 120_000);
+
   it("isolates a client leaf without shipping its server layout", async () => {
     const root = await createProductionFixture();
     const baselineRoot = await createProductionFixture();

--- a/packages/farm/src/__tests__/production-prebuilt-ssr.test.ts
+++ b/packages/farm/src/__tests__/production-prebuilt-ssr.test.ts
@@ -295,11 +295,15 @@ describe("production prebuilt SSR output", () => {
   }, 120_000);
 
   it.each([
-    { label: "from programmatic config", runtimeConfigWithoutProviders: false },
-    { label: "when runtime config omits providers", runtimeConfigWithoutProviders: true },
+    { label: "from programmatic config", runtimeProviders: null },
+    { label: "when runtime config omits providers", runtimeProviders: "" },
+    {
+      label: "when runtime config sets providers to undefined",
+      runtimeProviders: "providers: undefined,",
+    },
   ])(
     "renders custom integration providers in production $label",
-    async ({ runtimeConfigWithoutProviders }) => {
+    async ({ runtimeProviders }) => {
       const root = await createProductionFixture();
 
       try {
@@ -314,7 +318,7 @@ export function AcmeProvider({ children, label }) {
 }
 `.trim(),
         );
-        if (runtimeConfigWithoutProviders) {
+        if (runtimeProviders !== null) {
           await fs.writeFile(
             path.join(root, "farm.config.ts"),
             `
@@ -324,6 +328,7 @@ const acme = defineIntegration({
   category: "custom",
   type: "acme",
   instance: {},
+  ${runtimeProviders}
 });
 
 export default defineConfig({ integrations: { acme } });

--- a/packages/farm/src/__tests__/server-renderer-route-states.test.tsx
+++ b/packages/farm/src/__tests__/server-renderer-route-states.test.tsx
@@ -9,6 +9,8 @@ import { ServerRenderer } from "../server/renderer";
 import type { FarmConfig, FarmRequest, FarmResponse, LoadingProps, ErrorProps } from "../types";
 import { logger } from "../utils";
 import { defer } from "../deferred";
+import { defineIntegration } from "../integrations";
+import { REACT_RENDERER } from "../renderer";
 
 type MockResponse = FarmResponse & {
   body: string;
@@ -72,27 +74,46 @@ describe("file route loading.tsx and error.tsx", () => {
   it("renders the nearest error.tsx for file route render failures", async () => {
     vi.spyOn(logger, "error").mockImplementation(() => {});
     const response = createMockResponse();
-    const renderer = createRenderer({
-      [routeModulePath]: {
-        default: function DashboardPage() {
-          throw new Error("dashboard exploded");
+    const acme = defineIntegration({
+      category: "custom",
+      type: "acme",
+      instance: {},
+      providers: [
+        {
+          name: "acme",
+          type: "client",
+          component: function AcmeProvider({ children }) {
+            return React.createElement("div", { "data-acme-provider": "" }, children);
+          },
         },
-      },
-      [errorModulePath]: {
-        default: function DashboardError(props: ErrorProps) {
-          const message = props.error instanceof Error ? props.error.message : String(props.error);
-          return React.createElement(
-            "section",
-            null,
-            `Dashboard error ${message} ${props.path} ${props.search?.tab}`,
-          );
-        },
-      },
+      ],
     });
+    const renderer = createRenderer(
+      {
+        [routeModulePath]: {
+          default: function DashboardPage() {
+            throw new Error("dashboard exploded");
+          },
+        },
+        [errorModulePath]: {
+          default: function DashboardError(props: ErrorProps) {
+            const message =
+              props.error instanceof Error ? props.error.message : String(props.error);
+            return React.createElement(
+              "section",
+              null,
+              `Dashboard error ${message} ${props.path} ${props.search?.tab}`,
+            );
+          },
+        },
+      },
+      { integrations: { acme } },
+    );
 
     await renderer.renderPage(createMockRequest("/dashboard?tab=stats"), response);
 
     expect(response.statusCode).toBe(500);
+    expect(response.body).toContain("data-acme-provider");
     expect(response.body).toContain("Dashboard error dashboard exploded /dashboard stats");
     expect(response.body).not.toContain("Internal Server Error");
   });
@@ -541,6 +562,67 @@ describe("file route loading.tsx and error.tsx", () => {
 });
 
 describe("custom not-found rendering", () => {
+  it("renders a custom not-found page inside integration providers", async () => {
+    const directory = await mkdtemp(path.join(os.tmpdir(), "farm-not-found-provider-"));
+    temporaryDirectories.push(directory);
+    const appDirectory = path.join(directory, "src", "app");
+    const notFoundPath = path.join(appDirectory, "not-found.tsx");
+    const rootLayoutPath = path.join(appDirectory, "layout.tsx");
+    await mkdir(appDirectory, { recursive: true });
+    await Promise.all([writeFile(notFoundPath, ""), writeFile(rootLayoutPath, "")]);
+
+    const acme = defineIntegration({
+      category: "custom",
+      type: "acme",
+      instance: {},
+      providers: [
+        {
+          name: "acme",
+          type: "client",
+          component: function AcmeProvider({ children }) {
+            return React.createElement("div", { "data-acme-provider": "" }, children);
+          },
+        },
+      ],
+    });
+    const response = createMockResponse();
+    const routeManager = {
+      matchMetadataRoute: () => null,
+      matchMetadataImage: () => null,
+      matchRoute: () => ({ route: null, params: {}, layouts: [], slots: [] }),
+      async loadRouteModule(modulePath: string) {
+        expect(modulePath).toBe(notFoundPath);
+        return {
+          default: function CustomNotFound() {
+            return React.createElement("main", null, "Custom not found");
+          },
+        };
+      },
+      async loadLayoutModule(modulePath: string) {
+        expect(modulePath).toBe(rootLayoutPath);
+        return {
+          default: function RootLayout({ children }: { children: React.ReactNode }) {
+            return React.createElement("html", null, React.createElement("body", null, children));
+          },
+        };
+      },
+    };
+    const renderer = new ServerRenderer(
+      {
+        ...createConfig(),
+        root: directory,
+        integrations: { acme },
+      } as Required<FarmConfig>,
+      routeManager as any,
+    );
+
+    await renderer.renderPage(createMockRequest("/missing"), response);
+
+    expect(response.statusCode).toBe(404);
+    expect(response.body).toContain("data-acme-provider");
+    expect(response.body).toContain("Custom not found");
+  });
+
   it("surfaces a root layout import failure through the error response", async () => {
     const directory = await mkdtemp(path.join(os.tmpdir(), "farm-not-found-layout-"));
     temporaryDirectories.push(directory);
@@ -613,6 +695,7 @@ function createRenderer(
       islandStrategy?: string;
     };
     onGenerateClientManifest?: () => void;
+    integrations?: FarmConfig["integrations"];
   } = {},
 ) {
   const metadataImageEntry = {
@@ -785,7 +868,10 @@ function createRenderer(
     },
   };
 
-  return new ServerRenderer(createConfig(), routeManager as any);
+  return new ServerRenderer(
+    { ...createConfig(), integrations: options.integrations ?? {} },
+    routeManager as any,
+  );
 }
 
 function createConfig(): Required<FarmConfig> {
@@ -798,6 +884,7 @@ function createConfig(): Required<FarmConfig> {
     deploy: {},
     storage: {},
     integrations: {},
+    renderer: REACT_RENDERER,
     migrations: { commands: [] },
     workflows: {
       enabled: false,

--- a/packages/farm/src/integration-provider-build.ts
+++ b/packages/farm/src/integration-provider-build.ts
@@ -1,0 +1,106 @@
+import path from "node:path";
+import type { FarmIntegrationProvider } from "./integrations";
+import { isFarmIntegrationProviderComponentReference } from "./integrations";
+import { toViteModuleId } from "./utils";
+
+export type FarmIntegrationProviderClientCode = {
+  hasProviders: boolean;
+  imports: string;
+  runtime: string;
+};
+
+export function generateFarmIntegrationProviderClientCode(
+  providers: FarmIntegrationProvider[],
+  root: string,
+): FarmIntegrationProviderClientCode {
+  const renderedProviders = providers.filter(
+    (provider) => provider.component || provider.type === "clerk",
+  );
+  const imports: string[] = [];
+  const registrations: string[] = [];
+  let hasClerkProvider = false;
+
+  renderedProviders.forEach((provider, index) => {
+    let componentExpression = "null";
+    if (isFarmIntegrationProviderComponentReference(provider.component)) {
+      const namespace = `FarmIntegrationProviderModule${index}`;
+      imports.push(
+        `import * as ${namespace} from ${JSON.stringify(resolveProviderModule(provider.component.module, root))};`,
+      );
+      componentExpression = `${namespace}[${JSON.stringify(provider.component.export || "default")}]`;
+    } else if (typeof provider.component === "function") {
+      throw new Error(
+        `Integration provider "${provider.name}" must use an importable component reference for client hydration, for example component: { module: "@/components/provider" }.`,
+      );
+    } else if (provider.type === "clerk") {
+      hasClerkProvider = true;
+      componentExpression = "FarmClerkProvider";
+    }
+
+    registrations.push(`{
+  name: ${JSON.stringify(provider.name)},
+  type: ${JSON.stringify(provider.type)},
+  props: ${JSON.stringify(provider.props || {})},
+  Component: ${componentExpression},
+}`);
+  });
+
+  if (hasClerkProvider) {
+    imports.unshift(`import { ClerkProvider as FarmClerkProvider } from "@clerk/react";`);
+  }
+
+  return {
+    hasProviders: renderedProviders.length > 0,
+    imports: imports.join("\n"),
+    runtime: `const integrationProviders = [${registrations.join(",\n")}];
+
+function wrapWithIntegrationProviders(element) {
+  let wrapped = element;
+  for (let index = integrationProviders.length - 1; index >= 0; index--) {
+    const provider = integrationProviders[index];
+    if (!provider.Component) {
+      throw new Error("Integration provider " + provider.name + " did not export its configured component.");
+    }
+    wrapped = React.createElement(provider.Component, provider.props || {}, wrapped);
+  }
+  return wrapped;
+}`,
+  };
+}
+
+export function createFarmIntegrationProviderModuleKey(component: {
+  module: string;
+  export?: string;
+}): string {
+  return `${component.module}\0${component.export || "default"}`;
+}
+
+export function generateFarmIntegrationProviderServerModules(
+  providers: FarmIntegrationProvider[],
+  root: string,
+): { imports: string; entries: string; hasClerkProvider: boolean } {
+  const imports: string[] = [];
+  const entries: string[] = [];
+
+  providers.forEach((provider, index) => {
+    if (!isFarmIntegrationProviderComponentReference(provider.component)) return;
+    const namespace = `FarmServerIntegrationProviderModule${index}`;
+    imports.push(
+      `import * as ${namespace} from ${JSON.stringify(resolveProviderModule(provider.component.module, root))};`,
+    );
+    entries.push(
+      `[${JSON.stringify(createFarmIntegrationProviderModuleKey(provider.component))}, ${namespace}[${JSON.stringify(provider.component.export || "default")}]]`,
+    );
+  });
+
+  return {
+    imports: imports.join("\n"),
+    entries: entries.join(",\n"),
+    hasClerkProvider: providers.some((provider) => provider.type === "clerk"),
+  };
+}
+
+function resolveProviderModule(moduleId: string, root: string): string {
+  if (!moduleId.startsWith(".")) return moduleId;
+  return toViteModuleId(path.resolve(root, moduleId), root);
+}

--- a/packages/farm/src/integration-provider-build.ts
+++ b/packages/farm/src/integration-provider-build.ts
@@ -96,7 +96,9 @@ export function generateFarmIntegrationProviderServerModules(
   return {
     imports: imports.join("\n"),
     entries: entries.join(",\n"),
-    hasClerkProvider: providers.some((provider) => provider.type === "clerk"),
+    hasClerkProvider: providers.some(
+      (provider) => provider.type === "clerk" && !provider.component,
+    ),
   };
 }
 

--- a/packages/farm/src/integrations.ts
+++ b/packages/farm/src/integrations.ts
@@ -328,11 +328,20 @@ export interface FarmIntegrationProviderProps {
   children: ReactNode;
 }
 
+export interface FarmIntegrationProviderComponentReference {
+  /** Client-safe module specifier using `@/`, a path relative to the app root, or a package. */
+  module: string;
+  /** Named export to use. Defaults to the module's default export. */
+  export?: string;
+}
+
 export interface FarmIntegrationProvider {
   name: string;
   type: string;
   props?: Record<string, unknown>;
-  component?: ComponentType<FarmIntegrationProviderProps>;
+  component?:
+    | ComponentType<FarmIntegrationProviderProps>
+    | FarmIntegrationProviderComponentReference;
 }
 
 export interface FarmIntegrationDocumentNavigation {
@@ -1228,12 +1237,12 @@ function withIntegrationPluginOwner(
 
 export function getIntegrationProviders(
   integrations: FarmIntegrationsUserConfig | undefined,
-): Array<Pick<FarmIntegrationProvider, "name" | "type" | "props">> {
+): FarmIntegrationProvider[] {
   if (!integrations) {
     return [];
   }
 
-  const providers: Array<Pick<FarmIntegrationProvider, "name" | "type" | "props">> = [];
+  const providers: FarmIntegrationProvider[] = [];
   for (const integration of Object.values(integrations)) {
     if (!integration || !isFarmIntegration(integration) || !integration.providers?.length) {
       continue;
@@ -1244,11 +1253,24 @@ export function getIntegrationProviders(
         name: provider.name,
         type: provider.type,
         props: provider.props,
+        component: provider.component,
       });
     }
   }
 
   return providers;
+}
+
+export function isFarmIntegrationProviderComponentReference(
+  value: FarmIntegrationProvider["component"],
+): value is FarmIntegrationProviderComponentReference {
+  return Boolean(
+    value &&
+    typeof value === "object" &&
+    "module" in value &&
+    typeof value.module === "string" &&
+    value.module.length > 0,
+  );
 }
 
 export function getIntegrationDocumentNavigationMatchers(

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -3785,6 +3785,13 @@ function generateVirtualEntryCode(
     renderedIntegrationProviders,
     config.root,
   );
+  const resolvedIntegrationProviderFallback = Object.fromEntries(
+    Object.entries(config.integrations).flatMap(([name, integration]) => {
+      const configuredProviders = (integration as { providers?: unknown } | null)?.providers;
+      const providers = Array.isArray(configuredProviders) ? configuredProviders : [];
+      return providers.length > 0 ? [[name, { providers }]] : [];
+    }),
+  );
   const providerServerImports = [
     providerServerModules.hasClerkProvider
       ? `import { ClerkProvider as FarmClerkProvider } from "@clerk/react";`
@@ -4266,7 +4273,7 @@ const farmResolvedRuntimeConfig = Object.assign({}, ...farmRuntimeConfigs);
 setFarmTrailingSlashPreference(${JSON.stringify(config.trailingSlash)});
 const hasConfiguredRouteContext = typeof farmResolvedRuntimeConfig.context === "function";
 const configuredIntegrations = Object.assign(
-  {},
+  ${JSON.stringify(resolvedIntegrationProviderFallback)},
   ...farmRuntimeConfigs.map((runtimeConfig) => runtimeConfig.integrations || {}),
 );
 const farmIntegrationProviderModuleComponents = new Map([

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -3789,6 +3789,11 @@ function generateVirtualEntryCode(
     Object.entries(config.integrations).flatMap(([name, integration]) => {
       const configuredProviders = (integration as { providers?: unknown } | null)?.providers;
       const providers = Array.isArray(configuredProviders) ? configuredProviders : [];
+      if (providers.some((provider) => typeof provider?.component === "function")) {
+        throw new Error(
+          `Integration provider components in production must use an importable component reference, for example component: { module: "@/components/provider" }.`,
+        );
+      }
       return providers.length > 0 ? [[name, { providers }]] : [];
     }),
   );
@@ -4272,10 +4277,19 @@ const farmRuntimeConfigs = [${[...layerConfigValues, "farmUserConfig"].join(", "
 const farmResolvedRuntimeConfig = Object.assign({}, ...farmRuntimeConfigs);
 setFarmTrailingSlashPreference(${JSON.stringify(config.trailingSlash)});
 const hasConfiguredRouteContext = typeof farmResolvedRuntimeConfig.context === "function";
-const configuredIntegrations = Object.assign(
-  ${JSON.stringify(resolvedIntegrationProviderFallback)},
-  ...farmRuntimeConfigs.map((runtimeConfig) => runtimeConfig.integrations || {}),
-);
+const configuredIntegrations = ${JSON.stringify(resolvedIntegrationProviderFallback)};
+for (const runtimeConfig of farmRuntimeConfigs) {
+  for (const [name, integration] of Object.entries(runtimeConfig.integrations || {})) {
+    const fallback = configuredIntegrations[name];
+    configuredIntegrations[name] =
+      fallback?.providers &&
+      integration &&
+      typeof integration === "object" &&
+      !Object.prototype.hasOwnProperty.call(integration, "providers")
+        ? { ...integration, providers: fallback.providers }
+        : integration;
+  }
+}
 const farmIntegrationProviderModuleComponents = new Map([
 ${providerServerModules.entries}
 ]);

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -4285,7 +4285,7 @@ for (const runtimeConfig of farmRuntimeConfigs) {
       fallback?.providers &&
       integration &&
       typeof integration === "object" &&
-      !Object.prototype.hasOwnProperty.call(integration, "providers")
+      integration.providers === undefined
         ? { ...integration, providers: fallback.providers }
         : integration;
   }

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -68,7 +68,11 @@ import { createFarmNodeServerEntry } from "./node-server-entry";
 import { resolveFarmNotFoundComponentPath } from "../not-found";
 import { readFarmI18nCatalogs } from "../i18n/catalog";
 import type { FarmI18nCatalogs } from "../i18n/types";
-import { getFarmIntegrationPluginServerRuntime } from "../integrations";
+import { getFarmIntegrationPluginServerRuntime, getIntegrationProviders } from "../integrations";
+import {
+  generateFarmIntegrationProviderClientCode,
+  generateFarmIntegrationProviderServerModules,
+} from "../integration-provider-build";
 import type { TransformOptions } from "esbuild";
 import { loadFarmProductionVite, type FarmProductionViteRuntime } from "../build/production-vite";
 import { adaptTailwindVitePlugin } from "../build/vite-plugin-compat";
@@ -1338,6 +1342,7 @@ async function buildClient(
     config.renderer,
     config.publicRuntimeConfig,
     config.trailingSlash,
+    getIntegrationProviders(config.integrations),
   );
 
   // Write the client entry to a temporary file
@@ -1524,6 +1529,7 @@ async function buildClient(
         : undefined,
       // Ensure React is bundled for client
       resolve: {
+        alias: createFarmSourceAlias(root, config.srcDir),
         dedupe: [...(config.renderer.dedupe || [])],
       },
       // Optimize dependencies - exclude server-side code from client bundle
@@ -1853,6 +1859,7 @@ function generateClientHydrationEntry(
   renderer: FarmRenderer = REACT_RENDERER,
   publicRuntimeConfig: Record<string, unknown> | undefined = undefined,
   trailingSlash = false,
+  integrationProviders: ReturnType<typeof getIntegrationProviders> = [],
 ): string {
   const toImportPath = (targetPath: string) => targetPath.replace(/\\/g, "/");
   const clientPluginEntry: FarmClientPluginEntryCode = generateFarmClientPluginEntryCode(
@@ -1864,6 +1871,7 @@ function generateClientHydrationEntry(
   const rendererClientImports = isReactRenderer(renderer)
     ? `import React from "react";\nimport { createRoot, hydrateRoot } from "react-dom/client";`
     : `import React, { createRoot, hydrateRoot } from ${JSON.stringify(renderer.client)};`;
+  const providerClientCode = generateFarmIntegrationProviderClientCode(integrationProviders, root);
 
   // Always import global CSS for Tailwind
   const globalsCssPath = path.join(root, srcDir, "app", "globals.css");
@@ -1955,7 +1963,11 @@ async function hydrateFarmDocsAdapterRuntime() {
 }
 `;
 
-  if (clientPages.length === 0 && clientRouteSlots.length === 0) {
+  if (
+    clientPages.length === 0 &&
+    clientRouteSlots.length === 0 &&
+    !providerClientCode.hasProviders
+  ) {
     // No client pages - just basic runtime with CSS and SPA navigation
     return `
 // Farm.js Client Runtime (no client components)
@@ -2312,7 +2324,10 @@ async function hydrateFarmIsolatedClientBoundaries(scope = document) {
             throw new Error("compiled original export was not found");
           }
           const props = JSON.parse(container.getAttribute("data-farm-client-props") || "{}");
-          const root = hydrateRoot(container, React.createElement(Component, props));
+          const root = hydrateRoot(
+            container,
+            wrapWithIntegrationProviders(React.createElement(Component, props)),
+          );
           farmIsolatedBoundaryRoots.set(container, root);
         } catch (error) {
           console.warn(
@@ -2347,6 +2362,7 @@ async function hydrateFarmIsolatedClientBoundaries(scope = document) {
 ${cssImport}
 ${layoutImports}
 ${rendererClientImports}
+${providerClientCode.imports}
 import { createClientPluginManager, installChunkErrorRecovery, scheduleFarmIslandHydration, searchParamsToObject, setFarmTrailingSlashPreference } from "@farm.js/core/internal/client-runtime";
 import { matchFarmRoute } from "@farm.js/core/router";
 ${clientPluginEntry.imports}
@@ -2356,6 +2372,8 @@ ${docsAdapterRuntime}
 
 ${imports.join("\n")}
 ${generateFarmDocsSearchClientRuntime(docsSearchEnabled, docsSearchModuleId)}
+
+${providerClientCode.runtime}
 
 setFarmTrailingSlashPreference(${JSON.stringify(trailingSlash)});
 installChunkErrorRecovery();
@@ -2491,11 +2509,11 @@ async function createMatchedHydrationElement(matched, pathname, searchParams, se
   }
 
   if (!pageElement) return null;
-  if (!hydrateLayouts) return pageElement;
+  if (!hydrateLayouts) return wrapWithIntegrationProviders(pageElement);
   if (matched.route.pageShouldHydrate) {
     pageElement = createLayoutPageBoundary(matched.route, pageElement);
   }
-  return wrapWithLayouts(pageElement, pathname, params);
+  return wrapWithIntegrationProviders(wrapWithLayouts(pageElement, pathname, params));
 }
 
 function matchesRoutePrefix(pathname, pattern) {
@@ -2558,7 +2576,7 @@ function renderClientRouteSlot(slot, registration, mode) {
   const key = routeSlotKey(slot);
   const existingRoot = routeSlotRoots.get(key);
   const props = slot.props && typeof slot.props === "object" ? slot.props : {};
-  const element = React.createElement(registration.Component, props);
+  const element = wrapWithIntegrationProviders(React.createElement(registration.Component, props));
 
   if (mode === "hydrate") {
     if (existingRoot) return true;
@@ -2941,7 +2959,9 @@ ${generateUniversalRouterStateProperties()}
         if (hasHydratableLayout(pathname)) {
           pageElement = createLayoutPageBoundary(matched.route, pageElement);
         }
-        const wrappedElement = wrapWithLayouts(pageElement, pathname, params);
+        const wrappedElement = wrapWithIntegrationProviders(
+          wrapWithLayouts(pageElement, pathname, params),
+        );
 
         await farmClientRuntime.markNavigationLoaded(clientNavigation, {
           route: matched.route.pattern,
@@ -3418,6 +3438,9 @@ async function buildSSRInMemory(
       integration !== null &&
       (!("serverRuntime" in integration) || integration.serverRuntime !== false),
   );
+  const hasIntegrationProviders = getIntegrationProviders(config.integrations).some(
+    (provider) => provider.component || provider.type === "clerk",
+  );
   const hasObservabilityHandler =
     !!config.observability &&
     typeof config.observability === "object" &&
@@ -3432,7 +3455,8 @@ async function buildSSRInMemory(
     hasMdxComponentConfig ||
     hasMiddlewareConfig ||
     hasRouteContextConfig ||
-    hasServerRuntimePlugins
+    hasServerRuntimePlugins ||
+    hasIntegrationProviders
       ? await findFarmConfigPath(root)
       : null;
   const hasRuntimeConfigModule = hasFarmRuntimeConfigModule(config, configModulePath);
@@ -3750,6 +3774,25 @@ function generateVirtualEntryCode(
   const farmDocsFontAssets = config.docs?.enabled
     ? toFarmDocsPublicFontAssets(resolveFarmDocsFontAssets(config.root))
     : [];
+  const integrationProviders = getIntegrationProviders(config.integrations);
+  const renderedIntegrationProviders = integrationProviders.filter(
+    (provider) => provider.component || provider.type === "clerk",
+  );
+  if (renderedIntegrationProviders.length > 0 && !isReactRenderer(config.renderer)) {
+    throw new Error("Integration provider components currently require the React renderer.");
+  }
+  const providerServerModules = generateFarmIntegrationProviderServerModules(
+    renderedIntegrationProviders,
+    config.root,
+  );
+  const providerServerImports = [
+    providerServerModules.hasClerkProvider
+      ? `import { ClerkProvider as FarmClerkProvider } from "@clerk/react";`
+      : "",
+    providerServerModules.imports,
+  ]
+    .filter(Boolean)
+    .join("\n");
 
   // Generate imports for all API routes
   const apiImports: string[] = [];
@@ -4195,6 +4238,7 @@ ${markdownHandlerImport}
 ${appMarkdownImport}
 ${mdxComponentsImport}
 ${integrationImports}
+${providerServerImports}
 ${instrumentationImport}
 ${imageRuntimeImport}
 ${imageNodeRuntimeImport}
@@ -4225,6 +4269,34 @@ const configuredIntegrations = Object.assign(
   {},
   ...farmRuntimeConfigs.map((runtimeConfig) => runtimeConfig.integrations || {}),
 );
+const farmIntegrationProviderModuleComponents = new Map([
+${providerServerModules.entries}
+]);
+
+function wrapWithFarmIntegrationProviders(element) {
+  const providers = Object.values(configuredIntegrations).flatMap(function(integration) {
+    return Array.isArray(integration?.providers) ? integration.providers : [];
+  });
+  let wrapped = element;
+  for (let index = providers.length - 1; index >= 0; index--) {
+    const provider = providers[index];
+    let Component = null;
+    if (typeof provider.component === "function") {
+      Component = provider.component;
+    } else if (provider.component?.module) {
+      const componentKey = provider.component.module + "\\0" + (provider.component.export || "default");
+      Component = farmIntegrationProviderModuleComponents.get(componentKey);
+    } else if (provider.type === "clerk") {
+      Component = ${providerServerModules.hasClerkProvider ? "FarmClerkProvider" : "null"};
+    }
+    if (!Component) {
+      if (!provider.component && provider.type !== "clerk") continue;
+      throw new Error("Integration provider " + provider.name + " did not export its configured component.");
+    }
+    wrapped = React.createElement(Component, provider.props || {}, wrapped);
+  }
+  return wrapped;
+}
 const serverRuntimeIntegrations = Object.fromEntries(
   Object.entries(configuredIntegrations).filter(([, integration]) =>
     integration && typeof integration === "object" && integration.serverRuntime !== false
@@ -5553,7 +5625,11 @@ ${
 
   const renderedRoot = await renderFarmElement(
     ReactDOMServer,
-    React.createElement("div", { id: "root" }, wrappedElement),
+    React.createElement(
+      "div",
+      { id: "root" },
+      wrapWithFarmIntegrationProviders(wrappedElement),
+    ),
   );
   let rootMarkup = renderedRoot.html;
   if (rootMarkup === undefined) {
@@ -6294,6 +6370,7 @@ async function handleFarmRequestInContext(
               }
             }
 
+          wrappedElement = wrapWithFarmIntegrationProviders(wrappedElement);
           return renderFarmElement(ReactDOMServer, wrappedElement);
         };
         const renderedPage = ${
@@ -6641,6 +6718,8 @@ async function handleFarmRequestInContext(
             }
           }
 
+          errorElement = wrapWithFarmIntegrationProviders(errorElement);
+
           const renderErrorElement = () =>
             renderFarmElementToString(ReactDOMServer, errorElement);
           const errorHtml = ${
@@ -6760,6 +6839,7 @@ async function handleFarmRequestInContext(
         notFoundElement = React.createElement(LayoutComponent, { children: notFoundElement, params: {} });
       }
     }
+    notFoundElement = wrapWithFarmIntegrationProviders(notFoundElement);
     
     const html = await ReactDOMServer.renderToString(notFoundElement);
     

--- a/packages/farm/src/server/renderer.ts
+++ b/packages/farm/src/server/renderer.ts
@@ -10,7 +10,7 @@ import type {
   SSGPage,
 } from "../types";
 import type { MatchedRouteSlot, RouteManager } from "../routing/route-manager";
-import { logger, toRootRelativeUrlPath } from "../utils";
+import { logger, toRootRelativeUrlPath, toViteModuleId } from "../utils";
 import { collectDevStylesheetUrls } from "./dev-styles";
 import {
   composeFarmFullDocument,
@@ -1710,8 +1710,14 @@ export class ServerRenderer {
         }
         let ProviderComponent;
         if (isFarmIntegrationProviderComponentReference(provider.component)) {
+          const providerModuleId = provider.component.module.startsWith(".")
+            ? toViteModuleId(
+                path.resolve(this.config.root, provider.component.module),
+                this.config.root,
+              )
+            : provider.component.module;
           const providerModule = this.viteServer
-            ? await this.viteServer.ssrLoadModule(provider.component.module)
+            ? await this.viteServer.ssrLoadModule(providerModuleId)
             : await importRuntimeModule(
                 provider.component.module.startsWith(".")
                   ? pathToFileURL(path.resolve(this.config.root, provider.component.module)).href
@@ -2059,6 +2065,8 @@ export class ServerRenderer {
           params: options.params,
         });
       }
+
+      wrapped = await this.wrapWithIntegrationProviders(wrapped);
 
       const html = await _runWithMiddlewareData(options.middlewareMap, () =>
         _runWithMiddlewareContext(options.middlewareContext, () =>
@@ -2669,6 +2677,8 @@ ${getFarmI18nClientSnapshot() ? `window.__FARM_I18N__ = ${serializeInlineValue(g
               children: element,
             });
           }
+
+          element = await this.wrapWithIntegrationProviders(element);
 
           // Render to string
           const content = await this.rendererRuntime.renderToString(element);

--- a/packages/farm/src/server/renderer.ts
+++ b/packages/farm/src/server/renderer.ts
@@ -27,7 +27,11 @@ import {
 } from "../middleware/server";
 import { getRequestContextSnapshot } from "../request-context";
 import { matchSSGPage, resolveRouteRenderingConfigFromFile } from "../ssg";
-import { getIntegrationProviders, getRegisteredIntegrationAPIManifest } from "../integrations";
+import {
+  getIntegrationProviders,
+  getRegisteredIntegrationAPIManifest,
+  isFarmIntegrationProviderComponentReference,
+} from "../integrations";
 import { _runWithCurrentRequest, createWebRequestFromFarmRequest } from "./request";
 import { createFarmCacheKey, getFarmDataCache, normalizeRevalidatePath } from "../cache";
 import { resolveFarmNotFoundComponentPath } from "../not-found";
@@ -1698,18 +1702,42 @@ export class ServerRenderer {
 
     for (let i = providers.length - 1; i >= 0; i--) {
       const provider = providers[i];
-      if (provider.type === "clerk") {
+      if (provider.component || provider.type === "clerk") {
         if (!isReactRenderer(this.config.renderer)) {
           throw new Error(
             `Integration provider \`${provider.type}\` currently requires the React renderer.`,
           );
         }
-        if (!cachedClerkProvider) {
-          cachedClerkProvider = await importRuntimeModule("@clerk/react");
+        let ProviderComponent;
+        if (isFarmIntegrationProviderComponentReference(provider.component)) {
+          const providerModule = this.viteServer
+            ? await this.viteServer.ssrLoadModule(provider.component.module)
+            : await importRuntimeModule(
+                provider.component.module.startsWith(".")
+                  ? pathToFileURL(path.resolve(this.config.root, provider.component.module)).href
+                  : provider.component.module,
+              );
+          ProviderComponent = providerModule[provider.component.export || "default"];
+        } else if (typeof provider.component === "function") {
+          ProviderComponent = provider.component;
+        } else if (provider.type === "clerk") {
+          if (!cachedClerkProvider) {
+            cachedClerkProvider = await importRuntimeModule("@clerk/react");
+          }
+          ProviderComponent = cachedClerkProvider!.ClerkProvider;
+        } else {
+          throw new Error(
+            `Integration provider \`${provider.name}\` has an invalid component reference.`,
+          );
+        }
+        if (!ProviderComponent) {
+          throw new Error(
+            `Integration provider \`${provider.name}\` did not export its configured component.`,
+          );
         }
 
         wrapped = this.rendererRuntime.createElement(
-          cachedClerkProvider!.ClerkProvider,
+          ProviderComponent,
           provider.props || {},
           wrapped,
         );

--- a/packages/farm/src/vite.ts
+++ b/packages/farm/src/vite.ts
@@ -89,6 +89,7 @@ import {
   resolveFarmRenderer,
 } from "./renderer";
 import type { FarmRenderer } from "./renderer";
+import { generateFarmIntegrationProviderClientCode } from "./integration-provider-build";
 import type { FarmIslandStrategy } from "./island";
 import { resolveRouteRenderingConfig } from "./ssg";
 import {
@@ -3465,11 +3466,7 @@ function parseRouteModuleSchema(
 }
 
 function generateClientCode(
-  integrationProviders: Array<{
-    name: string;
-    type: string;
-    props?: Record<string, unknown>;
-  }> = [],
+  integrationProviders: ReturnType<typeof getIntegrationProviders> = [],
   documentNavigationMatchers: string[] = [],
   docsSearchClientRuntime = EMPTY_FARM_DOCS_SEARCH_CLIENT_RUNTIME,
   devtoolsClientRuntime = "",
@@ -3482,10 +3479,7 @@ function generateClientCode(
   isolatedHydrationEnabled = false,
   trailingSlash = false,
 ): string {
-  const hasClerkProvider = integrationProviders.some((provider) => provider.type === "clerk");
-  const providerImportBlock = hasClerkProvider
-    ? `import { ClerkProvider } from '@clerk/react';`
-    : "";
+  const providerClientCode = generateFarmIntegrationProviderClientCode(integrationProviders, root);
   const clientPluginEntry = generateFarmClientPluginEntryCode(
     plugins,
     root,
@@ -3545,7 +3539,10 @@ async function hydrateFarmIsolatedClientBoundaries(scope = document) {
             throw new Error('compiled original export was not found');
           }
           const props = JSON.parse(container.getAttribute('data-farm-client-props') || '{}');
-          const root = hydrateRoot(container, React.createElement(Component, props));
+          const root = hydrateRoot(
+            container,
+            wrapWithIntegrationProviders(React.createElement(Component, props)),
+          );
           farmIsolatedBoundaryRoots.set(container, root);
         } catch (error) {
           console.warn(
@@ -3572,7 +3569,7 @@ import {
   createFarmDeploymentRequestHeaders,
   isFarmDeploymentMismatchResponse,
 } from '@farm.js/core/deployment'
-${providerImportBlock}
+${providerClientCode.imports}
 ${clientPluginEntry.imports}
 ${docsSearchClientRuntime}
 ${devtoolsClientRuntime}
@@ -3584,7 +3581,6 @@ ${docsAdapterImportBlock}
 
 // Expose React for HMR
 window.__FARM_REACT__ = React;
-const integrationProviders = ${JSON.stringify(integrationProviders)};
 const integrationDocumentNavigationMatchers = ${JSON.stringify(documentNavigationMatchers)};
 
 setFarmTrailingSlashPreference(${JSON.stringify(trailingSlash)});
@@ -3606,18 +3602,7 @@ function matchesDocumentNavigation(pathname) {
   });
 }
 
-function wrapWithIntegrationProviders(element) {
-  let wrapped = element;
-
-  for (let i = integrationProviders.length - 1; i >= 0; i--) {
-    const provider = integrationProviders[i];
-    if (provider.type === 'clerk') {
-      wrapped = React.createElement(ClerkProvider, provider.props || {}, wrapped);
-    }
-  }
-
-  return wrapped;
-}
+${providerClientCode.runtime}
 
 window.__FARM_WRAP_PROVIDERS__ = wrapWithIntegrationProviders;
 


### PR DESCRIPTION
## Problem

Custom `FarmIntegrationProvider.component` values are declared and documented, but provider discovery drops them and both render paths only know how to mount Clerk. Custom context providers therefore disappear silently.

Fixes #577.

## Root cause

`getIntegrationProviders` narrowed provider records to name, type, and props. The development client, development server, and universal production runtime then hardcoded the Clerk component instead of composing the configured provider.

## Change

- Preserve configured provider components during integration discovery.
- Add an importable `{ module, export }` component reference so Farm can statically include client-safe providers without importing the server config into the browser.
- Compose custom providers across development SSR, client hydration and navigation, isolated roots, route slots, production SSR, errors, not-found pages, and docs responses.
- Keep Clerk as the fallback when its provider has no explicit component.
- Resolve relative provider modules from the app root and support the standard `@/` source alias in production client builds.
- Document the safe module-reference form and public-safe props requirement.

## Safety and compatibility

Provider components remain React-only, matching the existing Clerk behavior; other renderers receive an explicit error instead of silently losing the provider. Direct function components remain usable by server rendering, while client generation rejects them with guidance because their imports cannot be traced safely without exposing the server configuration module. Providers without a renderable component remain metadata-only and add no client wrapper.

## Verification

- `pnpm --filter @farm.js/core exec vitest run src/__tests__/integration-provider.test.tsx src/__tests__/integrations.test.ts src/__tests__/production-async-page.test.ts`
- `pnpm --filter @farm.js/core exec vitest run src/__tests__/production-prebuilt-ssr.test.ts -t "renders custom integration providers in production and ships them for hydration"`
- `pnpm --filter @farm.js/core test` — 188 files passed; 1,489 tests passed and 1 skipped
- `pnpm --filter @farm.js/core type-check`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @farm.js/core build`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm docs:build`
- `pnpm docs:check-navigation`
- Focused `oxfmt`, `oxlint`, and `git diff --check` (zero lint errors; three pre-existing unused-symbol warnings)

## Documentation and release

Updated the custom integrations provider guide. No release metadata or generated artifacts changed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes custom `FarmIntegrationProvider.component` values being dropped during discovery (#577), so custom context providers now render across development, production, and hydration instead of silently disappearing. Providers are preserved even when the runtime config omits them or sets them to `undefined`, and Clerk remains the fallback when its provider has no explicit component.

**Migration**
- Use a `{ module, export }` component reference for client-rendered providers, for example `{ module: "@/components/acme-provider", export: "AcmeProvider" }`.
- `@/` aliases, relative paths, and package specifiers are supported; relative paths resolve from the app root.
- Direct function components still work for server rendering, but client generation rejects them with guidance because their imports cannot be traced safely.
- Provider components are React-only; other renderers get an explicit error instead of silently losing the provider.

<sup>Written for commit 607cde7076a7252d5bb066b2999f65ed07fe92ab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/698?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

