### PR TITLE
perf(react): compose queued rolling-window updates

### DIFF
--- a/docs/src/app/docs/renderers/react/page.md
+++ b/docs/src/app/docs/renderers/react/page.md
@@ -1021,21 +1021,24 @@ The application still performs the same slice and array construction. Farm prese
 and argument evaluation order, evaluates the bound once, and records only metadata that connects
 the final array to its committed source and retained interval.
 
-At update time, Farm validates native arrays, the committed source token, the exact retained tail,
-every retained item identity, and every incoming key before changing the DOM. It removes the
-expired prefix, updates stored event indexes, preserves every retained element, and creates only
-the incoming suffix. Incoming keys are checked against the complete previous window; reusing an
-expired key takes full keyed reconciliation so React key identity is preserved.
+At update time, Farm validates native arrays, the complete metadata chain back to the committed
+source token, the exact retained tail, every retained item identity, and every final incoming key
+before changing the DOM. Multiple rolling setters queued before one compiler flush collapse into
+one cumulative prefix removal. Rows introduced by an earlier setter are created only if they remain
+in the final suffix. Farm removes the expired committed prefix, updates stored event indexes,
+preserves every retained element, and creates only that final incoming suffix. Incoming keys are
+checked against the complete committed window; reusing an expired key takes full keyed
+reconciliation so React key identity is preserved.
 
 The proof remains intentionally narrow: one compiler-safe slice bound, compiler-owned host rows,
 and index-independent render and key callbacks. A second slice bound, literal zero, effectful bound
 expressions, block-bodied updates, custom slice behavior, sparse or subclassed arrays, queued
-uncommitted windows, collection-reading bindings, index-aware rows, React-owned rows, nested host
-blocks, row conditionals, unrelated dirty dependencies, and failed runtime validation all keep
-complete keyed reconciliation. Runtime bounds that evaluate to a fractional, non-numeric, unsafe,
-or no-op value preserve native results and use that fallback. No new component or option is
-required. Reports expose emitted sites as `keyedArrayRollingWindowHints`; only modules with such a
-site retain the optional all-hint runtime.
+chains containing a mixed or unhinted intermediate update, collection-reading bindings, index-aware
+rows, React-owned rows, nested host blocks, row conditionals, unrelated dirty dependencies, and
+failed runtime validation all keep complete keyed reconciliation. Runtime bounds that evaluate to
+a fractional, non-numeric, unsafe, or no-op value preserve native results and use that fallback. No
+new component or option is required. Reports expose emitted sites as
+`keyedArrayRollingWindowHints`; only modules with such a site retain the optional all-hint runtime.
 
 #### Keyed array known-position hints
 
@@ -2000,10 +2003,12 @@ The package and example test suites verify more than generated code:
   focused controlled-input identity and selection, update delegated event indexes, and cover native
   evaluation and coercion, unsafe evaluated bounds, queued slice/filter chains, Strict Mode
   hydration, unmount cleanup, custom methods, proxies, and conservative fallback;
-- 250 committed fixed-bound and 1,000 randomized runtime-bound keyed rolling-window updates match
-  normal React; targeted tests require work to equal only the incoming suffix, preserve retained
-  DOM identity, and cover unsafe evaluated bounds, reused keys, custom slices, collection-dependent
-  rows, Strict Mode hydration, and unmount cleanup;
+- 250 committed fixed-bound, 1,000 randomized runtime-bound, and 1,000 randomized queued keyed
+  rolling-window commits match normal React; targeted tests require work to equal only the final
+  incoming suffix, preserve retained DOM identity, update delegated indexes, preserve controlled
+  focus and selection, and cover unsafe evaluated bounds, reused or discarded intermediate keys,
+  custom slices, mixed queued chains, collection-dependent rows, Strict Mode hydration, and unmount
+  cleanup;
 - 2,000 deterministic randomized keyed-array removals match normal React; targeted tests require
   zero surviving descriptor and binding reads, preserve DOM identity, and cover queued filters,
   unhinted-chain fallback, collection-reading rows, StrictMode hydration, and unmount cleanup;

--- a/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
+++ b/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
@@ -2,6 +2,39 @@
 
 Date: 2026-08-29
 
+## Queued rolling-window composition — 2026-09-05
+
+The 10,000-row table now has a separate workload that queues two functional rolling-window
+setters before one React commit. Each setter removes 500 rows and appends 500 rows. The compiled
+runtime validates both native updates back to the committed collection, removes the final
+1,000-row prefix once, preserves the 9,000 surviving DOM rows, and mounts only the final
+1,000-row suffix. It does not mount rows from the first setter that have already expired. The
+equivalent block-bodied setters remain the compiled fallback control.
+
+| Mode   | React median | Queued roll | Compiled control | vs React | vs control |
+| ------ | -----------: | ----------: | ---------------: | -------: | ---------: |
+| Static |      77.85 ms |    17.30 ms |         27.30 ms |    4.50x |      1.58x |
+| Hybrid |      77.85 ms |    16.70 ms |         26.60 ms |    4.66x |      1.59x |
+
+The independent gate requires at least 2x versus bracketed React and 1.25x versus the compiled
+control in both modes. The complete production run passed that gate, DOM identity assertions,
+zero-owner-execution checks, the general performance and scalability gates, and every older
+optimization gate without lowering a threshold. Both compiler reports emitted three
+`keyedArrayRollingWindowHints` sites: the existing single setter and both setters in the queued
+workload.
+
+Package tests separately prove work proportional only to the final incoming suffix, disjoint grow
+and shrink chains, committed-key fallback, discarded intermediate keys, mixed-chain fallback,
+controlled-input focus and selection, delegated event indexes, Strict Mode hydration, and
+unmount-before-flush cleanup. Another 1,000 randomized commits, each containing two to four queued
+rolling updates, match normal React exactly. The complete 633-test package suite, isolated stress
+suite, and packaged React 18.3.1 and 19.2.8 compatibility runs pass.
+
+The optional rolling-window fixture grows by 112 B gzip to a 13,069 B compiler premium. Direct and
+ordinary keyed fixtures remain byte-for-byte unchanged, and the compiler-selected core still
+removes 82.6% of the full compatibility-runtime premium. The recorded run used Chrome
+152.0.7977.82, Node.js 23.11.0, and Apple M1 macOS arm64.
+
 ## Compiler-safe runtime rolling-window bounds — 2026-09-02
 
 The 10,000-row rolling workload now passes an event-local `trimCount` to

--- a/examples/react-compiler-dashboard/README.md
+++ b/examples/react-compiler-dashboard/README.md
@@ -90,13 +90,14 @@ deterministic package tests separately require zero surviving key, descriptor, a
 preserve surviving DOM identity, and cover safe and effectful bound expressions plus unsafe
 evaluated-bound fallback.
 
-Rolling windows have a separate 10,000-row persistence gate. A concise
-`[...current.slice(trimCount), ...incoming]` update uses an event-local runtime bound and is
-measured against bracketed React and an equivalent block-bodied compiled control. Both compiler
-modes must remain at least 2x faster than React and 1.25x faster than the compiled control. The
-report must contain a nonzero `keyedArrayRollingWindowHints` count; package tests separately
-require retained DOM identity, work proportional only to the incoming suffix, randomized dynamic
-bounds, and complete fallback for unsafe evaluated bounds.
+Rolling windows have separate single-update and queued 10,000-row persistence gates. A concise
+`[...current.slice(trimCount), ...incoming]` update uses an event-local runtime bound; the queued
+case applies two 500-row rolls before one commit. Both are measured against bracketed React and
+equivalent block-bodied compiled controls. Both compiler modes must remain at least 2x faster than
+React and 1.25x faster than their compiled controls. The report must contain a nonzero
+`keyedArrayRollingWindowHints` count; package tests separately require retained DOM identity, work
+proportional only to the final incoming suffix, randomized dynamic and queued updates, and complete
+fallback for unsafe evaluated bounds or broken chains.
 
 Exact-position insertions, removals, and replacements have separate 10,000-row comparisons. Concise
 native `toSpliced(position, 0, item)`, `toSpliced(position, 0, ...items)`, `toSpliced(position, 1)`,

--- a/examples/react-compiler-dashboard/scripts/benchmark.mjs
+++ b/examples/react-compiler-dashboard/scripts/benchmark.mjs
@@ -584,6 +584,40 @@ async function measureTrial(browser, trial, compilerMode, port) {
           },
         );
 
+        const tableRollingWindowQueued = await measureTable(
+          async () => ensure10000(),
+          async () => {
+            const rows = table.querySelectorAll("tbody tr");
+            const firstSurvivor = rows[1_000];
+            const previousLast = rows[9_999]?.getAttribute("data-row-id");
+            await runTableAction(
+              () => tableButton("table-roll-window-queued").click(),
+              () =>
+                rowCount() === 10_000 &&
+                table.querySelector("tbody tr") === firstSurvivor &&
+                table.querySelector("tbody tr:last-child")?.getAttribute("data-row-id") !==
+                  previousLast,
+            );
+          },
+        );
+
+        const tableRollingWindowQueuedSnapshot = await measureTable(
+          async () => ensure10000(),
+          async () => {
+            const rows = table.querySelectorAll("tbody tr");
+            const firstSurvivor = rows[1_000];
+            const previousLast = rows[9_999]?.getAttribute("data-row-id");
+            await runTableAction(
+              () => tableButton("table-roll-window-queued-snapshot").click(),
+              () =>
+                rowCount() === 10_000 &&
+                table.querySelector("tbody tr") === firstSurvivor &&
+                table.querySelector("tbody tr:last-child")?.getAttribute("data-row-id") !==
+                  previousLast,
+            );
+          },
+        );
+
         const tablePositionInsert = await measureTable(
           async () => ensure10000(),
           async () => {
@@ -1507,6 +1541,8 @@ async function measureTrial(browser, trial, compilerMode, port) {
             removeSnapshot: tableRemoveSnapshot,
             replace: tableReplace,
             rollingWindow: tableRollingWindow,
+            rollingWindowQueued: tableRollingWindowQueued,
+            rollingWindowQueuedSnapshot: tableRollingWindowQueuedSnapshot,
             rollingWindowSnapshot: tableRollingWindowSnapshot,
             select: tableSelect,
             snapshotMapLookup: tableSnapshotMapLookup,
@@ -1633,6 +1669,8 @@ async function measureTrial(browser, trial, compilerMode, port) {
         removeSnapshot: timingSummary(result.table.removeSnapshot),
         replace: timingSummary(result.table.replace),
         rollingWindow: timingSummary(result.table.rollingWindow),
+        rollingWindowQueued: timingSummary(result.table.rollingWindowQueued),
+        rollingWindowQueuedSnapshot: timingSummary(result.table.rollingWindowQueuedSnapshot),
         rollingWindowSnapshot: timingSummary(result.table.rollingWindowSnapshot),
         select: timingSummary(result.table.select),
         snapshotMapLookup: timingSummary(result.table.snapshotMapLookup),
@@ -1753,6 +1791,8 @@ const tableMetrics = [
   "remove",
   "removeSnapshot",
   "rollingWindow",
+  "rollingWindowQueued",
+  "rollingWindowQueuedSnapshot",
   "rollingWindowSnapshot",
   "clear",
 ];
@@ -1976,6 +2016,29 @@ const keyedRollingWindowRegressions = keyedRollingWindowResults.filter(
     speedup < keyedRollingWindowMinimumSpeedup ||
     !Number.isFinite(snapshotSpeedup) ||
     snapshotSpeedup < keyedRollingWindowMinimumSnapshotSpeedup,
+);
+// Two queued rolling setters should collapse to the final retained committed suffix and incoming
+// rows. Keep the queued 10,000-row workload ahead of both React and an equivalent block-bodied
+// compiled control so an intermediate uncommitted array cannot silently restore the full scan.
+const keyedQueuedRollingWindowMinimumSpeedup = 2;
+const keyedQueuedRollingWindowMinimumSnapshotSpeedup = 1.25;
+const keyedQueuedRollingWindowResults = ["static", "hybrid"].map((mode) => {
+  const rollingMedianMs = comparisons.table.rollingWindowQueued[mode].medianMs;
+  const snapshotMedianMs = comparisons.table.rollingWindowQueuedSnapshot[mode].medianMs;
+  return {
+    mode,
+    rollingMedianMs,
+    snapshotMedianMs,
+    snapshotSpeedup: snapshotMedianMs / rollingMedianMs,
+    speedup: comparisons.table.rollingWindowQueued[`${mode}VsBaseline`].speedup,
+  };
+});
+const keyedQueuedRollingWindowRegressions = keyedQueuedRollingWindowResults.filter(
+  ({ snapshotSpeedup, speedup }) =>
+    !Number.isFinite(speedup) ||
+    speedup < keyedQueuedRollingWindowMinimumSpeedup ||
+    !Number.isFinite(snapshotSpeedup) ||
+    snapshotSpeedup < keyedQueuedRollingWindowMinimumSnapshotSpeedup,
 );
 // A compiler-proven toSpliced(position, 0, ...items) insertion creates the incoming rows in one
 // fragment and leaves both retained sides untouched. Protect that exact 10,000-row/64-row workload
@@ -2436,6 +2499,7 @@ const passed =
   keyedPrependRegressions.length === 0 &&
   keyedSliceRegressions.length === 0 &&
   keyedRollingWindowRegressions.length === 0 &&
+  keyedQueuedRollingWindowRegressions.length === 0 &&
   keyedBatchInsertRegressions.length === 0 &&
   keyedWindowReplaceRegressions.length === 0 &&
   keyedWindowReuseRegressions.length === 0 &&
@@ -2496,6 +2560,13 @@ const report = {
     regressions: keyedRollingWindowRegressions,
     results: keyedRollingWindowResults,
     status: keyedRollingWindowRegressions.length === 0 ? "PASS" : "FAIL",
+  },
+  keyedQueuedRollingWindowHintGate: {
+    minimumSnapshotSpeedup: keyedQueuedRollingWindowMinimumSnapshotSpeedup,
+    minimumSpeedup: keyedQueuedRollingWindowMinimumSpeedup,
+    regressions: keyedQueuedRollingWindowRegressions,
+    results: keyedQueuedRollingWindowResults,
+    status: keyedQueuedRollingWindowRegressions.length === 0 ? "PASS" : "FAIL",
   },
   keyedBatchInsertHintGate: {
     minimumSnapshotSpeedup: keyedBatchInsertMinimumSnapshotSpeedup,

--- a/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
+++ b/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
@@ -257,6 +257,46 @@ export function StandardTableBenchmark() {
           Roll runtime-count window (snapshot control)
         </button>
         <button
+          data-action="table-roll-window-queued"
+          type="button"
+          onClick={() => {
+            const firstSeed = seed + 1;
+            const secondSeed = seed + 2;
+            const firstAdditions = buildRows(500, firstSeed);
+            const secondAdditions = buildRows(500, secondSeed);
+            const trimCount = 500;
+            setSeed(secondSeed);
+            setRows((current) => [...current.slice(trimCount), ...firstAdditions]);
+            setRows((current) => [...current.slice(trimCount), ...secondAdditions]);
+            setOperation("roll two queued runtime-count windows");
+            setRevision((value) => value + 1);
+          }}
+        >
+          Roll two queued runtime-count windows
+        </button>
+        <button
+          data-action="table-roll-window-queued-snapshot"
+          type="button"
+          onClick={() => {
+            const firstSeed = seed + 1;
+            const secondSeed = seed + 2;
+            const firstAdditions = buildRows(500, firstSeed);
+            const secondAdditions = buildRows(500, secondSeed);
+            const trimCount = 500;
+            setSeed(secondSeed);
+            setRows((current) => {
+              return [...current.slice(trimCount), ...firstAdditions];
+            });
+            setRows((current) => {
+              return [...current.slice(trimCount), ...secondAdditions];
+            });
+            setOperation("roll two queued runtime-count windows (snapshot control)");
+            setRevision((value) => value + 1);
+          }}
+        >
+          Roll two queued runtime-count windows (snapshot control)
+        </button>
+        <button
           data-action="table-position-insert"
           type="button"
           onClick={() => {

--- a/packages/farm-react/README.md
+++ b/packages/farm-react/README.md
@@ -297,14 +297,17 @@ const trimCount = pageSize * pagesToExpire;
 setItems((current) => [...current.slice(trimCount), ...nextItems]);
 ```
 
-Farm executes the ordinary native slice and array construction, then validates the committed
-source, retained item identities, and incoming keys. It removes only the expired prefix, leaves
-the retained DOM rows in place, and creates only the incoming suffix. This form supports one
+Farm executes the ordinary native slice and array construction, then validates the complete hint
+chain back to the committed source, retained item identities, and final incoming keys. Multiple
+rolling setters queued before one compiler flush collapse into one cumulative prefix removal; rows
+introduced by an earlier setter are created only if they remain in the final suffix. Farm removes
+only the expired committed prefix, leaves the retained DOM rows in place, and creates only that
+final incoming suffix. This form supports one
 safe-integer literal or compiler-safe runtime slice bound and compiler-owned, index-independent
 host rows. Identifiers, property reads, side-effect-free arithmetic and conditionals, and safe
 `Math` calls are supported while preserving native lookup, evaluation, results, and errors.
 Effectful expressions, reused keys, block-bodied updaters, custom slice behavior,
-collection-reading or index-aware rows, nested or React-owned rows, queued uncommitted windows,
+collection-reading or index-aware rows, nested or React-owned rows, mixed or unhinted queued chains,
 unsafe or no-op evaluated bounds, and failed checks use complete keyed reconciliation. The
 optional all-hint runtime is selected only for modules that emit this optimization. Reports expose
 the site count as `keyedArrayRollingWindowHints`.

--- a/packages/farm-react/README.md
+++ b/packages/farm-react/README.md
@@ -42,7 +42,7 @@ definitions, while generated code uses the tree-shakable feature entry.
 
 The persisted production-size fixtures and regression gate live in
 [`RUNTIME_SIZE_RESULTS.md`](./RUNTIME_SIZE_RESULTS.md). The recorded direct-only runtime premium is
-82.5% smaller than the complete compatibility runtime premium; the feature-heavy keyed benchmark
+82.6% smaller than the complete compatibility runtime premium; the feature-heavy keyed benchmark
 application removes 6,185 gzip bytes from its previous compiler-on build.
 
 For selective adoption, use annotation mode:

--- a/packages/farm-react/RUNTIME_SIZE_RESULTS.json
+++ b/packages/farm-react/RUNTIME_SIZE_RESULTS.json
@@ -196,14 +196,14 @@
         "brotli": 51859
       },
       "compilerOn": {
-        "raw": 239514,
-        "gzip": 73065,
-        "brotli": 62602
+        "raw": 239845,
+        "gzip": 73177,
+        "brotli": 62691
       },
       "compilerPremium": {
-        "raw": 46585,
-        "gzip": 12957,
-        "brotli": 10743
+        "raw": 46916,
+        "gzip": 13069,
+        "brotli": 10832
       }
     },
     "isolatedRuntime": {
@@ -213,18 +213,18 @@
         "brotli": 51666
       },
       "full": {
-        "raw": 286816,
-        "gzip": 81444,
-        "brotli": 69471
+        "raw": 287010,
+        "gzip": 81533,
+        "brotli": 69607
       },
       "coreOnly": {
         "raw": 204922,
         "gzip": 63685,
         "brotli": 54902
       },
-      "fullRuntimePremiumGzip": 21525,
+      "fullRuntimePremiumGzip": 21614,
       "coreRuntimePremiumGzip": 3766,
-      "gzipReductionPercent": 82.5
+      "gzipReductionPercent": 82.6
     }
   }
 }

--- a/packages/farm-react/RUNTIME_SIZE_RESULTS.md
+++ b/packages/farm-react/RUNTIME_SIZE_RESULTS.md
@@ -34,10 +34,10 @@ is enforced on every pull request instead of serving only as a manually recorded
 | Keyed rows with exact-window hints                |          60,124 B |         74,297 B |         14,173 B |
 | Keyed rows with reverse hints                     |          60,058 B |         72,115 B |         12,057 B |
 | Keyed rows with sort hints                        |          60,077 B |         72,172 B |         12,095 B |
-| Keyed rows with rolling-window hints              |          60,108 B |         73,065 B |         12,957 B |
+| Keyed rows with rolling-window hints              |          60,108 B |         73,177 B |         13,069 B |
 
-The isolated compatibility runtime contributes 21,525 B gzip over the React control. The
-compiler-selected core contributes 3,766 B, an **82.5% reduction**. This comparison uses the same
+The isolated compatibility runtime contributes 21,614 B gzip over the React control. The
+compiler-selected core contributes 3,766 B, an **82.6% reduction**. This comparison uses the same
 hand-authored compiled definition and changes only the runtime entry used to create it.
 
 The keyed fixture retains `FarmCompiledKeyedRows` plus compiler-emitted `identityTarget`,
@@ -49,7 +49,7 @@ rolling-window modules select separate hint runtimes only when the compiler emit
 shapes. Reverse and sort share the optional reorder capability; the direct and isolated core
 results remain byte-for-byte unchanged. Over the ordinary keyed fixture, position pays 1,074 B
 gzip, batch-position pays 1,249 B, exact-window pays 2,979 B, reverse pays 863 B, sort pays 901 B,
-slice pays 1,028 B, and rolling-window pays 1,763 B. The exact-window figure includes fresh-key
+slice pays 1,028 B, and rolling-window pays 1,875 B. The exact-window figure includes fresh-key
 replacement, atomic same-key binding refresh, fixed- and variable-length window-local keyed reuse
 with LIS movement, queued same-key window composition, disjoint queued fresh-key replacement, and
 queued disjoint variable-length local-key reuse.

--- a/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-rolling-window-hints.test.tsx
+++ b/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-rolling-window-hints.test.tsx
@@ -173,6 +173,137 @@ describe("compiled keyed-array rolling-window hints", () => {
     expect(harness.counters.bindings).toBe(2);
   });
 
+  it("composes queued rolling windows and creates only the final incoming suffix", async () => {
+    const initialItems = ["a", "b", "c", "d"].map((id) => ({
+      id,
+      label: id.toUpperCase(),
+    }));
+    const harness = createRollingHarness(initialItems);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Feed />));
+    const survivor = container.querySelector('[data-key="c"]');
+    harness.counters.keys = 0;
+    harness.counters.descriptors = 0;
+    harness.counters.bindings = 0;
+
+    await act(async () => {
+      harness.roll(1, [{ id: "e", label: "E" }]);
+      harness.roll(1, [{ id: "f", label: "F" }]);
+      await flushCompilerUpdates();
+    });
+
+    expect(container.textContent).toBe("CDEF");
+    expect(container.querySelector('[data-key="c"]')).toBe(survivor);
+    expect(harness.counters.keys).toBe(2);
+    expect(harness.counters.descriptors).toBe(2);
+    expect(harness.counters.bindings).toBe(2);
+  });
+
+  it("collapses queued grow and shrink rolls after all committed rows expire", async () => {
+    const initialItems = ["a", "b", "c", "d"].map((id) => ({
+      id,
+      label: id.toUpperCase(),
+    }));
+    const harness = createRollingHarness(initialItems);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Feed />));
+    harness.counters.keys = 0;
+    harness.counters.descriptors = 0;
+    harness.counters.bindings = 0;
+
+    await act(async () => {
+      harness.roll(3, [
+        { id: "e", label: "E" },
+        { id: "f", label: "F" },
+        { id: "g", label: "G" },
+      ]);
+      harness.roll(2, [{ id: "h", label: "H" }]);
+      await flushCompilerUpdates();
+    });
+
+    expect(container.textContent).toBe("FGH");
+    expect(container.querySelector('[data-key="a"]')).toBeNull();
+    expect(container.querySelector('[data-key="d"]')).toBeNull();
+    expect(harness.counters.keys).toBe(3);
+    expect(harness.counters.descriptors).toBe(3);
+    expect(harness.counters.bindings).toBe(3);
+  });
+
+  it("validates final queued keys against the committed window", async () => {
+    const initialItems = ["a", "b", "c", "d"].map((id) => ({
+      id,
+      label: id.toUpperCase(),
+    }));
+    const reused = createRollingHarness(initialItems);
+    const reusedContainer = document.createElement("div");
+    document.body.append(reusedContainer);
+    const reusedRoot = createRoot(reusedContainer);
+    roots.push(reusedRoot);
+    await act(async () => reusedRoot.render(<reused.Feed />));
+    const alpha = reusedContainer.querySelector('[data-key="a"]');
+    reused.counters.keys = 0;
+
+    await act(async () => {
+      reused.roll(1, [{ id: "e", label: "E" }]);
+      reused.roll(1, [initialItems[0]]);
+      await flushCompilerUpdates();
+    });
+
+    expect(reusedContainer.textContent).toBe("CDEA");
+    expect(reusedContainer.querySelector('[data-key="a"]')).toBe(alpha);
+    // The optimized attempt reads the two final incoming keys, then complete
+    // reconciliation rereads all four after detecting the committed-key move.
+    expect(reused.counters.keys).toBe(6);
+
+    const discarded = createRollingHarness(initialItems);
+    const discardedContainer = document.createElement("div");
+    document.body.append(discardedContainer);
+    const discardedRoot = createRoot(discardedContainer);
+    roots.push(discardedRoot);
+    await act(async () => discardedRoot.render(<discarded.Feed />));
+    discarded.counters.keys = 0;
+    discarded.counters.descriptors = 0;
+    discarded.counters.bindings = 0;
+
+    await act(async () => {
+      discarded.roll(4, [initialItems[0]]);
+      discarded.roll(1, [{ id: "e", label: "E" }]);
+      await flushCompilerUpdates();
+    });
+
+    expect(discardedContainer.textContent).toBe("E");
+    expect(discarded.counters.keys).toBe(1);
+    expect(discarded.counters.descriptors).toBe(1);
+    expect(discarded.counters.bindings).toBe(1);
+  });
+
+  it("rejects a queued rolling chain after an unhinted intermediate update", async () => {
+    const harness = createRollingHarness(
+      ["a", "b", "c", "d"].map((id) => ({ id, label: id.toUpperCase() })),
+    );
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Feed />));
+    harness.counters.keys = 0;
+
+    await act(async () => {
+      harness.customRoll({ id: "e", label: "E" });
+      harness.roll(1, [{ id: "f", label: "F" }]);
+      await flushCompilerUpdates();
+    });
+
+    expect(container.textContent).toBe("CBEF");
+    expect(harness.counters.keys).toBe(4);
+  });
+
   it("falls back when an incoming row reuses a committed key", async () => {
     const initialItems: Item[] = [
       { id: "a", label: "Alpha" },
@@ -280,6 +411,112 @@ describe("compiled keyed-array rolling-window hints", () => {
     expect(container.textContent).toBe("BCDEFG");
     expect(container.querySelector('[data-key="b"]')).toBe(b);
     expect(harness.counters.keys).toBe(6);
+  });
+
+  it("preserves controlled focus and updates delegated indexes after queued rolls", async () => {
+    const initialItems = ["a", "b", "c", "d"].map((id) => ({
+      id,
+      label: id.toUpperCase().repeat(4),
+    }));
+    const calls: string[] = [];
+    let queue = () => undefined;
+    const Feed = createCompiledComponent({
+      displayName: "QueuedRollingInteractiveFeed",
+      initialize: () => [initialItems],
+      render(_props: Record<string, never>, state, blocks) {
+        const items = () => state[0].get() as Item[];
+        queue = () => {
+          state[0].set((previous) =>
+            hintedRoll(previous as Item[], 1, [{ id: "e", label: "EEEE" }]),
+          );
+          state[0].set((previous) =>
+            hintedRoll(previous as Item[], 1, [{ id: "f", label: "FFFF" }]),
+          );
+        };
+        return (
+          <section>
+            <blocks.KeyedRows
+              collectionDependency={0}
+              delegateEvents
+              dependencies={[0]}
+              events={[
+                {
+                  invoke: (item, index) => calls.push(`${(item as Item).id}:${index}`),
+                  name: "onClick",
+                  path: [1],
+                },
+              ]}
+              filterIndexIndependent
+              id={0}
+              items={items}
+              structureDependencies={[0]}
+              render={(event) => (
+                <ul>
+                  {items().map((item, index) => (
+                    <li data-key={item.id} key={item.id}>
+                      <input readOnly value={item.label} />
+                      <button data-row-button={item.id} onClick={event(item, index, 0)}>
+                        Select
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              )}
+              rowKey={(item) => (item as Item).id}
+              create={(item) => ({
+                kind: "element",
+                tag: "li",
+                attributes: [{ name: "data-key", value: (item as Item).id }],
+                styles: [],
+                children: [
+                  {
+                    kind: "element",
+                    tag: "input",
+                    attributes: [
+                      { name: "readOnly", value: true },
+                      { name: "value", value: (item as Item).label },
+                    ],
+                    styles: [],
+                    children: [],
+                  },
+                  {
+                    kind: "element",
+                    tag: "button",
+                    attributes: [{ name: "data-row-button", value: (item as Item).id }],
+                    styles: [],
+                    children: ["Select"],
+                  },
+                ],
+              })}
+              bindings={[]}
+            />
+          </section>
+        );
+      },
+      bindings: [{ kind: "block", id: 0, dependencies: [0] }],
+    });
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<Feed />));
+    const input = container.querySelector('[data-key="d"] input') as HTMLInputElement;
+    input.focus();
+    input.setSelectionRange(1, 3);
+
+    await act(async () => {
+      queue();
+      await flushCompilerUpdates();
+    });
+    await act(async () => {
+      (container.querySelector('[data-row-button="d"]') as HTMLButtonElement).click();
+    });
+
+    expect(container.textContent).toBe("SelectSelectSelectSelect");
+    expect(container.querySelector('[data-key="d"] input')).toBe(input);
+    expect(document.activeElement).toBe(input);
+    expect([input.selectionStart, input.selectionEnd]).toEqual([1, 3]);
+    expect(calls).toEqual(["d:1"]);
   });
 
   it("matches normal React through 250 committed rolling updates", async () => {
@@ -392,6 +629,83 @@ describe("compiled keyed-array rolling-window hints", () => {
     expect(harness.counters.bindings).toBe(incomingCount);
   }, 20_000);
 
+  it("matches React through 1,000 randomized queued rolling commits", async () => {
+    const initialItems = Array.from(
+      { length: 48 },
+      (_, index): Item => ({ id: `queued-row-${index}`, label: `Queued row ${index}` }),
+    );
+    const harness = createRollingHarness(initialItems);
+    let rollReact: (remove: number, incoming: readonly Item[]) => void = () => undefined;
+    let seed = 0x51ced;
+    let nextId = initialItems.length;
+    let expectedLength = initialItems.length;
+    let incomingCount = 0;
+    const random = () => {
+      seed = (Math.imul(seed, 1_664_525) + 1_013_904_223) >>> 0;
+      return seed;
+    };
+    function NormalFeed() {
+      const [items, setItems] = useState(initialItems);
+      rollReact = (remove, incoming) =>
+        setItems((previous) => [...previous.slice(remove), ...incoming]);
+      return (
+        <ol>
+          {items.map((item) => (
+            <li key={item.id}>{item.label}</li>
+          ))}
+        </ol>
+      );
+    }
+    const compiledContainer = document.createElement("div");
+    const reactContainer = document.createElement("div");
+    document.body.append(compiledContainer, reactContainer);
+    const compiledRoot = createRoot(compiledContainer);
+    const reactRoot = createRoot(reactContainer);
+    roots.push(compiledRoot, reactRoot);
+    await act(async () => {
+      compiledRoot.render(<harness.Feed />);
+      reactRoot.render(<NormalFeed />);
+    });
+    harness.counters.keys = 0;
+    harness.counters.descriptors = 0;
+    harness.counters.bindings = 0;
+
+    for (let update = 0; update < 1_000; update += 1) {
+      const operations: Array<{ incoming: Item[]; remove: number }> = [];
+      const operationCount = 2 + (random() % 3);
+      for (let operation = 0; operation < operationCount; operation += 1) {
+        const remove = 1 + (random() % 4);
+        let incomingLength = 1 + (random() % 5);
+        if (expectedLength < 36 && incomingLength < remove) incomingLength = remove;
+        if (expectedLength > 60 && incomingLength > remove) incomingLength = remove;
+        const incoming = Array.from({ length: incomingLength }, (): Item => {
+          const id = nextId++;
+          return { id: `queued-row-${id}`, label: `Queued row ${id}` };
+        });
+        operations.push({ incoming, remove });
+        expectedLength = expectedLength - remove + incomingLength;
+        incomingCount += incomingLength;
+      }
+
+      await act(async () => {
+        for (const operation of operations) {
+          harness.roll(operation.remove, operation.incoming);
+          rollReact(operation.remove, operation.incoming);
+        }
+        await flushCompilerUpdates();
+      });
+      if (update % 25 === 0) {
+        expect(compiledContainer.textContent).toBe(reactContainer.textContent);
+      }
+    }
+
+    expect(compiledContainer.textContent).toBe(reactContainer.textContent);
+    expect(compiledContainer.querySelectorAll("li")).toHaveLength(expectedLength);
+    expect(harness.counters.keys).toBe(incomingCount);
+    expect(harness.counters.descriptors).toBe(incomingCount);
+    expect(harness.counters.bindings).toBe(incomingCount);
+  }, 30_000);
+
   it("hydrates in StrictMode and drops a queued rolling update after unmount", async () => {
     const harness = createRollingHarness([
       { id: "a", label: "Alpha" },
@@ -419,14 +733,16 @@ describe("compiled keyed-array rolling-window hints", () => {
 
     await act(async () => {
       harness.roll(1, [{ id: "c", label: "Gamma" }]);
+      harness.roll(1, [{ id: "d", label: "Delta" }]);
       await flushCompilerUpdates();
     });
-    expect(container.textContent).toBe("BetaGamma");
+    expect(container.textContent).toBe("GammaDelta");
     expect(recoverable).toEqual([]);
 
     roots.pop();
     act(() => {
-      harness.roll(1, [{ id: "d", label: "Delta" }]);
+      harness.roll(1, [{ id: "e", label: "Epsilon" }]);
+      harness.roll(1, [{ id: "f", label: "Phi" }]);
       root.unmount();
     });
     await flushCompilerUpdates();

--- a/packages/farm-react/src/compiler-runtime.tsx
+++ b/packages/farm-react/src/compiler-runtime.tsx
@@ -43,6 +43,7 @@ interface CompilerKeyedArrayRollingWindowHint {
   readonly resultLength: number;
   readonly retainedEnd: number;
   readonly retainedStart: number;
+  readonly previous?: CompilerKeyedArrayRollingWindowHint;
 }
 
 interface CompilerKeyedArrayPositionHint {
@@ -317,26 +318,40 @@ function compilerKeyedArrayPrependLength(
   return length === value.length ? prefixLength : undefined;
 }
 
-function compilerKeyedArrayRollingWindow(
+function compilerKeyedArrayRollingWindows(
   value: unknown,
   sourceToken: object | undefined,
   expectedLength: number,
-): CompilerKeyedArrayRollingWindowHint | undefined {
+): readonly CompilerKeyedArrayRollingWindowHint[] | undefined {
   const target = compilerObject(value);
   if (!target || !sourceToken || !Array.isArray(value)) return undefined;
   const update = COMPILER_KEYED_ARRAY_ROLLING_WINDOWS.get(target);
-  if (
-    !update ||
-    update.sourceToken !== sourceToken ||
-    update.sourceLength !== expectedLength ||
-    update.resultLength !== value.length ||
-    update.retainedStart < 1 ||
-    update.retainedEnd !== update.sourceLength ||
-    update.resultLength <= update.retainedEnd - update.retainedStart
+  if (!update || update.sourceToken !== sourceToken) return undefined;
+  const updates: CompilerKeyedArrayRollingWindowHint[] = [];
+  for (
+    let current: CompilerKeyedArrayRollingWindowHint | undefined = update;
+    current;
+    current = current.previous
   ) {
-    return undefined;
+    if (current.sourceToken !== sourceToken) return undefined;
+    updates.push(current);
   }
-  return update;
+  updates.reverse();
+
+  let length = expectedLength;
+  for (const current of updates) {
+    if (
+      current.sourceLength !== length ||
+      current.retainedStart < 1 ||
+      current.retainedStart > current.sourceLength ||
+      current.retainedEnd !== current.sourceLength ||
+      current.resultLength <= current.retainedEnd - current.retainedStart
+    ) {
+      return undefined;
+    }
+    length = current.resultLength;
+  }
+  return length === value.length ? updates : undefined;
 }
 
 function compilerKeyedArrayPosition(
@@ -714,7 +729,6 @@ export function createCompilerKeyedArrayRollingWindow(
       !previousTarget ||
       !retainedTarget ||
       !valueTarget ||
-      !COMPILER_KEYED_COMMITTED_COLLECTIONS.has(previousTarget) ||
       !Array.isArray(previous) ||
       !Array.isArray(retained) ||
       !Array.isArray(value) ||
@@ -724,19 +738,27 @@ export function createCompilerKeyedArrayRollingWindow(
     ) {
       return value;
     }
-    const sourceToken = compilerKeyedCollectionToken(previousTarget);
+    const committedSource = COMPILER_KEYED_COMMITTED_COLLECTIONS.has(previousTarget);
+    const previousUpdate = committedSource
+      ? undefined
+      : COMPILER_KEYED_ARRAY_ROLLING_WINDOWS.get(previousTarget);
+    if (!committedSource && !previousUpdate) return value;
+    const immediateSourceToken = compilerKeyedCollectionToken(previousTarget);
+    const sourceToken = previousUpdate?.sourceToken || immediateSourceToken;
     const slice = COMPILER_KEYED_ARRAY_FILTERS.get(retainedTarget);
     if (
+      !immediateSourceToken ||
       !sourceToken ||
       !slice ||
       slice.previous ||
       slice.kind !== "slice" ||
-      slice.sourceToken !== sourceToken ||
+      slice.sourceToken !== immediateSourceToken ||
       slice.sourceLength !== previous.length ||
       slice.retainedStart === undefined ||
       slice.retainedEnd !== previous.length ||
       slice.retainedStart < 1 ||
       slice.resultLength !== retained.length ||
+      (previousUpdate && previousUpdate.resultLength !== previous.length) ||
       value.length <= retained.length
     ) {
       return value;
@@ -750,6 +772,7 @@ export function createCompilerKeyedArrayRollingWindow(
       resultLength: value.length,
       retainedEnd: slice.retainedEnd,
       retainedStart: slice.retainedStart,
+      ...(previousUpdate ? { previous: previousUpdate } : {}),
     });
   } catch {
     // Metadata must never change the result of a successful array update.
@@ -4544,14 +4567,18 @@ function reconcileCompilerKeyedArrayRollingWindow(
   }
 
   const finalValue = props.items();
-  const update = compilerKeyedArrayRollingWindow(finalValue, collectionToken, instances.size);
-  if (!update || !Array.isArray(finalValue)) return undefined;
+  const updates = compilerKeyedArrayRollingWindows(finalValue, collectionToken, instances.size);
+  if (!updates || !Array.isArray(finalValue)) return undefined;
   const previousInstances = [...instances.values()];
-  const retainedLength = update.retainedEnd - update.retainedStart;
+  let retainedStart = 0;
+  for (const update of updates) {
+    retainedStart += Math.min(update.retainedStart, previousInstances.length - retainedStart);
+  }
+  const retainedLength = previousInstances.length - retainedStart;
   const survivors: CompilerKeyedRowInstance[] = [];
   try {
     for (let index = 0; index < retainedLength; index += 1) {
-      const sourceIndex = update.retainedStart + index;
+      const sourceIndex = retainedStart + index;
       const instance = previousInstances[sourceIndex];
       if (
         !instance ||
@@ -4590,7 +4617,7 @@ function reconcileCompilerKeyedArrayRollingWindow(
     return undefined;
   }
 
-  for (let index = 0; index < update.retainedStart; index += 1) {
+  for (let index = 0; index < retainedStart; index += 1) {
     previousInstances[index].scope?.cleanup();
     previousInstances[index].element.remove();
   }


### PR DESCRIPTION
## Problem

Two or more concise rolling-window setters queued before one React commit lose the existing keyed-row fast path:

```tsx
setRows((current) => [...current.slice(trimCount), ...firstBatch]);
setRows((current) => [...current.slice(trimCount), ...secondBatch]);
```

The first updater returns an uncommitted array. The next updater previously could not attach trusted rolling metadata to that result, so the final collection used complete React reconciliation even though every operation was compiler-proven.

## Root cause

Rolling-window metadata described only one committed source-to-result transition. The helper rejected an uncommitted rolling result, and reconciliation could validate only a single retained tail. It could not safely relate a queued chain back to the DOM's committed collection.

## Change

- Link consecutive compiler-proven rolling-window hints back to the committed source token.
- Validate every queued transition, its native slice result, source/result length, and retained-tail shape before using the fast path.
- Compose the queued removals into one final committed prefix and prepare only the final incoming suffix.
- Preserve surviving keyed DOM instances and avoid mounting intermediate rows that expire before commit.
- Add a production dashboard workload and independent performance gate for two queued rolling setters.
- Document supported queued behavior, safety checks, fallback cases, benchmark results, and runtime-size impact.

## Safety and compatibility

The runtime does not mutate the DOM until the complete queued chain, final retained identities, incoming descriptors, and global key uniqueness are proven. Mixed hinted/unhinted chains, malformed metadata, committed-key reuse, unsupported arrays, or failed runtime validation use the existing complete React fallback.

React semantics for controlled input focus/selection, delegated event indexes, hydration, Strict Mode, unmount cleanup, and component ownership remain covered. React 18.3.1 and 19.2.8 package compatibility both pass. The optimization stays in the optional compiler runtime; compiler-disabled and ordinary keyed fixtures are unchanged.

The rolling-window fixture adds 112 B gzip, for a 13,069 B compiler premium. The compiler-selected core still removes 82.6% of the full compatibility-runtime premium.

## Verification

- `pnpm --filter @farm.js/react test` — 633 passed, 3 skipped; stress suite 3 passed, 17 skipped
- `pnpm --filter @farm.js/react exec vitest run src/__tests__/compiler-runtime-keyed-array-rolling-window-hints.test.tsx` — 13 passed, including 1,000 randomized queued commits
- `pnpm --filter @farm.js/react type-check`
- `pnpm --filter @farm.js/react test:compat` — React 18.3.1 and 19.2.8
- `pnpm --filter @farm.js/react test:runtime-size`
- `pnpm --dir examples/react-compiler-dashboard type-check`
- `FARM_EXPERIMENT_BROWSER_PATH="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" pnpm --dir examples/react-compiler-dashboard benchmark` — complete correctness, performance, persistence, and scalability gates passed
- `pnpm --dir docs exec farm generate --check`
- `pnpm docs:check-navigation`
- `pnpm docs:build`
- Focused `oxfmt`, `oxlint`, `node --check`, and `git diff --check`

Production Chrome 152.0.7977.82 results for the 10,000-row queued workload:

| Mode | React median | Queued rolling | Compiled control | vs React | vs control |
| --- | ---: | ---: | ---: | ---: | ---: |
| Static | 77.85 ms | 17.30 ms | 27.30 ms | 4.50x | 1.58x |
| Hybrid | 77.85 ms | 16.70 ms | 26.60 ms | 4.66x | 1.59x |

## Documentation and release

Updated the React renderer guide, package README, maintained compiler dashboard example, reproducible benchmark, benchmark record, and checked runtime-size artifacts. No version files or release tags are changed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Composes queued rolling-window updates so consecutive concise setters flushed in one React commit keep the keyed fast path instead of falling back to full keyed reconciliation.

**Behavior**
- Chains rolling-window hints back to the committed source and validates every queued transition, slice result, and retained-tail shape before using the fast path.
- Collapses removals into one prefix removal and mounts only the final incoming suffix, skipping intermediate rows that expire before commit.

**Safety and verification**
- Mixed or unhinted chains, malformed metadata, committed-key reuse, unsupported arrays, and failed validation fall back to complete keyed reconciliation.
- Adds a 10,000-row queued benchmark gate (4.5x vs React, 1.58x vs the compiled control) and 1,000 randomized queued commits.
- React 18.3.1 and 19.2.8 compatibility, controlled focus/selection, delegated indexes, Strict Mode hydration, and unmount cleanup stay covered.
- The rolling-window fixture grows 112 B gzip; the compiler-selected core still removes 82.6% of the full compatibility-runtime premium.

<sup>Written for commit b362231282e35a2aa2ec16aee8876786815f6241. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/723?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

