### PR TITLE
fix(api): reject unstable base paths

### DIFF
--- a/docs/src/app/docs/configuration/page.md
+++ b/docs/src/app/docs/configuration/page.md
@@ -315,7 +315,8 @@ public URL in the browser bundle.
 A root-relative API root is also mounted by Farm in development and production. For example,
 `api: { basePath: "/v2/api" }` makes a route declared at `app/api/users/route.ts` available at
 `/v2/api/users`. Farm treats an absolute `baseURL` as external and does not remount the current
-application's API routes for it.
+application's API routes for it. `basePath` rejects backslashes, control characters, and `.` or
+`..` segments so the server mount and browser URL cannot normalize to different paths.
 
 The option configures `createAPIClient()` automatically. An explicit per-client `baseURL` still
 takes precedence.

--- a/packages/farm/src/__tests__/api-config.test.ts
+++ b/packages/farm/src/__tests__/api-config.test.ts
@@ -83,6 +83,15 @@ describe("Farm API config", () => {
     expect(() => normalizeFarmAPIConfig({ basePath: "/api\\admin" })).toThrow(
       "cannot contain backslashes or control characters",
     );
+    expect(() => normalizeFarmAPIConfig({ basePath: "\n/api" })).toThrow(
+      "cannot contain backslashes or control characters",
+    );
+    expect(() => normalizeFarmAPIConfig({ basePath: "/api/\u0085admin" })).toThrow(
+      "cannot contain backslashes or control characters",
+    );
+    expect(() => normalizeFarmAPIConfig({ basePath: "/api/%0Aadmin" })).toThrow(
+      "cannot contain backslashes or control characters",
+    );
     expect(() => normalizeFarmAPIConfig({ basePath: "/api/../admin" })).toThrow(
       'cannot contain "." or ".." path segments',
     );

--- a/packages/farm/src/__tests__/api-config.test.ts
+++ b/packages/farm/src/__tests__/api-config.test.ts
@@ -80,6 +80,15 @@ describe("Farm API config", () => {
     expect(() => normalizeFarmAPIConfig({ basePath: "/api?version=1" })).toThrow(
       "cannot contain a query string or hash",
     );
+    expect(() => normalizeFarmAPIConfig({ basePath: "/api\\admin" })).toThrow(
+      "cannot contain backslashes or control characters",
+    );
+    expect(() => normalizeFarmAPIConfig({ basePath: "/api/../admin" })).toThrow(
+      'cannot contain "." or ".." path segments',
+    );
+    expect(() => normalizeFarmAPIConfig({ basePath: "/api/%2e%2e/admin" })).toThrow(
+      'cannot contain "." or ".." path segments',
+    );
   });
 
   it("replaces the canonical /api prefix when the API root has a path", () => {

--- a/packages/farm/src/api/config.ts
+++ b/packages/farm/src/api/config.ts
@@ -94,6 +94,17 @@ export function normalizeFarmAPIConfig(
 }
 
 export function normalizeFarmAPIBasePath(value: string): string {
+  const hasUnstableCharacters = (candidate: string) =>
+    candidate.includes("\\") ||
+    Array.from(candidate).some((character) => {
+      const code = character.charCodeAt(0);
+      return code <= 31 || (code >= 127 && code <= 159);
+    });
+
+  if (hasUnstableCharacters(value)) {
+    throw new Error("Farm api.basePath cannot contain backslashes or control characters.");
+  }
+
   const path = value.trim();
   if (!path) {
     throw new Error("Farm api.basePath cannot be empty.");
@@ -101,16 +112,6 @@ export function normalizeFarmAPIBasePath(value: string): string {
   if (path.includes("?") || path.includes("#")) {
     throw new Error("Farm api.basePath cannot contain a query string or hash.");
   }
-  if (
-    path.includes("\\") ||
-    Array.from(path).some((character) => {
-      const code = character.charCodeAt(0);
-      return code <= 31 || code === 127;
-    })
-  ) {
-    throw new Error("Farm api.basePath cannot contain backslashes or control characters.");
-  }
-
   for (const segment of path.split("/")) {
     let decoded = segment;
     try {
@@ -118,6 +119,9 @@ export function normalizeFarmAPIBasePath(value: string): string {
     } catch {
       // A malformed escape remains literal in a URL pathname. It cannot be a
       // dot segment, so leave the ordinary URL parser to preserve it.
+    }
+    if (hasUnstableCharacters(decoded)) {
+      throw new Error("Farm api.basePath cannot contain backslashes or control characters.");
     }
     if (decoded === "." || decoded === "..") {
       throw new Error('Farm api.basePath cannot contain "." or ".." path segments.');

--- a/packages/farm/src/api/config.ts
+++ b/packages/farm/src/api/config.ts
@@ -101,6 +101,28 @@ export function normalizeFarmAPIBasePath(value: string): string {
   if (path.includes("?") || path.includes("#")) {
     throw new Error("Farm api.basePath cannot contain a query string or hash.");
   }
+  if (
+    path.includes("\\") ||
+    Array.from(path).some((character) => {
+      const code = character.charCodeAt(0);
+      return code <= 31 || code === 127;
+    })
+  ) {
+    throw new Error("Farm api.basePath cannot contain backslashes or control characters.");
+  }
+
+  for (const segment of path.split("/")) {
+    let decoded = segment;
+    try {
+      decoded = decodeURIComponent(segment);
+    } catch {
+      // A malformed escape remains literal in a URL pathname. It cannot be a
+      // dot segment, so leave the ordinary URL parser to preserve it.
+    }
+    if (decoded === "." || decoded === "..") {
+      throw new Error('Farm api.basePath cannot contain "." or ".." path segments.');
+    }
+  }
 
   const normalized = `/${path.replace(/^\/+|\/+$/g, "")}`;
   return normalized === "/" ? "/" : normalized;


### PR DESCRIPTION
## Problem

`api.basePath` accepted backslashes and dot segments even though the browser URL parser rewrites them. A configured `/api\\admin` mounted literally on the server but generated requests to `/api/admin`; `/api/../admin` generated requests under `/admin`. The client and server therefore disagreed about the API root.

## Root cause

The base-path normalizer only trimmed outer slashes and rejected query/hash delimiters. It did not reject path syntax with browser-defined normalization behavior.

## Change

Reject literal backslashes, control characters, and literal or percent-encoded `.`/`..` segments during config resolution. Tests cover the two observed mismatches and encoded traversal syntax.

## Safety and compatibility

Ordinary root-relative paths, repeated slashes, Unicode segments, and malformed percent escapes retain their current behavior. Previously accepted paths whose browser and server meanings differed now fail during configuration with an actionable error.

## Verification

- `pnpm --filter @farm.js/core exec vitest run src/__tests__/api-config.test.ts --reporter=dot` (9 tests passed)
- `pnpm --filter @farm.js/core type-check`
- `pnpm exec oxfmt packages/farm/src/api/config.ts packages/farm/src/__tests__/api-config.test.ts docs/src/app/docs/configuration/page.md`
- `pnpm exec oxlint packages/farm/src/api/config.ts packages/farm/src/__tests__/api-config.test.ts` (0 warnings, 0 errors)
- `git diff --check`

Without the validation, the regression inputs are accepted and browser request construction changes their path.

## Documentation and release

Documented the rejected path syntax. No generated artifacts or template changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects `api.basePath` values containing backslashes, ASCII and C1 control characters, or literal or percent-encoded `.`/`..` segments. These syntaxes were previously accepted but rewritten by the browser URL parser, causing the server mount and client requests to point to different paths. Now config resolution fails with an actionable error.

- Adds tests for backslash, control characters, literal dot segments, and percent-encoded traversal.
- Updates the configuration docs to list the rejected syntax.

<sup>Written for commit e225beabbf5f46465c0ee73cbe463fff451b0038. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/721?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

