### PR TITLE
fix(navigation): refresh hydratable production routes

### DIFF
--- a/packages/farm/src/__tests__/client-component.test.ts
+++ b/packages/farm/src/__tests__/client-component.test.ts
@@ -757,7 +757,23 @@ export function Chart() {}
     );
     expect(source).toContain('if (error?.name === "FarmDeploymentMismatchError") return;');
     expect(source).toContain("this.fetchPage(pathname, false, false)");
-    expect(source).toContain("this.fetchPage(pathname, interceptFrom, false)");
+    expect(source).toContain("this.fetchPage(pathname, interceptFrom, false, false)");
+  });
+
+  it("refreshes hydratable production routes from uncached server HTML", () => {
+    const source = fs.readFileSync(
+      path.join(process.cwd(), "src", "nitro", "universal-build.ts"),
+      "utf-8",
+    );
+
+    expect(source.match(/refresh: function\(options = \{\}\)/g)).toHaveLength(2);
+    expect(source).toContain(
+      'if (!options.refresh && matched?.route.navigation === "client-render")',
+    );
+    expect(source).toContain("options.refresh ? null : matchInterceptedRouteSlot(pathname, from)");
+    expect(source).toContain("fetchPage: async function(url, interceptFrom, fresh = false");
+    expect(source).toContain("if (fresh) this.clearPrefetchedPath(url)");
+    expect(source).toContain("options.refresh === true,");
   });
 
   it("keeps the generated production router compatible with client navigation hooks", () => {
@@ -782,7 +798,9 @@ export function Chart() {}
     expect(source).toContain("this.observers.set(element, observer);");
     expect(source).toContain("createHistoryState(");
     expect(source).toContain("currentPath: window.location.pathname + window.location.search");
-    expect(source).toContain('if (action !== "pop" && to === this.currentPath)');
+    expect(source).toContain(
+      'if (!options.refresh && action !== "pop" && to === this.currentPath)',
+    );
     expect(source).toContain("this.currentPath = to;");
     expect(source).toContain("scheduleFarmIslandHydration");
     expect(source).toContain("pendingPageHydrationController?.abort()");

--- a/packages/farm/src/__tests__/universal-build-router-runtime.test.ts
+++ b/packages/farm/src/__tests__/universal-build-router-runtime.test.ts
@@ -70,6 +70,35 @@ describe("generateUniversalRouterStateProperties", () => {
     router.finishNavigation(second);
     expect(router.getNavigationState().state).toBe("idle");
   });
+
+  it("invalidates plain and interception-qualified prefetch entries together", () => {
+    const createRouter = new Function(
+      "window",
+      "IDLE_NAVIGATION_STATE",
+      "createNavigationLocation",
+      `return ({${runtime} prefetchCache: new Map([
+        ["/reports", "plain"],
+        ["/reports\\nintercept:/dashboard", "intercepted"],
+        ["/settings", "other"],
+      ])});`,
+    ) as (
+      windowValue: { location: { pathname: string; search: string } },
+      idleState: object,
+      createLocation: (url: URL) => object,
+    ) => {
+      clearPrefetchedPath(url: string): void;
+      prefetchCache: Map<string, string>;
+    };
+    const router = createRouter(
+      { location: { pathname: "/", search: "" } },
+      { state: "idle", pending: false },
+      (url) => ({ href: url.href }),
+    );
+
+    router.clearPrefetchedPath("/reports");
+
+    expect([...router.prefetchCache.keys()]).toEqual(["/settings"]);
+  });
 });
 
 describe("generated deployment navigation guard", () => {

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -1769,6 +1769,15 @@ export function generateUniversalRouterStateProperties(): string {
     this.setNavigationState(IDLE_NAVIGATION_STATE);
   },
 
+  clearPrefetchedPath: function(url) {
+    const interceptionPrefix = url + "\\nintercept:";
+    for (const key of this.prefetchCache.keys()) {
+      if (key === url || key.startsWith(interceptionPrefix)) {
+        this.prefetchCache.delete(key);
+      }
+    }
+  },
+
   setNavigationState: function(state) {
     this.navigationState = state;
     for (const listener of this.navigationListeners) listener(state);
@@ -2156,7 +2165,7 @@ ${generateUniversalRouterStateProperties()}
   },
   
   fetchPage: async function(url, fresh = false, recover = true, signal) {
-    if (fresh) this.prefetchCache.delete(url);
+    if (fresh) this.clearPrefetchedPath(url);
     const cached = fresh ? undefined : this.prefetchCache.get(url);
     if (cached) return cached;
     
@@ -2947,7 +2956,7 @@ ${generateUniversalRouterStateProperties()}
 
     const action = options.action || (options.replace ? "replace" : "push");
     const to = url.pathname + url.search;
-    if (action !== "pop" && to === this.currentPath) {
+    if (!options.refresh && action !== "pop" && to === this.currentPath) {
       this.cancelActiveNavigation();
       if (url.hash === window.location.hash) return;
       const pageState = options.state === undefined
@@ -2990,7 +2999,7 @@ ${generateUniversalRouterStateProperties()}
       navigation.clientNavigation = clientNavigation;
       if (!this.isCurrentNavigation(navigation, clientNavigation)) return;
 
-      if (activeRouteInterception && clearRouteInterception(to)) {
+      if (!options.refresh && activeRouteInterception && clearRouteInterception(to)) {
         this.currentPath = to;
         await farmClientRuntime.markNavigationLoaded(clientNavigation, {
           routeSlots: "restored",
@@ -3006,9 +3015,9 @@ ${generateUniversalRouterStateProperties()}
         clearRouteInterception(to);
       }
 
-      const intercepted = matchInterceptedRouteSlot(pathname, from);
+      const intercepted = options.refresh ? null : matchInterceptedRouteSlot(pathname, from);
       if (intercepted) {
-        const html = await this.fetchPage(to, from, true, navigation.controller.signal);
+        const html = await this.fetchPage(to, from, false, true, navigation.controller.signal);
         if (!this.isCurrentNavigation(navigation, clientNavigation)) return;
         const doc = new DOMParser().parseFromString(html, "text/html");
         const slotPayload = readRouteSlotPayload(doc);
@@ -3045,7 +3054,7 @@ ${generateUniversalRouterStateProperties()}
         }
       }
 
-      if (matched?.route.navigation === "client-render") {
+      if (!options.refresh && matched?.route.navigation === "client-render") {
         // Navigation itself signals intent, so destination routes load eagerly even
         // when their initial document hydration strategy is deferred.
         const Component = await loadRouteComponent(matched.route);
@@ -3096,6 +3105,7 @@ ${generateUniversalRouterStateProperties()}
         const html = await this.fetchPage(
           url.pathname + url.search,
           undefined,
+          options.refresh === true,
           true,
           navigation.controller.signal,
         );
@@ -3152,10 +3162,21 @@ ${generateUniversalRouterStateProperties()}
       else window.location.href = href;
     }
   },
+
+  refresh: function(options = {}) {
+    return this.navigate(window.location.href, {
+      ...options,
+      action: "replace",
+      replace: true,
+      refresh: true,
+      scroll: options.scroll === undefined ? false : options.scroll,
+    });
+  },
   
-  fetchPage: async function(url, interceptFrom, recover = true, signal) {
+  fetchPage: async function(url, interceptFrom, fresh = false, recover = true, signal) {
     const cacheKey = interceptFrom ? url + "\\nintercept:" + interceptFrom : url;
-    const cached = this.prefetchCache.get(cacheKey);
+    if (fresh) this.clearPrefetchedPath(url);
+    const cached = fresh ? undefined : this.prefetchCache.get(cacheKey);
     if (cached) return cached;
     
     const response = await fetchFarmNavigationDocument(
@@ -3312,7 +3333,7 @@ ${generateUniversalRouterStateProperties()}
     const cacheKey = pathname + "\\nintercept:" + interceptFrom;
     if (this.prefetchCache.has(cacheKey)) return;
     
-    this.fetchPage(pathname, interceptFrom, false)
+    this.fetchPage(pathname, interceptFrom, false, false)
       .then(function(html) { spaRouter.prefetchCache.set(cacheKey, html); })
       .catch(function(error) {
         clearFarmPrefetchCacheOnDeploymentMismatch(spaRouter, error);


### PR DESCRIPTION
## Problem

`router.refresh()` works in the shared router and the production runtime without client components, but the hydratable production router has no refresh method. Calling it through the public navigation API is therefore a no-op, and navigating to the current URL reuses client or prefetched state instead of asking the server for fresh output.

## Root cause

The hydratable runtime was missing the refresh facade and treated every same-path navigation as skippable. Its client-render and intercepted-route fast paths also prevented an explicit refresh from reaching server-rendered HTML, while `fetchPage` had no cache-bypass mode.

## Change

Add the same refresh contract used by the other runtimes. An explicit refresh preserves the document and scroll by default, replaces the current history entry, skips local rendering/interception shortcuts, evicts the matching prefetch entry, and swaps fresh server HTML.

## Safety and compatibility

- Changes behavior only for explicit `refresh: true` / `router.refresh()` calls.
- Normal client-render navigation, route interception, prefetching, hydration, and history behavior are unchanged.
- No public type or API addition is required; this implements the API already exposed by Farm's router facade.

## Verification

- `pnpm --filter @farm.js/core exec vitest run src/__tests__/client-component.test.ts src/__tests__/navigation-router-methods.test.tsx src/__tests__/navigation-state.test.tsx` (47 tests passed)
- `pnpm --filter @farm.js/core type-check`
- `pnpm exec oxlint packages/farm/src/nitro/universal-build.ts packages/farm/src/__tests__/client-component.test.ts` (0 errors; one pre-existing unused-variable warning in `universal-build.ts`)
- `git diff --check`

The generated-runtime regression assertion fails without the hydratable refresh implementation and fresh-fetch path.

## Documentation and release

None. The existing router refresh documentation now applies consistently to production hydration builds.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `router.refresh()` in the hydratable production router so it fetches fresh server HTML instead of reusing client or prefetched state.

- Adds a `refresh` option that bypasses client-render and intercepted-route shortcuts, evicts matching prefetch entries (plain and interception-qualified), and preserves document and scroll while replacing the current history entry.
- Only explicit `refresh: true` or `router.refresh()` calls change behavior; normal navigation, interception, prefetching, and history behavior are unchanged.
- No public API changes; this implements the refresh contract already exposed by Farm's router facade.

<sup>Written for commit c4af2476c54ba180a49a080997a1108b4f777558. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/702?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

