### PR TITLE
fix(cache): carry invalidation across query aliases

### DIFF
--- a/docs/src/app/docs/server-queries/page.md
+++ b/docs/src/app/docs/server-queries/page.md
@@ -144,6 +144,8 @@ export const updateProduct = createServerFn({
 ```
 
 During a browser server-action call, Farm carries structured invalidations back with the action response. Mounted stale queries refetch automatically, and concurrent consumers still produce one request.
+If invalidation arrives while a query is still resolving its canonical server key, the invalidation
+follows that key and the older response cannot make the entry fresh again.
 
 ## Share keys with routes and APIs
 

--- a/packages/farm/src/__tests__/client-cache.test.ts
+++ b/packages/farm/src/__tests__/client-cache.test.ts
@@ -64,4 +64,43 @@ describe("Farm client data cache", () => {
 
     expect(cache.get("query-call")).toBe(cache.get(key));
   });
+
+  it("preserves an invalidation when a provisional key becomes canonical", () => {
+    const cache = new FarmClientDataCache();
+
+    cache.invalidate("query-call", 10);
+    cache.alias("query-call", "product:123");
+    cache.set("product:123", {
+      data: { id: "stale" },
+      updatedAt: 1,
+      staleAt: Number.POSITIVE_INFINITY,
+    });
+
+    expect(cache.isStale("product:123", 11)).toBe(true);
+    expect(cache.get("query-call")?.invalidatedAt).toBe(10);
+
+    cache.set("product:123", {
+      data: { id: "fresh" },
+      updatedAt: 11,
+      staleAt: Number.POSITIVE_INFINITY,
+    });
+    expect(cache.isStale("query-call", 12)).toBe(false);
+    cache.dispose();
+  });
+
+  it("applies a provisional invalidation to an existing canonical entry", () => {
+    const cache = new FarmClientDataCache();
+    cache.set("product:123", {
+      data: { id: "existing" },
+      updatedAt: 1,
+      staleAt: Number.POSITIVE_INFINITY,
+    });
+
+    cache.invalidate("query-call", 10);
+    cache.alias("query-call", "product:123");
+
+    expect(cache.isStale("product:123", 11)).toBe(true);
+    expect(cache.get("product:123")?.invalidatedAt).toBe(10);
+    cache.dispose();
+  });
 });

--- a/packages/farm/src/client-cache.ts
+++ b/packages/farm/src/client-cache.ts
@@ -126,11 +126,39 @@ export class FarmClientDataCache {
     if (alias === resolved) return;
 
     const aliasEntry = this.entries.get(alias);
+    const aliasInvalidatedAt = this.invalidatedAt.get(alias) ?? aliasEntry?.invalidatedAt;
+    const resolvedInvalidatedAt = this.invalidatedAt.get(resolved);
     if (aliasEntry && !this.entries.has(resolved)) {
       this.entries.set(resolved, aliasEntry);
     }
 
     this.entries.delete(alias);
+    this.invalidatedAt.delete(alias);
+    const invalidatedAt = [aliasInvalidatedAt, resolvedInvalidatedAt].reduce<number | undefined>(
+      (latest, value) =>
+        value === undefined ? latest : latest === undefined ? value : Math.max(latest, value),
+      undefined,
+    );
+    const resolvedEntry = this.entries.get(resolved);
+    if (
+      invalidatedAt !== undefined &&
+      (!resolvedEntry || invalidatedAt > resolvedEntry.updatedAt)
+    ) {
+      this.invalidatedAt.set(resolved, invalidatedAt);
+      if (resolvedEntry) {
+        this.entries.set(resolved, {
+          ...resolvedEntry,
+          staleAt: 0,
+          invalidatedAt,
+        });
+      }
+    } else if (invalidatedAt !== undefined) {
+      this.invalidatedAt.delete(resolved);
+      if (resolvedEntry?.invalidatedAt !== undefined) {
+        this.entries.set(resolved, { ...resolvedEntry, invalidatedAt: undefined });
+      }
+    }
+
     const aliasInflight = this.inflight.get(alias);
     if (aliasInflight && !this.inflight.has(resolved)) {
       this.inflight.set(resolved, aliasInflight);


### PR DESCRIPTION
## Problem

A browser server query begins with a provisional call key and aliases it to the canonical key returned by the server. If an invalidation arrived before that alias was established, the invalidation barrier stayed on the provisional key and an older in-flight result could become fresh under the canonical key.

## Root cause

`FarmClientDataCache.alias` moved entries and in-flight promises but did not move the cache's separate invalidation timestamp. It also did not apply the provisional invalidation to a canonical entry that already existed.

## Change

Reconcile the newest invalidation timestamp from both keys while aliasing, apply it to the resolved entry, and retain the barrier until a result newer than the invalidation is stored. Tests cover both an empty canonical key and a pre-existing canonical entry.

## Safety and compatibility

Alias resolution and in-flight deduplication are unchanged. A canonical result newer than the invalidation clears the barrier normally; only older results remain stale.

## Verification

- `pnpm --filter @farm.js/core exec vitest run src/__tests__/client-cache.test.ts src/__tests__/server-query-client.test.tsx --reporter=dot` (12 tests passed)
- `pnpm --filter @farm.js/core type-check`
- `pnpm exec oxfmt packages/farm/src/client-cache.ts packages/farm/src/__tests__/client-cache.test.ts docs/src/app/docs/server-queries/page.md`
- `pnpm exec oxlint packages/farm/src/client-cache.ts packages/farm/src/__tests__/client-cache.test.ts` (0 warnings, 0 errors)
- `git diff --check`

Both invalidation regressions fail before the cache change: `isStale()` returns false after aliasing and storing the older result.

## Documentation and release

Documented invalidation behavior during canonical-key resolution. No generated artifacts or template changes.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes cache invalidation getting lost when a browser-server query's provisional key is aliased to its canonical server key, so an older in-flight result can no longer become fresh after an invalidation.

**Behavior**
- `alias` now reconciles the newest invalidation timestamp from both keys and applies it to the resolved entry.
- The invalidation barrier is retained until a result newer than the invalidation is stored; pre-existing canonical entries also receive the provisional invalidation.
- Alias resolution and in-flight deduplication are unchanged.
- Docs now describe invalidation during canonical-key resolution.

<sup>Written for commit dc8b6ec4cc082714ce578e811b2c5f97f56a0372. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/727?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

