### PR TITLE
fix(query): round-trip array item delimiters

### DIFF
--- a/docs/src/app/docs/query/page.md
+++ b/docs/src/app/docs/query/page.md
@@ -128,10 +128,18 @@ unsafe `page` values fall back to page 1. `totalItems` must be a non-negative sa
 | `asIsoDate`         | Calendar-valid `YYYY-MM-DD` values.                       |
 | `asIsoDateTime`     | Calendar-valid ISO date-times with `Z` or numeric offset. |
 
-`asArrayOf` keeps the readable comma-separated format for simple values. When an item contains a
-comma or would otherwise be ambiguous, Farm switches to a structured representation automatically
-so parsing the generated URL returns the original items. The representation uses a versioned
-`~farm-array:v1:` namespace; older values such as `~[]` keep their comma-format meaning.
+`asArrayOf` keeps its existing comma-separated format by default. When items can contain commas,
+empty strings, or significant surrounding whitespace, opt in to the structured format so generated
+URLs round-trip those values:
+
+```ts
+const locations = asArrayOf(asString, { format: "structured" });
+```
+
+The structured parser still accepts ordinary comma URLs during migration and emits a versioned
+`~farm-array:v1:` representation only when the comma format would lose information. Because the
+default parser never reserves that namespace, existing literal values such as
+`~farm-array:v1:["legacy"]` retain their comma-format meaning.
 
 ## Production notes
 

--- a/docs/src/app/docs/query/page.md
+++ b/docs/src/app/docs/query/page.md
@@ -130,7 +130,8 @@ unsafe `page` values fall back to page 1. `totalItems` must be a non-negative sa
 
 `asArrayOf` keeps the readable comma-separated format for simple values. When an item contains a
 comma or would otherwise be ambiguous, Farm switches to a structured representation automatically
-so parsing the generated URL returns the original items.
+so parsing the generated URL returns the original items. The representation uses a versioned
+`~farm-array:v1:` namespace; older values such as `~[]` keep their comma-format meaning.
 
 ## Production notes
 

--- a/docs/src/app/docs/query/page.md
+++ b/docs/src/app/docs/query/page.md
@@ -128,6 +128,10 @@ unsafe `page` values fall back to page 1. `totalItems` must be a non-negative sa
 | `asIsoDate`         | Calendar-valid `YYYY-MM-DD` values.                       |
 | `asIsoDateTime`     | Calendar-valid ISO date-times with `Z` or numeric offset. |
 
+`asArrayOf` keeps the readable comma-separated format for simple values. When an item contains a
+comma or would otherwise be ambiguous, Farm switches to a structured representation automatically
+so parsing the generated URL returns the original items.
+
 ## Production notes
 
 - Parse query on the server before passing values to database queries.

--- a/docs/src/app/docs/query/page.md
+++ b/docs/src/app/docs/query/page.md
@@ -129,11 +129,23 @@ unsafe `page` values fall back to page 1. `totalItems` must be a non-negative sa
 | `asIsoDateTime`     | Calendar-valid ISO date-times with `Z` or numeric offset. |
 
 `asArrayOf` keeps its existing comma-separated format by default. When items can contain commas,
-empty strings, or significant surrounding whitespace, opt in to the structured format so generated
-URLs round-trip those values:
+opt in to the structured format so generated URLs round-trip those values:
 
 ```ts
 const locations = asArrayOf(asString, { format: "structured" });
+```
+
+The item parser still decides how each value is normalized. `asString` trims surrounding whitespace
+and treats an empty string as missing. Use an exact string parser when those values are significant:
+
+```ts
+import { asArrayOf, createParser } from "@farm.js/core/query";
+
+const exactString = createParser<string>({
+  parse: (value) => value,
+  serialize: (value) => value,
+});
+const labels = asArrayOf(exactString, { format: "structured" });
 ```
 
 The structured parser still accepts ordinary comma URLs during migration and emits a versioned

--- a/packages/farm/src/__tests__/query-parsers.test.ts
+++ b/packages/farm/src/__tests__/query-parsers.test.ts
@@ -31,6 +31,33 @@ describe("query parsers", () => {
     expect(stringParser.parse(stringParser.serialize(["", "value"]))).toEqual(["", "value"]);
   });
 
+  it("round-trips items whose surrounding whitespace is significant", () => {
+    const parser = asArrayOf({
+      parse: (value: string) => value,
+      serialize: (value: string) => value,
+    });
+
+    expect(parser.parse(parser.serialize([" leading", "trailing ", " "]))).toEqual([
+      " leading",
+      "trailing ",
+      " ",
+    ]);
+  });
+
+  it("keeps legacy values using the old structured-looking prefix", () => {
+    const parser = asArrayOf(asString);
+
+    expect(parser.parse("~[]")).toEqual(["~[]"]);
+    expect(parser.parse('~["a"]')).toEqual(['~["a"]']);
+  });
+
+  it("escapes values in the versioned structured namespace", () => {
+    const parser = asArrayOf(asString);
+    const value = ['~farm-array:v1:["legacy"]'];
+
+    expect(parser.parse(parser.serialize(value))).toEqual(value);
+  });
+
   it("keeps malformed structured-looking values on the legacy path", () => {
     const parser = asArrayOf(asString);
 

--- a/packages/farm/src/__tests__/query-parsers.test.ts
+++ b/packages/farm/src/__tests__/query-parsers.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { asArrayOf, asJson, asString } from "../query/parsers";
+
+describe("query parsers", () => {
+  it("keeps the readable comma format for simple arrays", () => {
+    const parser = asArrayOf(asString);
+
+    expect(parser.serialize(["react", "vite"])).toBe("react,vite");
+    expect(parser.parse("react,vite")).toEqual(["react", "vite"]);
+  });
+
+  it("round-trips array items containing the delimiter", () => {
+    const parser = asArrayOf(asString);
+    const value = ["New York, NY", "Los Angeles, CA"];
+
+    expect(parser.parse(parser.serialize(value))).toEqual(value);
+  });
+
+  it("round-trips serialized nested values and empty items", () => {
+    const jsonParser = asArrayOf(asJson<{ label: string; count: number }>());
+    const jsonValue = [
+      { label: "alpha, beta", count: 1 },
+      { label: "gamma", count: 2 },
+    ];
+    const stringParser = asArrayOf({
+      parse: (value: string) => value,
+      serialize: (value: string) => value,
+    });
+
+    expect(jsonParser.parse(jsonParser.serialize(jsonValue))).toEqual(jsonValue);
+    expect(stringParser.parse(stringParser.serialize(["", "value"]))).toEqual(["", "value"]);
+  });
+
+  it("keeps malformed structured-looking values on the legacy path", () => {
+    const parser = asArrayOf(asString);
+
+    expect(parser.parse("~[not-json,second")).toEqual(["~[not-json", "second"]);
+  });
+});

--- a/packages/farm/src/__tests__/query-parsers.test.ts
+++ b/packages/farm/src/__tests__/query-parsers.test.ts
@@ -10,32 +10,40 @@ describe("query parsers", () => {
   });
 
   it("round-trips array items containing the delimiter", () => {
-    const parser = asArrayOf(asString);
+    const parser = asArrayOf(asString, { format: "structured" });
     const value = ["New York, NY", "Los Angeles, CA"];
 
     expect(parser.parse(parser.serialize(value))).toEqual(value);
   });
 
   it("round-trips serialized nested values and empty items", () => {
-    const jsonParser = asArrayOf(asJson<{ label: string; count: number }>());
+    const jsonParser = asArrayOf(asJson<{ label: string; count: number }>(), {
+      format: "structured",
+    });
     const jsonValue = [
       { label: "alpha, beta", count: 1 },
       { label: "gamma", count: 2 },
     ];
-    const stringParser = asArrayOf({
-      parse: (value: string) => value,
-      serialize: (value: string) => value,
-    });
+    const stringParser = asArrayOf(
+      {
+        parse: (value: string) => value,
+        serialize: (value: string) => value,
+      },
+      { format: "structured" },
+    );
 
     expect(jsonParser.parse(jsonParser.serialize(jsonValue))).toEqual(jsonValue);
     expect(stringParser.parse(stringParser.serialize(["", "value"]))).toEqual(["", "value"]);
   });
 
   it("round-trips items whose surrounding whitespace is significant", () => {
-    const parser = asArrayOf({
-      parse: (value: string) => value,
-      serialize: (value: string) => value,
-    });
+    const parser = asArrayOf(
+      {
+        parse: (value: string) => value,
+        serialize: (value: string) => value,
+      },
+      { format: "structured" },
+    );
 
     expect(parser.parse(parser.serialize([" leading", "trailing ", " "]))).toEqual([
       " leading",
@@ -51,8 +59,16 @@ describe("query parsers", () => {
     expect(parser.parse('~["a"]')).toEqual(['~["a"]']);
   });
 
-  it("escapes values in the versioned structured namespace", () => {
+  it("does not reserve the structured namespace in the default comma format", () => {
     const parser = asArrayOf(asString);
+    const value = '~farm-array:v1:["legacy"]';
+
+    expect(parser.parse(value)).toEqual([value]);
+    expect(parser.serialize([value])).toBe(value);
+  });
+
+  it("escapes values in the versioned structured namespace", () => {
+    const parser = asArrayOf(asString, { format: "structured" });
     const value = ['~farm-array:v1:["legacy"]'];
 
     expect(parser.parse(parser.serialize(value))).toEqual(value);

--- a/packages/farm/src/query/client.ts
+++ b/packages/farm/src/query/client.ts
@@ -24,6 +24,7 @@ export {
   asIsoDate,
   asIsoDateTime,
   createParser,
+  type ArrayParserOptions,
   type Parser,
   type inferParserType,
 } from "./parsers";

--- a/packages/farm/src/query/index.ts
+++ b/packages/farm/src/query/index.ts
@@ -20,6 +20,7 @@ export {
   asIsoDate,
   asIsoDateTime,
   createParser,
+  type ArrayParserOptions,
   type Parser,
   type inferParserType,
 } from "./parsers";

--- a/packages/farm/src/query/parsers.ts
+++ b/packages/farm/src/query/parsers.ts
@@ -123,12 +123,12 @@ export const asBoolean: Parser<boolean> = {
 };
 
 // Array parser
-const STRUCTURED_ARRAY_PREFIX = "~[";
+const STRUCTURED_ARRAY_PREFIX = "~farm-array:v1:";
 
 function parseArrayItems(value: string): string[] {
   if (value.startsWith(STRUCTURED_ARRAY_PREFIX)) {
     try {
-      const parsed = JSON.parse(value.slice(1));
+      const parsed = JSON.parse(value.slice(STRUCTURED_ARRAY_PREFIX.length));
       if (Array.isArray(parsed) && parsed.every((item) => typeof item === "string")) {
         return parsed;
       }
@@ -146,9 +146,14 @@ function parseArrayItems(value: string): string[] {
 function serializeArrayItems(values: string[]): string {
   const needsStructuredEncoding = values.some(
     (value, index) =>
-      value === "" || value.includes(",") || (index === 0 && value.startsWith("~[")),
+      value === "" ||
+      value.trim() !== value ||
+      value.includes(",") ||
+      (index === 0 && value.startsWith(STRUCTURED_ARRAY_PREFIX)),
   );
-  return needsStructuredEncoding ? `~${JSON.stringify(values)}` : values.join(",");
+  return needsStructuredEncoding
+    ? `${STRUCTURED_ARRAY_PREFIX}${JSON.stringify(values)}`
+    : values.join(",");
 }
 
 export function asArrayOf<T>(itemParser: Parser<T>): Parser<T[]> {

--- a/packages/farm/src/query/parsers.ts
+++ b/packages/farm/src/query/parsers.ts
@@ -124,9 +124,13 @@ export const asBoolean: Parser<boolean> = {
 
 // Array parser
 const STRUCTURED_ARRAY_PREFIX = "~farm-array:v1:";
+export interface ArrayParserOptions {
+  /** Preserve comma URLs by default; opt in when item delimiters must round-trip. */
+  format?: "comma" | "structured";
+}
 
-function parseArrayItems(value: string): string[] {
-  if (value.startsWith(STRUCTURED_ARRAY_PREFIX)) {
+function parseArrayItems(value: string, structured: boolean): string[] {
+  if (structured && value.startsWith(STRUCTURED_ARRAY_PREFIX)) {
     try {
       const parsed = JSON.parse(value.slice(STRUCTURED_ARRAY_PREFIX.length));
       if (Array.isArray(parsed) && parsed.every((item) => typeof item === "string")) {
@@ -143,7 +147,9 @@ function parseArrayItems(value: string): string[] {
     .map((item) => item.trim());
 }
 
-function serializeArrayItems(values: string[]): string {
+function serializeArrayItems(values: string[], structured: boolean): string {
+  if (!structured) return values.join(",");
+
   const needsStructuredEncoding = values.some(
     (value, index) =>
       value === "" ||
@@ -156,15 +162,19 @@ function serializeArrayItems(values: string[]): string {
     : values.join(",");
 }
 
-export function asArrayOf<T>(itemParser: Parser<T>): Parser<T[]> {
+export function asArrayOf<T>(itemParser: Parser<T>, options: ArrayParserOptions = {}): Parser<T[]> {
+  const structured = options.format === "structured";
   const parse = (value: string): T[] | null => {
     if (!value) return null;
-    return parseArrayItems(value)
+    return parseArrayItems(value, structured)
       .map((item) => itemParser.parse(item))
       .filter((item) => item !== null) as T[];
   };
   const serialize = (value: T[]) =>
-    serializeArrayItems(value.map((item) => itemParser.serialize(item)));
+    serializeArrayItems(
+      value.map((item) => itemParser.serialize(item)),
+      structured,
+    );
 
   return {
     parse,

--- a/packages/farm/src/query/parsers.ts
+++ b/packages/farm/src/query/parsers.ts
@@ -123,27 +123,50 @@ export const asBoolean: Parser<boolean> = {
 };
 
 // Array parser
+const STRUCTURED_ARRAY_PREFIX = "~[";
+
+function parseArrayItems(value: string): string[] {
+  if (value.startsWith(STRUCTURED_ARRAY_PREFIX)) {
+    try {
+      const parsed = JSON.parse(value.slice(1));
+      if (Array.isArray(parsed) && parsed.every((item) => typeof item === "string")) {
+        return parsed;
+      }
+    } catch {
+      // Keep accepting legacy values that happen to begin with the prefix.
+    }
+  }
+
+  return value
+    .split(",")
+    .filter(Boolean)
+    .map((item) => item.trim());
+}
+
+function serializeArrayItems(values: string[]): string {
+  const needsStructuredEncoding = values.some(
+    (value, index) =>
+      value === "" || value.includes(",") || (index === 0 && value.startsWith("~[")),
+  );
+  return needsStructuredEncoding ? `~${JSON.stringify(values)}` : values.join(",");
+}
+
 export function asArrayOf<T>(itemParser: Parser<T>): Parser<T[]> {
+  const parse = (value: string): T[] | null => {
+    if (!value) return null;
+    return parseArrayItems(value)
+      .map((item) => itemParser.parse(item))
+      .filter((item) => item !== null) as T[];
+  };
+  const serialize = (value: T[]) =>
+    serializeArrayItems(value.map((item) => itemParser.serialize(item)));
+
   return {
-    parse: (value: string) => {
-      if (!value) return null;
-      return value
-        .split(",")
-        .filter(Boolean)
-        .map((item) => itemParser.parse(item.trim()))
-        .filter((item) => item !== null) as T[];
-    },
-    serialize: (value: T[]) => value.map((item) => itemParser.serialize(item)).join(","),
+    parse,
+    serialize,
     withDefault: (defaultValue: T[]) => ({
-      parse: (value: string) => {
-        if (!value) return defaultValue;
-        return value
-          .split(",")
-          .filter(Boolean)
-          .map((item) => itemParser.parse(item.trim()))
-          .filter((item) => item !== null) as T[];
-      },
-      serialize: (value: T[]) => value.map((item) => itemParser.serialize(item)).join(","),
+      parse: (value: string) => parse(value) ?? defaultValue,
+      serialize,
     }),
   };
 }

--- a/packages/farm/src/query/server.ts
+++ b/packages/farm/src/query/server.ts
@@ -17,6 +17,7 @@ export {
   asIsoDate,
   asIsoDateTime,
   createParser,
+  type ArrayParserOptions,
   type Parser,
   type inferParserType,
 } from "./parsers";


### PR DESCRIPTION
## Problem

`asArrayOf` joined every serialized item with commas and split every comma during parsing. Values such as `New York, NY`, nested JSON, and empty items therefore could not round-trip. Changing the default parser to recognize a new in-band marker would also reinterpret some existing literal URLs.

## Root cause

The array parser had only a comma format even though the public `Parser<T>` contract allows item serializers to return commas and other ambiguous strings. Every possible marker can also be a historical literal value, so structured decoding cannot be enabled implicitly without a compatibility break.

## Change

Add `asArrayOf(parser, { format: "structured" })`. Structured mode preserves the readable comma representation for simple values and uses the versioned `~farm-array:v1:` representation only when comma encoding would lose information. It also accepts ordinary comma URLs during migration. Export `ArrayParserOptions` from every query entry point.

## Safety and compatibility

The default `asArrayOf(parser)` behavior is unchanged and reserves no prefix, so all existing URLs retain their historical meaning. Structured decoding is explicit. Simple values still serialize as `react,vite` in either mode. The item parser remains responsible for normalization; the docs now show an exact string parser when empty or whitespace-significant items must be retained.

## Verification

- `pnpm --filter @farm.js/core exec vitest run src/__tests__/query-parsers.test.ts src/__tests__/load-search-params.test.ts src/__tests__/query-client-shallow.test.tsx --reporter=dot` (33 tests passed)
- `pnpm --filter @farm.js/core type-check`
- `pnpm exec oxlint packages/farm/src/query/parsers.ts packages/farm/src/query/index.ts packages/farm/src/query/client.ts packages/farm/src/query/server.ts packages/farm/src/__tests__/query-parsers.test.ts` (0 warnings, 0 errors)
- `git diff --check`

The tests prove structured delimiter and nested JSON round trips, plus empty and whitespace-sensitive round trips with an exact item parser, while preserving legacy prefix-like literals in default mode.

## Documentation and release

Documented the opt-in format, item-parser normalization, and migration behavior. No generated artifacts or template changes.