### PR TITLE
fix(navigation): preserve production download anchors

### DIFF
--- a/packages/farm/src/__tests__/client-component.test.ts
+++ b/packages/farm/src/__tests__/client-component.test.ts
@@ -756,6 +756,11 @@ export function Chart() {}
     expect(source).toContain("writePageState: function(action, state, href)");
     expect(source).toContain("runViewTransition: async function(enabled, callback)");
     expect(source).toContain('const href = element.getAttribute("href");');
+    expect(
+      source.match(
+        /const href = anchor\.getAttribute\("href"\);\s+if \(!href\) return;\s+if \(anchor\.hasAttribute\("download"\)\) return;/g,
+      ),
+    ).toHaveLength(2);
     expect(source).toContain("this.observers.set(element, observer);");
     expect(source).toContain("createHistoryState(");
     expect(source).toContain("currentPath: window.location.pathname + window.location.search");

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -2241,6 +2241,7 @@ document.addEventListener("click", function(e) {
   
   const href = anchor.getAttribute("href");
   if (!href) return;
+  if (anchor.hasAttribute("download")) return;
   if (href.startsWith("http://") || href.startsWith("https://") || href.startsWith("//")) return;
   if (href.startsWith("#")) return;
   if (anchor.target && anchor.target !== "_self") return;
@@ -3256,6 +3257,7 @@ document.addEventListener("click", function(e) {
   
   const href = anchor.getAttribute("href");
   if (!href) return;
+  if (anchor.hasAttribute("download")) return;
   if (href.startsWith("http://") || href.startsWith("https://") || href.startsWith("//")) return;
   if (href.startsWith("#")) return;
   if (anchor.target && anchor.target !== "_self") return;


### PR DESCRIPTION
## Problem

Internal `<a download>` links are intercepted by Farm's generated production routers. Instead of invoking the browser's download behavior, the runtime fetches the resource as page HTML and attempts an SPA document swap.

## Root cause

Farm's `Link` component and docs runtime already exclude download anchors, but the two click delegates generated for production applications only check origin, hash, target, modifiers, and mouse button.

## Change

Return early from both generated click delegates when the nearest anchor has a `download` attribute.

## Safety and compatibility

- Restores native browser semantics for same-origin downloads.
- Does not affect ordinary navigation or prefetch behavior.
- Works for both server-rendered and hydratable production clients.
- No public API changes.

## Verification

- `pnpm --filter @farm.js/core exec vitest run src/__tests__/client-component.test.ts src/__tests__/link.test.tsx` (68 tests passed)
- `pnpm --filter @farm.js/core type-check`
- `pnpm exec oxlint packages/farm/src/nitro/universal-build.ts packages/farm/src/__tests__/client-component.test.ts` (0 errors; one pre-existing unused-variable warning in `universal-build.ts`)
- `git diff --check`

The regression assertion verifies both generated production click delegates preserve download anchors.

## Documentation and release

None. This aligns the generated runtime with the existing documented `Link` behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Production-generated routers now leave `<a download>` links to the browser instead of intercepting them as SPA navigations, restoring native same-origin downloads without changing ordinary navigation.

- Applies to both server-rendered and hydratable production clients.
- Adds regression coverage for both generated click delegates.

<sup>Written for commit 383b8f71c71c442ad1becf3e63374c84cf8c8ae6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/704?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

