### PR TITLE
fix(navigation): use destination request in route context

### DIFF
--- a/packages/farm/src/__tests__/navigation-request-context.test.ts
+++ b/packages/farm/src/__tests__/navigation-request-context.test.ts
@@ -10,7 +10,9 @@ describe("SPA navigation request context", () => {
   it("passes the destination request to development route contexts", () => {
     const source = readSource("vite.ts");
     const start = source.indexOf("// Handle SPA page-data requests for client-side navigation");
-    const end = source.indexOf("// Handle API routes", start);
+    const end = source.indexOf("const startTime = Date.now();", start);
+    expect(start).toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(start);
     const pageDataRuntime = source.slice(start, end);
 
     expect(pageDataRuntime.match(/request: targetRequest/g)).toHaveLength(2);

--- a/packages/farm/src/__tests__/navigation-request-context.test.ts
+++ b/packages/farm/src/__tests__/navigation-request-context.test.ts
@@ -1,0 +1,26 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+function readSource(...segments: string[]): string {
+  return fs.readFileSync(path.join(process.cwd(), "src", ...segments), "utf8");
+}
+
+describe("SPA navigation request context", () => {
+  it("passes the destination request to development route contexts", () => {
+    const source = readSource("vite.ts");
+    const start = source.indexOf("// Handle SPA page-data requests for client-side navigation");
+    const end = source.indexOf("// Handle API routes", start);
+    const pageDataRuntime = source.slice(start, end);
+
+    expect(pageDataRuntime.match(/request: targetRequest/g)).toHaveLength(2);
+    expect(pageDataRuntime).not.toMatch(/resolveFarmRouteContext[\s\S]*?\{\s*request,/);
+  });
+
+  it("passes the destination request to the secondary production handler", () => {
+    const source = readSource("nitro", "server-entry.ts");
+
+    expect(source).toContain("const targetRequest = new Request(targetUrl");
+    expect(source).toMatch(/sr\.resolveRouteContext\(\{\s*request: targetRequest,/);
+  });
+});

--- a/packages/farm/src/nitro/server-entry.ts
+++ b/packages/farm/src/nitro/server-entry.ts
@@ -141,6 +141,10 @@ async function defaultHandler({
       // Parse the target path
       const targetUrl = new URL(targetPath, url.origin);
       const targetPathname = targetUrl.pathname;
+      const targetRequest = new Request(targetUrl, {
+        method: "GET",
+        headers: request.headers,
+      });
 
       // Find the route
       const match = rm.matchRoute(targetPathname);
@@ -224,7 +228,7 @@ async function defaultHandler({
       const searchParams = searchParamsToObject(targetUrl.searchParams);
       const routeContext = sr
         ? await sr.resolveRouteContext({
-            request,
+            request: targetRequest,
             params,
             search: searchParams,
             path: targetUrl.pathname,

--- a/packages/farm/src/vite.ts
+++ b/packages/farm/src/vite.ts
@@ -2022,7 +2022,7 @@ window.__FARM_MANIFEST__ = ${inlineValue({
                 const targetUrl = new URL(targetPath, "http://localhost");
                 const searchParams = searchParamsToObject(targetUrl.searchParams);
                 const routeContext = await resolveFarmRouteContext(farmApp.getConfig(), {
-                  request,
+                  request: targetRequest,
                   params,
                   search: searchParams,
                   path: targetUrl.pathname,
@@ -2050,7 +2050,7 @@ window.__FARM_MANIFEST__ = ${inlineValue({
                           entry.pattern === slot.route.pattern,
                       ) ?? getClientModuleMetadata(slot.route.modulePath, server.config.root);
                     const slotContext = await resolveFarmRouteContext(farmApp.getConfig(), {
-                      request,
+                      request: targetRequest,
                       params: slot.params,
                       search: searchParams,
                       path: targetUrl.pathname,


### PR DESCRIPTION
## Problem

During SPA page-data rendering, application route-context factories can receive the internal /__farm/page-data request instead of the destination route URL.

## Root cause

The page-data handlers construct a destination Request for rendering but pass the original transport request to route-context resolution.

## Change

Pass the destination request consistently to page and slot route-context factories in development and to the secondary production page-data handler.

## Safety and compatibility

Headers and the GET method are preserved. Deployment checks and internal endpoint routing continue to use the original transport request.

## Verification

- pnpm --filter @farm.js/core exec vitest run src/__tests__/navigation-request-context.test.ts src/__tests__/searchparams.test.ts
- pnpm --filter @farm.js/core type-check
- pnpm exec oxlint packages/farm/src/vite.ts packages/farm/src/nitro/server-entry.ts packages/farm/src/__tests__/navigation-request-context.test.ts
- git diff --check

The source-contract regression finds the original request passed to resolveFarmRouteContext before this fix.

## Documentation and release

None; this restores the documented request context to the navigated route URL.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes SPA page-data rendering so route-context factories receive the destination route URL instead of the internal `/__farm/page-data` request.

- Passes the destination request to page and slot route-context factories in development and to the secondary production page-data handler.
- Preserves request headers and the GET method; deployment checks and internal endpoint routing continue to use the original transport request.
- Adds a bounded source-contract regression test that verifies the destination request is passed.

<sup>Written for commit 307176d03a2cf87ef26ed845cd144e3dc8780008. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/716?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

