### PR TITLE
fix(router): skip prefetch for document routes

### DIFF
--- a/packages/farm/src/__tests__/client-component.test.ts
+++ b/packages/farm/src/__tests__/client-component.test.ts
@@ -800,6 +800,7 @@ export function Chart() {}
     expect(
       source.match(/isFarmExternalNavigationURL\(url, window\.location\.origin\)/g),
     ).toHaveLength(4);
+    expect(source.match(/if \(isFarmDocsPath\(url\.pathname\)\) return;/g)).toHaveLength(2);
     expect(source.match(/if \(hasAbsoluteNavigationHref\(href\)\) return;/g)).toHaveLength(2);
     expect(source).toContain('const href = element.getAttribute("href");');
     expect(

--- a/packages/farm/src/__tests__/spa-router-external-navigation.test.ts
+++ b/packages/farm/src/__tests__/spa-router-external-navigation.test.ts
@@ -50,4 +50,16 @@ describe("external SPA router URLs", () => {
     expect(fetch).not.toHaveBeenCalled();
     router.destroy();
   });
+
+  it("does not prefetch routes that require document navigation", async () => {
+    const router = new SPARouter({
+      scrollRestoration: false,
+      shouldUseDocumentNavigation: (pathname) => pathname.startsWith("/docs"),
+    });
+
+    await router.prefetch("/docs/getting-started");
+
+    expect(fetch).not.toHaveBeenCalled();
+    router.destroy();
+  });
 });

--- a/packages/farm/src/client/spa-router.ts
+++ b/packages/farm/src/client/spa-router.ts
@@ -399,6 +399,7 @@ export class SPARouter {
     if (isFarmLocaleChangeHref(href)) return;
     const url = new URL(href, window.location.origin);
     if (isFarmExternalNavigationURL(url, window.location.origin)) return;
+    if (this.options.shouldUseDocumentNavigation(url.pathname)) return;
     const fullPath = url.pathname + url.search;
     const interceptFrom = window.location.pathname + window.location.search;
 

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -2292,6 +2292,7 @@ ${generateUniversalRouterStateProperties()}
   prefetch: function(href) {
     const url = new URL(href, window.location.origin);
     if (isFarmExternalNavigationURL(url, window.location.origin)) return;
+    if (isFarmDocsPath(url.pathname)) return;
     
     const pathname = url.pathname + url.search;
     if (this.prefetchCache.has(pathname)) return;
@@ -3340,6 +3341,7 @@ ${generateUniversalRouterStateProperties()}
   prefetch: function(href) {
     const url = new URL(href, window.location.origin);
     if (isFarmExternalNavigationURL(url, window.location.origin)) return;
+    if (isFarmDocsPath(url.pathname)) return;
     
     const pathname = url.pathname + url.search;
     const interceptFrom = this.currentPath;


### PR DESCRIPTION
## Problem

Routes configured to use full-document navigation are still prefetched through Farm SPA endpoints, even though that data cannot be consumed by their navigation path.

## Root cause

The navigation guard checks document-only routes, but the corresponding prefetch implementations only reject external URLs.

## Change

Apply the same document-navigation predicate before development prefetch and skip docs paths in both generated production router variants.

## Safety and compatibility

SPA-enabled routes retain existing prefetch behavior. External URL and deployment-mismatch handling are unchanged.

## Verification

- pnpm --filter @farm.js/core exec vitest run src/__tests__/spa-router-external-navigation.test.ts src/__tests__/client-component.test.ts
- pnpm --filter @farm.js/core type-check
- pnpm exec oxlint on all changed TypeScript files
- git diff --check

The development regression calls fetch for a document-only docs path before this change.

## Documentation and release

None; this removes unused work without changing the public API.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the prefetch behavior for document routes so they no longer fetch SPA data that can't be consumed.

- Applies the same document-navigation predicate used by the navigation guard to prefetch in development and both generated production router variants.
- Adds a regression test verifying document routes do not trigger prefetch.

<sup>Written for commit 0ddff5f4840e78c44ff43c727512e57d6547e252. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/715?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

