### PR TITLE
fix(query): cancel throttled writes on unmount

### DIFF
--- a/docs/src/app/docs/query/page.md
+++ b/docs/src/app/docs/query/page.md
@@ -46,7 +46,8 @@ export function SearchControls() {
 `throttleMs` coalesces rapid writes to the same query key. Updates to different keys are
 composed against the latest URL, and returning a value to the current URL cancels its queued write.
 If a component changes the key or parser it passes to the hook, the returned value is immediately
-re-read from the current URL.
+re-read from the current URL. A queued write is cancelled when its owning hook changes keys or
+unmounts, preventing an old component from modifying the URL of a later page.
 
 ## Multiple query values
 

--- a/packages/farm/src/__tests__/query-client-shallow.test.tsx
+++ b/packages/farm/src/__tests__/query-client-shallow.test.tsx
@@ -562,6 +562,63 @@ describe("useQueryState shallow routing", () => {
     expect(window.location.search).toBe("?q=second");
   });
 
+  it("cancels an older throttled write before an immediate update", () => {
+    vi.useFakeTimers();
+    let setQuery!: (value: string | null) => void;
+
+    function App({ throttle }: { throttle: boolean }) {
+      const [, updateQuery] = useQueryState("q", asString, {
+        throttleMs: throttle ? 50 : 0,
+      });
+      setQuery = updateQuery;
+      return null;
+    }
+
+    root = createRoot(container);
+    act(() => {
+      root?.render(createElement(App, { throttle: true }));
+    });
+    act(() => {
+      setQuery("old");
+      root?.render(createElement(App, { throttle: false }));
+    });
+    act(() => {
+      setQuery("new");
+      vi.runAllTimers();
+    });
+
+    expect(window.location.search).toBe("?q=new");
+  });
+
+  it("cancels an older throttled multi-key write before an immediate update", () => {
+    vi.useFakeTimers();
+    let setQueries!: (updates: { q?: string | null; page?: string | null }) => void;
+    const parsers = { q: asString, page: asString };
+
+    function App({ throttle }: { throttle: boolean }) {
+      const [, updateQueries] = useQueryStates(parsers, {
+        throttleMs: throttle ? 50 : 0,
+      });
+      setQueries = updateQueries;
+      return null;
+    }
+
+    root = createRoot(container);
+    act(() => {
+      root?.render(createElement(App, { throttle: true }));
+    });
+    act(() => {
+      setQueries({ q: "old", page: "1" });
+      root?.render(createElement(App, { throttle: false }));
+    });
+    act(() => {
+      setQueries({ q: "new", page: "2" });
+      vi.runAllTimers();
+    });
+
+    expect(window.location.search).toBe("?q=new&page=2");
+  });
+
   it("preserves Farm page history state when updating query params", async () => {
     vi.useFakeTimers();
     spaRouter = new SPARouter({ scrollRestoration: false });

--- a/packages/farm/src/__tests__/query-client-shallow.test.tsx
+++ b/packages/farm/src/__tests__/query-client-shallow.test.tsx
@@ -496,6 +496,72 @@ describe("useQueryState shallow routing", () => {
     expect(window.location.search).toBe("?q=old");
   });
 
+  it("cancels a throttled update when its hook unmounts", () => {
+    vi.useFakeTimers();
+    let setQuery!: (value: string | null) => void;
+
+    function App() {
+      const [, updateQuery] = useQueryState("q", asString, { throttleMs: 50 });
+      setQuery = updateQuery;
+      return null;
+    }
+
+    root = createRoot(container);
+    act(() => {
+      root?.render(createElement(App));
+    });
+    act(() => {
+      setQuery("old-page");
+      root?.unmount();
+    });
+    root = undefined;
+    window.history.replaceState(null, "", "/next");
+
+    act(() => {
+      vi.runAllTimers();
+    });
+
+    expect(window.location.pathname + window.location.search).toBe("/next");
+  });
+
+  it("does not let an earlier hook cancel a newer throttled update", () => {
+    vi.useFakeTimers();
+    let setFirst!: (value: string | null) => void;
+    let setSecond!: (value: string | null) => void;
+
+    function First() {
+      const [, updateQuery] = useQueryState("q", asString, { throttleMs: 50 });
+      setFirst = updateQuery;
+      return null;
+    }
+    function Second() {
+      const [, updateQuery] = useQueryState("q", asString, { throttleMs: 50 });
+      setSecond = updateQuery;
+      return null;
+    }
+    function App({ showFirst }: { showFirst: boolean }) {
+      return createElement(
+        "div",
+        null,
+        showFirst ? createElement(First) : null,
+        createElement(Second),
+      );
+    }
+
+    root = createRoot(container);
+    act(() => {
+      root?.render(createElement(App, { showFirst: true }));
+    });
+    act(() => {
+      setFirst("first");
+      setSecond("second");
+      root?.render(createElement(App, { showFirst: false }));
+      vi.runAllTimers();
+    });
+
+    expect(window.location.search).toBe("?q=second");
+  });
+
   it("preserves Farm page history state when updating query params", async () => {
     vi.useFakeTimers();
     spaRouter = new SPARouter({ scrollRestoration: false });

--- a/packages/farm/src/__tests__/query-client-shallow.test.tsx
+++ b/packages/farm/src/__tests__/query-client-shallow.test.tsx
@@ -619,6 +619,30 @@ describe("useQueryState shallow routing", () => {
     expect(window.location.search).toBe("?q=new&page=2");
   });
 
+  it("keeps throttled useQueryStates writes for different key sets", () => {
+    vi.useFakeTimers();
+    let setQueries!: (updates: { q?: string | null; page?: string | null }) => void;
+    const parsers = { q: asString, page: asString };
+
+    function App() {
+      const [, updateQueries] = useQueryStates(parsers, { throttleMs: 50 });
+      setQueries = updateQueries;
+      return null;
+    }
+
+    root = createRoot(container);
+    act(() => {
+      root?.render(createElement(App));
+    });
+    act(() => {
+      setQueries({ q: "search" });
+      setQueries({ page: "2" });
+      vi.runAllTimers();
+    });
+
+    expect(window.location.search).toBe("?q=search&page=2");
+  });
+
   it("preserves Farm page history state when updating query params", async () => {
     vi.useFakeTimers();
     spaRouter = new SPARouter({ scrollRestoration: false });

--- a/packages/farm/src/__tests__/query-client-shallow.test.tsx
+++ b/packages/farm/src/__tests__/query-client-shallow.test.tsx
@@ -643,6 +643,37 @@ describe("useQueryState shallow routing", () => {
     expect(window.location.search).toBe("?q=search&page=2");
   });
 
+  it("keeps throttled key sets distinct when query names contain commas", () => {
+    vi.useFakeTimers();
+    let setQueries!: (updates: {
+      "a,b"?: string | null;
+      a?: string | null;
+      b?: string | null;
+    }) => void;
+    const parsers = { "a,b": asString, a: asString, b: asString };
+
+    function App() {
+      const [, updateQueries] = useQueryStates(parsers, { throttleMs: 50 });
+      setQueries = updateQueries;
+      return null;
+    }
+
+    root = createRoot(container);
+    act(() => {
+      root?.render(createElement(App));
+    });
+    act(() => {
+      setQueries({ "a,b": "combined" });
+      setQueries({ a: "left", b: "right" });
+      vi.runAllTimers();
+    });
+
+    const searchParams = new URLSearchParams(window.location.search);
+    expect(searchParams.get("a,b")).toBe("combined");
+    expect(searchParams.get("a")).toBe("left");
+    expect(searchParams.get("b")).toBe("right");
+  });
+
   it("preserves Farm page history state when updating query params", async () => {
     vi.useFakeTimers();
     spaRouter = new SPARouter({ scrollRestoration: false });

--- a/packages/farm/src/query/client.ts
+++ b/packages/farm/src/query/client.ts
@@ -184,7 +184,7 @@ const updateURL = (
   updates: Record<string, string | null>,
   options: Options = {},
   emitUpdate = true,
-) => {
+): (() => void) | undefined => {
   if (typeof window === "undefined") return;
 
   const { throttleMs } = options;
@@ -212,6 +212,11 @@ const updateURL = (
   }, throttleMs);
 
   throttleTimers.set(throttleKey, timeout);
+  return () => {
+    if (throttleTimers.get(throttleKey) !== timeout) return;
+    clearTimeout(timeout);
+    throttleTimers.delete(throttleKey);
+  };
 };
 
 export function useQueryState<TParser extends Parser<any>>(
@@ -246,6 +251,7 @@ export function useQueryState<TParser extends Parser<any>>(
   const stateRef = useRef(state);
   const stateKeyRef = useRef(key);
   const isInternalUpdateRef = useRef(false);
+  const cancelPendingUpdateRef = useRef<(() => void) | undefined>(undefined);
   stateRef.current = state;
 
   const setValue = useCallback(
@@ -259,7 +265,7 @@ export function useQueryState<TParser extends Parser<any>>(
 
       emitter.emitKey(key, { state: value, query: serialized });
 
-      updateURL({ [key]: serialized }, options, true);
+      cancelPendingUpdateRef.current = updateURL({ [key]: serialized }, options, true);
 
       setTimeout(() => {
         isInternalUpdateRef.current = false;
@@ -323,6 +329,14 @@ export function useQueryState<TParser extends Parser<any>>(
     };
   }, [key, parser]);
 
+  useEffect(
+    () => () => {
+      cancelPendingUpdateRef.current?.();
+      cancelPendingUpdateRef.current = undefined;
+    },
+    [key],
+  );
+
   return [state, setValue];
 }
 
@@ -349,6 +363,7 @@ export function useQueryStates<T extends Record<string, Parser<any>>>(
   });
 
   const stateRef = useRef(state);
+  const cancelPendingUpdateRef = useRef<(() => void) | undefined>(undefined);
   stateRef.current = state;
 
   const setValues = useCallback(
@@ -374,7 +389,7 @@ export function useQueryStates<T extends Record<string, Parser<any>>>(
         }
       });
 
-      updateURL(urlUpdates, options, true);
+      cancelPendingUpdateRef.current = updateURL(urlUpdates, options, true);
     },
     [parsers, options],
   );
@@ -424,6 +439,14 @@ export function useQueryStates<T extends Record<string, Parser<any>>>(
       emitter.off("update", onEmitterUpdate);
     };
   }, [watchKeys, parsers]);
+
+  useEffect(
+    () => () => {
+      cancelPendingUpdateRef.current?.();
+      cancelPendingUpdateRef.current = undefined;
+    },
+    [watchKeys],
+  );
 
   return [state, setValues];
 }

--- a/packages/farm/src/query/client.ts
+++ b/packages/farm/src/query/client.ts
@@ -364,7 +364,7 @@ export function useQueryStates<T extends Record<string, Parser<any>>>(
   });
 
   const stateRef = useRef(state);
-  const cancelPendingUpdateRef = useRef<(() => void) | undefined>(undefined);
+  const pendingUpdatesRef = useRef(new Map<string, () => void>());
   stateRef.current = state;
 
   const setValues = useCallback(
@@ -390,8 +390,14 @@ export function useQueryStates<T extends Record<string, Parser<any>>>(
         }
       });
 
-      cancelPendingUpdateRef.current?.();
-      cancelPendingUpdateRef.current = updateURL(urlUpdates, options, true);
+      const updateKey = Object.keys(urlUpdates).sort().join(",");
+      pendingUpdatesRef.current.get(updateKey)?.();
+      const cancelPendingUpdate = updateURL(urlUpdates, options, true);
+      if (cancelPendingUpdate) {
+        pendingUpdatesRef.current.set(updateKey, cancelPendingUpdate);
+      } else {
+        pendingUpdatesRef.current.delete(updateKey);
+      }
     },
     [parsers, options],
   );
@@ -444,8 +450,10 @@ export function useQueryStates<T extends Record<string, Parser<any>>>(
 
   useEffect(
     () => () => {
-      cancelPendingUpdateRef.current?.();
-      cancelPendingUpdateRef.current = undefined;
+      for (const cancelPendingUpdate of pendingUpdatesRef.current.values()) {
+        cancelPendingUpdate();
+      }
+      pendingUpdatesRef.current.clear();
     },
     [watchKeys],
   );

--- a/packages/farm/src/query/client.ts
+++ b/packages/farm/src/query/client.ts
@@ -265,6 +265,7 @@ export function useQueryState<TParser extends Parser<any>>(
 
       emitter.emitKey(key, { state: value, query: serialized });
 
+      cancelPendingUpdateRef.current?.();
       cancelPendingUpdateRef.current = updateURL({ [key]: serialized }, options, true);
 
       setTimeout(() => {
@@ -389,6 +390,7 @@ export function useQueryStates<T extends Record<string, Parser<any>>>(
         }
       });
 
+      cancelPendingUpdateRef.current?.();
       cancelPendingUpdateRef.current = updateURL(urlUpdates, options, true);
     },
     [parsers, options],

--- a/packages/farm/src/query/client.ts
+++ b/packages/farm/src/query/client.ts
@@ -55,6 +55,10 @@ const getCurrentSearchParams = (): URLSearchParams => {
 
 const throttleTimers = new Map<string, ReturnType<typeof setTimeout>>();
 
+function getUpdateKey(updates: Record<string, unknown>): string {
+  return JSON.stringify(Object.keys(updates).sort());
+}
+
 const compareStructuredValues = (
   current: unknown,
   next: unknown,
@@ -193,7 +197,7 @@ const updateURL = (
     return;
   }
 
-  const throttleKey = Object.keys(updates).sort().join(",");
+  const throttleKey = getUpdateKey(updates);
   const existingTimeout = throttleTimers.get(throttleKey);
   if (existingTimeout) {
     clearTimeout(existingTimeout);
@@ -390,7 +394,7 @@ export function useQueryStates<T extends Record<string, Parser<any>>>(
         }
       });
 
-      const updateKey = Object.keys(urlUpdates).sort().join(",");
+      const updateKey = getUpdateKey(urlUpdates);
       pendingUpdatesRef.current.get(updateKey)?.();
       const cancelPendingUpdate = updateURL(urlUpdates, options, true);
       if (cancelPendingUpdate) {


### PR DESCRIPTION
## Problem

A throttled `useQueryState` or `useQueryStates` write remained queued after its component unmounted. If navigation occurred before the timer fired, the callback composed the old update against the new page and changed `/next` into `/next?q=old-page`.

## Root cause

Throttle timers were stored only in a module-level map. Hooks had no ownership handles to cancel their pending callbacks during key changes or unmount.

## Change

Return an ownership-aware cancellation function for each scheduled update. `useQueryState` retains its current key timer; `useQueryStates` retains timers by a collision-free serialization of each sorted update-key set, so a new write replaces only the same set while distinct sets can coexist. Cleanup cancels every timer still owned by the hook.

## Safety and compatibility

Immediate updates and cross-hook coalescing are preserved. Cancellation checks timer identity, so an earlier component cannot cancel a replacement scheduled by another hook. Switching a key set from throttled to immediate cancels only that stale set.

## Verification

- `pnpm --filter @farm.js/core exec vitest run src/__tests__/query-client-shallow.test.tsx` (24 tests passed)
- `pnpm --filter @farm.js/core type-check`
- `pnpm exec oxlint packages/farm/src/query/client.ts packages/farm/src/__tests__/query-client-shallow.test.tsx` (0 warnings, 0 errors)
- `git diff --check`

Regressions cover unmount cancellation, stale-owner safety, throttled-to-immediate replacement, distinct multi-key timer sets, and the former collision between `["a,b"]` and `["a", "b"]`.

## Documentation and release

Documented throttle ownership and cleanup. No generated artifacts or template changes.