### PR TITLE
fix(router): skip inactive unload blockers

### DIFF
--- a/packages/farm/src/__tests__/client-component.test.ts
+++ b/packages/farm/src/__tests__/client-component.test.ts
@@ -788,7 +788,7 @@ export function Chart() {}
 
     expect(source).toContain("getNavigationState: function()");
     expect(source).toContain("subscribeNavigation: function(listener)");
-    expect(source).toContain("addBlocker: function(blocker)");
+    expect(source).toContain("addBlocker: function(blocker, shouldBlockUnload)");
     expect(source).toContain("registerScrollElement: function(key, element)");
     expect(source).toContain("stripFarmBasePath(pathname)");
     expect(source).toContain("writePageState: function(action, state, href)");

--- a/packages/farm/src/__tests__/navigation-state.test.tsx
+++ b/packages/farm/src/__tests__/navigation-state.test.tsx
@@ -75,6 +75,17 @@ describe("navigation state and blocking", () => {
     expect(window.location.pathname).toBe("/");
   });
 
+  it("does not prompt for a blocker that is inactive during unload", () => {
+    const router = new SPARouter({ scrollRestoration: false });
+    router.addBlocker(() => false);
+    const shouldBlockUnload = (
+      router as unknown as { shouldBlockUnload(): boolean }
+    ).shouldBlockUnload();
+
+    expect(shouldBlockUnload).toBe(false);
+    router.destroy();
+  });
+
   it("stores page state in history without changing route data", () => {
     pushState({ modal: "cart" });
     expect(readPageState()).toEqual({ modal: "cart" });

--- a/packages/farm/src/__tests__/universal-build-router-runtime.test.ts
+++ b/packages/farm/src/__tests__/universal-build-router-runtime.test.ts
@@ -34,6 +34,11 @@ describe("generateUniversalRouterStateProperties", () => {
     expect(runtime).toContain("writePageState: function(action, state, href)");
   });
 
+  it("checks blocker activity before prompting on unload", () => {
+    expect(runtime).toContain("shouldBlockUnload: function()");
+    expect(runtime).toContain("return result === true");
+  });
+
   it("aborts superseded navigations without letting them reset current state", () => {
     const createRouter = new Function(
       "window",

--- a/packages/farm/src/client/router.ts
+++ b/packages/farm/src/client/router.ts
@@ -40,6 +40,27 @@ export interface UseBlockerReturn {
   active: boolean;
 }
 
+function shouldBlockUnload(options: UseBlockerOptions): boolean {
+  const path = window.location.pathname + window.location.search;
+  const context: FarmNavigationBlockerContext = {
+    from: path,
+    to: path,
+    action: "replace",
+  };
+  const when = typeof options.when === "function" ? options.when(context) : options.when;
+  if (!when) return false;
+  if (!options.shouldBlock) return true;
+
+  try {
+    const result = options.shouldBlock(context);
+    if (typeof result === "boolean") return result;
+    void result.catch(() => undefined);
+    return true;
+  } catch {
+    return true;
+  }
+}
+
 /**
  * Hook for accessing router state and navigation
  */
@@ -176,22 +197,25 @@ export function useBlocker(options: UseBlockerOptions): UseBlockerReturn {
       return;
     }
 
-    return getSPARouter().addBlocker(async (context) => {
-      const current = optionsRef.current;
-      const when = typeof current.when === "function" ? current.when(context) : current.when;
+    return getSPARouter().addBlocker(
+      async (context) => {
+        const current = optionsRef.current;
+        const when = typeof current.when === "function" ? current.when(context) : current.when;
 
-      if (!when) return false;
+        if (!when) return false;
 
-      if (current.shouldBlock && !(await current.shouldBlock(context))) {
-        return false;
-      }
+        if (current.shouldBlock && !(await current.shouldBlock(context))) {
+          return false;
+        }
 
-      if (current.message && typeof window.confirm === "function") {
-        return !window.confirm(current.message);
-      }
+        if (current.message && typeof window.confirm === "function") {
+          return !window.confirm(current.message);
+        }
 
-      return true;
-    });
+        return true;
+      },
+      () => shouldBlockUnload(optionsRef.current),
+    );
   }, [active]);
 
   return { active };

--- a/packages/farm/src/client/spa-router.ts
+++ b/packages/farm/src/client/spa-router.ts
@@ -156,6 +156,7 @@ export class SPARouter {
   private prefetchingUrls: Set<string> = new Set();
   private observers: Map<Element, IntersectionObserver> = new Map();
   private blockers: Set<FarmNavigationBlocker> = new Set();
+  private unloadBlockers: Map<FarmNavigationBlocker, () => boolean> = new Map();
   private navigationListeners: Set<FarmNavigationListener> = new Set();
   private navigationState: FarmNavigationState = IDLE_NAVIGATION_STATE;
   private currentHistoryPath: string | null = null;
@@ -184,7 +185,7 @@ export class SPARouter {
   };
 
   private readonly onBeforeUnload = (event: BeforeUnloadEvent) => {
-    if (this.blockers.size > 0) {
+    if (this.shouldBlockUnload()) {
       event.preventDefault();
       event.returnValue = "";
     }
@@ -459,10 +460,15 @@ export class SPARouter {
     }
   }
 
-  addBlocker(blocker: FarmNavigationBlocker): () => void {
+  addBlocker(blocker: FarmNavigationBlocker, shouldBlockUnload?: () => boolean): () => void {
     this.blockers.add(blocker);
+    this.unloadBlockers.set(
+      blocker,
+      shouldBlockUnload ?? (() => this.evaluateBlockerForUnload(blocker)),
+    );
     return () => {
       this.blockers.delete(blocker);
+      this.unloadBlockers.delete(blocker);
     };
   }
 
@@ -792,6 +798,27 @@ export class SPARouter {
   private async shouldBlockNavigation(context: FarmNavigationBlockerContext): Promise<boolean> {
     for (const blocker of this.blockers) {
       if (await blocker(context)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private evaluateBlockerForUnload(blocker: FarmNavigationBlocker): boolean {
+    const path = window.location.pathname + window.location.search;
+    const result = blocker({ from: path, to: path, action: "replace" });
+    if (result && typeof result !== "boolean") {
+      void result.catch(() => undefined);
+      return true;
+    }
+    return result === true;
+  }
+
+  private shouldBlockUnload(): boolean {
+    for (const blocker of this.blockers) {
+      try {
+        if (this.unloadBlockers.get(blocker)?.()) return true;
+      } catch {
         return true;
       }
     }

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -1708,6 +1708,7 @@ function matchRuntimePathPattern(pattern, pathname) {
 export function generateUniversalRouterStateProperties(): string {
   return `
   blockers: new Set(),
+  unloadBlockers: new Map(),
   navigationListeners: new Set(),
   navigationState: IDLE_NAVIGATION_STATE,
   navigationSequence: 0,
@@ -1751,14 +1752,36 @@ export function generateUniversalRouterStateProperties(): string {
     return () => this.navigationListeners.delete(listener);
   },
 
-  addBlocker: function(blocker) {
+  addBlocker: function(blocker, shouldBlockUnload) {
     this.blockers.add(blocker);
-    return () => this.blockers.delete(blocker);
+    this.unloadBlockers.set(blocker, shouldBlockUnload || (() => {
+      const result = blocker({ from: this.currentPath, to: this.currentPath, action: "replace" });
+      if (result && typeof result.then === "function") {
+        result.catch(() => undefined);
+        return true;
+      }
+      return result === true;
+    }));
+    return () => {
+      this.blockers.delete(blocker);
+      this.unloadBlockers.delete(blocker);
+    };
   },
 
   shouldBlockNavigation: async function(context) {
     for (const blocker of this.blockers) {
       if (await blocker(context)) return true;
+    }
+    return false;
+  },
+
+  shouldBlockUnload: function() {
+    for (const blocker of this.blockers) {
+      try {
+        if (this.unloadBlockers.get(blocker)?.()) return true;
+      } catch {
+        return true;
+      }
     }
     return false;
   },
@@ -2355,7 +2378,7 @@ window.__FARM_SPA_ROUTER__ = spaRouter;
 void hydrateFarmDocsAdapterRuntime();
 
 window.addEventListener("beforeunload", function(event) {
-  if (spaRouter.blockers.size > 0) {
+  if (spaRouter.shouldBlockUnload()) {
     event.preventDefault();
     event.returnValue = "";
   }
@@ -3399,7 +3422,7 @@ spaRouter.initializeHistory();
 window.__FARM_SPA_ROUTER__ = spaRouter;
 
 window.addEventListener("beforeunload", function(event) {
-  if (spaRouter.blockers.size > 0) {
+  if (spaRouter.shouldBlockUnload()) {
     event.preventDefault();
     event.returnValue = "";
   }


### PR DESCRIPTION
## Problem

Registering a conditional blocker causes a native browser-leave prompt even when the blocker currently returns false.

## Root cause

Development and generated production runtimes only check whether the blocker set is non-empty during beforeunload; they never evaluate current blocker activity.

## Change

Track a synchronous unload predicate for each blocker and prompt only when one is active. React useBlocker supplies a predicate based on its latest when and shouldBlock values. Asynchronous predicates remain conservatively blocking because beforeunload cannot await them.

## Safety and compatibility

SPA push, replace, and pop blocking remains asynchronous and unchanged. Rejected async unload checks are consumed and fail closed. The generated production runtime follows the same behavior as development.

## Verification

- pnpm --filter @farm.js/core exec vitest run src/__tests__/navigation-state.test.tsx src/__tests__/universal-build-router-runtime.test.ts src/__tests__/client-component.test.ts
- pnpm --filter @farm.js/core type-check
- pnpm exec oxlint on all changed TypeScript files
- git diff --check

The regression reports an unload block for a blocker returning false before this change.

## Documentation and release

Existing routing documentation already describes conditional unload blocking; no prose change is required.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes conditional unload blockers so the native browser-leave prompt only fires when a blocker is currently active, not whenever any blocker is registered.

- Adds a synchronous unload predicate per blocker; async predicates remain conservatively blocking because `beforeunload` cannot await them.
- Applies the same behavior in the generated production runtime.

<sup>Written for commit 1ee54d139c54347f4b37311f99621e93177f9b18. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/714?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

