### PR TITLE
fix(middleware): preserve cookies on returned responses

### DIFF
--- a/docs/src/app/docs/middleware/page.md
+++ b/docs/src/app/docs/middleware/page.md
@@ -26,7 +26,8 @@ Data and headers written during middleware are request-scoped:
 | `return new Response(...)`                                           | Stops the chain and sends that response immediately.                                          |
 
 Cookies set by multiple matching middleware handlers are accumulated into separate `Set-Cookie`
-headers; a later handler does not replace cookies already written by an earlier handler.
+headers. They are also preserved when the short-circuiting `Response` supplies its own cookies, so
+a returned response does not replace cookies already written through `ctx.cookies`.
 
 ## Route middleware
 

--- a/packages/farm/src/__tests__/middleware.test.ts
+++ b/packages/farm/src/__tests__/middleware.test.ts
@@ -2047,6 +2047,37 @@ describe("Middleware Manager Data Flow", () => {
     expect(res.setHeader).toHaveBeenCalledWith("x-middleware", "/dashboard/settings");
   });
 
+  it("keeps context cookies when middleware returns a Response with cookies", async () => {
+    const manager = new MiddlewareManager("/tmp", undefined, [
+      {
+        matcher: "/dashboard/:path*",
+        handler(ctx) {
+          ctx.cookies.set("session", "abc", { httpOnly: true });
+          return new Response(null, {
+            status: 204,
+            headers: { "Set-Cookie": "theme=dark; Path=/" },
+          });
+        },
+      },
+    ]);
+    const req = createMockRequest("/dashboard/settings");
+    const res = createMockResponse();
+    let setCookieHeader: string | string[] | undefined;
+    vi.mocked(res.setHeader).mockImplementation((name, value) => {
+      if (String(name).toLowerCase() === "set-cookie") {
+        setCookieHeader = value as string | string[];
+      }
+      return res;
+    });
+    vi.spyOn(res, "getHeader").mockImplementation((name) =>
+      String(name).toLowerCase() === "set-cookie" ? setCookieHeader : undefined,
+    );
+
+    await expect(manager.execute(req, res)).resolves.toBe(true);
+
+    expect(setCookieHeader).toEqual(["session=abc; Path=/; HttpOnly", "theme=dark; Path=/"]);
+  });
+
   it("emits middleware observability events", async () => {
     const events: FarmEvent[] = [];
     configureFarmObservability({ onEvent: (event) => events.push(event) });

--- a/packages/farm/src/__tests__/server-response.test.ts
+++ b/packages/farm/src/__tests__/server-response.test.ts
@@ -2,6 +2,40 @@ import { describe, expect, it } from "vitest";
 import { sendWebResponse } from "../server/response";
 
 describe("sendWebResponse", () => {
+  it("keeps comma-joined fallback cookies separate without splitting Expires", async () => {
+    const headers = new Map<string, string | string[]>();
+    const res = {
+      statusCode: 200,
+      writableEnded: false,
+      getHeader: (key: string) => headers.get(key),
+      setHeader: (key: string, value: string | string[]) => {
+        headers.set(key, value);
+      },
+      end: () => {
+        res.writableEnded = true;
+      },
+    };
+    const response = {
+      status: 204,
+      body: null,
+      headers: {
+        forEach(callback: (value: string, key: string) => void) {
+          callback(
+            "session=abc; Expires=Wed, 21 Oct 2030 07:28:00 GMT; Path=/, theme=dark; Path=/",
+            "set-cookie",
+          );
+        },
+      },
+    };
+
+    await sendWebResponse(res as any, response as Response);
+
+    expect(headers.get("Set-Cookie")).toEqual([
+      "session=abc; Expires=Wed, 21 Oct 2030 07:28:00 GMT; Path=/",
+      "theme=dark; Path=/",
+    ]);
+  });
+
   it("streams bodies to Node-compatible response adapters without EventEmitter internals", async () => {
     const chunks: Buffer[] = [];
     const headers = new Map<string, string | string[]>();

--- a/packages/farm/src/server/response.ts
+++ b/packages/farm/src/server/response.ts
@@ -72,6 +72,36 @@ async function waitForWritable(res: ServerResponse): Promise<boolean> {
   }
 }
 
+/**
+ * Older Fetch implementations expose repeated Set-Cookie fields as one
+ * comma-joined value. Split only at a comma followed by another cookie-pair;
+ * commas inside Expires dates remain part of the current cookie.
+ */
+function splitSetCookieHeader(value: string): string[] {
+  const cookies: string[] = [];
+  let start = 0;
+
+  for (let index = 0; index < value.length; index += 1) {
+    if (value[index] !== ",") continue;
+
+    let next = index + 1;
+    while (value[next] === " " || value[next] === "\t") next += 1;
+
+    const equals = value.indexOf("=", next);
+    if (equals === -1) continue;
+
+    const separator = value.slice(next, equals);
+    if (separator.length === 0 || /[;,\s]/.test(separator)) continue;
+
+    cookies.push(value.slice(start, index).trim());
+    start = next;
+    index = next - 1;
+  }
+
+  cookies.push(value.slice(start).trim());
+  return cookies.filter(Boolean);
+}
+
 export async function sendWebResponse(res: ServerResponse, response: Response): Promise<void> {
   res.statusCode = response.status;
 
@@ -87,15 +117,17 @@ export async function sendWebResponse(res: ServerResponse, response: Response): 
 
   const responseHeaders = response.headers as Headers & {
     getSetCookie?: () => string[];
+    raw?: () => Record<string, string[]>;
   };
-  const setCookies = responseHeaders.getSetCookie?.() || [];
+  const rawSetCookies = responseHeaders.raw?.()["set-cookie"];
+  const setCookies = responseHeaders.getSetCookie?.() || rawSetCookies || [];
   if (setCookies.length > 0) {
     appendSetCookies(setCookies);
   }
 
   response.headers.forEach((value, key) => {
     if (key.toLowerCase() === "set-cookie") {
-      if (setCookies.length === 0) appendSetCookies([value]);
+      if (setCookies.length === 0) appendSetCookies(splitSetCookieHeader(value));
       return;
     }
     res.setHeader(key, value);

--- a/packages/farm/src/server/response.ts
+++ b/packages/farm/src/server/response.ts
@@ -75,16 +75,27 @@ async function waitForWritable(res: ServerResponse): Promise<boolean> {
 export async function sendWebResponse(res: ServerResponse, response: Response): Promise<void> {
   res.statusCode = response.status;
 
+  const appendSetCookies = (cookies: readonly string[]) => {
+    const existing = typeof res.getHeader === "function" ? res.getHeader("Set-Cookie") : undefined;
+    const existingCookies = Array.isArray(existing)
+      ? existing.map(String)
+      : existing === undefined
+        ? []
+        : [String(existing)];
+    res.setHeader("Set-Cookie", [...existingCookies, ...cookies]);
+  };
+
   const responseHeaders = response.headers as Headers & {
     getSetCookie?: () => string[];
   };
   const setCookies = responseHeaders.getSetCookie?.() || [];
   if (setCookies.length > 0) {
-    res.setHeader("Set-Cookie", setCookies);
+    appendSetCookies(setCookies);
   }
 
   response.headers.forEach((value, key) => {
-    if (key.toLowerCase() === "set-cookie" && setCookies.length > 0) {
+    if (key.toLowerCase() === "set-cookie") {
+      if (setCookies.length === 0) appendSetCookies([value]);
       return;
     }
     res.setHeader(key, value);

--- a/packages/farm/src/server/response.ts
+++ b/packages/farm/src/server/response.ts
@@ -75,7 +75,9 @@ async function waitForWritable(res: ServerResponse): Promise<boolean> {
 /**
  * Older Fetch implementations expose repeated Set-Cookie fields as one
  * comma-joined value. Split only at a comma followed by another cookie-pair;
- * commas inside Expires dates remain part of the current cookie.
+ * commas inside Expires dates remain part of the current cookie. RFC cookie
+ * values exclude commas, so a comma followed by a cookie-pair is unambiguous
+ * for valid Set-Cookie syntax once the original field boundaries are lost.
  */
 function splitSetCookieHeader(value: string): string[] {
   const cookies: string[] = [];


### PR DESCRIPTION
## Problem

A middleware handler could set a cookie through `ctx.cookies` and then return a Web `Response` with another `Set-Cookie` header. The Node response bridge replaced the cookies already accumulated on the response, so development dropped the context cookie while the production middleware runtime preserved both.

## Root cause

`sendWebResponse` assigned the returned response's `Set-Cookie` array directly with `setHeader`, overwriting any value already present on the Node response.

## Change

Append response cookies to the Node response's existing cookie header. The fallback path for runtimes without `Headers.getSetCookie()` uses the same append behavior. A middleware-manager regression test covers the complete short-circuit path.

## Safety and compatibility

Ordinary headers retain their existing replacement behavior. Only `Set-Cookie`, whose HTTP semantics require separate fields, is accumulated. This aligns Vite development with the existing production middleware behavior.

## Verification

- `pnpm --filter @farm.js/core exec vitest run src/__tests__/middleware.test.ts src/__tests__/server-response.test.ts --reporter=dot` (93 tests passed)
- `pnpm --filter @farm.js/core type-check`
- `pnpm exec oxfmt packages/farm/src/server/response.ts packages/farm/src/__tests__/middleware.test.ts docs/src/app/docs/middleware/page.md`
- `pnpm exec oxlint packages/farm/src/server/response.ts packages/farm/src/__tests__/middleware.test.ts` (existing warnings only)
- `git diff --check`

The regression test fails before the response bridge change: only `theme=dark` remains instead of both cookies.

## Documentation and release

Updated the middleware cookie behavior documentation. No generated artifacts or template changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Vite development middleware runtime so cookies set through `ctx.cookies` are no longer dropped when a middleware returns a `Response` with its own `Set-Cookie` header. The returned response's cookies are now appended to the already-accumulated cookies, matching production middleware behavior where both are preserved.

- Only `Set-Cookie` headers are accumulated; all other headers keep their existing replacement behavior.
- The fallback path for runtimes without `Headers.getSetCookie()` appends cookies and splits comma-joined values without corrupting `Expires` dates.
- Adds regression tests for the short-circuit and fallback paths and updates the middleware cookie documentation.

<sup>Written for commit a1fd61e339f2705a1bee681c4c311b557b0e5504. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/720?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

