### PR TITLE
fix(router): honor app base path across client navigation

### DIFF
--- a/docs/src/app/docs/routing/page.md
+++ b/docs/src/app/docs/routing/page.md
@@ -191,6 +191,8 @@ export function CurrentUserTab() {
 
 Imperative `push()` and `replace()` calls use SPA navigation for same-origin routes. Absolute
 cross-origin URLs use normal document navigation instead of Farm's local page-data endpoint.
+Internal router paths use the configured application `basePath`, matching `Link`; already-prefixed
+paths are preserved.
 
 ## Navigation blocking
 

--- a/packages/farm/src/__tests__/base-path.test.ts
+++ b/packages/farm/src/__tests__/base-path.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { applyFarmBasePath, stripFarmBasePath } from "../base-path";
+
+describe("Farm base paths", () => {
+  it("applies the base path only to app-relative hrefs", () => {
+    expect(applyFarmBasePath("/reports", "/console")).toBe("/console/reports");
+    expect(applyFarmBasePath("/console/reports", "/console")).toBe("/console/reports");
+    expect(applyFarmBasePath("//cdn.example/reports", "/console")).toBe("//cdn.example/reports");
+  });
+
+  it("strips the base path without changing paths outside it", () => {
+    expect(stripFarmBasePath("/console/reports", "/console")).toBe("/reports");
+    expect(stripFarmBasePath("/console", "/console")).toBe("/");
+    expect(stripFarmBasePath("/reports", "/console")).toBe("/reports");
+  });
+});

--- a/packages/farm/src/__tests__/client-component.test.ts
+++ b/packages/farm/src/__tests__/client-component.test.ts
@@ -753,6 +753,7 @@ export function Chart() {}
     expect(source).toContain("subscribeNavigation: function(listener)");
     expect(source).toContain("addBlocker: function(blocker)");
     expect(source).toContain("registerScrollElement: function(key, element)");
+    expect(source).toContain("stripFarmBasePath(pathname)");
     expect(source).toContain("writePageState: function(action, state, href)");
     expect(source).toContain("runViewTransition: async function(enabled, callback)");
     expect(source).toContain('const href = element.getAttribute("href");');

--- a/packages/farm/src/__tests__/renderer-client.test.ts
+++ b/packages/farm/src/__tests__/renderer-client.test.ts
@@ -12,14 +12,18 @@ import {
 } from "../renderer-client";
 import type { ServerFn } from "../server-fn";
 import type { ServerQuery } from "../server-query";
+import { setFarmBasePath } from "../base-path";
+import { getRouter } from "../client/spa-router";
 
 describe("renderer-neutral client primitives", () => {
   beforeEach(() => {
+    setFarmBasePath("/");
     getFarmClientDataCache().clear();
     window.history.replaceState(null, "", "/products/42?tab=details");
   });
 
   afterEach(() => {
+    setFarmBasePath("/");
     delete window.__FARM_THEME__;
     vi.restoreAllMocks();
   });
@@ -36,6 +40,23 @@ describe("renderer-neutral client primitives", () => {
 
     expect(listener).toHaveBeenCalled();
     unsubscribe();
+  });
+
+  it("uses the configured app base path for renderer-neutral routing", async () => {
+    setFarmBasePath("/console");
+    window.history.replaceState(null, "", "/console/products/42?tab=details");
+    const router = createRendererRouter({ routes: ["/products/[id]"] });
+    const navigate = vi.spyOn(getRouter(), "navigate").mockResolvedValue();
+
+    expect(router.getSnapshot()).toMatchObject({
+      pathname: "/products/42",
+      params: { id: "42" },
+    });
+    await router.push("/orders");
+    await router.replace("/console/settings");
+
+    expect(navigate).toHaveBeenNthCalledWith(1, "/console/orders", undefined);
+    expect(navigate).toHaveBeenNthCalledWith(2, "/console/settings", { replace: true });
   });
 
   it("runs typed actions with observable optimistic and settled state", async () => {

--- a/packages/farm/src/__tests__/router-push-delegation.test.tsx
+++ b/packages/farm/src/__tests__/router-push-delegation.test.tsx
@@ -6,6 +6,7 @@ import { createRoot } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useRouter } from "../client/router";
 import { pushState as pushFarmPageState, readPageState, SPARouter } from "../client/spa-router";
+import { setFarmBasePath } from "../base-path";
 
 let router: SPARouter | undefined;
 let container: HTMLDivElement;
@@ -25,6 +26,7 @@ function renderHook() {
 const settle = () => new Promise((resolve) => setTimeout(resolve, 50));
 
 beforeEach(() => {
+  setFarmBasePath("/");
   window.history.replaceState(null, "", "/");
   (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
   container = document.createElement("div");
@@ -32,6 +34,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  setFarmBasePath("/");
   if (root) act(() => root?.unmount());
   container.remove();
   root = undefined;
@@ -72,6 +75,22 @@ describe("useRouter push/replace delegation", () => {
     await settle();
 
     expect(navigate).toHaveBeenCalledWith("/pricing", { replace: true });
+  });
+
+  it("uses the configured app base path without duplicating it", async () => {
+    setFarmBasePath("/console");
+    const spa = installRouter();
+    const navigate = vi.spyOn(spa, "navigate").mockResolvedValue();
+    const getApi = renderHook();
+
+    act(() => {
+      getApi().push("/reports");
+      getApi().replace("/console/settings");
+    });
+    await settle();
+
+    expect(navigate).toHaveBeenNthCalledWith(1, "/console/reports", { replace: false });
+    expect(navigate).toHaveBeenNthCalledWith(2, "/console/settings", { replace: true });
   });
 
   it("leaves the URL unchanged when a blocker cancels the navigation", async () => {

--- a/packages/farm/src/__tests__/searchparams.test.ts
+++ b/packages/farm/src/__tests__/searchparams.test.ts
@@ -226,7 +226,7 @@ describe("SearchParams in the production runtime", () => {
     const source = readSource("nitro", "universal-build.ts");
 
     expect(source).toContain(
-      'import { createClientPluginManager, installChunkErrorRecovery, scheduleFarmIslandHydration, searchParamsToObject, setFarmBasePath, setFarmTrailingSlashPreference } from "@farm.js/core/internal/client-runtime";',
+      'import { createClientPluginManager, installChunkErrorRecovery, scheduleFarmIslandHydration, searchParamsToObject, setFarmBasePath, setFarmTrailingSlashPreference, stripFarmBasePath } from "@farm.js/core/internal/client-runtime";',
     );
     expect(source).toContain(
       "const searchParams = searchParamsToObject(new URLSearchParams(window.location.search));",

--- a/packages/farm/src/base-path.ts
+++ b/packages/farm/src/base-path.ts
@@ -16,7 +16,7 @@ export function getFarmBasePath(): string {
 
 export function applyFarmBasePath(href: string, basePath = getFarmBasePath()): string {
   const normalizedBasePath = normalizeFarmBasePath(basePath);
-  if (!normalizedBasePath || !href.startsWith("/")) return href;
+  if (!normalizedBasePath || !href.startsWith("/") || href.startsWith("//")) return href;
   if (
     href === normalizedBasePath ||
     href.startsWith(`${normalizedBasePath}/`) ||
@@ -26,6 +26,14 @@ export function applyFarmBasePath(href: string, basePath = getFarmBasePath()): s
     return href;
   }
   return `${normalizedBasePath}${href}`;
+}
+
+export function stripFarmBasePath(pathname: string, basePath = getFarmBasePath()): string {
+  const normalizedBasePath = normalizeFarmBasePath(basePath);
+  if (!normalizedBasePath) return pathname || "/";
+  if (pathname === normalizedBasePath) return "/";
+  if (!pathname.startsWith(`${normalizedBasePath}/`)) return pathname || "/";
+  return pathname.slice(normalizedBasePath.length) || "/";
 }
 
 export function normalizeFarmBasePath(basePath: string | undefined): string {

--- a/packages/farm/src/client/production-runtime.ts
+++ b/packages/farm/src/client/production-runtime.ts
@@ -3,4 +3,4 @@ export { scheduleFarmIslandHydration } from "./island-runtime";
 export { createClientPluginManager } from "./plugin";
 export { searchParamsToObject } from "../search-params";
 export { setFarmTrailingSlashPreference } from "../trailing-slash";
-export { setFarmBasePath } from "../base-path";
+export { setFarmBasePath, stripFarmBasePath } from "../base-path";

--- a/packages/farm/src/client/router.ts
+++ b/packages/farm/src/client/router.ts
@@ -11,6 +11,12 @@ import { notifyHistoryChange, subscribeHistoryChange } from "./history-sync";
 import { getFarmI18nClientState } from "../i18n/client-runtime";
 import { _resolveCurrentRequest } from "../server/request-bridge";
 import { stripFarmLocaleFromPathname } from "../i18n/routing";
+import {
+  applyFarmBasePath,
+  getFarmBasePath,
+  normalizeFarmBasePath,
+  stripFarmBasePath,
+} from "../base-path";
 
 interface RouterState {
   pathname: string;
@@ -48,7 +54,7 @@ export interface UseBlockerReturn {
 function navigateViaRouter(href: string, basePath: string, replace: boolean): void {
   if (typeof window === "undefined") return;
 
-  const url = href.startsWith("/") ? basePath + href : href;
+  const url = applyFarmBasePath(href, basePath);
   const spaRouter = getInstalledFarmSPARouter();
   if (spaRouter) {
     void spaRouter.navigate(url, { replace });
@@ -64,7 +70,8 @@ function navigateViaRouter(href: string, basePath: string, replace: boolean): vo
 }
 
 export function useRouter(options: UseRouterOptions = {}) {
-  const basePath = options.basePath || "";
+  const basePath =
+    options.basePath === undefined ? getFarmBasePath() : normalizeFarmBasePath(options.basePath);
   const routes = options.routes;
   const routeKey =
     routes?.map((route) => (typeof route === "string" ? route : route.path)).join("\n") || "";
@@ -253,14 +260,10 @@ function readCurrentUrl(): URL | undefined {
 }
 
 function normalizeClientPathname(pathname: string, basePath: string) {
-  const normalizedBase = basePath.replace(/\/+$/, "");
-  const isUnderBase =
-    normalizedBase && (pathname === normalizedBase || pathname.startsWith(`${normalizedBase}/`));
-  const withoutBase = isUnderBase ? pathname.slice(normalizedBase.length) || "/" : pathname;
-  return withoutBase || "/";
+  return stripFarmBasePath(pathname, basePath);
 }
 
 function resolveClientHref(href: string | undefined, basePath: string): string | undefined {
   if (!href) return undefined;
-  return href.startsWith("/") ? basePath + href : href;
+  return applyFarmBasePath(href, basePath);
 }

--- a/packages/farm/src/navigation.ts
+++ b/packages/farm/src/navigation.ts
@@ -1,5 +1,6 @@
 import { useRouter as useFarmRouter } from "./client/router";
 import { getRouter as getFarmSPARouter } from "./client/spa-router";
+import { applyFarmBasePath } from "./base-path";
 
 export {
   getFarmRedirectError,
@@ -24,7 +25,7 @@ export function useRouter() {
     },
     prefetch(href: string) {
       if (typeof window === "undefined") return Promise.resolve();
-      return getFarmSPARouter().prefetch(href);
+      return getFarmSPARouter().prefetch(applyFarmBasePath(href));
     },
   };
 }

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -1911,7 +1911,7 @@ if (window.__FARM_I18N__) {
 }
 
 function getFarmRoutePathname(pathname) {
-  return stripFarmLocaleFromPathname(pathname, farmI18nConfig);
+  return stripFarmLocaleFromPathname(stripFarmBasePath(pathname), farmI18nConfig);
 }
 
 function isFarmLocaleDocumentChange(doc) {
@@ -1922,7 +1922,7 @@ function isFarmLocaleDocumentChange(doc) {
 `
     : `
 function getFarmRoutePathname(pathname) {
-  return pathname;
+  return stripFarmBasePath(pathname);
 }
 
 function isFarmLocaleDocumentChange() {
@@ -1933,7 +1933,8 @@ function isFarmLocaleDocumentChange() {
     ? `
 const farmDocsEntryPath = ${JSON.stringify(docsEntryPath)};
 function isFarmDocsPath(pathname) {
-  const normalizedPath = pathname.length > 1 ? pathname.replace(/\\/+$/, "") : pathname;
+  const routePathname = getFarmRoutePathname(pathname);
+  const normalizedPath = routePathname.length > 1 ? routePathname.replace(/\\/+$/, "") : routePathname;
   return normalizedPath === farmDocsEntryPath || normalizedPath.startsWith(farmDocsEntryPath + "/");
 }
 `
@@ -1975,7 +1976,7 @@ async function hydrateFarmDocsAdapterRuntime() {
 // Farm.js Client Runtime (no client components)
 ${cssImport}
 ${layoutImports}
-import { createClientPluginManager, installChunkErrorRecovery, setFarmBasePath, setFarmTrailingSlashPreference } from "@farm.js/core/internal/client-runtime";
+import { createClientPluginManager, installChunkErrorRecovery, setFarmBasePath, setFarmTrailingSlashPreference, stripFarmBasePath } from "@farm.js/core/internal/client-runtime";
 ${clientPluginEntry.imports}
 ${i18nClientRuntime}
 ${docsNavigationRuntime}
@@ -2366,7 +2367,7 @@ ${cssImport}
 ${layoutImports}
 ${rendererClientImports}
 ${providerClientCode.imports}
-import { createClientPluginManager, installChunkErrorRecovery, scheduleFarmIslandHydration, searchParamsToObject, setFarmBasePath, setFarmTrailingSlashPreference } from "@farm.js/core/internal/client-runtime";
+import { createClientPluginManager, installChunkErrorRecovery, scheduleFarmIslandHydration, searchParamsToObject, setFarmBasePath, setFarmTrailingSlashPreference, stripFarmBasePath } from "@farm.js/core/internal/client-runtime";
 import { matchFarmRoute } from "@farm.js/core/router";
 ${clientPluginEntry.imports}
 ${i18nClientRuntime}

--- a/packages/farm/src/renderer-client.ts
+++ b/packages/farm/src/renderer-client.ts
@@ -26,6 +26,12 @@ import {
   subscribeFarmI18n,
 } from "./i18n/client-runtime";
 import type { FarmI18nClientSnapshot, FarmI18nLocale, FarmTranslator } from "./i18n/types";
+import {
+  applyFarmBasePath,
+  getFarmBasePath,
+  normalizeFarmBasePath,
+  stripFarmBasePath,
+} from "./base-path";
 
 export interface FarmClientStore<TSnapshot> {
   getSnapshot(): TSnapshot;
@@ -57,7 +63,8 @@ export interface FarmRendererRouter extends FarmClientStore<FarmRendererRouterSn
 }
 
 export function createRendererRouter(options: FarmRendererRouterOptions = {}): FarmRendererRouter {
-  const basePath = options.basePath || "";
+  const basePath =
+    options.basePath === undefined ? getFarmBasePath() : normalizeFarmBasePath(options.basePath);
   const matcher = options.routes?.length ? createFarmRouter([...options.routes]) : null;
   const router = getSPARouter();
   let snapshot = readRendererRouterSnapshot(basePath, matcher, router.getNavigationState());
@@ -386,12 +393,7 @@ function readRendererRouterSnapshot(
   }
 
   const url = new URL(window.location.href);
-  const normalizedBase = basePath.replace(/\/+$/, "");
-  const pathname =
-    normalizedBase &&
-    (url.pathname === normalizedBase || url.pathname.startsWith(`${normalizedBase}/`))
-      ? url.pathname.slice(normalizedBase.length) || "/"
-      : url.pathname;
+  const pathname = stripFarmBasePath(url.pathname, basePath);
   const i18n = getFarmI18nClientState();
   const routePathname = i18n ? stripFarmLocaleFromPathname(pathname, i18n) : pathname;
 
@@ -405,7 +407,7 @@ function readRendererRouterSnapshot(
 }
 
 function resolveRendererHref(href: string, basePath: string): string {
-  return href.startsWith("/") ? `${basePath}${href}` : href;
+  return applyFarmBasePath(href, basePath);
 }
 
 function resolveRendererServerFn<TInput, TResult, TError extends Error>(

--- a/packages/farm/src/vite.ts
+++ b/packages/farm/src/vite.ts
@@ -3564,7 +3564,7 @@ async function hydrateFarmIsolatedClientBoundaries(scope = document) {
 ${rendererClientImports}
 import { installChunkErrorRecovery, SPARouter } from '@farm.js/core/client'
 import { createClientPluginManager } from '@farm.js/core/plugin/client'
-import { scheduleFarmIslandHydration, searchParamsToObject, setFarmBasePath, setFarmTrailingSlashPreference } from '@farm.js/core/internal/client-runtime'
+import { scheduleFarmIslandHydration, searchParamsToObject, setFarmBasePath, setFarmTrailingSlashPreference, stripFarmBasePath } from '@farm.js/core/internal/client-runtime'
 import { reviveDeferredData } from '@farm.js/core/deferred'
 import {
   createFarmDeploymentMismatchError,
@@ -3593,6 +3593,7 @@ let reactRoot = null;
 ${isolatedHydrationRuntime}
 
 function matchesDocumentNavigation(pathname) {
+  pathname = stripFarmBasePath(pathname);
   return integrationDocumentNavigationMatchers.some((matcher) => {
     if (matcher === '/(.*)' || matcher === '*') {
       return true;
@@ -3663,6 +3664,7 @@ function matchRoute(pathname, routeSegments) {
 }
 
 function findRoute(pathname) {
+  pathname = stripFarmBasePath(pathname);
   const manifest = getManifest();
   const routes = Object.values(manifest.routes);
   
@@ -3676,6 +3678,7 @@ function findRoute(pathname) {
 }
 
 function findLayouts(pathname) {
+  pathname = stripFarmBasePath(pathname);
   const manifest = getManifest();
   const layouts = Object.values(manifest.layouts);
   const normalizedPath = pathname === '/' ? '/' : pathname.replace(/\\/$/, '');


### PR DESCRIPTION
## Problem

Applications mounted under `basePath` render correctly on the server, but the generated production client matches the mounted browser pathname against canonical route patterns. Imperative React and renderer-neutral routers also default to an empty base path and can either omit or duplicate the mount prefix.

## Root cause

The app-wide base path was initialized for `Link`, but route matching and router href resolution did not consume the same normalized preference. The production matcher stripped locale prefixes only, while the development matcher and document-navigation matchers used the browser pathname verbatim.

## Change

Add a shared `stripFarmBasePath()` helper and use the existing base-path state for React and renderer-neutral router snapshots and navigation. Strip the mount prefix before generated development and production route matching, and preserve already-prefixed hrefs.

## Safety and compatibility

Root-mounted applications retain their current paths. External and relative non-root URLs are unchanged. Explicit router `basePath` options still override the app-wide value. React, Vue, Svelte, and Solid bindings share the renderer-neutral fix.

## Verification

- `pnpm --filter @farm.js/core exec vitest run src/__tests__/router-push-delegation.test.tsx src/__tests__/renderer-client.test.ts src/__tests__/client-component.test.ts src/__tests__/searchparams.test.ts src/__tests__/link.test.tsx`
- `pnpm --filter @farm.js/core type-check`
- focused `oxfmt` and `oxlint` (one pre-existing `deployOutputDir` warning in `universal-build.ts`)

The regressions cover app-wide prefixing, already-prefixed hrefs, renderer-neutral pathname/param matching, and the generated production matcher.

## Documentation and release

Updated the routing guide to state that imperative router paths use the configured application `basePath`. No manual release changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes client navigation so apps mounted under a base path no longer omit or duplicate the mount prefix during route matching and router href resolution.

**Behavior**
- Adds a shared `stripFarmBasePath()` helper and applies it to development, production, and document-navigation route matching.
- Router snapshots and imperative `push()`, `replace()`, and `prefetch()` now use the app-wide base path, matching `Link`.
- Already-prefixed hrefs are preserved, and explicit router `basePath` options still override the app-wide value.
- Root-mounted apps and external URLs keep their current behavior.

<sup>Written for commit 884469fd1b38fbe4125fae6ddd3a90f6e057f05f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/699?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

