### PR TITLE
fix(router): clear stale metadata after navigation

### DIFF
--- a/packages/farm/src/__tests__/spa-router-metadata.test.ts
+++ b/packages/farm/src/__tests__/spa-router-metadata.test.ts
@@ -38,4 +38,28 @@ describe("SPA router metadata", () => {
     expect(document.querySelector('meta[name="description"]')).toBeNull();
     router.destroy();
   });
+
+  it("removes absent metadata during back and forward navigation", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        Response.json({
+          props: {},
+          modulePath: "/src/app/previous/page.tsx",
+          metadata: {},
+        }),
+      ),
+    );
+    const router = new SPARouter({ scrollRestoration: false });
+    router.setNavigationHandler(async () => undefined);
+    window.history.replaceState({ path: "/previous" }, "", "/previous");
+
+    await (
+      router as unknown as { handlePopState(event: PopStateEvent): Promise<void> }
+    ).handlePopState(new PopStateEvent("popstate", { state: window.history.state }));
+
+    expect(document.title).toBe("Farm.js App");
+    expect(document.querySelector('meta[name="description"]')).toBeNull();
+    router.destroy();
+  });
 });

--- a/packages/farm/src/__tests__/spa-router-metadata.test.ts
+++ b/packages/farm/src/__tests__/spa-router-metadata.test.ts
@@ -1,0 +1,41 @@
+/** @vitest-environment jsdom */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SPARouter } from "../client/spa-router";
+
+describe("SPA router metadata", () => {
+  beforeEach(() => {
+    window.history.replaceState(null, "", "/old");
+    document.title = "Old page";
+    const description = document.createElement("meta");
+    description.name = "description";
+    description.content = "Old description";
+    document.head.appendChild(description);
+  });
+
+  afterEach(() => {
+    document.head.innerHTML = "";
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("removes metadata that is absent from the destination route", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        Response.json({
+          props: {},
+          modulePath: "/src/app/next/page.tsx",
+          metadata: {},
+        }),
+      ),
+    );
+    const router = new SPARouter({ scrollRestoration: false });
+    router.setNavigationHandler(async () => undefined);
+
+    await router.navigate("/next", { scroll: false });
+
+    expect(document.title).toBe("Farm.js App");
+    expect(document.querySelector('meta[name="description"]')).toBeNull();
+    router.destroy();
+  });
+});

--- a/packages/farm/src/client/spa-router.ts
+++ b/packages/farm/src/client/spa-router.ts
@@ -543,19 +543,7 @@ export class SPARouter {
       new URL(historyPath, window.location.origin).pathname +
       new URL(historyPath, window.location.origin).search;
 
-    document.title = options.pageData.metadata?.title || "Farm.js App";
-
-    let metaDesc = document.querySelector('meta[name="description"]');
-    if (options.pageData.metadata?.description) {
-      if (!metaDesc) {
-        metaDesc = document.createElement("meta");
-        metaDesc.setAttribute("name", "description");
-        document.head.appendChild(metaDesc);
-      }
-      metaDesc.setAttribute("content", options.pageData.metadata.description);
-    } else {
-      metaDesc?.remove();
-    }
+    this.updateDocumentMetadata(options.pageData.metadata);
 
     _hydrateFarmI18n(options.pageData.i18n);
 
@@ -752,10 +740,7 @@ export class SPARouter {
       }
       if (!this.isCurrentNavigation(navigation, clientNavigation)) return;
 
-      // Update document title
-      if (pageData.metadata?.title) {
-        document.title = pageData.metadata.title;
-      }
+      this.updateDocumentMetadata(pageData.metadata);
 
       _hydrateFarmI18n(pageData.i18n);
 
@@ -829,6 +814,23 @@ export class SPARouter {
       }
     }
     return false;
+  }
+
+  private updateDocumentMetadata(metadata: PageData["metadata"]): void {
+    document.title = metadata?.title || "Farm.js App";
+
+    let description = document.querySelector('meta[name="description"]');
+    if (!metadata?.description) {
+      description?.remove();
+      return;
+    }
+
+    if (!description) {
+      description = document.createElement("meta");
+      description.setAttribute("name", "description");
+      document.head.appendChild(description);
+    }
+    description.setAttribute("content", metadata.description);
   }
 
   private startNavigation(options: {

--- a/packages/farm/src/client/spa-router.ts
+++ b/packages/farm/src/client/spa-router.ts
@@ -543,18 +543,18 @@ export class SPARouter {
       new URL(historyPath, window.location.origin).pathname +
       new URL(historyPath, window.location.origin).search;
 
-    if (options.pageData.metadata?.title) {
-      document.title = options.pageData.metadata.title;
-    }
+    document.title = options.pageData.metadata?.title || "Farm.js App";
 
+    let metaDesc = document.querySelector('meta[name="description"]');
     if (options.pageData.metadata?.description) {
-      let metaDesc = document.querySelector('meta[name="description"]');
       if (!metaDesc) {
         metaDesc = document.createElement("meta");
         metaDesc.setAttribute("name", "description");
         document.head.appendChild(metaDesc);
       }
       metaDesc.setAttribute("content", options.pageData.metadata.description);
+    } else {
+      metaDesc?.remove();
     }
 
     _hydrateFarmI18n(options.pageData.i18n);


### PR DESCRIPTION
## Problem

After development SPA navigation, a destination without title or description metadata inherits those values from the previous route.

## Root cause

The router only updates metadata fields when the destination provides a truthy value, so absent fields are never cleared.

## Change

Restore the framework title fallback when the destination has no title and remove the managed description element when no description is present.

## Safety and compatibility

This aligns development navigation with production document-head reconciliation. Stylesheets and unrelated head elements are untouched.

## Verification

- pnpm --filter @farm.js/core exec vitest run src/__tests__/spa-router-metadata.test.ts src/__tests__/spa-router-concurrency.test.ts
- pnpm --filter @farm.js/core type-check
- pnpm exec oxlint packages/farm/src/client/spa-router.ts packages/farm/src/__tests__/spa-router-metadata.test.ts
- git diff --check

The regression retains Old page and Old description without this fix.

## Documentation and release

None; this corrects existing navigation behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale document metadata after SPA navigation, including back and forward navigation, so a destination without a title or description no longer inherits the previous route's values.

- Restores the `"Farm.js App"` title fallback when the destination has no title.
- Removes the managed description `<meta>` element when the destination has no description.
- Aligns development navigation with production document-head reconciliation; stylesheets and unrelated head elements are untouched.

<sup>Written for commit 818c501e36f4f48ce8d4e9e6b87fe8db02b45c67. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/711?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

