### PR TITLE
fix(deployment): guard production HTML navigation across releases

### DIFF
--- a/packages/farm/src/__tests__/client-component.test.ts
+++ b/packages/farm/src/__tests__/client-component.test.ts
@@ -743,6 +743,23 @@ export function Chart() {}
     expect(source).toContain("resetReactRoot();");
   });
 
+  it("guards generated production HTML requests against stale deployments", () => {
+    const source = fs.readFileSync(
+      path.join(process.cwd(), "src", "nitro", "universal-build.ts"),
+      "utf-8",
+    );
+
+    expect(source).toContain("async function fetchFarmNavigationDocument(");
+    expect(source).toContain("headers: createFarmDeploymentRequestHeaders(deploymentId, headers)");
+    expect(source).toContain("isFarmDeploymentMismatchResponse(response, deploymentId)");
+    expect(source).toContain(
+      'window.dispatchEvent(new CustomEvent("farm:deployment-mismatch", { detail: error }))',
+    );
+    expect(source).toContain('if (error?.name === "FarmDeploymentMismatchError") return;');
+    expect(source).toContain("this.fetchPage(pathname, false, false)");
+    expect(source).toContain("this.fetchPage(pathname, interceptFrom, false)");
+  });
+
   it("keeps the generated production router compatible with client navigation hooks", () => {
     const source = fs.readFileSync(
       path.join(process.cwd(), "src", "nitro", "universal-build.ts"),

--- a/packages/farm/src/__tests__/universal-build-router-runtime.test.ts
+++ b/packages/farm/src/__tests__/universal-build-router-runtime.test.ts
@@ -1,10 +1,20 @@
 // @vitest-environment node
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { FARM_HISTORY_CHANGE_EVENT } from "../client/history-sync";
 import {
+  createFarmDeploymentMismatchError,
+  createFarmDeploymentRequestHeaders,
+  isFarmDeploymentMismatchResponse,
+} from "../deployment";
+import {
   generateRuntimePathMatcherSource,
+  generateUniversalRouterStateRuntime,
   generateUniversalRouterStateProperties,
 } from "../nitro/universal-build";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
 
 describe("generateUniversalRouterStateProperties", () => {
   // Shared by both production runtime variants (node and edge templates).
@@ -59,6 +69,114 @@ describe("generateUniversalRouterStateProperties", () => {
     expect(router.getNavigationState().state).toBe("loading");
     router.finishNavigation(second);
     expect(router.getNavigationState().state).toBe("idle");
+  });
+});
+
+describe("generated deployment navigation guard", () => {
+  const createGuard = () =>
+    new Function(
+      "createFarmDeploymentMismatchError",
+      "createFarmDeploymentRequestHeaders",
+      "isFarmDeploymentMismatchResponse",
+      `${generateUniversalRouterStateRuntime()}; return fetchFarmNavigationDocument;`,
+    )(
+      createFarmDeploymentMismatchError,
+      createFarmDeploymentRequestHeaders,
+      isFarmDeploymentMismatchResponse,
+    ) as (url: string, headers: HeadersInit, recover?: boolean) => Promise<Response>;
+
+  it("reports a prefetched deployment mismatch without navigating", async () => {
+    const assign = vi.fn();
+    const dispatchEvent = vi.fn();
+    vi.stubGlobal("window", {
+      __FARM_DEPLOYMENT_ID__: "release-1",
+      dispatchEvent,
+      location: { assign },
+    });
+    vi.stubGlobal(
+      "CustomEvent",
+      class {
+        constructor(
+          readonly type: string,
+          readonly init: { detail: unknown },
+        ) {}
+      },
+    );
+    const response = new Response(null, {
+      status: 409,
+      headers: {
+        "x-farm-deployment-id": "release-2",
+        "x-farm-deployment-mismatch": "1",
+      },
+    });
+    const fetchMock = vi.fn().mockResolvedValue(response);
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(createGuard()("/reports", { Accept: "text/html" }, false)).rejects.toMatchObject({
+      name: "FarmDeploymentMismatchError",
+      clientDeploymentId: "release-1",
+      serverDeploymentId: "release-2",
+    });
+
+    const requestHeaders = fetchMock.mock.calls[0]?.[1]?.headers as Headers;
+    expect(requestHeaders.get("x-farm-deployment-id")).toBe("release-1");
+    expect(dispatchEvent).toHaveBeenCalledTimes(1);
+    expect(assign).not.toHaveBeenCalled();
+  });
+
+  it("navigates to the requested URL when recovery is enabled", async () => {
+    const assign = vi.fn();
+    vi.stubGlobal("window", {
+      __FARM_DEPLOYMENT_ID__: "release-1",
+      dispatchEvent: vi.fn(),
+      location: { assign },
+    });
+    vi.stubGlobal(
+      "CustomEvent",
+      class {
+        constructor(
+          readonly type: string,
+          readonly init: { detail: unknown },
+        ) {}
+      },
+    );
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(null, {
+          status: 409,
+          headers: {
+            "x-farm-deployment-id": "release-2",
+            "x-farm-deployment-mismatch": "1",
+          },
+        }),
+      ),
+    );
+
+    await expect(createGuard()("/reports", { Accept: "text/html" })).rejects.toMatchObject({
+      name: "FarmDeploymentMismatchError",
+    });
+    expect(assign).toHaveBeenCalledWith("/reports");
+  });
+
+  it("clears older prefetched HTML after a deployment mismatch", () => {
+    const getHandler = new Function(
+      `${generateUniversalRouterStateRuntime()}; return clearFarmPrefetchCacheOnDeploymentMismatch;`,
+    ) as () => (router: { prefetchCache: Map<string, string> }, error: Error) => void;
+    const clearOnMismatch = getHandler();
+    const router = {
+      prefetchCache: new Map([
+        ["/reports", "old release"],
+        ["/settings", "old release"],
+      ]),
+    };
+
+    clearOnMismatch(
+      router,
+      Object.assign(new Error("mismatch"), { name: "FarmDeploymentMismatchError" }),
+    );
+
+    expect(router.prefetchCache.size).toBe(0);
   });
 });
 

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -1558,7 +1558,7 @@ async function buildClient(
 /**
  * Generate client hydration entry that imports and hydrates client components
  */
-function generateUniversalRouterStateRuntime(): string {
+export function generateUniversalRouterStateRuntime(): string {
   return `
 const FARM_PAGE_STATE_KEY = "__farmPageState";
 const IDLE_NAVIGATION_STATE = {
@@ -1590,6 +1590,27 @@ function createHistoryState(path, pageState, currentState) {
     path,
     [FARM_PAGE_STATE_KEY]: pageState,
   };
+}
+
+async function fetchFarmNavigationDocument(url, headers, recover = true, signal) {
+  const deploymentId = window.__FARM_DEPLOYMENT_ID__;
+  const response = await fetch(url, {
+    headers: createFarmDeploymentRequestHeaders(deploymentId, headers),
+    signal,
+  });
+  if (isFarmDeploymentMismatchResponse(response, deploymentId)) {
+    const error = createFarmDeploymentMismatchError(response, deploymentId || "unknown");
+    window.dispatchEvent(new CustomEvent("farm:deployment-mismatch", { detail: error }));
+    if (recover) window.location.assign(url);
+    throw error;
+  }
+  return response;
+}
+
+function clearFarmPrefetchCacheOnDeploymentMismatch(router, error) {
+  if (error?.name === "FarmDeploymentMismatchError") {
+    router.prefetchCache.clear();
+  }
 }
 `.trim();
 }
@@ -2006,6 +2027,7 @@ async function hydrateFarmDocsAdapterRuntime() {
 ${cssImport}
 ${layoutImports}
 import { createClientPluginManager, installChunkErrorRecovery, setFarmBasePath, setFarmTrailingSlashPreference, stripFarmBasePath } from "@farm.js/core/internal/client-runtime";
+import { createFarmDeploymentMismatchError, createFarmDeploymentRequestHeaders, isFarmDeploymentMismatchResponse } from "@farm.js/core/deployment";
 ${clientPluginEntry.imports}
 ${i18nClientRuntime}
 ${docsNavigationRuntime}
@@ -2076,6 +2098,7 @@ ${generateUniversalRouterStateProperties()}
       const html = await this.fetchPage(
         url.pathname + url.search,
         options.refresh === true,
+        true,
         navigation.controller.signal,
       );
       if (!this.isCurrentNavigation(navigation, clientNavigation)) return;
@@ -2115,6 +2138,7 @@ ${generateUniversalRouterStateProperties()}
         await farmClientRuntime.failNavigation(clientNavigation, error);
       }
       this.finishNavigation(navigation);
+      if (error?.name === "FarmDeploymentMismatchError") return;
       console.error("[Farm.js] Navigation error:", error);
       if (action === "pop") window.location.reload();
       else window.location.href = href;
@@ -2131,15 +2155,17 @@ ${generateUniversalRouterStateProperties()}
     });
   },
   
-  fetchPage: async function(url, fresh = false, signal) {
+  fetchPage: async function(url, fresh = false, recover = true, signal) {
     if (fresh) this.prefetchCache.delete(url);
     const cached = fresh ? undefined : this.prefetchCache.get(url);
     if (cached) return cached;
     
-    const response = await fetch(url, {
+    const response = await fetchFarmNavigationDocument(
+      url,
+      { "Accept": "text/html" },
+      recover,
       signal,
-      headers: { "Accept": "text/html" }
-    });
+    );
     if (!response.ok) throw new Error("Failed to fetch page");
     return response.text();
   },
@@ -2213,9 +2239,11 @@ ${generateUniversalRouterStateProperties()}
     const pathname = url.pathname + url.search;
     if (this.prefetchCache.has(pathname)) return;
     
-    this.fetchPage(pathname)
+    this.fetchPage(pathname, false, false)
       .then(function(html) { spaRouter.prefetchCache.set(pathname, html); })
-      .catch(function() {});
+      .catch(function(error) {
+        clearFarmPrefetchCacheOnDeploymentMismatch(spaRouter, error);
+      });
   },
 
   clearCache: function() {
@@ -2419,6 +2447,7 @@ ${layoutImports}
 ${rendererClientImports}
 ${providerClientCode.imports}
 import { createClientPluginManager, installChunkErrorRecovery, scheduleFarmIslandHydration, searchParamsToObject, setFarmBasePath, setFarmTrailingSlashPreference, stripFarmBasePath } from "@farm.js/core/internal/client-runtime";
+import { createFarmDeploymentMismatchError, createFarmDeploymentRequestHeaders, isFarmDeploymentMismatchResponse } from "@farm.js/core/deployment";
 import { matchFarmRoute } from "@farm.js/core/router";
 ${clientPluginEntry.imports}
 ${i18nClientRuntime}
@@ -2979,7 +3008,7 @@ ${generateUniversalRouterStateProperties()}
 
       const intercepted = matchInterceptedRouteSlot(pathname, from);
       if (intercepted) {
-        const html = await this.fetchPage(to, from, navigation.controller.signal);
+        const html = await this.fetchPage(to, from, true, navigation.controller.signal);
         if (!this.isCurrentNavigation(navigation, clientNavigation)) return;
         const doc = new DOMParser().parseFromString(html, "text/html");
         const slotPayload = readRouteSlotPayload(doc);
@@ -3067,6 +3096,7 @@ ${generateUniversalRouterStateProperties()}
         const html = await this.fetchPage(
           url.pathname + url.search,
           undefined,
+          true,
           navigation.controller.signal,
         );
         if (!this.isCurrentNavigation(navigation, clientNavigation)) return;
@@ -3116,24 +3146,27 @@ ${generateUniversalRouterStateProperties()}
         await farmClientRuntime.failNavigation(clientNavigation, error);
       }
       this.finishNavigation(navigation);
+      if (error?.name === "FarmDeploymentMismatchError") return;
       console.error("[Farm.js] Navigation error:", error);
       if (action === "pop") window.location.reload();
       else window.location.href = href;
     }
   },
   
-  fetchPage: async function(url, interceptFrom, signal) {
+  fetchPage: async function(url, interceptFrom, recover = true, signal) {
     const cacheKey = interceptFrom ? url + "\\nintercept:" + interceptFrom : url;
     const cached = this.prefetchCache.get(cacheKey);
     if (cached) return cached;
     
-    const response = await fetch(url, {
-      signal,
-      headers: {
+    const response = await fetchFarmNavigationDocument(
+      url,
+      {
         "Accept": "text/html",
         ...(interceptFrom ? { "X-Farm-Intercept-From": interceptFrom } : {}),
-      }
-    });
+      },
+      recover,
+      signal,
+    );
     if (!response.ok) throw new Error("Failed to fetch page");
     const html = await response.text();
     this.prefetchCache.set(cacheKey, html);
@@ -3279,9 +3312,11 @@ ${generateUniversalRouterStateProperties()}
     const cacheKey = pathname + "\\nintercept:" + interceptFrom;
     if (this.prefetchCache.has(cacheKey)) return;
     
-    this.fetchPage(pathname, interceptFrom)
+    this.fetchPage(pathname, interceptFrom, false)
       .then(function(html) { spaRouter.prefetchCache.set(cacheKey, html); })
-      .catch(function() {});
+      .catch(function(error) {
+        clearFarmPrefetchCacheOnDeploymentMismatch(spaRouter, error);
+      });
   },
   
   observeForPrefetch: function(element) {


### PR DESCRIPTION
## Problem

The generated production routers fetch HTML without sending the active Farm deployment ID. If a user keeps an old client bundle open while a new release is deployed, that old runtime can consume HTML from the new release instead of taking the framework's deployment-mismatch recovery path.

## Root cause

The shared SPA router and Vite compatibility fallback use the deployment request and response helpers, but the two HTML-fetching runtimes generated by `universal-build.ts` bypassed them. Safe GET requests cannot rely on the deployment cookie fallback, so the server never received the stale client ID.

## Change

Route both generated HTML fetchers through one deployment-aware helper. It adds `x-farm-deployment-id`, detects mismatch responses, emits `farm:deployment-mismatch`, and performs a document navigation for user-initiated requests. Prefetch requests detect and discard mismatches without unexpectedly redirecting the page.

## Safety and compatibility

- Applies to both the server-rendered HTML-swap runtime and the hydratable production runtime.
- Preserves normal HTML caching and interception headers.
- Does not redirect on hover or viewport prefetch.
- Uses the existing public deployment helpers and event contract; no new API is introduced.

## Verification

- `pnpm --filter @farm.js/core exec vitest run src/__tests__/client-component.test.ts src/__tests__/deployment.test.ts` (43 tests passed)
- `pnpm --filter @farm.js/core type-check`
- `pnpm exec oxlint packages/farm/src/nitro/universal-build.ts packages/farm/src/__tests__/client-component.test.ts` (0 errors; one pre-existing unused-variable warning in `universal-build.ts`)
- `git diff --check`

## Documentation and release

No documentation change. This makes the production implementation match the existing deployment-mismatch contract.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Generated production routers previously fetched HTML without the active deployment ID, allowing stale client bundles to consume HTML from a newer release. They now detect deployment mismatches and enter the recovery path instead.

- Both HTML-fetching runtimes send `x-farm-deployment-id` through a shared deployment-aware helper.
- User navigation dispatches `farm:deployment-mismatch` and navigates to the requested document; prefetch mismatches avoid redirects and clear cached HTML from the old deployment.

<sup>Written for commit 2d4bb9e4a563badc549763a55ff1353f4020cd9b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/700?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

