### PR TITLE
fix(api): isolate credentialed client caches

### DIFF
--- a/docs/src/app/docs/api-client/page.md
+++ b/docs/src/app/docs/api-client/page.md
@@ -285,11 +285,14 @@ changing the completed API result.
 Use a structured cache key when an API response intentionally shares data with route data or a [`createServerQuery`](/docs/server-queries):
 
 ```ts
-const product = await api.products.get(
+const publicApi = createAPIClient<APIRouter>({ credentials: "omit" });
+
+const product = await publicApi.products.get(
   { query: { id } },
   {
     cache: {
       key: ["product", id],
+      scope: "shared",
       policy: "stale-while-revalidate",
       staleTime: 30_000,
     },
@@ -303,8 +306,8 @@ changing explicit headers or credentials clears that private cache. This prevent
 reusing a response produced under an earlier cookie identity without placing credential values in a
 public cache key. Invalidate session-specific reads when the same client logs in or out.
 
-Use `scope: "shared"` only for public data that intentionally shares a structured key with route
-data or another API client:
+Use `scope: "shared"` only for public data requested with `credentials: "omit"` and no custom
+headers that intentionally shares a structured key with route data or another API client:
 
 ```ts
 cache: {
@@ -315,7 +318,8 @@ cache: {
 ```
 
 Requests with `credentials: "omit"` and no custom headers may share by default because they carry
-no browser identity. `scope: "client"` can keep those requests private as well.
+no browser identity. `scope: "client"` can keep those requests private as well. Credentialed or
+header-carrying requests remain client-scoped even if `scope: "shared"` is supplied.
 
 Set `cache.dedupeMs` to join identical requests started within that window. If an older request is
 still running after the window expires, the newer request becomes the cache owner; the older result

--- a/docs/src/app/docs/api-client/page.md
+++ b/docs/src/app/docs/api-client/page.md
@@ -298,11 +298,24 @@ const product = await api.products.get(
 ```
 
 Structured keys use Farm's route-data key contract. Default API cache keys include the API origin.
-Clients that configure headers or non-default credentials keep their cache private to that client,
-and changing that request context clears the private cache. This prevents an authenticated response
-from being reused by a client with a different identity without placing credential values in a
-public cache key. Clients using the default same-origin request context can still share structured
-keys with Farm's route-data cache.
+Same-origin and otherwise credentialed requests keep their cache private to the created client, and
+changing explicit headers or credentials clears that private cache. This prevents a new client from
+reusing a response produced under an earlier cookie identity without placing credential values in a
+public cache key. Invalidate session-specific reads when the same client logs in or out.
+
+Use `scope: "shared"` only for public data that intentionally shares a structured key with route
+data or another API client:
+
+```ts
+cache: {
+  key: ["catalog", "featured"],
+  scope: "shared",
+  policy: "cache-first",
+}
+```
+
+Requests with `credentials: "omit"` and no custom headers may share by default because they carry
+no browser identity. `scope: "client"` can keep those requests private as well.
 
 Set `cache.dedupeMs` to join identical requests started within that window. If an older request is
 still running after the window expires, the newer request becomes the cache owner; the older result

--- a/packages/farm/src/__tests__/api-client.test.ts
+++ b/packages/farm/src/__tests__/api-client.test.ts
@@ -464,6 +464,7 @@ describe("createAPIClient", () => {
     const cache = {
       key: ["user", "1"] as const,
       policy: "cache-first" as const,
+      scope: "shared" as const,
       staleTime: 10_000,
     };
 
@@ -472,6 +473,26 @@ describe("createAPIClient", () => {
 
     expect(cached.data).toEqual({ id: "1", name: "Alice" });
     expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("isolates default same-origin caches between client instances", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(buildResponse({ session: "anonymous" }))
+      .mockResolvedValueOnce(buildResponse({ session: "signed-in" }));
+    globalThis.fetch = fetchMock as any;
+    const first = createAPIClient<APIRouter>({ baseURL: "/api" });
+    const second = createAPIClient<APIRouter>({ baseURL: "/api" });
+    const cache = { policy: "cache-first" as const, staleTime: 10_000 };
+
+    const anonymous = await first.users.get({}, { cache });
+    const signedIn = await second.users.get({}, { cache });
+    const cachedSignedIn = await second.users.get({}, { cache });
+
+    expect(anonymous.data).toEqual({ session: "anonymous" });
+    expect(signedIn.data).toEqual({ session: "signed-in" });
+    expect(cachedSignedIn.data).toEqual({ session: "signed-in" });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
   it("isolates cached responses between clients with different request contexts", async () => {
@@ -695,7 +716,11 @@ describe("createAPIClient", () => {
     globalThis.fetch = fetchMock as any;
     const api = createAPIClient<APIRouter>({ baseURL: "http://example.com" });
     const usersKey = ["users", "list"] as const;
-    const cache = { key: usersKey, policy: "cache-first" as const, staleTime: 10_000 };
+    const cache = {
+      key: usersKey,
+      policy: "cache-first" as const,
+      staleTime: 10_000,
+    };
 
     const initial = await api.users.get({}, { cache });
     const mutation = await api.users.post(
@@ -955,12 +980,18 @@ describe("createAPIClient", () => {
     const usersKey = defineCacheKey<UsersData>()(() => ["users", "list"] as const)();
     const normalizedUsersKey = normalizeFarmClientCacheKey(usersKey);
     const api = createAPIClient<APIRouter>({ baseURL: "http://example.com" });
-    const cache = { key: usersKey, policy: "cache-first" as const, staleTime: 10_000 };
+    const cache = {
+      key: usersKey,
+      policy: "cache-first" as const,
+      scope: "shared" as const,
+      staleTime: 10_000,
+    };
 
     await api.users.get({}, { cache });
     const mutation = api.users.post(
       { body: { name: "Ada", email: "ada@example.com" } },
       {
+        cache: { scope: "shared" },
         optimistic: {
           update: [
             [
@@ -1009,11 +1040,17 @@ describe("createAPIClient", () => {
     const usersKey = defineCacheKey<UsersData>()(() => ["users", "list"] as const)();
     const api = createAPIClient<APIRouter>({ baseURL: "http://example.com" });
     const secondApi = createAPIClient<APIRouter>({ baseURL: "http://example.com" });
-    const cache = { key: usersKey, policy: "cache-first" as const, staleTime: 10_000 };
+    const cache = {
+      key: usersKey,
+      policy: "cache-first" as const,
+      scope: "shared" as const,
+      staleTime: 10_000,
+    };
     const optimisticMutation = (client: typeof api, id: string) =>
       client.users.post(
         { body: { name: id, email: `${id}@example.com` } },
         {
+          cache: { scope: "shared" },
           optimistic: {
             update: [
               [

--- a/packages/farm/src/__tests__/api-client.test.ts
+++ b/packages/farm/src/__tests__/api-client.test.ts
@@ -459,8 +459,14 @@ describe("createAPIClient", () => {
     const fetchMock = vi.fn(async () => buildResponse({ id: "1", name: "Alice" }));
     globalThis.fetch = fetchMock as any;
 
-    const first = createAPIClient<APIRouter>({ baseURL: "http://example.com" });
-    const second = createAPIClient<APIRouter>({ baseURL: "http://example.com" });
+    const first = createAPIClient<APIRouter>({
+      baseURL: "http://example.com",
+      credentials: "omit",
+    });
+    const second = createAPIClient<APIRouter>({
+      baseURL: "http://example.com",
+      credentials: "omit",
+    });
     const cache = {
       key: ["user", "1"] as const,
       policy: "cache-first" as const,
@@ -473,6 +479,63 @@ describe("createAPIClient", () => {
 
     expect(cached.data).toEqual({ id: "1", name: "Alice" });
     expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not let shared scope expose credentialed responses to another client", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(buildResponse({ session: "first" }))
+      .mockResolvedValueOnce(buildResponse({ session: "second" }));
+    globalThis.fetch = fetchMock as any;
+    const first = createAPIClient<APIRouter>({
+      baseURL: "http://example.com",
+      credentials: "include",
+    });
+    const second = createAPIClient<APIRouter>({
+      baseURL: "http://example.com",
+      credentials: "include",
+    });
+    const cache = {
+      policy: "cache-first" as const,
+      scope: "shared" as const,
+      staleTime: 10_000,
+    };
+
+    const firstResult = await first.users.get({}, { cache });
+    const secondResult = await second.users.get({}, { cache });
+
+    expect(firstResult.data).toEqual({ session: "first" });
+    expect(secondResult.data).toEqual({ session: "second" });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not let shared scope expose header-scoped responses to another client", async () => {
+    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) =>
+      buildResponse({ authorization: new Headers(init?.headers).get("authorization") }),
+    );
+    globalThis.fetch = fetchMock as any;
+    const first = createAPIClient<APIRouter>({
+      baseURL: "http://example.com",
+      credentials: "omit",
+      headers: { authorization: "Bearer first" },
+    });
+    const second = createAPIClient<APIRouter>({
+      baseURL: "http://example.com",
+      credentials: "omit",
+      headers: { authorization: "Bearer second" },
+    });
+    const cache = {
+      policy: "cache-first" as const,
+      scope: "shared" as const,
+      staleTime: 10_000,
+    };
+
+    const firstResult = await first.users.get({}, { cache });
+    const secondResult = await second.users.get({}, { cache });
+
+    expect(firstResult.data).toEqual({ authorization: "Bearer first" });
+    expect(secondResult.data).toEqual({ authorization: "Bearer second" });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
   it("isolates default same-origin caches between client instances", async () => {
@@ -979,7 +1042,10 @@ describe("createAPIClient", () => {
     type UsersData = APIRouter["users"]["get"]["__types"]["response"];
     const usersKey = defineCacheKey<UsersData>()(() => ["users", "list"] as const)();
     const normalizedUsersKey = normalizeFarmClientCacheKey(usersKey);
-    const api = createAPIClient<APIRouter>({ baseURL: "http://example.com" });
+    const api = createAPIClient<APIRouter>({
+      baseURL: "http://example.com",
+      credentials: "omit",
+    });
     const cache = {
       key: usersKey,
       policy: "cache-first" as const,
@@ -1038,8 +1104,14 @@ describe("createAPIClient", () => {
 
     type UsersData = APIRouter["users"]["get"]["__types"]["response"];
     const usersKey = defineCacheKey<UsersData>()(() => ["users", "list"] as const)();
-    const api = createAPIClient<APIRouter>({ baseURL: "http://example.com" });
-    const secondApi = createAPIClient<APIRouter>({ baseURL: "http://example.com" });
+    const api = createAPIClient<APIRouter>({
+      baseURL: "http://example.com",
+      credentials: "omit",
+    });
+    const secondApi = createAPIClient<APIRouter>({
+      baseURL: "http://example.com",
+      credentials: "omit",
+    });
     const cache = {
       key: usersKey,
       policy: "cache-first" as const,

--- a/packages/farm/src/__tests__/server-query-client.test.tsx
+++ b/packages/farm/src/__tests__/server-query-client.test.tsx
@@ -166,10 +166,14 @@ describe("server query client", () => {
 
     const fetchMock = vi.fn();
     vi.stubGlobal("fetch", fetchMock);
-    const api = createAPIClient<ProductAPI>({ baseURL: "https://farm.test" });
+    const api = createAPIClient<ProductAPI>({
+      baseURL: "https://farm.test",
+      credentials: "omit",
+    });
     const result = await api.products.get(undefined, {
       cache: {
         key: ["product", "123"],
+        scope: "shared",
         policy: "cache-first",
         staleTime: 10_000,
       },

--- a/packages/farm/src/api/client.ts
+++ b/packages/farm/src/api/client.ts
@@ -147,7 +147,7 @@ export type CacheScope = "client" | "shared";
 export type CacheOptions = {
   key?: FarmClientCacheKey;
   policy?: CachePolicy;
-  /** Keep credentialed responses private to this client unless sharing is explicit. */
+  /** Select client-local or public shared storage. Identity-carrying requests always stay local. */
   scope?: CacheScope;
   staleTime?: number;
   gcTime?: number;
@@ -1424,8 +1424,8 @@ function getRequestCacheContext(
     new Headers(requestHeaders as HeadersInit).forEach((value, key) => headers.set(key, value));
   }
 
-  if (scope === "shared") return undefined;
-  if (scope !== "client" && credentials === "omit" && [...headers].length === 0) return undefined;
+  const carriesBrowserIdentity = credentials !== "omit" || [...headers].length > 0;
+  if (scope !== "client" && !carriesBrowserIdentity) return undefined;
 
   return stableStringify({
     credentials,

--- a/packages/farm/src/api/client.ts
+++ b/packages/farm/src/api/client.ts
@@ -142,10 +142,13 @@ export type ResponseEvent<TData = unknown, TError = Error> = {
 };
 
 export type CachePolicy = "cache-first" | "network-only" | "stale-while-revalidate";
+export type CacheScope = "client" | "shared";
 
 export type CacheOptions = {
   key?: FarmClientCacheKey;
   policy?: CachePolicy;
+  /** Keep credentialed responses private to this client unless sharing is explicit. */
+  scope?: CacheScope;
   staleTime?: number;
   gcTime?: number;
   dedupeMs?: number;
@@ -656,7 +659,7 @@ export function createAPIClient<
     let requestContextError: Error | undefined;
     if (needsCacheState) {
       try {
-        requestCacheContext = getRequestCacheContext(options, input);
+        requestCacheContext = getRequestCacheContext(options, input, cacheOptions?.scope);
       } catch (error) {
         requestCacheContext = `invalid:${requestId}`;
         requestContextError = normalizeError(error);
@@ -1410,6 +1413,7 @@ function getHeader(headers: unknown, name: string): string | undefined {
 function getRequestCacheContext(
   options: Pick<APIClientOptions, "headers" | "credentials">,
   input: unknown,
+  scope: CacheScope | undefined,
 ): string | undefined {
   const credentials = options.credentials ?? "same-origin";
   const headers = new Headers(options.headers);
@@ -1420,7 +1424,8 @@ function getRequestCacheContext(
     new Headers(requestHeaders as HeadersInit).forEach((value, key) => headers.set(key, value));
   }
 
-  if (credentials === "same-origin" && [...headers].length === 0) return undefined;
+  if (scope === "shared") return undefined;
+  if (scope !== "client" && credentials === "omit" && [...headers].length === 0) return undefined;
 
   return stableStringify({
     credentials,


### PR DESCRIPTION
## Problem

Default same-origin API clients shared the global route-data cache even though their requests may carry opaque HttpOnly cookies. Creating a client after an authentication transition could therefore reuse a cached response produced for the earlier cookie identity without issuing a request.

## Root cause

The cache-context resolver treated `credentials: "same-origin"` with no JavaScript-visible headers as public. Browser code cannot include HttpOnly cookie identity in the key, so distinct clients collapsed into the same global entry.

## Change

Make same-origin and otherwise credentialed caches private to each created API client by default. Add `cache.scope` so public requests can explicitly opt into `"shared"` route/API cache entries, while `"client"` can isolate even credential-free requests. `credentials: "omit"` with no custom headers remains safely shareable by default.

## Safety and compatibility

Network-only behavior is unchanged. Cache reuse within one client remains intact. Explicit headers and credentials retain their context rotation. Applications intentionally sharing public structured keys can preserve that behavior with `scope: "shared"`; session-specific keys still need invalidation when the same long-lived client logs in or out.

## Verification

- `pnpm --filter @farm.js/core exec vitest run src/__tests__/api-client.test.ts --reporter=dot` (43 tests passed)
- `pnpm --filter @farm.js/core type-check`
- `pnpm exec oxfmt packages/farm/src/api/client.ts packages/farm/src/__tests__/api-client.test.ts docs/src/app/docs/api-client/page.md`
- `pnpm exec oxlint packages/farm/src/api/client.ts packages/farm/src/__tests__/api-client.test.ts` (one pre-existing warning in the test file)
- `git diff --check`

The new regression fails before the change: two default same-origin clients receive the first cached session response and `fetch` runs only once.

## Documentation and release

Documented private credentialed caches, explicit shared scope, and same-client auth invalidation. No generated artifacts or template changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops default same-origin API clients from sharing a global cache, so a client created after an auth change no longer reuses a cached response from an earlier cookie identity. Adds `cache.scope` so public requests can opt back into shared cache entries.

**Bug Fixes**
- Same-origin and credentialed requests now cache per client instance instead of shared across clients.
- `credentials: "omit"` with no custom headers still shares across clients by default, and it's the only case where `scope: "shared"` has effect.

**Migration**
- Set `scope: "shared"` to share public cache entries between clients or with route data; credentialed or header-carrying requests stay client-scoped regardless.
- Use `scope: "client"` to isolate even credential-free requests.

<sup>Written for commit df10707b4a06897d7eda257a9d1f79a9987a4c6a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/729?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

