### PR TITLE
fix(navigation): restore queried scroll containers

### DIFF
--- a/packages/farm/src/__tests__/universal-build-router-runtime.test.ts
+++ b/packages/farm/src/__tests__/universal-build-router-runtime.test.ts
@@ -179,6 +179,15 @@ describe("generateUniversalRouterStateProperties", () => {
     expect(readHistoryIndex({ __farmHistoryIndex: Number.POSITIVE_INFINITY })).toBeNull();
     expect(readHistoryIndex({ __farmHistoryIndex: Number.MAX_SAFE_INTEGER + 1 })).toBeNull();
   });
+
+  it("restores registered scroll elements with the current query string", () => {
+    expect(runtime).toContain(
+      "this.restoreScrollElement(window.location.pathname + window.location.search, key, element)",
+    );
+    expect(runtime).not.toContain(
+      "this.restoreScrollElement(window.location.pathname, key, element)",
+    );
+  });
 });
 
 describe("generated deployment navigation guard", () => {

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -1876,7 +1876,7 @@ export function generateUniversalRouterStateProperties(): string {
 
   registerScrollElement: function(key, element) {
     this.scrollElements.set(key, element);
-    this.restoreScrollElement(window.location.pathname, key, element);
+    this.restoreScrollElement(window.location.pathname + window.location.search, key, element);
     return () => {
       if (this.scrollElements.get(key) === element) this.scrollElements.delete(key);
     };


### PR DESCRIPTION
## Problem

Nested scroll containers registered after navigation restore from a pathname-only storage key. Routes that differ by query, such as `/items?page=1` and `/items?page=2`, can restore the wrong position or no position in generated production clients.

## Root cause

Navigation save/restore already keys both window and nested positions by pathname plus search. Only `registerScrollElement` in the generated router dropped `window.location.search` during its initial restoration.

## Change

Use the complete pathname and query when restoring a newly registered scroll element.

## Safety and compatibility

- Matches the existing save path and shared SPA router behavior.
- Affects both generated production runtime variants through their shared state properties.
- Does not alter window scroll, navigation, or storage formats.
- No public API changes.

## Verification

- `pnpm --filter @farm.js/core exec vitest run src/__tests__/universal-build-router-runtime.test.ts src/__tests__/spa-router-scroll-query.test.ts` (5 tests passed)
- `pnpm --filter @farm.js/core type-check`
- `pnpm exec oxlint packages/farm/src/nitro/universal-build.ts packages/farm/src/__tests__/universal-build-router-runtime.test.ts` (0 errors; one pre-existing unused-variable warning in `universal-build.ts`)
- `git diff --check`

The generated-runtime regression fails on the old pathname-only lookup; the shared-router test remains the behavioral control.

## Documentation and release

None. This corrects the existing documented scroll-restoration contract.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Generated production routers now restore newly registered nested scroll containers with the pathname and query string instead of the pathname alone, so routes such as `/items?page=1` and `/items?page=2` keep separate positions. This matches the existing save keys without changing window scrolling, storage formats, or public APIs.

**Tests**

- Adds regression coverage to verify the generated runtime uses the current query string during restoration.

<sup>Written for commit 5333de83aef3aef87b00fd2d4bea81b25c1101df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/706?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

