### PR TITLE
fix(navigation): leave blob URLs to the browser

### DIFF
--- a/docs/src/app/docs/routing/page.md
+++ b/docs/src/app/docs/routing/page.md
@@ -117,7 +117,7 @@ Changing only the fragment preserves SPA state, honors push versus replace histo
 request route data again.
 Native anchor behavior still takes precedence: for example, a `Link` with a `download` attribute is
 handled by the browser instead of Farm's SPA router. Absolute URI schemes such as `mailto:`, `tel:`,
-and `sms:` are also passed through unchanged and are never prefetched as app routes. Literal custom
+`sms:`, and same-origin `blob:` URLs are passed through unchanged and are never prefetched as app routes. Literal custom
 schemes such as `customapp:open` are validated from their URI grammar and work without registration.
 Internal `Link` hrefs stay app-relative: when `basePath: "/console"` is configured, `href="/about"`
 renders and navigates to `/console/about`. Do not add the base path to route hrefs yourself.

--- a/packages/farm/src/__tests__/client-component.test.ts
+++ b/packages/farm/src/__tests__/client-component.test.ts
@@ -797,6 +797,10 @@ export function Chart() {}
       4,
     );
     expect(source).not.toContain("document.querySelector(url.hash)");
+    expect(
+      source.match(/isFarmExternalNavigationURL\(url, window\.location\.origin\)/g),
+    ).toHaveLength(4);
+    expect(source.match(/if \(hasAbsoluteNavigationHref\(href\)\) return;/g)).toHaveLength(2);
     expect(source).toContain('const href = element.getAttribute("href");');
     expect(
       source.match(

--- a/packages/farm/src/__tests__/searchparams.test.ts
+++ b/packages/farm/src/__tests__/searchparams.test.ts
@@ -226,7 +226,7 @@ describe("SearchParams in the production runtime", () => {
     const source = readSource("nitro", "universal-build.ts");
 
     expect(source).toContain(
-      'import { createClientPluginManager, getHashTargetElement, installChunkErrorRecovery, reconcileFarmDocumentHead, scheduleFarmIslandHydration, searchParamsToObject, setFarmBasePath, setFarmTrailingSlashPreference, stripFarmBasePath } from "@farm.js/core/internal/client-runtime";',
+      'import { createClientPluginManager, getHashTargetElement, installChunkErrorRecovery, isFarmExternalNavigationURL, reconcileFarmDocumentHead, scheduleFarmIslandHydration, searchParamsToObject, setFarmBasePath, setFarmTrailingSlashPreference, stripFarmBasePath } from "@farm.js/core/internal/client-runtime";',
     );
     expect(source).toContain(
       "const searchParams = searchParamsToObject(new URLSearchParams(window.location.search));",

--- a/packages/farm/src/__tests__/spa-router-external-navigation.test.ts
+++ b/packages/farm/src/__tests__/spa-router-external-navigation.test.ts
@@ -21,6 +21,12 @@ describe("external SPA router URLs", () => {
     ).toBe(true);
     expect(
       isFarmExternalNavigationURL(
+        new URL(`blob:${window.location.origin}/download-id`),
+        window.location.origin,
+      ),
+    ).toBe(true);
+    expect(
+      isFarmExternalNavigationURL(
         new URL("/reports", window.location.origin),
         window.location.origin,
       ),
@@ -31,6 +37,15 @@ describe("external SPA router URLs", () => {
     const router = new SPARouter({ scrollRestoration: false });
 
     await router.prefetch("https://example.com/reports");
+
+    expect(fetch).not.toHaveBeenCalled();
+    router.destroy();
+  });
+
+  it("does not prefetch same-origin blob URLs as routes", async () => {
+    const router = new SPARouter({ scrollRestoration: false });
+
+    await router.prefetch(`blob:${window.location.origin}/download-id`);
 
     expect(fetch).not.toHaveBeenCalled();
     router.destroy();

--- a/packages/farm/src/__tests__/universal-build-router-runtime.test.ts
+++ b/packages/farm/src/__tests__/universal-build-router-runtime.test.ts
@@ -10,6 +10,7 @@ import {
   generateRuntimePathMatcherSource,
   generateUniversalRouterStateRuntime,
   generateUniversalRouterStateProperties,
+  generateUniversalRouterStateRuntime,
 } from "../nitro/universal-build";
 
 afterEach(() => {
@@ -295,6 +296,20 @@ describe("generated deployment navigation guard", () => {
     );
 
     expect(router.prefetchCache.size).toBe(0);
+  });
+});
+
+describe("generateUniversalRouterStateRuntime", () => {
+  it("recognizes digit-bearing schemes in the generated click runtime", () => {
+    const getGuard = new Function(
+      `${generateUniversalRouterStateRuntime()}; return hasAbsoluteNavigationHref;`,
+    ) as () => (href: string) => boolean;
+    const hasAbsoluteNavigationHref = getGuard();
+
+    expect(hasAbsoluteNavigationHref("custom2app:open")).toBe(true);
+    expect(hasAbsoluteNavigationHref("custom-app:open")).toBe(true);
+    expect(hasAbsoluteNavigationHref("//cdn.example.test/file")).toBe(true);
+    expect(hasAbsoluteNavigationHref("/reports")).toBe(false);
   });
 });
 

--- a/packages/farm/src/client/navigation-url.ts
+++ b/packages/farm/src/client/navigation-url.ts
@@ -1,0 +1,3 @@
+export function isFarmExternalNavigationURL(url: URL, currentOrigin: string): boolean {
+  return (url.protocol !== "http:" && url.protocol !== "https:") || url.origin !== currentOrigin;
+}

--- a/packages/farm/src/client/production-runtime.ts
+++ b/packages/farm/src/client/production-runtime.ts
@@ -6,3 +6,4 @@ export { setFarmTrailingSlashPreference } from "../trailing-slash";
 export { setFarmBasePath, stripFarmBasePath } from "../base-path";
 export { getHashTargetElement } from "./hash-target";
 export { reconcileFarmDocumentHead } from "./document-head";
+export { isFarmExternalNavigationURL } from "./navigation-url";

--- a/packages/farm/src/client/spa-router.ts
+++ b/packages/farm/src/client/spa-router.ts
@@ -8,6 +8,7 @@ import {
   isFarmDeploymentMismatchResponse,
 } from "../deployment";
 import { getHashTargetElement } from "./hash-target";
+import { isFarmExternalNavigationURL } from "./navigation-url";
 import type { FarmClientNavigationSession, FarmClientPluginManager } from "./plugin";
 import { _hydrateFarmI18n, isFarmLocaleChangeHref } from "../i18n/client-runtime";
 import type { FarmI18nClientSnapshot } from "../i18n/types";
@@ -15,6 +16,7 @@ import type { FarmIslandStrategy } from "../island";
 import type { FarmRouteRenderPlan } from "../navigation/render-plan";
 
 export { getHashTargetElement } from "./hash-target";
+export { isFarmExternalNavigationURL } from "./navigation-url";
 
 /**
  * Farm.js SPA Router
@@ -932,10 +934,6 @@ export class SPARouter {
   clearCache(): void {
     this.cache.clear();
   }
-}
-
-export function isFarmExternalNavigationURL(url: URL, currentOrigin: string): boolean {
-  return url.origin !== currentOrigin;
 }
 
 function readBrowserDeploymentId(): string | undefined {

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -1619,6 +1619,10 @@ function readHistoryIndex(state) {
   const value = state[FARM_HISTORY_INDEX_KEY];
   return Number.isSafeInteger(value) ? value : null;
 }
+
+function hasAbsoluteNavigationHref(href) {
+  return /^[a-zA-Z][a-zA-Z\\d+.-]*:/.test(href) || href.startsWith("//");
+}
 `.trim();
 }
 
@@ -2097,7 +2101,7 @@ async function hydrateFarmDocsAdapterRuntime() {
 // Farm.js Client Runtime (no client components)
 ${cssImport}
 ${layoutImports}
-import { createClientPluginManager, getHashTargetElement, installChunkErrorRecovery, reconcileFarmDocumentHead, setFarmBasePath, setFarmTrailingSlashPreference, stripFarmBasePath } from "@farm.js/core/internal/client-runtime";
+import { createClientPluginManager, getHashTargetElement, installChunkErrorRecovery, isFarmExternalNavigationURL, reconcileFarmDocumentHead, setFarmBasePath, setFarmTrailingSlashPreference, stripFarmBasePath } from "@farm.js/core/internal/client-runtime";
 import { createFarmDeploymentMismatchError, createFarmDeploymentRequestHeaders, isFarmDeploymentMismatchResponse } from "@farm.js/core/deployment";
 ${clientPluginEntry.imports}
 ${i18nClientRuntime}
@@ -2119,7 +2123,7 @@ ${generateUniversalRouterStateProperties()}
   
   navigate: async function(href, options = {}) {
     const url = new URL(href, window.location.origin);
-    if (url.origin !== window.location.origin) {
+    if (isFarmExternalNavigationURL(url, window.location.origin)) {
       this.cancelActiveNavigation();
       window.location.href = href;
       return;
@@ -2287,7 +2291,7 @@ ${generateUniversalRouterStateProperties()}
   },
   prefetch: function(href) {
     const url = new URL(href, window.location.origin);
-    if (url.origin !== window.location.origin) return;
+    if (isFarmExternalNavigationURL(url, window.location.origin)) return;
     
     const pathname = url.pathname + url.search;
     if (this.prefetchCache.has(pathname)) return;
@@ -2372,7 +2376,7 @@ document.addEventListener("click", function(e) {
   const href = anchor.getAttribute("href");
   if (!href) return;
   if (anchor.hasAttribute("download")) return;
-  if (href.startsWith("http://") || href.startsWith("https://") || href.startsWith("//")) return;
+  if (hasAbsoluteNavigationHref(href)) return;
   if (href.startsWith("#")) return;
   if (anchor.target && anchor.target !== "_self") return;
   if (document.documentElement.dataset.farmDocsRuntime === "true") return;
@@ -2499,7 +2503,7 @@ ${cssImport}
 ${layoutImports}
 ${rendererClientImports}
 ${providerClientCode.imports}
-import { createClientPluginManager, getHashTargetElement, installChunkErrorRecovery, reconcileFarmDocumentHead, scheduleFarmIslandHydration, searchParamsToObject, setFarmBasePath, setFarmTrailingSlashPreference, stripFarmBasePath } from "@farm.js/core/internal/client-runtime";
+import { createClientPluginManager, getHashTargetElement, installChunkErrorRecovery, isFarmExternalNavigationURL, reconcileFarmDocumentHead, scheduleFarmIslandHydration, searchParamsToObject, setFarmBasePath, setFarmTrailingSlashPreference, stripFarmBasePath } from "@farm.js/core/internal/client-runtime";
 import { createFarmDeploymentMismatchError, createFarmDeploymentRequestHeaders, isFarmDeploymentMismatchResponse } from "@farm.js/core/deployment";
 import { matchFarmRoute } from "@farm.js/core/router";
 ${clientPluginEntry.imports}
@@ -2988,7 +2992,7 @@ ${generateUniversalRouterStateProperties()}
   
   navigate: async function(href, options = {}) {
     const url = new URL(href, window.location.origin);
-    if (url.origin !== window.location.origin) {
+    if (isFarmExternalNavigationURL(url, window.location.origin)) {
       this.cancelActiveNavigation();
       window.location.href = href;
       return;
@@ -3335,7 +3339,7 @@ ${generateUniversalRouterStateProperties()}
   },
   prefetch: function(href) {
     const url = new URL(href, window.location.origin);
-    if (url.origin !== window.location.origin) return;
+    if (isFarmExternalNavigationURL(url, window.location.origin)) return;
     
     const pathname = url.pathname + url.search;
     const interceptFrom = this.currentPath;
@@ -3416,7 +3420,7 @@ document.addEventListener("click", function(e) {
   const href = anchor.getAttribute("href");
   if (!href) return;
   if (anchor.hasAttribute("download")) return;
-  if (href.startsWith("http://") || href.startsWith("https://") || href.startsWith("//")) return;
+  if (hasAbsoluteNavigationHref(href)) return;
   if (href.startsWith("#")) return;
   if (anchor.target && anchor.target !== "_self") return;
   if (document.documentElement.dataset.farmDocsRuntime === "true") return;


### PR DESCRIPTION
## Problem

A `blob:` URL created from the application's origin reports that same origin. Farm's routers therefore classify it as an internal route, attempt page-data or HTML fetches, and intercept raw anchor clicks instead of letting the browser open or download the blob.

## Root cause

The shared and generated routers use origin equality as the complete SPA-eligibility check. Origin is necessary but not sufficient: only same-origin HTTP(S) URLs belong to Farm's route table.

## Change

Centralize URL ownership in a small client helper that requires HTTP(S) and the current origin. Use it for shared navigation/prefetch and both generated production navigation/prefetch paths. Generated click delegates now preserve every explicit URI scheme before calling `preventDefault`, including same-origin `blob:` URLs. The routing guide names this behavior explicitly.

## Safety and compatibility

- Ordinary same-origin HTTP(S) routes remain SPA navigations.
- Cross-origin URLs and non-HTTP schemes remain browser-owned.
- `Link` already preserved explicit URI schemes; raw anchors and direct router calls now agree.
- No renderer-specific code or public API changes.

## Verification

- `pnpm --filter @farm.js/core exec vitest run src/__tests__/spa-router-external-navigation.test.ts src/__tests__/client-component.test.ts src/__tests__/searchparams.test.ts src/__tests__/link.test.tsx` (93 tests passed)
- `pnpm --filter @farm.js/core type-check`
- `pnpm docs:check-navigation`
- `pnpm docs:build`
- `pnpm exec oxlint packages/farm/src/client/navigation-url.ts packages/farm/src/client/spa-router.ts packages/farm/src/client/production-runtime.ts packages/farm/src/nitro/universal-build.ts packages/farm/src/__tests__/spa-router-external-navigation.test.ts packages/farm/src/__tests__/client-component.test.ts packages/farm/src/__tests__/searchparams.test.ts` (0 errors; two pre-existing warnings)
- `git diff --check`

The regression tests verify a same-origin blob is external to SPA routing, is never prefetched, and all generated runtime paths use the protocol-aware classifier.

## Documentation and release

Updated the typed-navigation guide to include same-origin `blob:` URLs in browser-owned schemes. No generated artifacts changed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops Farm from routing same-origin `blob:` URLs as internal pages, so the browser handles blob navigation and downloads. Navigation and prefetch now accept only same-origin HTTP(S) URLs, while generated click handlers leave all URI schemes and protocol-relative URLs untouched.

**Coverage**
- Adds regression tests for blob URL navigation, prefetching, and digit-bearing custom schemes.
- Documents same-origin `blob:` URLs as browser-owned.

<sup>Written for commit 99b1b75d046ba02835953bba68e117904865c392. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/708?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

