### PR TITLE
fix(query): preserve repeated values in client hooks

### DIFF
--- a/docs/src/app/docs/query/page.md
+++ b/docs/src/app/docs/query/page.md
@@ -48,6 +48,9 @@ composed against the latest URL, and returning a value to the current URL cancel
 If a component changes the key or parser it passes to the hook, the returned value is immediately
 re-read from the current URL.
 
+Repeated keys have the same meaning during server rendering and in client hooks. For example,
+`?tag=react&tag=vite` is read as both values by `asArrayOf(asString)`.
+
 ## Multiple query values
 
 Use `useQueryStates` when several controls should update together. This keeps the browser URL as the source of shareable state for filters, pagination, and tabs.

--- a/packages/farm/src/__tests__/query-client-shallow.test.tsx
+++ b/packages/farm/src/__tests__/query-client-shallow.test.tsx
@@ -8,7 +8,14 @@ import { useSearchParams } from "../navigation";
 import { pushState as pushFarmPageState, readPageState, SPARouter } from "../client/spa-router";
 import { usePageState } from "../client/router";
 import { FARM_HISTORY_CHANGE_EVENT, notifyHistoryChange } from "../client/history-sync";
-import { asJson, asString, createParser, useQueryState, useQueryStates } from "../query/client";
+import {
+  asArrayOf,
+  asJson,
+  asString,
+  createParser,
+  useQueryState,
+  useQueryStates,
+} from "../query/client";
 
 describe("useQueryState shallow routing", () => {
   let container: HTMLDivElement;
@@ -96,6 +103,41 @@ describe("useQueryState shallow routing", () => {
 
     expect(window.location.search).toBe("?url=https%3A%2F%2Fexample.com");
     expect(popstate).not.toHaveBeenCalled();
+  });
+
+  it("reads every repeated value through useQueryState", () => {
+    window.history.replaceState(null, "", "/?tag=react&tag=vite");
+    let value: string[] | null = null;
+
+    function App() {
+      [value] = useQueryState("tag", asArrayOf(asString));
+      return null;
+    }
+
+    root = createRoot(container);
+    act(() => {
+      root?.render(createElement(App));
+    });
+
+    expect(value).toEqual(["react", "vite"]);
+  });
+
+  it("reads every repeated value through useQueryStates", () => {
+    window.history.replaceState(null, "", "/?tag=react&tag=vite");
+    let value: string[] | null = null;
+
+    function App() {
+      const [state] = useQueryStates({ tag: asArrayOf(asString) });
+      value = state.tag;
+      return null;
+    }
+
+    root = createRoot(container);
+    act(() => {
+      root?.render(createElement(App));
+    });
+
+    expect(value).toEqual(["react", "vite"]);
   });
 
   it("does not trigger SPA navigation when shallow is true and Farm router is installed", async () => {

--- a/packages/farm/src/query/client.ts
+++ b/packages/farm/src/query/client.ts
@@ -53,6 +53,11 @@ const getCurrentSearchParams = (): URLSearchParams => {
   }
 };
 
+const readSearchParam = (searchParams: URLSearchParams, key: string): string => {
+  const values = searchParams.getAll(key);
+  return values.length > 1 ? values.join(",") : (values[0] ?? "");
+};
+
 const throttleTimers = new Map<string, ReturnType<typeof setTimeout>>();
 
 const compareStructuredValues = (
@@ -238,8 +243,7 @@ export function useQueryState<TParser extends Parser<any>>(
   type T = NonNullable<ReturnType<TParser["parse"]>>;
   const [state, setState] = useState<T | null>(() => {
     const searchParams = getCurrentSearchParams();
-    const value = searchParams.get(key);
-    const parsed = parser.parse(value ?? "");
+    const parsed = parser.parse(readSearchParam(searchParams, key));
     return parsed;
   });
 
@@ -273,8 +277,7 @@ export function useQueryState<TParser extends Parser<any>>(
 
     const onPopState = () => {
       const searchParams = getCurrentSearchParams();
-      const value = searchParams.get(key);
-      const parsed = parser.parse(value ?? "");
+      const parsed = parser.parse(readSearchParam(searchParams, key));
       const sourceChanged = stateKeyRef.current !== key;
       stateKeyRef.current = key;
       if (sourceChanged || !areParsedValuesEqual(parser, stateRef.current, parsed)) {
@@ -288,8 +291,7 @@ export function useQueryState<TParser extends Parser<any>>(
         return;
       }
 
-      const value = searchParams.get(key);
-      const parsed = parser.parse(value ?? "");
+      const parsed = parser.parse(readSearchParam(searchParams, key));
       if (!areParsedValuesEqual(parser, stateRef.current, parsed)) {
         setState(parsed);
         stateRef.current = parsed;
@@ -341,8 +343,7 @@ export function useQueryStates<T extends Record<string, Parser<any>>>(
     const result = {} as { [K in keyof T]: ReturnType<T[K]["parse"]> };
 
     Object.entries(parsers).forEach(([key, parser]) => {
-      const value = searchParams.get(key);
-      result[key as keyof T] = parser.parse(value ?? "");
+      result[key as keyof T] = parser.parse(readSearchParam(searchParams, key));
     });
 
     return result;
@@ -390,8 +391,7 @@ export function useQueryStates<T extends Record<string, Parser<any>>>(
         currentKeys.some((key) => !Object.prototype.hasOwnProperty.call(parsers, key));
 
       Object.entries(parsers).forEach(([key, parser]) => {
-        const value = searchParams.get(key);
-        const parsed = parser.parse(value ?? "");
+        const parsed = parser.parse(readSearchParam(searchParams, key));
         const currentValue = stateRef.current[key as keyof T];
 
         if (!areParsedValuesEqual(parser, currentValue, parsed)) {


### PR DESCRIPTION
## Problem

For `?tag=react&tag=vite`, server-side `loadSearchParams` supplied both values to `asArrayOf`, but `useQueryState` and `useQueryStates` supplied only `react`. A page could therefore render different state on the server and during browser hydration.

## Root cause

The server path uses `URLSearchParams.getAll()` and joins repeated values for the string-based parser contract. Every client read path used `URLSearchParams.get()`, which returns only the first value.

## Change

Route all client query reads through one helper with the server's established `getAll()` semantics. Regression tests cover both single-state and multi-state hooks.

## Safety and compatibility

Missing and single-valued parameters are unchanged. Repeated parameters now consistently produce the same parser input on the server, initial hydration, history traversal, and cross-hook synchronization.

## Verification

- `pnpm --filter @farm.js/core exec vitest run src/__tests__/query-client-shallow.test.tsx src/__tests__/load-search-params.test.ts --reporter=dot` (30 tests passed)
- `pnpm --filter @farm.js/core type-check`
- `pnpm exec oxfmt packages/farm/src/query/client.ts packages/farm/src/__tests__/query-client-shallow.test.tsx docs/src/app/docs/query/page.md`
- `pnpm exec oxlint packages/farm/src/query/client.ts packages/farm/src/__tests__/query-client-shallow.test.tsx` (0 warnings, 0 errors)
- `git diff --check`

The new hook tests fail on the previous implementation with `["react"]` instead of `["react", "vite"]`.

## Documentation and release

Documented server/client repeated-key parity. This is a client-side follow-up to the server correction tracked in #492; it does not reopen or duplicate that completed work.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes client query hooks dropping repeated query parameter values, so `?tag=react&tag=vite` now parses as `["react", "vite"]` in both `useQueryState` and `useQueryStates`, matching server-side rendering and preventing hydration mismatch.

**Bug Fixes**
- Routes all client query reads through one helper using `URLSearchParams.getAll()` semantics.
- Missing and single-valued parameters behave as before.
- Adds regression tests for both hooks and documents the repeated-key parity.

<sup>Written for commit 12f48e8da5df3b53f268561fe38f8a734e0a550b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/724?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

