### PR TITLE
fix(ci): remove duplicate router runtime import

### DIFF
--- a/packages/farm/src/__tests__/universal-build-router-runtime.test.ts
+++ b/packages/farm/src/__tests__/universal-build-router-runtime.test.ts
@@ -10,7 +10,6 @@ import {
   generateRuntimePathMatcherSource,
   generateUniversalRouterStateRuntime,
   generateUniversalRouterStateProperties,
-  generateUniversalRouterStateRuntime,
 } from "../nitro/universal-build";
 
 afterEach(() => {


### PR DESCRIPTION
## Problem

The current main branch fails lint because the universal router runtime test imports the same identifier twice.

## Root cause

A duplicate named import was left in the test file, which oxlint reports as a redeclaration.

## Change

Remove the duplicate import.

## Safety and compatibility

Test-only change with no runtime or public API impact.

## Verification

- pnpm exec oxlint packages/farm/src/__tests__/universal-build-router-runtime.test.ts
- pnpm --filter @farm.js/core exec vitest run src/__tests__/universal-build-router-runtime.test.ts
- git diff --check

## Documentation and release

None.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the duplicate `generateUniversalRouterStateRuntime` import from the universal router runtime test so lint no longer fails.

<sup>Written for commit 2a4b430e3b8ef980df26ac670fc37f12397a2b5c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/709?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

