### PR TITLE
fix(router): preserve state on route replacement

### DIFF
--- a/packages/farm/src/__tests__/spa-router-history-state.test.ts
+++ b/packages/farm/src/__tests__/spa-router-history-state.test.ts
@@ -1,0 +1,35 @@
+/** @vitest-environment jsdom */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { SPARouter } from "../client/spa-router";
+
+describe("SPA router history state", () => {
+  afterEach(() => {
+    window.history.replaceState(null, "", "/");
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("preserves unrelated state when replacing the current route", async () => {
+    window.history.replaceState({ analyticsEntry: "keep" }, "", "/old");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        Response.json({
+          props: {},
+          modulePath: "/src/app/next/page.tsx",
+          metadata: {},
+        }),
+      ),
+    );
+    const router = new SPARouter({ scrollRestoration: false });
+    router.setNavigationHandler(async () => undefined);
+
+    await router.navigate("/next", { replace: true, scroll: false });
+
+    expect(window.history.state).toMatchObject({
+      analyticsEntry: "keep",
+      path: "/next",
+    });
+    router.destroy();
+  });
+});

--- a/packages/farm/src/client/spa-router.ts
+++ b/packages/farm/src/client/spa-router.ts
@@ -509,7 +509,7 @@ export class SPARouter {
     const historyState = createHistoryState(
       historyPath,
       options.state,
-      undefined,
+      options.replace ? window.history.state : undefined,
       options.pageData.interception?.from ?? null,
     ) as Record<string, unknown>;
     const nextHistoryIndex =


### PR DESCRIPTION
## Problem

Development router.replace navigation removes unrelated values stored in the current browser history entry.

## Root cause

Route commits create replacement state without using window.history.state as their base, unlike the generated production router.

## Change

When replacing a route, merge Farm state into the current history state before writing the entry.

## Safety and compatibility

Push navigation remains unchanged and does not copy state from the previous entry. Farm-owned path, page state, interception, and index fields continue to be authoritative.

## Verification

- pnpm --filter @farm.js/core exec vitest run src/__tests__/spa-router-history-state.test.ts src/__tests__/spa-router-popstate.test.ts
- pnpm --filter @farm.js/core type-check
- pnpm exec oxlint packages/farm/src/client/spa-router.ts packages/farm/src/__tests__/spa-router-history-state.test.ts
- git diff --check

The regression loses analyticsEntry before the fix.

## Documentation and release

None; this aligns development with existing production behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the development router so `replace` navigation no longer wipes unrelated values from the browser history entry.

- Route replacement now merges the existing `window.history.state` instead of starting from scratch.
- Push navigation is unchanged and still does not copy state from the previous entry.

<sup>Written for commit 4caf16c427a3427e9851960982e53ffff17d2079. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/713?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

