### PR TITLE
fix(navigation): ignore stale generated-router responses

### DIFF
--- a/packages/farm/src/__tests__/client-component.test.ts
+++ b/packages/farm/src/__tests__/client-component.test.ts
@@ -736,7 +736,7 @@ export function Chart() {}
     expect(source).toContain("delete window.__farmDocsRuntime;");
     expect(source).toContain("script.replaceWith(freshScript);");
     expect(source).toContain('document.documentElement.dataset.farmDocsRuntime === "true"');
-    expect(source).toContain("this.swapContent(html, url.pathname + url.search)");
+    expect(source).toContain("const swapped = await this.swapContent(");
     expect(source).toContain(
       "const targetUrl = new URL(targetPath || window.location.href, window.location.origin);",
     );
@@ -763,6 +763,17 @@ export function Chart() {}
     expect(source).toContain("this.currentPath = to;");
     expect(source).toContain("scheduleFarmIslandHydration");
     expect(source).toContain("pendingPageHydrationController?.abort()");
+    expect(source.match(/const navigation = this\.startNavigation/g)).toHaveLength(2);
+    expect(source).toContain(
+      "if (!this.isCurrentNavigation(navigation, clientNavigation)) return;",
+    );
+    expect(source).toContain("navigation.controller.signal");
+    expect(source).toContain("navigation.clientNavigation = clientNavigation;");
+    expect(source).toContain("farmClientRuntime.cancelNavigation(");
+    expect(source).toContain(
+      "swapContent: async function(html, targetPath, navigation, clientNavigation)",
+    );
+    expect(source).toContain("if (!isNavigationCurrent()) return false;");
     expect(source).toContain("reactRootContainer !== container");
     expect(source).toContain('document.getElementById("__farm_page__") || currentRoot');
     expect(source).toContain("Navigation itself signals intent");

--- a/packages/farm/src/__tests__/client-plugin.test.ts
+++ b/packages/farm/src/__tests__/client-plugin.test.ts
@@ -219,6 +219,19 @@ describe("client plugin lifecycle", () => {
     expect(loaded).toEqual(["/second"]);
   });
 
+  it("cancels the active navigation session explicitly", async () => {
+    const manager = createManager([]);
+    const navigation = await manager.beginNavigation({
+      to: "/account",
+      action: "push",
+    });
+
+    manager.cancelNavigation(navigation, "document-navigation");
+
+    expect(navigation.signal.aborted).toBe(true);
+    expect(navigation.signal.reason).toBe("document-navigation");
+  });
+
   it("isolates failed hooks and reports them to sibling plugins", async () => {
     const calls: string[] = [];
     vi.spyOn(console, "error").mockImplementation(() => {});

--- a/packages/farm/src/__tests__/universal-build-router-runtime.test.ts
+++ b/packages/farm/src/__tests__/universal-build-router-runtime.test.ts
@@ -23,6 +23,43 @@ describe("generateUniversalRouterStateProperties", () => {
     expect(runtime).toContain("replaceState: function(state, href)");
     expect(runtime).toContain("writePageState: function(action, state, href)");
   });
+
+  it("aborts superseded navigations without letting them reset current state", () => {
+    const createRouter = new Function(
+      "window",
+      "IDLE_NAVIGATION_STATE",
+      "createNavigationLocation",
+      `return ({${runtime}});`,
+    ) as (
+      windowValue: { location: { pathname: string; search: string } },
+      idleState: object,
+      createLocation: (url: URL) => object,
+    ) => {
+      activeNavigation: { id: number; controller: AbortController } | null;
+      finishNavigation(navigation: { id: number; controller: AbortController }): void;
+      getNavigationState(): { state: string };
+      startNavigation(
+        from: string,
+        to: URL,
+        action: string,
+      ): { id: number; controller: AbortController };
+    };
+    const router = createRouter(
+      { location: { pathname: "/start", search: "" } },
+      { state: "idle", pending: false },
+      (url) => ({ href: url.href }),
+    );
+
+    const first = router.startNavigation("/start", new URL("https://example.test/slow"), "push");
+    const second = router.startNavigation("/start", new URL("https://example.test/fast"), "push");
+
+    expect(first.controller.signal.aborted).toBe(true);
+    expect(router.activeNavigation?.id).toBe(second.id);
+    router.finishNavigation(first);
+    expect(router.getNavigationState().state).toBe("loading");
+    router.finishNavigation(second);
+    expect(router.getNavigationState().state).toBe("idle");
+  });
 });
 
 describe("generateRuntimePathMatcherSource", () => {

--- a/packages/farm/src/client/plugin.ts
+++ b/packages/farm/src/client/plugin.ts
@@ -345,6 +345,13 @@ export class FarmClientPluginManager {
     );
   }
 
+  cancelNavigation(session?: FarmClientNavigationSession, reason: unknown = "canceled"): void {
+    const current = this.currentNavigation;
+    if (!current || (session && current.session !== session)) return;
+    current.controller.abort(reason);
+    this.currentNavigation = undefined;
+  }
+
   async resolveNavigation(session: FarmClientNavigationSession): Promise<void> {
     if (session.signal.aborted) return;
     await this.runHook("navigation.resolved", (instance) =>

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -1678,6 +1678,8 @@ export function generateUniversalRouterStateProperties(): string {
   blockers: new Set(),
   navigationListeners: new Set(),
   navigationState: IDLE_NAVIGATION_STATE,
+  navigationSequence: 0,
+  activeNavigation: null,
   observers: new Map(),
   scrollElements: new Map(),
   currentPath: window.location.pathname + window.location.search,
@@ -1705,6 +1707,13 @@ export function generateUniversalRouterStateProperties(): string {
   },
 
   startNavigation: function(from, to, action) {
+    this.activeNavigation?.controller.abort("superseded");
+    const navigation = {
+      id: ++this.navigationSequence,
+      controller: new AbortController(),
+      clientNavigation: null,
+    };
+    this.activeNavigation = navigation;
     this.setNavigationState({
       state: "loading",
       pending: true,
@@ -1713,9 +1722,29 @@ export function generateUniversalRouterStateProperties(): string {
       action,
       startedAt: Date.now(),
     });
+    return navigation;
   },
 
-  finishNavigation: function() {
+  isCurrentNavigation: function(navigation, clientNavigation) {
+    return this.activeNavigation?.id === navigation.id &&
+      !navigation.controller.signal.aborted &&
+      !clientNavigation?.signal.aborted;
+  },
+
+  finishNavigation: function(navigation) {
+    if (this.activeNavigation?.id !== navigation.id) return;
+    this.activeNavigation = null;
+    this.setNavigationState(IDLE_NAVIGATION_STATE);
+  },
+
+  cancelActiveNavigation: function() {
+    if (!this.activeNavigation) return;
+    farmClientRuntime.cancelNavigation(
+      this.activeNavigation.clientNavigation || undefined,
+      "superseded",
+    );
+    this.activeNavigation.controller.abort("superseded");
+    this.activeNavigation = null;
     this.setNavigationState(IDLE_NAVIGATION_STATE);
   },
 
@@ -1997,10 +2026,12 @@ ${generateUniversalRouterStateProperties()}
   navigate: async function(href, options = {}) {
     const url = new URL(href, window.location.origin);
     if (url.origin !== window.location.origin) {
+      this.cancelActiveNavigation();
       window.location.href = href;
       return;
     }
     if (isFarmDocsPath(url.pathname)) {
+      this.cancelActiveNavigation();
       window.location.href = href;
       return;
     }
@@ -2008,6 +2039,7 @@ ${generateUniversalRouterStateProperties()}
     const action = options.action || (options.replace ? "replace" : "push");
     const to = url.pathname + url.search;
     if (!options.refresh && action !== "pop" && to === this.currentPath) {
+      this.cancelActiveNavigation();
       if (url.hash === window.location.hash) return;
       const pageState = options.state === undefined
         ? window.history.state?.[FARM_PAGE_STATE_KEY]
@@ -2021,13 +2053,16 @@ ${generateUniversalRouterStateProperties()}
       }
       return;
     }
-    if (action === "pop" && to === this.currentPath) return;
+    if (action === "pop" && to === this.currentPath) {
+      this.cancelActiveNavigation();
+      return;
+    }
 
     const from = this.currentPath;
     if (await this.shouldBlockNavigation({ from, to, action })) return;
 
     this.saveScrollPosition(window.location.pathname + window.location.search);
-    this.startNavigation(from, url, action);
+    const navigation = this.startNavigation(from, url, action);
     let clientNavigation;
     try {
       clientNavigation = await farmClientRuntime.beginNavigation({
@@ -2035,9 +2070,18 @@ ${generateUniversalRouterStateProperties()}
         to: url,
         action,
       });
-      const html = await this.fetchPage(url.pathname + url.search, options.refresh === true);
+      navigation.clientNavigation = clientNavigation;
+      if (!this.isCurrentNavigation(navigation, clientNavigation)) return;
+      const html = await this.fetchPage(
+        url.pathname + url.search,
+        options.refresh === true,
+        navigation.controller.signal,
+      );
+      if (!this.isCurrentNavigation(navigation, clientNavigation)) return;
       await farmClientRuntime.markNavigationLoaded(clientNavigation, html);
+      if (!this.isCurrentNavigation(navigation, clientNavigation)) return;
       await this.runViewTransition(options.viewTransition, async () => {
+        if (!this.isCurrentNavigation(navigation, clientNavigation)) return;
         if (!this.swapContent(html)) {
           throw new Error("Farm could not swap the target document");
         }
@@ -2051,6 +2095,7 @@ ${generateUniversalRouterStateProperties()}
         } else if (action !== "pop") {
           window.history.pushState(historyState, "", url);
         }
+        this.currentPath = to;
         if (options.scroll !== false) {
           if (url.hash) document.querySelector(url.hash)?.scrollIntoView();
           else window.scrollTo(0, 0);
@@ -2058,15 +2103,17 @@ ${generateUniversalRouterStateProperties()}
           this.restoreScrollPosition(to);
         }
       });
+      if (!this.isCurrentNavigation(navigation, clientNavigation)) return;
       await farmClientRuntime.resolveNavigation(clientNavigation);
+      if (!this.isCurrentNavigation(navigation, clientNavigation)) return;
       void farmClientRuntime.scheduleNavigationRendered(clientNavigation);
-      this.currentPath = to;
-      this.finishNavigation();
+      this.finishNavigation(navigation);
     } catch (error) {
+      if (!this.isCurrentNavigation(navigation, clientNavigation)) return;
       if (clientNavigation) {
         await farmClientRuntime.failNavigation(clientNavigation, error);
       }
-      this.finishNavigation();
+      this.finishNavigation(navigation);
       console.error("[Farm.js] Navigation error:", error);
       if (action === "pop") window.location.reload();
       else window.location.href = href;
@@ -2083,12 +2130,13 @@ ${generateUniversalRouterStateProperties()}
     });
   },
   
-  fetchPage: async function(url, fresh = false) {
+  fetchPage: async function(url, fresh = false, signal) {
     if (fresh) this.prefetchCache.delete(url);
     const cached = fresh ? undefined : this.prefetchCache.get(url);
     if (cached) return cached;
     
     const response = await fetch(url, {
+      signal,
       headers: { "Accept": "text/html" }
     });
     if (!response.ok) throw new Error("Failed to fetch page");
@@ -2301,7 +2349,7 @@ function disposeFarmIsolatedClientBoundaries(scope) {
   }
 }
 
-async function hydrateFarmIsolatedClientBoundaries(scope = document) {
+async function hydrateFarmIsolatedClientBoundaries(scope = document, signal) {
   const candidates = Array.from(scope.querySelectorAll("farm-client-boundary[data-farm-client-boundary]"));
   const boundaries = candidates.filter((container) => {
     if (farmIsolatedBoundaryRoots.has(container)) return false;
@@ -2321,7 +2369,9 @@ async function hydrateFarmIsolatedClientBoundaries(scope = document) {
       strategy,
       hydrate: async function() {
         try {
+          if (signal?.aborted || !container.isConnected) return;
           const module = await loader();
+          if (signal?.aborted || !container.isConnected) return;
           const Component = module.__farm_client_boundary_originals__?.[exportName];
           if (typeof Component !== "function" && typeof Component !== "object") {
             throw new Error("compiled original export was not found");
@@ -2854,10 +2904,12 @@ ${generateUniversalRouterStateProperties()}
   navigate: async function(href, options = {}) {
     const url = new URL(href, window.location.origin);
     if (url.origin !== window.location.origin) {
+      this.cancelActiveNavigation();
       window.location.href = href;
       return;
     }
     if (isFarmDocsPath(url.pathname)) {
+      this.cancelActiveNavigation();
       window.location.href = href;
       return;
     }
@@ -2865,6 +2917,7 @@ ${generateUniversalRouterStateProperties()}
     const action = options.action || (options.replace ? "replace" : "push");
     const to = url.pathname + url.search;
     if (action !== "pop" && to === this.currentPath) {
+      this.cancelActiveNavigation();
       if (url.hash === window.location.hash) return;
       const pageState = options.state === undefined
         ? window.history.state?.[FARM_PAGE_STATE_KEY]
@@ -2878,7 +2931,10 @@ ${generateUniversalRouterStateProperties()}
       }
       return;
     }
-    if (action === "pop" && to === this.currentPath) return;
+    if (action === "pop" && to === this.currentPath) {
+      this.cancelActiveNavigation();
+      return;
+    }
     
     const pathname = url.pathname;
     const matched = matchRoute(pathname);
@@ -2888,7 +2944,7 @@ ${generateUniversalRouterStateProperties()}
     // A route transition invalidates any trigger waiting on the previous DOM boundary.
     cancelPendingPageHydration();
     this.saveScrollPosition(window.location.pathname + window.location.search);
-    this.startNavigation(from, url, action);
+    const navigation = this.startNavigation(from, url, action);
     let clientNavigation;
 
     try {
@@ -2900,15 +2956,19 @@ ${generateUniversalRouterStateProperties()}
           ? { pattern: matched.route.pattern, params: matched.params }
           : undefined,
       });
+      navigation.clientNavigation = clientNavigation;
+      if (!this.isCurrentNavigation(navigation, clientNavigation)) return;
 
       if (activeRouteInterception && clearRouteInterception(to)) {
+        this.currentPath = to;
         await farmClientRuntime.markNavigationLoaded(clientNavigation, {
           routeSlots: "restored",
         });
+        if (!this.isCurrentNavigation(navigation, clientNavigation)) return;
         await farmClientRuntime.resolveNavigation(clientNavigation);
+        if (!this.isCurrentNavigation(navigation, clientNavigation)) return;
         void farmClientRuntime.scheduleNavigationRendered(clientNavigation);
-        this.currentPath = to;
-        this.finishNavigation();
+        this.finishNavigation(navigation);
         return;
       }
       if (activeRouteInterception) {
@@ -2917,7 +2977,8 @@ ${generateUniversalRouterStateProperties()}
 
       const intercepted = matchInterceptedRouteSlot(pathname, from);
       if (intercepted) {
-        const html = await this.fetchPage(to, from);
+        const html = await this.fetchPage(to, from, navigation.controller.signal);
+        if (!this.isCurrentNavigation(navigation, clientNavigation)) return;
         const doc = new DOMParser().parseFromString(html, "text/html");
         const slotPayload = readRouteSlotPayload(doc);
         const selectedSlot = slotPayload.find(function(slot) {
@@ -2926,29 +2987,30 @@ ${generateUniversalRouterStateProperties()}
             slot.ownerPattern === intercepted.slot.ownerPattern;
         });
 
-        if (
-          selectedSlot &&
-          renderRouteInterception(selectedSlot, intercepted.slot, from)
-        ) {
+        if (selectedSlot) {
           await farmClientRuntime.markNavigationLoaded(clientNavigation, {
             route: intercepted.slot.pattern,
             params: intercepted.params,
           });
-          const historyState = createHistoryState(
-            to,
-            options.state,
-            window.history.state,
-          );
-          if (action === "replace") {
-            window.history.replaceState(historyState, "", url);
-          } else if (action !== "pop") {
-            window.history.pushState(historyState, "", url);
+          if (!this.isCurrentNavigation(navigation, clientNavigation)) return;
+          if (renderRouteInterception(selectedSlot, intercepted.slot, from)) {
+            const historyState = createHistoryState(
+              to,
+              options.state,
+              window.history.state,
+            );
+            if (action === "replace") {
+              window.history.replaceState(historyState, "", url);
+            } else if (action !== "pop") {
+              window.history.pushState(historyState, "", url);
+            }
+            this.currentPath = to;
+            await farmClientRuntime.resolveNavigation(clientNavigation);
+            if (!this.isCurrentNavigation(navigation, clientNavigation)) return;
+            void farmClientRuntime.scheduleNavigationRendered(clientNavigation);
+            this.finishNavigation(navigation);
+            return;
           }
-          await farmClientRuntime.resolveNavigation(clientNavigation);
-          void farmClientRuntime.scheduleNavigationRendered(clientNavigation);
-          this.currentPath = to;
-          this.finishNavigation();
-          return;
         }
       }
 
@@ -2956,6 +3018,7 @@ ${generateUniversalRouterStateProperties()}
         // Navigation itself signals intent, so destination routes load eagerly even
         // when their initial document hydration strategy is deferred.
         const Component = await loadRouteComponent(matched.route);
+        if (!this.isCurrentNavigation(navigation, clientNavigation)) return;
         const params = matched.params;
         const searchParams = searchParamsToObject(url.searchParams);
         const props = { params: params, searchParams: Promise.resolve(searchParams) };
@@ -2971,8 +3034,10 @@ ${generateUniversalRouterStateProperties()}
           route: matched.route.pattern,
           params,
         });
+        if (!this.isCurrentNavigation(navigation, clientNavigation)) return;
 
         await this.runViewTransition(options.viewTransition, async () => {
+          if (!this.isCurrentNavigation(navigation, clientNavigation)) return;
           const historyState = createHistoryState(
             url.pathname + url.search,
             options.state,
@@ -2994,12 +3059,27 @@ ${generateUniversalRouterStateProperties()}
             reactRoot.render(wrappedElement);
             currentPathname = pathname;
           }
+          this.currentPath = to;
         });
       } else {
-        const html = await this.fetchPage(url.pathname + url.search);
+        const html = await this.fetchPage(
+          url.pathname + url.search,
+          undefined,
+          navigation.controller.signal,
+        );
+        if (!this.isCurrentNavigation(navigation, clientNavigation)) return;
         await farmClientRuntime.markNavigationLoaded(clientNavigation, html);
+        if (!this.isCurrentNavigation(navigation, clientNavigation)) return;
         await this.runViewTransition(options.viewTransition, async () => {
-          if (!(await this.swapContent(html, url.pathname + url.search))) {
+          if (!this.isCurrentNavigation(navigation, clientNavigation)) return;
+          const swapped = await this.swapContent(
+            html,
+            url.pathname + url.search,
+            navigation,
+            clientNavigation,
+          );
+          if (!this.isCurrentNavigation(navigation, clientNavigation)) return;
+          if (!swapped) {
             throw new Error("Farm could not swap the target document");
           }
           const historyState = createHistoryState(
@@ -3013,9 +3093,11 @@ ${generateUniversalRouterStateProperties()}
             window.history.pushState(historyState, "", url);
           }
           currentPathname = pathname;
+          this.currentPath = to;
         });
       }
 
+      if (!this.isCurrentNavigation(navigation, clientNavigation)) return;
       if (options.scroll !== false) {
         if (url.hash) document.querySelector(url.hash)?.scrollIntoView();
         else window.scrollTo(0, 0);
@@ -3023,26 +3105,28 @@ ${generateUniversalRouterStateProperties()}
         this.restoreScrollPosition(to);
       }
       await farmClientRuntime.resolveNavigation(clientNavigation);
+      if (!this.isCurrentNavigation(navigation, clientNavigation)) return;
       void farmClientRuntime.scheduleNavigationRendered(clientNavigation);
-      this.currentPath = to;
-      this.finishNavigation();
+      this.finishNavigation(navigation);
     } catch (error) {
+      if (!this.isCurrentNavigation(navigation, clientNavigation)) return;
       if (clientNavigation) {
         await farmClientRuntime.failNavigation(clientNavigation, error);
       }
-      this.finishNavigation();
+      this.finishNavigation(navigation);
       console.error("[Farm.js] Navigation error:", error);
       if (action === "pop") window.location.reload();
       else window.location.href = href;
     }
   },
   
-  fetchPage: async function(url, interceptFrom) {
+  fetchPage: async function(url, interceptFrom, signal) {
     const cacheKey = interceptFrom ? url + "\\nintercept:" + interceptFrom : url;
     const cached = this.prefetchCache.get(cacheKey);
     if (cached) return cached;
     
     const response = await fetch(url, {
+      signal,
       headers: {
         "Accept": "text/html",
         ...(interceptFrom ? { "X-Farm-Intercept-From": interceptFrom } : {}),
@@ -3054,12 +3138,14 @@ ${generateUniversalRouterStateProperties()}
     return html;
   },
   
-  swapContent: async function(html, targetPath) {
+  swapContent: async function(html, targetPath, navigation, clientNavigation) {
     const parser = new DOMParser();
     const doc = parser.parseFromString(html, "text/html");
     if (isFarmLocaleDocumentChange(doc)) return false;
     if (doc.getElementById("nd-docs-layout")) return false;
     const nextRouteSlots = readRouteSlotPayload(doc);
+    const isNavigationCurrent = () =>
+      this.isCurrentNavigation(navigation, clientNavigation);
     
     // Update title
     const newTitle = doc.querySelector("title");
@@ -3082,7 +3168,10 @@ ${generateUniversalRouterStateProperties()}
     // Swap root content
     const newRoot = doc.getElementById("root");
     const currentRoot = document.getElementById("root");
-    if (!newRoot || !currentRoot) return this.swapDocument(doc);
+    if (!newRoot || !currentRoot) {
+      if (!isNavigationCurrent()) return false;
+      return this.swapDocument(doc);
+    }
     const targetUrl = new URL(targetPath || window.location.href, window.location.origin);
     const newPathname = targetUrl.pathname;
     const matched = matchRoute(newPathname);
@@ -3099,6 +3188,7 @@ ${generateUniversalRouterStateProperties()}
         searchParams,
         nextPage ? nextPage.innerHTML : "",
       );
+      if (!isNavigationCurrent()) return false;
       if (wrappedElement) {
         reactRoot.render(wrappedElement);
         window.__FARM_ROUTE_SLOTS__ = nextRouteSlots;
@@ -3128,6 +3218,7 @@ ${generateUniversalRouterStateProperties()}
         newPathname,
         searchParams,
       );
+      if (!isNavigationCurrent()) return false;
       if (wrappedElement) {
         reactRoot = hydrateRoot(pageContainer, wrappedElement);
         reactRootContainer = pageContainer;
@@ -3135,7 +3226,8 @@ ${generateUniversalRouterStateProperties()}
       }${
         isolatedHydrationEnabled
           ? ` else if (matched.route.hasIsolatedClientBoundaries) {
-        await hydrateFarmIsolatedClientBoundaries(currentRoot);
+        await hydrateFarmIsolatedClientBoundaries(currentRoot, navigation.controller.signal);
+        if (!isNavigationCurrent()) return false;
       }`
           : ""
       }


### PR DESCRIPTION
## Problem

In a production build, two overlapping navigations can finish out of order. The older generated-router request remains active and can overwrite the DOM, history, scroll position, and navigation state after the newer route has already rendered.

## Root cause

The shared `SPARouter` has an abortable navigation sequence, but the two routers emitted by `universal-build.ts` only expose loading state. They neither abort superseded fetches nor verify ownership after asynchronous plugin, fetch, route-loading, transition, and rendering boundaries.

## Change

Add the shared navigation ownership model to the generated runtime: each navigation gets an incrementing ID and `AbortController`; starting a newer navigation aborts the previous request; every asynchronous commit boundary confirms the navigation is still current. Same-document and document-owned navigation also cancel pending work.

## Safety and compatibility

- Covers both HTML-swap and hydratable production routers.
- Aborts only work superseded by a newer browser intent.
- Preserves plugin lifecycle ordering, view transitions, route interception, history, and scroll behavior for the active navigation.
- Adds no public API and no cost outside the generated client router.

## Verification

- `pnpm --filter @farm.js/core exec vitest run src/__tests__/universal-build-router-runtime.test.ts src/__tests__/client-component.test.ts src/__tests__/spa-router-concurrency.test.ts` (40 tests passed)
- `pnpm --filter @farm.js/core type-check`
- `pnpm exec oxlint packages/farm/src/nitro/universal-build.ts packages/farm/src/__tests__/client-component.test.ts packages/farm/src/__tests__/universal-build-router-runtime.test.ts` (0 errors; one pre-existing unused-variable warning in `universal-build.ts`)
- `git diff --check`

The new generated-runtime regression test fails without the navigation ownership and guarded completion behavior.

## Documentation and release

None. This aligns production-generated routing with the existing shared SPA router contract.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents stale navigation responses from overwriting newer routes in production builds by making each generated-router navigation abort superseded work and verify it is still current at every async boundary.

- Adds an incrementing ID and `AbortController` to each navigation; starting a newer navigation aborts the previous request.
- Guards every asynchronous commit point (fetch, plugin, route loading, view transition, rendering) with a check that the navigation is still current.
- Covers both HTML-swap and hydratable production routers, and same-document and document-owned navigation.
- Adds no public API and no cost outside the generated client router.

<sup>Written for commit 005b6d7f4fea055dc3789cb5e19754781b775e1e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/701?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

