### PR TITLE
fix(query): synchronize SPA history indexes

### DIFF
--- a/docs/src/app/docs/query/page.md
+++ b/docs/src/app/docs/query/page.md
@@ -51,6 +51,10 @@ re-read from the current URL.
 Repeated keys have the same meaning during server rendering and in client hooks. For example,
 `?tag=react&tag=vite` is read as both values by `asArrayOf(asString)`.
 
+When Farm's SPA router is installed, shallow query pushes participate in its normal history index.
+Back/forward blockers therefore receive the rendered query location and can restore a blocked
+traversal without inserting a duplicate entry.
+
 ## Multiple query values
 
 Use `useQueryStates` when several controls should update together. This keeps the browser URL as the source of shareable state for filters, pagination, and tabs.

--- a/packages/farm/src/__tests__/query-client-shallow.test.tsx
+++ b/packages/farm/src/__tests__/query-client-shallow.test.tsx
@@ -614,6 +614,56 @@ describe("useQueryState shallow routing", () => {
     expect((spaRouter as any).currentHistoryIndex).toBe(2);
   });
 
+  it("keeps the hash in SPA router state during shallow query writes", () => {
+    vi.useFakeTimers();
+    window.history.replaceState(null, "", "/#details");
+    spaRouter = new SPARouter({ scrollRestoration: false });
+    (window as any).__FARM_SPA_ROUTER__ = spaRouter;
+    let setQuery!: (value: string | null) => void;
+
+    function App() {
+      const [, set] = useQueryState("q", asString);
+      setQuery = set;
+      return null;
+    }
+
+    root = createRoot(container);
+    act(() => {
+      root?.render(createElement(App));
+    });
+    act(() => {
+      setQuery("value");
+    });
+
+    expect(window.location.hash).toBe("#details");
+    expect(window.history.state).toMatchObject({ path: "/?q=value#details" });
+  });
+
+  it("preserves primitive history state through the router fallback", () => {
+    vi.useFakeTimers();
+    spaRouter = new SPARouter({ scrollRestoration: false });
+    (window as any).__FARM_SPA_ROUTER__ = spaRouter;
+    window.history.replaceState("app-owned", "", "/");
+    let setQuery!: (value: string | null) => void;
+
+    function App() {
+      const [, set] = useQueryState("q", asString);
+      setQuery = set;
+      return null;
+    }
+
+    root = createRoot(container);
+    act(() => {
+      root?.render(createElement(App));
+    });
+    act(() => {
+      setQuery("value");
+    });
+
+    expect(window.location.search).toBe("?q=value");
+    expect(window.history.state).toBe("app-owned");
+  });
+
   it("does not leak SPA router popstate listeners across tests", async () => {
     vi.useFakeTimers();
     spaRouter = new SPARouter({ scrollRestoration: false });

--- a/packages/farm/src/__tests__/query-client-shallow.test.tsx
+++ b/packages/farm/src/__tests__/query-client-shallow.test.tsx
@@ -577,6 +577,43 @@ describe("useQueryState shallow routing", () => {
     );
   });
 
+  it("advances the SPA router history index for shallow query pushes", () => {
+    vi.useFakeTimers();
+    spaRouter = new SPARouter({ scrollRestoration: false });
+    (window as any).__FARM_SPA_ROUTER__ = spaRouter;
+    let setQuery!: (value: string | null) => void;
+
+    function App() {
+      const [, set] = useQueryState("q", asString);
+      setQuery = set;
+      return null;
+    }
+
+    root = createRoot(container);
+    act(() => {
+      root?.render(createElement(App));
+    });
+    act(() => {
+      setQuery("first");
+    });
+
+    expect(window.history.state).toMatchObject({
+      path: "/?q=first",
+      __farmHistoryIndex: 1,
+    });
+    expect((spaRouter as any).currentHistoryPath).toBe("/?q=first");
+
+    act(() => {
+      setQuery("second");
+    });
+
+    expect(window.history.state).toMatchObject({
+      path: "/?q=second",
+      __farmHistoryIndex: 2,
+    });
+    expect((spaRouter as any).currentHistoryIndex).toBe(2);
+  });
+
   it("does not leak SPA router popstate listeners across tests", async () => {
     vi.useFakeTimers();
     spaRouter = new SPARouter({ scrollRestoration: false });

--- a/packages/farm/src/__tests__/universal-build-router-runtime.test.ts
+++ b/packages/farm/src/__tests__/universal-build-router-runtime.test.ts
@@ -47,7 +47,9 @@ describe("generateUniversalRouterStateProperties", () => {
       pushState: vi.fn((state: Record<string, unknown>) => {
         history.state = state as typeof history.state;
       }),
-      replaceState: vi.fn(),
+      replaceState: vi.fn((state: Record<string, unknown>) => {
+        history.state = state as typeof history.state;
+      }),
     };
     const windowValue = {
       history,
@@ -97,7 +99,24 @@ describe("generateUniversalRouterStateProperties", () => {
       expect.any(URL),
     );
     expect(router.currentHistoryIndex).toBe(3);
+    expect(router.currentPath).toBe("/start?q=value");
     expect(windowValue.dispatchEvent).not.toHaveBeenCalled();
+
+    history.state = { __farmPageState: { draft: true }, __farmHistoryIndex: 2 };
+    router.currentHistoryIndex = 2;
+    router.writeURLSearch("replace", "/start?q=replaced#details");
+
+    expect(history.replaceState).toHaveBeenCalledWith(
+      expect.objectContaining({
+        __farmPageState: { draft: true },
+        __farmHistoryIndex: 2,
+        path: "/start?q=replaced#details",
+      }),
+      "",
+      expect.any(URL),
+    );
+    expect(router.currentHistoryIndex).toBe(2);
+    expect(router.currentPath).toBe("/start?q=replaced");
   });
 
   it("checks blocker activity before prompting on unload", () => {

--- a/packages/farm/src/__tests__/universal-build-router-runtime.test.ts
+++ b/packages/farm/src/__tests__/universal-build-router-runtime.test.ts
@@ -37,6 +37,67 @@ describe("generateUniversalRouterStateProperties", () => {
     expect(runtime).toContain("pushState: function(state, href)");
     expect(runtime).toContain("replaceState: function(state, href)");
     expect(runtime).toContain("writePageState: function(action, state, href)");
+    expect(runtime).toContain("writeURLSearch: function(action, href)");
+    expect(runtime).toContain("url.pathname + url.search + url.hash");
+  });
+
+  it("keeps shallow query writes inside universal router bookkeeping", () => {
+    const history = {
+      state: { __farmPageState: { draft: true }, __farmHistoryIndex: 2 },
+      pushState: vi.fn((state: Record<string, unknown>) => {
+        history.state = state as typeof history.state;
+      }),
+      replaceState: vi.fn(),
+    };
+    const windowValue = {
+      history,
+      dispatchEvent: vi.fn(),
+      location: {
+        href: "https://example.test/start",
+        origin: "https://example.test",
+        pathname: "/start",
+        search: "",
+      },
+    };
+    const createRouter = new Function(
+      "window",
+      "IDLE_NAVIGATION_STATE",
+      "createHistoryState",
+      "FARM_PAGE_STATE_KEY",
+      "FARM_HISTORY_INDEX_KEY",
+      "URL",
+      "CustomEvent",
+      `return ({${runtime}});`,
+    );
+    const createHistoryState = (path: string, pageState: unknown, currentState?: unknown) => ({
+      ...(currentState && typeof currentState === "object" ? currentState : {}),
+      path,
+      __farmPageState: pageState,
+    });
+    const router = createRouter(
+      windowValue,
+      { state: "idle" },
+      createHistoryState,
+      "__farmPageState",
+      "__farmHistoryIndex",
+      URL,
+      Event,
+    );
+    router.currentHistoryIndex = 2;
+
+    router.writeURLSearch("push", "/start?q=value#details");
+
+    expect(history.pushState).toHaveBeenCalledWith(
+      expect.objectContaining({
+        __farmPageState: { draft: true },
+        __farmHistoryIndex: 3,
+        path: "/start?q=value#details",
+      }),
+      "",
+      expect.any(URL),
+    );
+    expect(router.currentHistoryIndex).toBe(3);
+    expect(windowValue.dispatchEvent).not.toHaveBeenCalled();
   });
 
   it("checks blocker activity before prompting on unload", () => {

--- a/packages/farm/src/client/history-sync.ts
+++ b/packages/farm/src/client/history-sync.ts
@@ -1,4 +1,4 @@
-import { getInstalledFarmSPARouter } from "./spa-router";
+import { getInstalledFarmSPARouter, type SPARouter } from "./spa-router";
 
 /** Fired after programmatic history writes that must not start a navigation. */
 export const FARM_HISTORY_CHANGE_EVENT = "farm:historychange";
@@ -13,7 +13,11 @@ export interface FarmHistoryChangeDetail {
 export function writeFarmURLSearchHistory(action: "push" | "replace", href: string): boolean {
   const router = getInstalledFarmSPARouter();
   if (!router) return false;
-  router.writeURLSearch(action, href);
+  const writeURLSearch = (router as { writeURLSearch?: SPARouter["writeURLSearch"] })
+    .writeURLSearch;
+  if (typeof writeURLSearch !== "function") return false;
+  if (window.history.state !== null && typeof window.history.state !== "object") return false;
+  writeURLSearch.call(router, action, href);
   return true;
 }
 

--- a/packages/farm/src/client/history-sync.ts
+++ b/packages/farm/src/client/history-sync.ts
@@ -9,6 +9,14 @@ export interface FarmHistoryChangeDetail {
   kind: FarmHistoryChangeKind;
 }
 
+/** Write shallow URL history through the installed SPA router when available. */
+export function writeFarmURLSearchHistory(action: "push" | "replace", href: string): boolean {
+  const router = getInstalledFarmSPARouter();
+  if (!router) return false;
+  router.writeURLSearch(action, href);
+  return true;
+}
+
 function dispatchHistoryChange(kind: FarmHistoryChangeKind): void {
   window.dispatchEvent(
     new CustomEvent<FarmHistoryChangeDetail>(FARM_HISTORY_CHANGE_EVENT, {

--- a/packages/farm/src/client/spa-router.ts
+++ b/packages/farm/src/client/spa-router.ts
@@ -901,8 +901,10 @@ export class SPARouter {
     if (typeof window === "undefined") return;
 
     const url = href ? new URL(href, window.location.origin).toString() : window.location.href;
-    const nextPath = new URL(url).pathname + new URL(url).search;
-    const nextState = createHistoryState(nextPath, state, window.history.state) as Record<
+    const parsedUrl = new URL(url);
+    const nextPath = parsedUrl.pathname + parsedUrl.search;
+    const historyPath = nextPath + parsedUrl.hash;
+    const nextState = createHistoryState(historyPath, state, window.history.state) as Record<
       string,
       unknown
     >;

--- a/packages/farm/src/client/spa-router.ts
+++ b/packages/farm/src/client/spa-router.ts
@@ -503,6 +503,11 @@ export class SPARouter {
     this.writePageState("replace", state, href);
   }
 
+  /** @internal Keep shallow URL-search writes inside the router's history bookkeeping. */
+  writeURLSearch(action: "push" | "replace", href: string): void {
+    this.writePageState(action, readPageState(), href, false);
+  }
+
   private async commitNavigation(options: {
     fullPath: string;
     pageData: PageData;
@@ -887,7 +892,12 @@ export class SPARouter {
     }
   }
 
-  private writePageState(action: "push" | "replace", state: unknown, href?: string): void {
+  private writePageState(
+    action: "push" | "replace",
+    state: unknown,
+    href?: string,
+    notify = true,
+  ): void {
     if (typeof window === "undefined") return;
 
     const url = href ? new URL(href, window.location.origin).toString() : window.location.href;
@@ -909,7 +919,7 @@ export class SPARouter {
     }
     this.currentHistoryPath = nextPath;
 
-    notifyHistoryChange("page-state");
+    if (notify) notifyHistoryChange("page-state");
   }
 
   /**

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -1876,10 +1876,26 @@ export function generateUniversalRouterStateProperties(): string {
 
   writePageState: function(action, state, href) {
     const url = new URL(href || window.location.href, window.location.origin);
-    this.writeHistoryEntry(action, url.pathname + url.search, state, url, "page-state");
+    this.writeHistoryEntry(action, url.pathname + url.search + url.hash, state, url, "page-state");
   },
 
-  writeHistoryEntry: function(action, path, pageState, url, changeKind = "url-search") {
+  writeURLSearch: function(action, href) {
+    const url = new URL(href || window.location.href, window.location.origin);
+    const currentState = window.history.state;
+    const pageState = currentState && typeof currentState === "object"
+      ? currentState[FARM_PAGE_STATE_KEY]
+      : undefined;
+    this.writeHistoryEntry(
+      action,
+      url.pathname + url.search + url.hash,
+      pageState,
+      url,
+      "url-search",
+      false,
+    );
+  },
+
+  writeHistoryEntry: function(action, path, pageState, url, changeKind = "url-search", notify = true) {
     if (action === "pop") return;
     const nextState = createHistoryState(path, pageState, window.history.state);
     const nextIndex = this.currentHistoryIndex == null
@@ -1894,9 +1910,11 @@ export function generateUniversalRouterStateProperties(): string {
     this.currentHistoryState = nextState;
     // Announce programmatic history writes without synthesizing popstate,
     // which the router reserves for real back/forward navigation.
-    window.dispatchEvent(
-      new CustomEvent("farm:historychange", { detail: { kind: changeKind } }),
-    );
+    if (notify) {
+      window.dispatchEvent(
+        new CustomEvent("farm:historychange", { detail: { kind: changeKind } }),
+      );
+    }
   },
 
   registerScrollElement: function(key, element) {

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -1893,6 +1893,7 @@ export function generateUniversalRouterStateProperties(): string {
       "url-search",
       false,
     );
+    this.currentPath = url.pathname + url.search;
   },
 
   writeHistoryEntry: function(action, path, pageState, url, changeKind = "url-search", notify = true) {

--- a/packages/farm/src/query/client.ts
+++ b/packages/farm/src/query/client.ts
@@ -7,7 +7,11 @@
  */
 
 import { useState, useEffect, useCallback, useRef } from "react";
-import { notifyHistoryChange, subscribeHistoryChange } from "../client/history-sync";
+import {
+  notifyHistoryChange,
+  subscribeHistoryChange,
+  writeFarmURLSearchHistory,
+} from "../client/history-sync";
 import { _resolveCurrentRequest } from "../server/request-bridge";
 import { emitter } from "./sync";
 export { parseRouteParams, loadRouteParams, type RouteParamsInput } from "./params";
@@ -158,19 +162,14 @@ const commitURLUpdate = (
 
   if (newUrl === currentUrl) return;
 
-  // Preserve Farm's history state (page state, interception markers) and
-  // keep its recorded path in sync with the new query string so pops
-  // report the entry's real location.
-  const historyState = window.history.state;
-  const nextHistoryState =
-    historyState && typeof historyState === "object" && "path" in historyState
-      ? { ...historyState, path: newUrl }
-      : historyState;
-
-  if (history === "replaceState") {
-    window.history.replaceState(nextHistoryState, "", newUrl);
-  } else {
-    window.history.pushState(nextHistoryState, "", newUrl);
+  const historyAction = history === "replaceState" ? "replace" : "push";
+  if (!writeFarmURLSearchHistory(historyAction, newUrl)) {
+    const historyState = window.history.state;
+    const nextHistoryState =
+      historyState && typeof historyState === "object" && "path" in historyState
+        ? { ...historyState, path: newUrl }
+        : historyState;
+    window.history[history](nextHistoryState, "", newUrl);
   }
 
   if (emitUpdate) {


### PR DESCRIPTION
## Problem

A shallow query `pushState` copied the current Farm history state, including its `__farmHistoryIndex`, into the new entry. Consecutive entries therefore shared one index and the SPA router did not update its tracked rendered path. A blocked back traversal could calculate a zero delta and insert a duplicate entry instead of reversing the traversal.

## Root cause

The query hook wrote directly to `window.history`, bypassing SPA-router bookkeeping. The later history-change notification only informed subscribers; it did not repair the router index and rendered location. The generated universal router also lacked the new shallow-write capability.

## Change

Route query history through an internal shallow-search method when the installed router supports it, in both the standard and generated universal runtimes. Older router shapes and primitive app-owned history state use the direct History API fallback. Query notifications remain separate, so shallow semantics do not change.

## Safety and compatibility

Page state, interception metadata, unrelated object state, hashes, and router-less hooks are preserved. Replace writes keep the current index; push writes advance it exactly once. Both runtimes track pathname plus search as the rendered blocker location while storing the full hash-bearing path in history state.

## Verification

- `pnpm --filter @farm.js/core exec vitest run src/__tests__/universal-build-router-runtime.test.ts src/__tests__/query-client-shallow.test.tsx --reporter=dot` (38 tests passed)
- `pnpm --filter @farm.js/core type-check`
- Focused formatting and linting completed; only pre-existing warnings remain in `spa-router.ts` and `universal-build.ts`.
- `git diff --check`

The regressions cover push and replace indexes, universal runtime bookkeeping, hash preservation, primitive state, and the direct fallback.

## Documentation and release

Documented shallow-query history behavior. No generated artifacts or template changes.