### PR TITLE
fix(navigation): forward abort signals to route work

### DIFF
--- a/packages/farm/src/__tests__/navigation-request-context.test.ts
+++ b/packages/farm/src/__tests__/navigation-request-context.test.ts
@@ -16,6 +16,7 @@ describe("SPA navigation request context", () => {
     const pageDataRuntime = source.slice(start, end);
 
     expect(pageDataRuntime.match(/request: targetRequest/g)).toHaveLength(2);
+    expect(pageDataRuntime).toContain("signal: request.signal");
     expect(pageDataRuntime).not.toMatch(/resolveFarmRouteContext[\s\S]*?\{\s*request,/);
   });
 
@@ -23,6 +24,7 @@ describe("SPA navigation request context", () => {
     const source = readSource("nitro", "server-entry.ts");
 
     expect(source).toContain("const targetRequest = new Request(targetUrl");
+    expect(source).toContain("signal: request.signal");
     expect(source).toMatch(/sr\.resolveRouteContext\(\{\s*request: targetRequest,/);
   });
 });

--- a/packages/farm/src/__tests__/navigation-request-context.test.ts
+++ b/packages/farm/src/__tests__/navigation-request-context.test.ts
@@ -1,6 +1,8 @@
+import { EventEmitter } from "node:events";
 import fs from "node:fs";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
+import { createFarmNodeRequestAbortSignal } from "../vite";
 
 function readSource(...segments: string[]): string {
   return fs.readFileSync(path.join(process.cwd(), "src", ...segments), "utf8");
@@ -18,6 +20,31 @@ describe("SPA navigation request context", () => {
     expect(pageDataRuntime.match(/request: targetRequest/g)).toHaveLength(2);
     expect(pageDataRuntime).toContain("signal: request.signal");
     expect(pageDataRuntime).not.toMatch(/resolveFarmRouteContext[\s\S]*?\{\s*request,/);
+  });
+
+  it("aborts destination work when the development client disconnects", () => {
+    const request = new EventEmitter();
+    const response = Object.assign(new EventEmitter(), { writableEnded: false });
+    const signal = createFarmNodeRequestAbortSignal(request, response);
+
+    request.emit("aborted");
+
+    expect(signal.aborted).toBe(true);
+    expect(request.listenerCount("aborted")).toBe(0);
+    expect(response.listenerCount("close")).toBe(0);
+  });
+
+  it("does not abort after a development response finishes normally", () => {
+    const request = new EventEmitter();
+    const response = Object.assign(new EventEmitter(), { writableEnded: true });
+    const signal = createFarmNodeRequestAbortSignal(request, response);
+
+    response.emit("finish");
+    response.emit("close");
+
+    expect(signal.aborted).toBe(false);
+    expect(request.listenerCount("aborted")).toBe(0);
+    expect(response.listenerCount("close")).toBe(0);
   });
 
   it("passes the destination request to the secondary production handler", () => {

--- a/packages/farm/src/nitro/server-entry.ts
+++ b/packages/farm/src/nitro/server-entry.ts
@@ -144,6 +144,7 @@ async function defaultHandler({
       const targetRequest = new Request(targetUrl, {
         method: "GET",
         headers: request.headers,
+        signal: request.signal,
       });
 
       // Find the route

--- a/packages/farm/src/vite.ts
+++ b/packages/farm/src/vite.ts
@@ -255,6 +255,7 @@ function createRequestFromNodeRequest(
     headers: Record<string, string | string[] | undefined>;
   },
   url: URL,
+  signal?: AbortSignal,
 ): Request {
   const headers = new Headers();
   for (const [key, value] of Object.entries(req.headers)) {
@@ -268,7 +269,42 @@ function createRequestFromNodeRequest(
   return new Request(url.toString(), {
     method: req.method || "GET",
     headers,
+    signal,
   });
+}
+
+interface FarmNodeAbortRequest {
+  once(event: "aborted", listener: () => void): unknown;
+  off(event: "aborted", listener: () => void): unknown;
+}
+
+interface FarmNodeAbortResponse {
+  writableEnded: boolean;
+  once(event: "close" | "finish", listener: () => void): unknown;
+  off(event: "close" | "finish", listener: () => void): unknown;
+}
+
+/** Exported for tests: forwards a disconnected dev client to Web Request consumers. */
+export function createFarmNodeRequestAbortSignal(
+  req: FarmNodeAbortRequest,
+  res: FarmNodeAbortResponse,
+): AbortSignal {
+  const controller = new AbortController();
+  const dispose = () => {
+    req.off("aborted", abort);
+    res.off("close", abortOnEarlyClose);
+    res.off("finish", dispose);
+  };
+  const abort = () => controller.abort();
+  const abortOnEarlyClose = () => {
+    if (!res.writableEnded) abort();
+  };
+
+  req.once("aborted", abort);
+  res.once("close", abortOnEarlyClose);
+  res.once("finish", dispose);
+  controller.signal.addEventListener("abort", dispose, { once: true });
+  return controller.signal;
 }
 
 /** Exported for tests: the request boundary all Farm dev middlewares share. */
@@ -1901,7 +1937,11 @@ window.__FARM_MANIFEST__ = ${inlineValue({
             const targetPath = urlObj.searchParams.get("path") || "/";
 
             try {
-              const request = createRequestFromNodeRequest(req, urlObj);
+              const request = createRequestFromNodeRequest(
+                req,
+                urlObj,
+                createFarmNodeRequestAbortSignal(req, res),
+              );
               const deploymentMismatch = getFarmDeploymentMismatch(
                 request,
                 farmConfig.deploymentId,

--- a/packages/farm/src/vite.ts
+++ b/packages/farm/src/vite.ts
@@ -1918,6 +1918,7 @@ window.__FARM_MANIFEST__ = ${inlineValue({
               const targetRequest = new Request(targetRequestUrl, {
                 method: "GET",
                 headers: request.headers,
+                signal: request.signal,
               });
               await farmApp.getServerRenderer().runWithRequestContext(targetRequest, async () => {
                 const routeManager = farmApp.getRouteManager();


### PR DESCRIPTION
## Problem

When a page-data request is cancelled, work using the derived destination Request cannot observe that cancellation.

## Root cause

The destination Request copies the method and headers but omits the source request signal.

## Change

Forward the transport request AbortSignal to destination requests in development and the secondary production page-data handler.

## Safety and compatibility

No cancellation policy changes are introduced. Existing request cancellation now reaches loaders and request-local code through standard Request.signal semantics.

## Verification

- pnpm --filter @farm.js/core exec vitest run src/__tests__/navigation-request-context.test.ts
- pnpm --filter @farm.js/core type-check
- pnpm exec oxlint packages/farm/src/vite.ts packages/farm/src/nitro/server-entry.ts packages/farm/src/__tests__/navigation-request-context.test.ts
- git diff --check

The request-construction regression fails before the signal is forwarded.

## Documentation and release

None; this restores native cancellation propagation.

Stacked temporarily on #716 because that PR introduces the shared destination Request in the secondary handler. This PR will be retargeted to main after #716 merges.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Forwards the transport request abort signal to destination page-data Requests in development and the secondary production handler, so cancelled requests now propagate to loaders and request-local code through standard `Request.signal` semantics.

- The destination Request previously copied method and headers but omitted the signal, so cancellation was invisible to derived work.
- No cancellation policy changes are introduced; existing cancellation now reaches route work as expected.

<sup>Written for commit f6c82131ee4c07e01813c397916ac984822eb7fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/717?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

