### PR TITLE
fix(navigation): resolve production hash targets by id

### DIFF
--- a/packages/farm/src/__tests__/client-component.test.ts
+++ b/packages/farm/src/__tests__/client-component.test.ts
@@ -789,6 +789,10 @@ export function Chart() {}
     expect(source).toContain("stripFarmBasePath(pathname)");
     expect(source).toContain("writePageState: function(action, state, href)");
     expect(source).toContain("runViewTransition: async function(enabled, callback)");
+    expect(source.match(/getHashTargetElement\(url\.hash\)\?\.scrollIntoView\(\)/g)).toHaveLength(
+      4,
+    );
+    expect(source).not.toContain("document.querySelector(url.hash)");
     expect(source).toContain('const href = element.getAttribute("href");');
     expect(
       source.match(

--- a/packages/farm/src/__tests__/searchparams.test.ts
+++ b/packages/farm/src/__tests__/searchparams.test.ts
@@ -226,7 +226,7 @@ describe("SearchParams in the production runtime", () => {
     const source = readSource("nitro", "universal-build.ts");
 
     expect(source).toContain(
-      'import { createClientPluginManager, installChunkErrorRecovery, scheduleFarmIslandHydration, searchParamsToObject, setFarmBasePath, setFarmTrailingSlashPreference, stripFarmBasePath } from "@farm.js/core/internal/client-runtime";',
+      'import { createClientPluginManager, getHashTargetElement, installChunkErrorRecovery, scheduleFarmIslandHydration, searchParamsToObject, setFarmBasePath, setFarmTrailingSlashPreference, stripFarmBasePath } from "@farm.js/core/internal/client-runtime";',
     );
     expect(source).toContain(
       "const searchParams = searchParamsToObject(new URLSearchParams(window.location.search));",

--- a/packages/farm/src/client/hash-target.ts
+++ b/packages/farm/src/client/hash-target.ts
@@ -1,0 +1,20 @@
+export function getHashTargetElement(hash: string): Element | null {
+  // A fragment is not a CSS selector. Match by decoded id, raw id, then the
+  // legacy anchor name so SPA navigation follows native browser semantics.
+  const fragment = hash.startsWith("#") ? hash.slice(1) : hash;
+  if (!fragment) return null;
+
+  let decoded = fragment;
+  try {
+    decoded = decodeURIComponent(fragment);
+  } catch {
+    // Keep the raw fragment when its percent-encoding is malformed.
+  }
+
+  return (
+    document.getElementById(decoded) ||
+    document.getElementById(fragment) ||
+    document.getElementsByName(decoded)[0] ||
+    null
+  );
+}

--- a/packages/farm/src/client/production-runtime.ts
+++ b/packages/farm/src/client/production-runtime.ts
@@ -4,3 +4,4 @@ export { createClientPluginManager } from "./plugin";
 export { searchParamsToObject } from "../search-params";
 export { setFarmTrailingSlashPreference } from "../trailing-slash";
 export { setFarmBasePath, stripFarmBasePath } from "../base-path";
+export { getHashTargetElement } from "./hash-target";

--- a/packages/farm/src/client/spa-router.ts
+++ b/packages/farm/src/client/spa-router.ts
@@ -7,11 +7,14 @@ import {
   createFarmDeploymentRequestHeaders,
   isFarmDeploymentMismatchResponse,
 } from "../deployment";
+import { getHashTargetElement } from "./hash-target";
 import type { FarmClientNavigationSession, FarmClientPluginManager } from "./plugin";
 import { _hydrateFarmI18n, isFarmLocaleChangeHref } from "../i18n/client-runtime";
 import type { FarmI18nClientSnapshot } from "../i18n/types";
 import type { FarmIslandStrategy } from "../island";
 import type { FarmRouteRenderPlan } from "../navigation/render-plan";
+
+export { getHashTargetElement } from "./hash-target";
 
 /**
  * Farm.js SPA Router
@@ -1042,29 +1045,4 @@ function createNavigationLocation(url: URL): FarmNavigationLocation {
 
 function getScrollElementStorageKey(path: string, key: string): string {
   return `farm-scroll-${path}:${key}`;
-}
-
-export function getHashTargetElement(hash: string): Element | null {
-  // The fragment is not a CSS selector: ids starting with a digit or
-  // containing selector characters (#2-installation, #a.b) throw in
-  // querySelector. Match by id (decoded first, then raw) and fall back to
-  // anchor name, mirroring native fragment navigation.
-  const fragment = hash.startsWith("#") ? hash.slice(1) : hash;
-  if (!fragment) {
-    return null;
-  }
-
-  let decoded = fragment;
-  try {
-    decoded = decodeURIComponent(fragment);
-  } catch {
-    // Keep the raw fragment when the percent-encoding is malformed.
-  }
-
-  return (
-    document.getElementById(decoded) ||
-    document.getElementById(fragment) ||
-    document.getElementsByName(decoded)[0] ||
-    null
-  );
 }

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -2097,7 +2097,7 @@ async function hydrateFarmDocsAdapterRuntime() {
 // Farm.js Client Runtime (no client components)
 ${cssImport}
 ${layoutImports}
-import { createClientPluginManager, installChunkErrorRecovery, setFarmBasePath, setFarmTrailingSlashPreference, stripFarmBasePath } from "@farm.js/core/internal/client-runtime";
+import { createClientPluginManager, getHashTargetElement, installChunkErrorRecovery, setFarmBasePath, setFarmTrailingSlashPreference, stripFarmBasePath } from "@farm.js/core/internal/client-runtime";
 import { createFarmDeploymentMismatchError, createFarmDeploymentRequestHeaders, isFarmDeploymentMismatchResponse } from "@farm.js/core/deployment";
 ${clientPluginEntry.imports}
 ${i18nClientRuntime}
@@ -2140,7 +2140,7 @@ ${generateUniversalRouterStateProperties()}
         : options.state;
       this.writeHistoryEntry(action, to, pageState, url);
       if (options.scroll !== false) {
-        if (url.hash) document.querySelector(url.hash)?.scrollIntoView();
+        if (url.hash) getHashTargetElement(url.hash)?.scrollIntoView();
         else window.scrollTo(0, 0);
       }
       return;
@@ -2190,7 +2190,7 @@ ${generateUniversalRouterStateProperties()}
         this.writeHistoryEntry(action, url.pathname + url.search, options.state, url);
         this.currentPath = to;
         if (options.scroll !== false) {
-          if (url.hash) document.querySelector(url.hash)?.scrollIntoView();
+          if (url.hash) getHashTargetElement(url.hash)?.scrollIntoView();
           else window.scrollTo(0, 0);
         } else {
           this.restoreScrollPosition(to);
@@ -2515,7 +2515,7 @@ ${cssImport}
 ${layoutImports}
 ${rendererClientImports}
 ${providerClientCode.imports}
-import { createClientPluginManager, installChunkErrorRecovery, scheduleFarmIslandHydration, searchParamsToObject, setFarmBasePath, setFarmTrailingSlashPreference, stripFarmBasePath } from "@farm.js/core/internal/client-runtime";
+import { createClientPluginManager, getHashTargetElement, installChunkErrorRecovery, scheduleFarmIslandHydration, searchParamsToObject, setFarmBasePath, setFarmTrailingSlashPreference, stripFarmBasePath } from "@farm.js/core/internal/client-runtime";
 import { createFarmDeploymentMismatchError, createFarmDeploymentRequestHeaders, isFarmDeploymentMismatchResponse } from "@farm.js/core/deployment";
 import { matchFarmRoute } from "@farm.js/core/router";
 ${clientPluginEntry.imports}
@@ -3024,7 +3024,7 @@ ${generateUniversalRouterStateProperties()}
         : options.state;
       this.writeHistoryEntry(action, to, pageState, url);
       if (options.scroll !== false) {
-        if (url.hash) document.querySelector(url.hash)?.scrollIntoView();
+        if (url.hash) getHashTargetElement(url.hash)?.scrollIntoView();
         else window.scrollTo(0, 0);
       }
       return;
@@ -3181,7 +3181,7 @@ ${generateUniversalRouterStateProperties()}
 
       if (!this.isCurrentNavigation(navigation, clientNavigation)) return;
       if (options.scroll !== false) {
-        if (url.hash) document.querySelector(url.hash)?.scrollIntoView();
+        if (url.hash) getHashTargetElement(url.hash)?.scrollIntoView();
         else window.scrollTo(0, 0);
       } else {
         this.restoreScrollPosition(to);


### PR DESCRIPTION
## Problem

Production-generated SPA navigation passes URL fragments directly to `document.querySelector`. Valid fragment targets such as `#2-installation` or `#a.b` can throw or select the wrong element because URL fragments are identifiers, not CSS selectors.

## Root cause

The shared router already resolves decoded IDs, raw IDs, and legacy named anchors safely, but that helper lived inside the larger router module and the generated production runtimes duplicated the old selector behavior.

## Change

Extract the existing fragment lookup into a small client helper, keep its shared-router export compatible, expose it to Farm's generated client runtime, and use it at all four production scroll sites.

## Safety and compatibility

- Preserves the existing shared-router API.
- Handles percent-encoded and malformed fragments without throwing.
- Mirrors native fragment lookup with decoded ID, raw ID, then named-anchor fallback.
- The isolated helper keeps generated-runtime imports tree-shakeable.
- No renderer-specific behavior is introduced.

## Verification

- `pnpm --filter @farm.js/core exec vitest run src/__tests__/spa-router-hash.test.ts src/__tests__/client-component.test.ts` (40 tests passed)
- `pnpm --filter @farm.js/core type-check`
- `pnpm exec oxlint packages/farm/src/client/hash-target.ts packages/farm/src/client/spa-router.ts packages/farm/src/client/production-runtime.ts packages/farm/src/nitro/universal-build.ts packages/farm/src/__tests__/client-component.test.ts` (0 errors; two pre-existing warnings)
- `git diff --check`

The regression coverage exercises invalid-selector IDs, encoded Unicode, malformed escapes, named anchors, and verifies all generated production scroll paths call the safe helper.

## Documentation and release

None. This completes the already-documented hash-navigation behavior in generated production clients.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes production SPA navigation so URL fragments like `#2-installation` or `#a.b` scroll to the correct element instead of throwing or selecting the wrong one.

**Bug Fixes**
- Replaces `document.querySelector(url.hash)` with the `getHashTargetElement` helper at all four production scroll sites.
- Extracts the shared router's fragment lookup into a standalone client helper, re-exported from `production-runtime` and `spa-router`.
- Handles percent-encoded and malformed fragments without throwing, matching native fragment lookup semantics.

<sup>Written for commit f4707fc798a554d597f6ee6684cc73f618c53577. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/705?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

