### PR TITLE
fix(metadata): reconcile the document head on navigation

### DIFF
--- a/docs/src/app/docs/routing/page.md
+++ b/docs/src/app/docs/routing/page.md
@@ -675,6 +675,10 @@ from the rendered React page automatically.
 
 Export `metadata` for static head tags or `generateMetadata` when the values depend on route params, search params, middleware data, or route data. Farm merges layout metadata from root to leaf, then applies the page metadata last.
 
+During HTML-based client navigation, Farm reconciles the destination document's title, meta tags,
+canonical and alternate links, icons, and manifest link. Tags omitted by the destination are removed,
+so metadata from the previous route cannot remain active.
+
 A layout can define a default title and a `%s` template for child segments. The layout itself uses
 the default; a child string title is substituted into the nearest parent template:
 

--- a/packages/farm/src/__tests__/client-component.test.ts
+++ b/packages/farm/src/__tests__/client-component.test.ts
@@ -741,6 +741,10 @@ export function Chart() {}
       "const targetUrl = new URL(targetPath || window.location.href, window.location.origin);",
     );
     expect(source).toContain("resetReactRoot();");
+    expect(source.match(/reconcileFarmDocumentHead\(doc\);/g)).toHaveLength(2);
+    expect(source).toContain("renderRouteInterception(selectedSlot, intercepted.slot, from, doc)");
+    expect(source).toContain("reconcileFarmDocumentHead(nextDocument);");
+    expect(source).not.toContain('const newMetas = doc.querySelectorAll("meta[name]")');
   });
 
   it("guards generated production HTML requests against stale deployments", () => {

--- a/packages/farm/src/__tests__/document-head.test.ts
+++ b/packages/farm/src/__tests__/document-head.test.ts
@@ -1,0 +1,71 @@
+/** @vitest-environment jsdom */
+import { afterEach, describe, expect, it } from "vitest";
+import { reconcileFarmDocumentHead } from "../client/document-head";
+
+afterEach(() => {
+  document.head.innerHTML = "";
+});
+
+describe("reconcileFarmDocumentHead", () => {
+  it("replaces route metadata and removes tags absent from the next document", () => {
+    document.head.innerHTML = `
+      <title>Old page</title>
+      <meta name="viewport" content="width=320">
+      <meta name="description" content="Old description">
+      <meta name="twitter:card" content="summary">
+      <meta property="og:title" content="Old page">
+      <meta itemprop="dateModified" content="2026-08-01">
+      <link rel="canonical" href="https://example.test/old">
+      <link rel="prev" href="https://example.test/page/1">
+      <link rel="help" href="https://example.test/old-help">
+      <link rel="stylesheet" href="/app.css">
+    `;
+    const nextDocument = new DOMParser().parseFromString(
+      `<!doctype html><html><head>
+        <title>New page</title>
+        <meta name="viewport" content="width=device-width">
+        <meta name="description" content="New description">
+        <meta property="og:title" content="New page">
+        <meta itemprop="dateModified" content="2026-09-03">
+        <link rel="canonical" href="https://example.test/new">
+        <link rel="alternate icon" hreflang="fr" href="https://example.test/fr/new">
+        <link rel="next" href="https://example.test/page/3">
+        <link rel="search" href="/opensearch.xml" type="application/opensearchdescription+xml">
+      </head><body></body></html>`,
+      "text/html",
+    );
+
+    reconcileFarmDocumentHead(nextDocument);
+
+    expect(document.title).toBe("New page");
+    expect(document.querySelector('meta[name="viewport"]')?.getAttribute("content")).toBe(
+      "width=device-width",
+    );
+    expect(document.querySelector('meta[name="description"]')?.getAttribute("content")).toBe(
+      "New description",
+    );
+    expect(document.querySelector('meta[property="og:title"]')?.getAttribute("content")).toBe(
+      "New page",
+    );
+    expect(document.querySelector('meta[itemprop="dateModified"]')?.getAttribute("content")).toBe(
+      "2026-09-03",
+    );
+    expect(document.querySelector('meta[name="twitter:card"]')).toBeNull();
+    expect(document.querySelector('link[rel="canonical"]')?.getAttribute("href")).toBe(
+      "https://example.test/new",
+    );
+    expect(document.querySelector('link[rel~="alternate"]')?.getAttribute("hreflang")).toBe("fr");
+    expect(document.querySelector('link[rel~="icon"]')?.getAttribute("href")).toBe(
+      "https://example.test/fr/new",
+    );
+    expect(document.querySelector('link[rel="prev"]')).toBeNull();
+    expect(document.querySelector('link[rel="help"]')).toBeNull();
+    expect(document.querySelector('link[rel="next"]')?.getAttribute("href")).toBe(
+      "https://example.test/page/3",
+    );
+    expect(document.querySelector('link[rel="search"]')?.getAttribute("href")).toBe(
+      "/opensearch.xml",
+    );
+    expect(document.querySelector('link[rel="stylesheet"]')?.getAttribute("href")).toBe("/app.css");
+  });
+});

--- a/packages/farm/src/__tests__/searchparams.test.ts
+++ b/packages/farm/src/__tests__/searchparams.test.ts
@@ -226,7 +226,7 @@ describe("SearchParams in the production runtime", () => {
     const source = readSource("nitro", "universal-build.ts");
 
     expect(source).toContain(
-      'import { createClientPluginManager, getHashTargetElement, installChunkErrorRecovery, scheduleFarmIslandHydration, searchParamsToObject, setFarmBasePath, setFarmTrailingSlashPreference, stripFarmBasePath } from "@farm.js/core/internal/client-runtime";',
+      'import { createClientPluginManager, getHashTargetElement, installChunkErrorRecovery, reconcileFarmDocumentHead, scheduleFarmIslandHydration, searchParamsToObject, setFarmBasePath, setFarmTrailingSlashPreference, stripFarmBasePath } from "@farm.js/core/internal/client-runtime";',
     );
     expect(source).toContain(
       "const searchParams = searchParamsToObject(new URLSearchParams(window.location.search));",

--- a/packages/farm/src/client/document-head.ts
+++ b/packages/farm/src/client/document-head.ts
@@ -1,0 +1,33 @@
+const FARM_NAVIGATION_HEAD_SELECTOR = [
+  "meta[name]",
+  "meta[property]",
+  "meta[http-equiv]",
+  "meta[charset]",
+  "meta[itemprop]",
+  'link[rel~="author"]',
+  'link[rel~="canonical"]',
+  'link[rel~="alternate"]',
+  'link[rel~="icon"]',
+  'link[rel~="apple-touch-icon"]',
+  'link[rel~="manifest"]',
+  'link[rel~="search"]',
+  'link[rel~="next"]',
+  'link[rel~="prev"]',
+  'link[rel~="publisher"]',
+  'link[rel~="license"]',
+  'link[rel~="help"]',
+  'link[rel~="me"]',
+  'link[rel~="pingback"]',
+  'link[rel~="privacy-policy"]',
+  'link[rel~="terms-of-service"]',
+].join(",");
+
+export function reconcileFarmDocumentHead(nextDocument: Document): void {
+  const nextTitle = nextDocument.querySelector("title");
+  document.title = nextTitle?.textContent || "";
+
+  document.head.querySelectorAll(FARM_NAVIGATION_HEAD_SELECTOR).forEach((node) => node.remove());
+  nextDocument.head
+    .querySelectorAll(FARM_NAVIGATION_HEAD_SELECTOR)
+    .forEach((node) => document.head.appendChild(document.importNode(node, true)));
+}

--- a/packages/farm/src/client/production-runtime.ts
+++ b/packages/farm/src/client/production-runtime.ts
@@ -5,3 +5,4 @@ export { searchParamsToObject } from "../search-params";
 export { setFarmTrailingSlashPreference } from "../trailing-slash";
 export { setFarmBasePath, stripFarmBasePath } from "../base-path";
 export { getHashTargetElement } from "./hash-target";
+export { reconcileFarmDocumentHead } from "./document-head";

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -2097,7 +2097,7 @@ async function hydrateFarmDocsAdapterRuntime() {
 // Farm.js Client Runtime (no client components)
 ${cssImport}
 ${layoutImports}
-import { createClientPluginManager, getHashTargetElement, installChunkErrorRecovery, setFarmBasePath, setFarmTrailingSlashPreference, stripFarmBasePath } from "@farm.js/core/internal/client-runtime";
+import { createClientPluginManager, getHashTargetElement, installChunkErrorRecovery, reconcileFarmDocumentHead, setFarmBasePath, setFarmTrailingSlashPreference, stripFarmBasePath } from "@farm.js/core/internal/client-runtime";
 import { createFarmDeploymentMismatchError, createFarmDeploymentRequestHeaders, isFarmDeploymentMismatchResponse } from "@farm.js/core/deployment";
 ${clientPluginEntry.imports}
 ${i18nClientRuntime}
@@ -2245,23 +2245,7 @@ ${generateUniversalRouterStateProperties()}
     if (isFarmLocaleDocumentChange(doc)) return false;
     if (doc.getElementById("nd-docs-layout")) return false;
     
-    // Update title
-    const newTitle = doc.querySelector("title");
-    if (newTitle) document.title = newTitle.textContent || "";
-    
-    // Update meta tags
-    const newMetas = doc.querySelectorAll("meta[name]");
-    newMetas.forEach(function(meta) {
-      const name = meta.getAttribute("name");
-      if (name) {
-        const existing = document.querySelector("meta[name=\\"" + name + "\\"]");
-        if (existing) {
-          existing.setAttribute("content", meta.getAttribute("content") || "");
-        } else {
-          document.head.appendChild(meta.cloneNode(true));
-        }
-      }
-    });
+    reconcileFarmDocumentHead(doc);
     
     // Swap root content
     const newRoot = doc.getElementById("root");
@@ -2515,7 +2499,7 @@ ${cssImport}
 ${layoutImports}
 ${rendererClientImports}
 ${providerClientCode.imports}
-import { createClientPluginManager, getHashTargetElement, installChunkErrorRecovery, scheduleFarmIslandHydration, searchParamsToObject, setFarmBasePath, setFarmTrailingSlashPreference, stripFarmBasePath } from "@farm.js/core/internal/client-runtime";
+import { createClientPluginManager, getHashTargetElement, installChunkErrorRecovery, reconcileFarmDocumentHead, scheduleFarmIslandHydration, searchParamsToObject, setFarmBasePath, setFarmTrailingSlashPreference, stripFarmBasePath } from "@farm.js/core/internal/client-runtime";
 import { createFarmDeploymentMismatchError, createFarmDeploymentRequestHeaders, isFarmDeploymentMismatchResponse } from "@farm.js/core/deployment";
 import { matchFarmRoute } from "@farm.js/core/router";
 ${clientPluginEntry.imports}
@@ -2766,15 +2750,16 @@ function hydrateInitialRouteSlots() {
   }
 }
 
-function renderRouteInterception(slot, registration, from) {
+function renderRouteInterception(slot, registration, from, nextDocument) {
   const container = document.getElementById(slot.containerId);
-  if (!container) return false;
+  if (!container || !registration?.Component) return false;
   const key = routeSlotKey(slot);
   const previousSlot = (window.__FARM_ROUTE_SLOTS__ || []).find(function(candidate) {
     return routeSlotKey(candidate) === key;
   }) || null;
   const previousHtml = container.innerHTML;
 
+  reconcileFarmDocumentHead(nextDocument);
   if (!renderClientRouteSlot(slot, registration, "render")) return false;
   activeRouteInterception = {
     from: from,
@@ -3100,7 +3085,7 @@ ${generateUniversalRouterStateProperties()}
             params: intercepted.params,
           });
           if (!this.isCurrentNavigation(navigation, clientNavigation)) return;
-          if (renderRouteInterception(selectedSlot, intercepted.slot, from)) {
+          if (renderRouteInterception(selectedSlot, intercepted.slot, from, doc)) {
             this.writeHistoryEntry(action, to, options.state, url);
             this.currentPath = to;
             await farmClientRuntime.resolveNavigation(clientNavigation);
@@ -3243,23 +3228,7 @@ ${generateUniversalRouterStateProperties()}
     const isNavigationCurrent = () =>
       this.isCurrentNavigation(navigation, clientNavigation);
     
-    // Update title
-    const newTitle = doc.querySelector("title");
-    if (newTitle) document.title = newTitle.textContent || "";
-    
-    // Update meta tags
-    const newMetas = doc.querySelectorAll("meta[name]");
-    newMetas.forEach(function(meta) {
-      const name = meta.getAttribute("name");
-      if (name) {
-        const existing = document.querySelector("meta[name=\\"" + name + "\\"]");
-        if (existing) {
-          existing.setAttribute("content", meta.getAttribute("content") || "");
-        } else {
-          document.head.appendChild(meta.cloneNode(true));
-        }
-      }
-    });
+    reconcileFarmDocumentHead(doc);
     
     // Swap root content
     const newRoot = doc.getElementById("root");


### PR DESCRIPTION
## Problem

HTML-based client navigation updates the title and adds or updates `meta[name]` tags, but it leaves metadata from the previous route behind and ignores Open Graph properties, canonical/alternate links, icons, and manifest links. The visible page can therefore disagree with the document head after navigation.

## Root cause

Both generated production routers contain the same additive-only metadata loop. It has no authoritative destination set and uses a narrow selector that cannot represent Farm's full metadata output.

## Change

Add a small shared client-head reconciler and call it from both generated HTML swap paths. It replaces the destination document's named/property/http-equiv meta tags and metadata links, removes tags omitted by the destination, updates the title, and leaves non-metadata resources such as stylesheets and scripts intact. The routing docs now state this navigation behavior.

## Safety and compatibility

- Uses the complete server-rendered destination head as the source of truth.
- Covers server-rendered and hydratable production clients across renderers.
- Preserves stylesheets, preloads, scripts, and other non-metadata head resources.
- Full-document fallbacks retain their existing behavior.
- The helper is internal and tree-shakeable; no public API changes.

## Verification

- `pnpm --filter @farm.js/core exec vitest run src/__tests__/document-head.test.ts src/__tests__/client-component.test.ts src/__tests__/searchparams.test.ts src/__tests__/metadata.test.ts` (62 tests passed)
- `pnpm --filter @farm.js/core type-check`
- `pnpm docs:check-navigation`
- `pnpm docs:build`
- `pnpm exec oxlint packages/farm/src/client/document-head.ts packages/farm/src/client/production-runtime.ts packages/farm/src/nitro/universal-build.ts packages/farm/src/__tests__/document-head.test.ts packages/farm/src/__tests__/client-component.test.ts packages/farm/src/__tests__/searchparams.test.ts` (0 errors; one pre-existing unused-variable warning in `universal-build.ts`)
- `git diff --check`

The DOM regression starts with stale Twitter/Open Graph/canonical metadata, reconciles a new document, verifies stale tags are removed and destination tags are installed, and confirms the stylesheet survives.

## Documentation and release

Updated the routing metadata guide with the HTML client-navigation reconciliation contract. No generated artifacts changed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale document head metadata during HTML-based client navigation. Previously Farm updated only the title and `meta[name]` tags, leaving Open Graph, canonical, alternate, icon, and manifest metadata from the previous route active; now a shared reconciler replaces destination metadata and removes omitted tags while preserving stylesheets and scripts.

- Uses the reconciler for generated HTML swaps and intercepted route rendering.
- Covers named, property, `http-equiv`, and `itemprop` meta tags plus supported metadata links.
- Documents the behavior and adds regression coverage for stale-tag removal and resource preservation.

<sup>Written for commit 54f5756c4efc09d519968954bce08f6d9b84b041. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/707?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

