### PR TITLE
fix(router): preserve fragments across SPA routes

### DIFF
--- a/packages/farm/src/__tests__/spa-router-hash-navigation.test.ts
+++ b/packages/farm/src/__tests__/spa-router-hash-navigation.test.ts
@@ -44,4 +44,30 @@ describe("same-page hash navigation", () => {
     router.destroy();
     target.remove();
   });
+
+  it("preserves a fragment when navigating to another route", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(
+      Response.json({
+        canonicalPath: "/reference",
+        props: {},
+        modulePath: "/src/app/reference/page.tsx",
+        metadata: {},
+      }),
+    );
+    const router = new SPARouter({ scrollRestoration: false });
+    router.setNavigationHandler(async () => undefined);
+    const target = document.createElement("h2");
+    target.id = "api";
+    target.scrollIntoView = vi.fn();
+    document.body.appendChild(target);
+
+    await router.navigate("/reference#api");
+
+    expect(window.location.pathname).toBe("/reference");
+    expect(window.location.hash).toBe("#api");
+    expect(window.history.state.path).toBe("/reference#api");
+    expect(target.scrollIntoView).toHaveBeenCalledTimes(1);
+    router.destroy();
+    target.remove();
+  });
 });

--- a/packages/farm/src/client/spa-router.ts
+++ b/packages/farm/src/client/spa-router.ts
@@ -505,7 +505,12 @@ export class SPARouter {
     state: unknown;
     url: URL;
   }): Promise<void> {
-    const historyPath = options.pageData.canonicalPath || options.fullPath;
+    const historyUrl = new URL(
+      options.pageData.canonicalPath || options.fullPath,
+      window.location.origin,
+    );
+    historyUrl.hash = options.url.hash;
+    const historyPath = historyUrl.pathname + historyUrl.search + historyUrl.hash;
     const historyState = createHistoryState(
       historyPath,
       options.state,


### PR DESCRIPTION
## Problem

Development SPA navigation to another route drops the requested URL fragment. The destination may scroll once, but the address bar and history entry lose the fragment.

## Root cause

The router builds its history URL from pathname and search only. The parsed destination hash is used for scrolling but never written into history.

## Change

Apply the requested fragment to the canonical destination before creating the history entry.

## Safety and compatibility

Same-page hash behavior is unchanged. Page-data requests and route matching still exclude fragments, while browser history now preserves native URL semantics.

## Verification

- pnpm --filter @farm.js/core exec vitest run src/__tests__/spa-router-hash-navigation.test.ts
- pnpm --filter @farm.js/core type-check
- pnpm exec oxlint packages/farm/src/client/spa-router.ts packages/farm/src/__tests__/spa-router-hash-navigation.test.ts
- git diff --check

The added regression fails before the fix because window.location.hash is empty.

## Documentation and release

None; this restores documented typed href hash behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes SPA navigation so URL fragments survive route changes. Previously the fragment was used to scroll but dropped from the history URL, so the address bar and history lost it. Now the fragment is applied to the canonical destination before the history entry is created. Same-page hash behavior is unchanged, and page-data requests and route matching still ignore fragments.

Adds a regression test that fails without the fix.

<sup>Written for commit 9cc54cf443ac9b3f1e35e5346b92e4f9ecc1e4af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/710?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

