### PR TITLE
fix(router): honor replace for document navigation

### DIFF
--- a/packages/farm/src/__tests__/client-component.test.ts
+++ b/packages/farm/src/__tests__/client-component.test.ts
@@ -732,7 +732,7 @@ export function Chart() {}
     expect(source).toContain("window.location.href = href;");
     expect(
       source.match(
-        /if \(options\.replace \|\| options\.action === "replace"\) window\.location\.replace\(url\.toString\(\)\);/g,
+        /if \(options\.replace \|\| options\.action === "replace"\) window\.location\.replace\(href\);/g,
       ),
     ).toHaveLength(4);
     expect(source).toContain("if (!newRoot || !currentRoot) return this.swapDocument(doc);");

--- a/packages/farm/src/__tests__/client-component.test.ts
+++ b/packages/farm/src/__tests__/client-component.test.ts
@@ -730,6 +730,11 @@ export function Chart() {}
 
     expect(source).toContain("if (!this.swapContent(html))");
     expect(source).toContain("window.location.href = href;");
+    expect(
+      source.match(
+        /if \(options\.replace \|\| options\.action === "replace"\) window\.location\.replace\(url\.toString\(\)\);/g,
+      ),
+    ).toHaveLength(4);
     expect(source).toContain("if (!newRoot || !currentRoot) return this.swapDocument(doc);");
     expect(source).toContain("swapDocument: function(doc)");
     expect(source).toContain("document.body.innerHTML = doc.body.innerHTML;");

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -2125,13 +2125,13 @@ ${generateUniversalRouterStateProperties()}
     const url = new URL(href, window.location.origin);
     if (isFarmExternalNavigationURL(url, window.location.origin)) {
       this.cancelActiveNavigation();
-      if (options.replace || options.action === "replace") window.location.replace(url.toString());
+      if (options.replace || options.action === "replace") window.location.replace(href);
       else window.location.href = href;
       return;
     }
     if (isFarmDocsPath(url.pathname)) {
       this.cancelActiveNavigation();
-      if (options.replace || options.action === "replace") window.location.replace(url.toString());
+      if (options.replace || options.action === "replace") window.location.replace(href);
       else window.location.href = href;
       return;
     }
@@ -2996,13 +2996,13 @@ ${generateUniversalRouterStateProperties()}
     const url = new URL(href, window.location.origin);
     if (isFarmExternalNavigationURL(url, window.location.origin)) {
       this.cancelActiveNavigation();
-      if (options.replace || options.action === "replace") window.location.replace(url.toString());
+      if (options.replace || options.action === "replace") window.location.replace(href);
       else window.location.href = href;
       return;
     }
     if (isFarmDocsPath(url.pathname)) {
       this.cancelActiveNavigation();
-      if (options.replace || options.action === "replace") window.location.replace(url.toString());
+      if (options.replace || options.action === "replace") window.location.replace(href);
       else window.location.href = href;
       return;
     }

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -2125,12 +2125,14 @@ ${generateUniversalRouterStateProperties()}
     const url = new URL(href, window.location.origin);
     if (isFarmExternalNavigationURL(url, window.location.origin)) {
       this.cancelActiveNavigation();
-      window.location.href = href;
+      if (options.replace || options.action === "replace") window.location.replace(url.toString());
+      else window.location.href = href;
       return;
     }
     if (isFarmDocsPath(url.pathname)) {
       this.cancelActiveNavigation();
-      window.location.href = href;
+      if (options.replace || options.action === "replace") window.location.replace(url.toString());
+      else window.location.href = href;
       return;
     }
 
@@ -2994,12 +2996,14 @@ ${generateUniversalRouterStateProperties()}
     const url = new URL(href, window.location.origin);
     if (isFarmExternalNavigationURL(url, window.location.origin)) {
       this.cancelActiveNavigation();
-      window.location.href = href;
+      if (options.replace || options.action === "replace") window.location.replace(url.toString());
+      else window.location.href = href;
       return;
     }
     if (isFarmDocsPath(url.pathname)) {
       this.cancelActiveNavigation();
-      window.location.href = href;
+      if (options.replace || options.action === "replace") window.location.replace(url.toString());
+      else window.location.href = href;
       return;
     }
 


### PR DESCRIPTION
## Problem

In generated production routers, replace navigation to an external URL or a docs route creates a new history entry instead of replacing the current one.

## Root cause

Document-navigation branches assign location.href before considering the requested replace action.

## Change

Use location.replace for replace actions in both generated router variants while retaining the existing assignment behavior for push and pop navigation.

## Safety and compatibility

Development already follows these semantics. SPA navigation, route matching, and ordinary push behavior are unchanged.

## Verification

- pnpm --filter @farm.js/core exec vitest run src/__tests__/client-component.test.ts
- pnpm --filter @farm.js/core type-check
- pnpm exec oxlint packages/farm/src/nitro/universal-build.ts packages/farm/src/__tests__/client-component.test.ts
- git diff --check

The generated-runtime regression finds no location.replace branch before this fix.

## Documentation and release

None; this restores the existing router.replace contract.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes document navigation in generated production routers so replace actions now call `location.replace` instead of assigning `location.href`, which previously created a new history entry instead of replacing the current one. Push and pop navigation, SPA routing, and external URL handling remain unchanged.

<sup>Written for commit 6912948e6ff345ec8638f936ab72a9b36841b1ae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/718?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

