### PR TITLE
fix(router): notify hooks after route navigation

### DIFF
--- a/packages/farm/src/__tests__/history-sync.test.tsx
+++ b/packages/farm/src/__tests__/history-sync.test.tsx
@@ -10,7 +10,7 @@ import {
   subscribeHistoryChange,
   type FarmHistoryChangeDetail,
 } from "../client/history-sync";
-import { usePageState } from "../client/router";
+import { usePageState, useRouter } from "../client/router";
 import { readPageState, SPARouter } from "../client/spa-router";
 import { asString, useQueryState } from "../query/client";
 
@@ -250,5 +250,34 @@ describe("page state writes do not navigate", () => {
 
     expect(h.fetched().length).toBeGreaterThan(0);
     expect(h.navigationStates).toContain("loading");
+  });
+});
+
+describe("route navigation history updates", () => {
+  it("keeps useRouter state in sync after a completed SPA navigation", async () => {
+    const h = mountRouter();
+    delete (window as unknown as { __FARM_SPA_ROUTER__?: SPARouter }).__FARM_SPA_ROUTER__;
+    const popstate = vi.fn();
+    listen("popstate", popstate);
+    let pathname = "";
+
+    function Probe() {
+      pathname = useRouter().pathname;
+      return null;
+    }
+
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    act(() => root?.render(createElement(Probe)));
+
+    await act(async () => {
+      await h.router.navigate("/next", { scroll: false });
+      await settle();
+    });
+
+    expect(pathname).toBe("/next");
+    expect(popstate).not.toHaveBeenCalled();
+    expect(h.fetched()).toHaveLength(1);
   });
 });

--- a/packages/farm/src/__tests__/universal-build-router-runtime.test.ts
+++ b/packages/farm/src/__tests__/universal-build-router-runtime.test.ts
@@ -25,7 +25,12 @@ describe("generateUniversalRouterStateProperties", () => {
     // synthetic popstate here reintroduces #420 in production builds (#424).
     expect(runtime).not.toContain("new PopStateEvent");
     expect(runtime).toContain(`new CustomEvent("${FARM_HISTORY_CHANGE_EVENT}"`);
-    expect(runtime).toContain('kind: "page-state"');
+    expect(runtime).toContain('state, url, "page-state"');
+  });
+
+  it("announces ordinary route history writes to client hooks", () => {
+    expect(runtime).toContain('changeKind = "url-search"');
+    expect(runtime).toContain("detail: { kind: changeKind }");
   });
 
   it("keeps the page-state write API intact", () => {
@@ -118,6 +123,7 @@ describe("generateUniversalRouterStateProperties", () => {
     };
     const windowValue = {
       history,
+      dispatchEvent: vi.fn(),
       location: {
         href: "https://example.test/",
         origin: "https://example.test",

--- a/packages/farm/src/client/history-sync.ts
+++ b/packages/farm/src/client/history-sync.ts
@@ -9,6 +9,14 @@ export interface FarmHistoryChangeDetail {
   kind: FarmHistoryChangeKind;
 }
 
+function dispatchHistoryChange(kind: FarmHistoryChangeKind): void {
+  window.dispatchEvent(
+    new CustomEvent<FarmHistoryChangeDetail>(FARM_HISTORY_CHANGE_EVENT, {
+      detail: { kind },
+    }),
+  );
+}
+
 /**
  * Notify history observers after pushState/replaceState.
  *
@@ -26,12 +34,14 @@ export function notifyHistoryChange(kind: FarmHistoryChangeKind): void {
       return;
     }
 
-    window.dispatchEvent(
-      new CustomEvent<FarmHistoryChangeDetail>(FARM_HISTORY_CHANGE_EVENT, {
-        detail: { kind },
-      }),
-    );
+    dispatchHistoryChange(kind);
   }, 0);
+}
+
+/** Notify observers after a Farm router commit without simulating traversal. */
+export function notifyRouterHistoryChange(): void {
+  if (typeof window === "undefined") return;
+  setTimeout(() => dispatchHistoryChange("url-search"), 0);
 }
 
 export function subscribeHistoryChange(listener: () => void): () => void {

--- a/packages/farm/src/client/spa-router.ts
+++ b/packages/farm/src/client/spa-router.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { readDeferredDataResponse } from "../deferred";
-import { notifyHistoryChange } from "./history-sync";
+import { notifyHistoryChange, notifyRouterHistoryChange } from "./history-sync";
 import {
   createFarmDeploymentMismatchError,
   createFarmDeploymentRequestHeaders,
@@ -542,6 +542,7 @@ export class SPARouter {
     this.currentHistoryPath =
       new URL(historyPath, window.location.origin).pathname +
       new URL(historyPath, window.location.origin).search;
+    notifyRouterHistoryChange();
 
     if (options.pageData.metadata?.title) {
       document.title = options.pageData.metadata.title;

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -1876,17 +1876,10 @@ export function generateUniversalRouterStateProperties(): string {
 
   writePageState: function(action, state, href) {
     const url = new URL(href || window.location.href, window.location.origin);
-    this.writeHistoryEntry(action, url.pathname + url.search, state, url);
-    // Announce on the dedicated history channel; a synthetic popstate would
-    // be treated as back/forward by the popstate listener below and trigger
-    // a full navigation for a shallow page-state write. The bundled client
-    // hooks subscribe to this event via subscribeHistoryChange.
-    window.dispatchEvent(
-      new CustomEvent("farm:historychange", { detail: { kind: "page-state" } }),
-    );
+    this.writeHistoryEntry(action, url.pathname + url.search, state, url, "page-state");
   },
 
-  writeHistoryEntry: function(action, path, pageState, url) {
+  writeHistoryEntry: function(action, path, pageState, url, changeKind = "url-search") {
     if (action === "pop") return;
     const nextState = createHistoryState(path, pageState, window.history.state);
     const nextIndex = this.currentHistoryIndex == null
@@ -1899,6 +1892,11 @@ export function generateUniversalRouterStateProperties(): string {
     else window.history.pushState(nextState, "", url);
     this.currentHistoryIndex = nextIndex;
     this.currentHistoryState = nextState;
+    // Announce programmatic history writes without synthesizing popstate,
+    // which the router reserves for real back/forward navigation.
+    window.dispatchEvent(
+      new CustomEvent("farm:historychange", { detail: { kind: changeKind } }),
+    );
   },
 
   registerScrollElement: function(key, element) {


### PR DESCRIPTION
## Problem

Router hooks in persistent layouts can keep the previous pathname and search parameters after a successful SPA navigation.

## Root cause

Farm announces shallow page-state and search writes on its history channel, but ordinary route commits write browser history without notifying the same subscribers.

## Change

Announce completed route history writes in both the development router and generated production routers. Page-state writes retain their dedicated event kind.

## Safety and compatibility

No synthetic popstate is introduced, so real back/forward navigation remains distinct. Both client-render and document-swap production paths use the shared history writer.

## Verification

- pnpm --filter @farm.js/core exec vitest run src/__tests__/history-sync.test.tsx src/__tests__/universal-build-router-runtime.test.ts
- pnpm --filter @farm.js/core type-check
- pnpm exec oxlint on all changed TypeScript files
- git diff --check

The useRouter regression stays at / before this change after navigating to /next.

## Documentation and release

None; this restores the existing hook synchronization contract.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes router hooks in persistent layouts not receiving updates after SPA navigation, so they no longer keep stale pathname and search parameters.

- Announces completed route history writes in both dev and production routers.
- Keeps page-state writes on their own event kind and avoids synthetic popstate, so back/forward navigation stays distinct.

<sup>Written for commit b0bcf2a053c734d8cdf5917139797955f8df0df1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/712?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

