### PR TITLE
fix(router): cancel stale viewport prefetches

### DIFF
--- a/docs/src/app/docs/routing/page.md
+++ b/docs/src/app/docs/routing/page.md
@@ -119,6 +119,8 @@ Native anchor behavior still takes precedence: for example, a `Link` with a `dow
 handled by the browser instead of Farm's SPA router. Absolute URI schemes such as `mailto:`, `tel:`,
 `sms:`, and same-origin `blob:` URLs are passed through unchanged and are never prefetched as app routes. Literal custom
 schemes such as `customapp:open` are validated from their URI grammar and work without registration.
+Viewport prefetch uses a short scroll guard and is cancelled if its link unmounts before the guard
+expires.
 Internal `Link` hrefs stay app-relative: when `basePath: "/console"` is configured, `href="/about"`
 renders and navigates to `/console/about`. Do not add the base path to route hrefs yourself.
 For a reusable custom-scheme type, use ``ExternalHref<`customapp:${string}`>`` (or declaration-merge

--- a/packages/farm/src/__tests__/spa-router-prefetch.test.ts
+++ b/packages/farm/src/__tests__/spa-router-prefetch.test.ts
@@ -27,6 +27,7 @@ describe("SPA router viewport prefetch", () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.unstubAllGlobals();
     vi.useRealTimers();
   });
 
@@ -60,6 +61,21 @@ describe("SPA router viewport prefetch", () => {
     router.observeForPrefetch(link);
     intersect();
     router.unobserveForPrefetch(link);
+    vi.advanceTimersByTime(50);
+
+    expect(prefetch).not.toHaveBeenCalled();
+    router.destroy();
+  });
+
+  it("ignores an observer callback queued before the link was unobserved", () => {
+    const router = new SPARouter({ prefetchTimeout: 50, scrollRestoration: false });
+    const prefetch = vi.spyOn(router, "prefetch").mockResolvedValue();
+    const link = document.createElement("a");
+    link.setAttribute("href", "/removed-before-callback");
+
+    router.observeForPrefetch(link);
+    router.unobserveForPrefetch(link);
+    intersect();
     vi.advanceTimersByTime(50);
 
     expect(prefetch).not.toHaveBeenCalled();

--- a/packages/farm/src/__tests__/spa-router-prefetch.test.ts
+++ b/packages/farm/src/__tests__/spa-router-prefetch.test.ts
@@ -1,0 +1,86 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SPARouter } from "../client/spa-router";
+
+describe("SPA router viewport prefetch", () => {
+  const callbacks: IntersectionObserverCallback[] = [];
+  const disconnect = vi.fn();
+
+  class MockIntersectionObserver {
+    constructor(callback: IntersectionObserverCallback) {
+      callbacks.push(callback);
+    }
+    observe() {}
+    unobserve() {}
+    disconnect = disconnect;
+  }
+
+  beforeEach(() => {
+    callbacks.length = 0;
+    disconnect.mockClear();
+    vi.useFakeTimers();
+    vi.stubGlobal("IntersectionObserver", MockIntersectionObserver);
+    window.history.replaceState(null, "", "/");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  function intersect(index = 0) {
+    callbacks[index]?.(
+      [{ isIntersecting: true } as IntersectionObserverEntry],
+      {} as IntersectionObserver,
+    );
+  }
+
+  it("prefetches after the viewport delay while the link remains mounted", () => {
+    const router = new SPARouter({ prefetchTimeout: 50, scrollRestoration: false });
+    const prefetch = vi.spyOn(router, "prefetch").mockResolvedValue();
+    const link = document.createElement("a");
+    link.setAttribute("href", "/products");
+
+    router.observeForPrefetch(link);
+    intersect();
+    vi.advanceTimersByTime(50);
+
+    expect(prefetch).toHaveBeenCalledWith("/products");
+    router.destroy();
+  });
+
+  it("cancels a scheduled prefetch when the link is unobserved", () => {
+    const router = new SPARouter({ prefetchTimeout: 50, scrollRestoration: false });
+    const prefetch = vi.spyOn(router, "prefetch").mockResolvedValue();
+    const link = document.createElement("a");
+    link.setAttribute("href", "/removed");
+
+    router.observeForPrefetch(link);
+    intersect();
+    router.unobserveForPrefetch(link);
+    vi.advanceTimersByTime(50);
+
+    expect(prefetch).not.toHaveBeenCalled();
+    router.destroy();
+  });
+
+  it("disconnects observers and cancels scheduled prefetches on destroy", () => {
+    const router = new SPARouter({ prefetchTimeout: 50, scrollRestoration: false });
+    const prefetch = vi.spyOn(router, "prefetch").mockResolvedValue();
+    const pending = document.createElement("a");
+    pending.setAttribute("href", "/pending");
+    const observed = document.createElement("a");
+    observed.setAttribute("href", "/observed");
+
+    router.observeForPrefetch(pending);
+    intersect(0);
+    router.observeForPrefetch(observed);
+    router.destroy();
+    vi.advanceTimersByTime(50);
+
+    expect(prefetch).not.toHaveBeenCalled();
+    expect(disconnect).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/farm/src/client/spa-router.ts
+++ b/packages/farm/src/client/spa-router.ts
@@ -155,6 +155,7 @@ export class SPARouter {
   private cache: Map<string, CacheEntry> = new Map();
   private prefetchingUrls: Set<string> = new Set();
   private observers: Map<Element, IntersectionObserver> = new Map();
+  private prefetchTimers: Map<Element, ReturnType<typeof setTimeout>> = new Map();
   private blockers: Set<FarmNavigationBlocker> = new Set();
   private unloadBlockers: Map<FarmNavigationBlocker, () => boolean> = new Map();
   private navigationListeners: Set<FarmNavigationListener> = new Set();
@@ -236,6 +237,10 @@ export class SPARouter {
   destroy(): void {
     if (typeof window === "undefined") return;
     this.cancelActiveNavigation();
+    for (const observer of this.observers.values()) observer.disconnect();
+    for (const timer of this.prefetchTimers.values()) clearTimeout(timer);
+    this.observers.clear();
+    this.prefetchTimers.clear();
     window.removeEventListener("popstate", this.onPopState);
     window.removeEventListener("beforeunload", this.onBeforeUnload);
   }
@@ -427,15 +432,19 @@ export class SPARouter {
 
     const href = element.getAttribute("href");
     if (!href || this.isExternalUrl(href)) return;
+    this.unobserveForPrefetch(element);
 
     const observer = new IntersectionObserver(
       (entries) => {
         for (const entry of entries) {
           if (entry.isIntersecting) {
             // Delay prefetch slightly to avoid prefetching during scroll
-            setTimeout(() => {
-              this.prefetch(href);
+            const timer = setTimeout(() => {
+              if (this.prefetchTimers.get(element) !== timer) return;
+              this.prefetchTimers.delete(element);
+              void this.prefetch(href);
             }, this.options.prefetchTimeout);
+            this.prefetchTimers.set(element, timer);
 
             // Stop observing after first intersection
             observer.unobserve(element);
@@ -458,6 +467,11 @@ export class SPARouter {
     if (observer) {
       observer.unobserve(element);
       this.observers.delete(element);
+    }
+    const timer = this.prefetchTimers.get(element);
+    if (timer !== undefined) {
+      clearTimeout(timer);
+      this.prefetchTimers.delete(element);
     }
   }
 

--- a/packages/farm/src/client/spa-router.ts
+++ b/packages/farm/src/client/spa-router.ts
@@ -438,6 +438,7 @@ export class SPARouter {
       (entries) => {
         for (const entry of entries) {
           if (entry.isIntersecting) {
+            if (this.observers.get(element) !== observer) continue;
             // Delay prefetch slightly to avoid prefetching during scroll
             const timer = setTimeout(() => {
               if (this.prefetchTimers.get(element) !== timer) return;


### PR DESCRIPTION
## Problem

After a link entered the viewport, Farm scheduled its prefetch with a short scroll guard. Unmounting the link or destroying the router during that delay did not cancel the timer, so stale links could still request page data after they no longer existed.

## Root cause

The router tracked `IntersectionObserver` instances but discarded the timer handle immediately. `unobserveForPrefetch` could stop future intersections but could not cancel work already scheduled, and `destroy` did not disconnect remaining observers.

## Change

Track delayed prefetches by their owning element. Unobserving cancels that element's current timer, repeat observation replaces prior work, and router teardown disconnects all observers and clears every pending prefetch.

## Safety and compatibility

Mounted links still prefetch after the existing delay. Cancellation is element- and timer-specific, so a replacement observation is not removed by stale cleanup. External and document-navigation URLs retain their existing exclusions.

## Verification

- `pnpm --filter @farm.js/core exec vitest run src/__tests__/spa-router-prefetch.test.ts src/__tests__/link.test.tsx src/__tests__/spa-router-concurrency.test.ts --reporter=dot` (37 tests passed)
- `pnpm --filter @farm.js/core type-check`
- `pnpm exec oxfmt packages/farm/src/client/spa-router.ts packages/farm/src/__tests__/spa-router-prefetch.test.ts docs/src/app/docs/routing/page.md`
- `pnpm exec oxlint packages/farm/src/client/spa-router.ts packages/farm/src/__tests__/spa-router-prefetch.test.ts` (one pre-existing warning in `spa-router.ts`)
- `git diff --check`

The unobserve and destroy regressions both call `prefetch` on the previous implementation.

## Documentation and release

Documented viewport-prefetch cancellation. No generated artifacts or template changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale viewport prefetches so scheduled prefetches are cancelled when a link is unobserved or the router is destroyed. Previously, unmounting a link or destroying the router during the scroll guard still fired the prefetch request. The router now tracks pending timers per element, clears them on unobservation, ignores intersection callbacks from detached observers, and disconnects observers and clears all timers on destroy.

<sup>Written for commit 82eca0f4d573e5f01cbe23c32730e9ddfe8741be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/726?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

