### PR TITLE
perf(react): compose queued native reorders

### DIFF
--- a/docs/src/app/docs/renderers/react/page.md
+++ b/docs/src/app/docs/renderers/react/page.md
@@ -1143,9 +1143,10 @@ setItems((current) => current.toReversed());
 ```
 
 Farm recognizes only this concise functional-setter form. It preserves the original method lookup,
-native call, returned array, and thrown errors. Metadata is recorded only when the committed source
-and result are ordinary native arrays and the executed method is the native `toReversed()` method.
-A custom or unavailable method therefore keeps its normal behavior and never enters the fast path.
+native call, returned array, and thrown errors. Metadata is recorded only when the result is an
+ordinary native array, the executed method is the native `toReversed()` method, and the reorder
+chain starts at the committed collection. A custom or unavailable method therefore keeps its normal
+behavior and never enters the fast path.
 
 At update time, Farm verifies the committed source token, equal lengths, every source row identity,
 and the exact reversed result before moving the DOM. The runtime leaves one row in place and moves
@@ -1153,13 +1154,28 @@ the other rows through connected `insertBefore()` operations, the minimum `n - 1
 reverse. It does not call row keys, recreate descriptors, reread bindings, or run the generic LIS
 calculation. Existing elements, handlers, form state, and focus stay attached to their keys.
 
+Multiple concise native reorder setters may run before the same compiler flush:
+
+```tsx
+setItems((current) => current.toSorted((left, right) => left.rank - right.rank));
+setItems((current) => current.toReversed());
+```
+
+Each setter still executes in order with normal JavaScript semantics. Farm carries the original
+committed token through consecutive native `toSorted()` and `toReversed()` results, validates the
+final array as the exact same set of unique item identities, and reconciles that final permutation
+once. Intermediate orders never reach the DOM. The final generic path uses LIS, so two queued
+reversals that cancel preserve every row without a DOM move. A single direct reverse keeps the
+smaller specialized `n - 1` move path described above.
+
 The first proof requires compiler-owned host rows whose render and key do not observe the index.
 Arguments, computed or chained calls, block-bodied updaters, subclassed or sparse behavior,
-collection-reading bindings, custom methods, two reversals queued before one commit, React-owned
-rows, nested host blocks, row conditionals, unrelated dirty dependencies, and any identity mismatch
-use complete keyed reconciliation. No option or component is added. Reports expose emitted sites as
-`keyedArrayReorderHints`; modules without one do not retain the optional reorder runtime. The
-application runtime must provide `Array.prototype.toReversed`; Farm does not polyfill it.
+collection-reading bindings, custom methods, an unhinted or structural update between reorder
+setters, React-owned rows, nested host blocks, row conditionals, unrelated dirty dependencies, and
+any identity mismatch use complete keyed reconciliation. No option or component is added. Reports
+expose emitted sites as `keyedArrayReorderHints`; modules without one do not retain the optional
+reorder runtime. The application runtime must provide `Array.prototype.toReversed`; Farm does not
+polyfill it.
 
 #### Keyed array sort hints
 
@@ -1176,18 +1192,20 @@ comparator execution, native result, stable-sort behavior, and thrown errors. Th
 does the comparison work; this optimization removes repeated keyed-row work after the result is
 known.
 
-At commit time, Farm verifies a committed ordinary dense array, the native `toSorted()` method,
-equal lengths, and a one-to-one identity match between the previous and sorted items. It then
-computes the longest increasing subsequence of the resulting permutation and moves only the rows
-outside that subsequence. Keys, descriptors, and bindings are not reread, the owner component does
-not rerun, and existing elements, handlers, form state, focus, and text selection remain attached
-to their rows.
+At commit time, Farm verifies an ordinary dense array whose reorder chain starts at the committed
+collection, the native `toSorted()` method, equal lengths, and a one-to-one identity match between
+the committed and final items. It then computes the longest increasing subsequence of the resulting
+permutation and moves only the rows outside that subsequence. Consecutive concise native sorts and
+reverses queued before one flush share this final reconciliation. Keys, descriptors, and bindings
+are not reread, the owner component does not rerun, and existing elements, handlers, form state,
+focus, and text selection remain attached to their rows.
 
 This proof requires compiler-owned host rows whose render and key do not observe the row index.
 Referenced comparators, block-bodied updaters, computed or chained calls, custom methods, sparse or
-subclassed arrays, duplicate item identities, collection-reading bindings, queued uncommitted
-sorts, React-owned rows, nested host blocks, row conditionals, unrelated dirty dependencies, and
-failed validation keep complete keyed reconciliation. Reports expose emitted sites as
+subclassed arrays, duplicate item identities, collection-reading bindings, an unhinted or
+structural update between queued sorts, React-owned rows, nested host blocks, row conditionals,
+unrelated dirty dependencies, and failed validation keep complete keyed
+reconciliation. Reports expose emitted sites as
 `keyedArraySortHints`. Sort shares the optional reorder runtime, and Farm does not polyfill
 `Array.prototype.toSorted`.
 
@@ -2038,13 +2056,14 @@ The package and example test suites verify more than generated code:
   another 1,000 queued overlapping fresh-key replacements match React while targeted tests require
   work to equal only the final touched union, preserve untouched DOM identity, and cover atomic
   preparation, existing-key-move fallback, Strict Mode hydration, and unmount cleanup;
-- 2,000 deterministic randomized reversals match normal React; a 4,096-row targeted test requires
-  exactly `n - 1` connected DOM moves and zero key, descriptor, or binding reads, while fallback
-  tests cover custom methods, queued updates, collection-reading rows, StrictMode hydration, and
-  unmount cleanup;
-- 2,000 deterministic randomized sorts match normal React; a 4,096-row targeted test requires
-  exactly `n - LIS` connected DOM moves and zero key, descriptor, or binding reads, while native
-  semantics, focus and selection, fallback cases, StrictMode hydration, and cleanup are covered;
+- 2,000 deterministic batches of two to four reversals match normal React with zero key reads; a
+  4,096-row direct test requires exactly `n - 1` connected DOM moves, while double-reverse and
+  fallback tests cover zero-move cancellation, custom or unhinted chains, collection-reading rows,
+  StrictMode hydration, and unmount cleanup;
+- 2,000 deterministic batches of two to four randomized sorts match normal React with zero key
+  reads; a 4,096-row direct test requires exactly `n - LIS` connected DOM moves, while mixed
+  sort/reverse chains, native semantics, focus and selection, fallback cases, StrictMode hydration,
+  and cleanup are covered;
 - the production browser experiment derives a keyed window from 2,048 source rows without
   rerunning the owner component or corrupting the existing compiler experiments;
 - the package reactivity benchmark updates one prop across 2,048 bindings, requires identical

--- a/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
+++ b/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
@@ -2,6 +2,39 @@
 
 Date: 2026-08-29
 
+## Queued native reorder composition — 2026-09-05
+
+The 10,000-row table now has a separate workload that queues two concise native `toReversed()`
+setters before one React commit. Both setters execute, but the final order equals the committed
+order. The compiled runtime carries the committed source token across both immutable results,
+validates one final item-identity permutation, retains every keyed DOM node, and performs no DOM
+moves. The equivalent block-bodied setters remain the compiled fallback control.
+
+| Mode   | React median | Queued reorder | Compiled control | vs React | vs control |
+| ------ | -----------: | -------------: | ---------------: | -------: | ---------: |
+| Static |      56.05 ms |        4.10 ms |         10.60 ms |   13.67x |      2.59x |
+| Hybrid |      56.05 ms |        4.20 ms |         11.00 ms |   13.35x |      2.62x |
+
+The independent gate requires at least 2x versus bracketed React and 1.25x versus the compiled
+control in both modes. An unchanged second production run passed that gate, DOM identity checks,
+zero-owner-execution checks, the general performance and scalability gates, and every older
+optimization gate without lowering a threshold. Both compiled reports emitted three
+`keyedArrayReorderHints` sites: the existing direct reverse and both setters in this queued
+workload.
+
+Package tests separately prove zero DOM moves for a cancelling double reverse, minimum LIS moves
+for a queued final permutation, native sort and reverse composition in both orders, explicit
+fallback after an unhinted intermediate update, focus and selection preservation, Strict Mode
+hydration, and unmount-before-flush cleanup. Two independent 2,000-commit differential suites,
+each queuing two to four reverses or randomized sorts, match normal React with zero row-key reads.
+The complete 637-test package suite, isolated stress suite, and packaged React 18.3.1 and 19.2.8
+compatibility runs pass.
+
+The optional reverse fixture grows by 42 B gzip to a 12,099 B compiler premium; the sort fixture
+grows by 35 B gzip to 12,130 B. Direct and ordinary keyed fixtures remain byte-for-byte unchanged,
+and the compiler-selected core still removes 82.6% of the complete compatibility-runtime premium.
+The recorded run used Chrome 152.0.7977.82, Node.js 23.11.0, and Apple M1 macOS arm64.
+
 ## Queued rolling-window composition — 2026-09-05
 
 The 10,000-row table now has a separate workload that queues two functional rolling-window

--- a/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
+++ b/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
@@ -12,13 +12,14 @@ moves. The equivalent block-bodied setters remain the compiled fallback control.
 
 | Mode   | React median | Queued reorder | Compiled control | vs React | vs control |
 | ------ | -----------: | -------------: | ---------------: | -------: | ---------: |
-| Static |      56.05 ms |        4.10 ms |         10.60 ms |   13.67x |      2.59x |
-| Hybrid |      56.05 ms |        4.20 ms |         11.00 ms |   13.35x |      2.62x |
+| Static |      54.45 ms |        5.90 ms |         12.30 ms |    9.23x |      2.08x |
+| Hybrid |      54.45 ms |        7.00 ms |         14.70 ms |    7.78x |      2.10x |
 
 The independent gate requires at least 2x versus bracketed React and 1.25x versus the compiled
-control in both modes. An unchanged second production run passed that gate, DOM identity checks,
-zero-owner-execution checks, the general performance and scalability gates, and every older
-optimization gate without lowering a threshold. Both compiled reports emitted three
+control in both modes. The production rerun passed that gate while checking all 10,000 DOM row
+identities after every queued action, plus zero-owner-execution checks, the general performance and
+scalability gates, and every older optimization gate without lowering a threshold. Both compiled
+reports emitted three
 `keyedArrayReorderHints` sites: the existing direct reverse and both setters in this queued
 workload.
 

--- a/examples/react-compiler-dashboard/README.md
+++ b/examples/react-compiler-dashboard/README.md
@@ -192,6 +192,13 @@ report must contain a nonzero `keyedArrayReorderHints` count; package tests sepa
 minimum `n - 1` connected DOM moves, zero key/descriptor/binding reads, randomized differential
 correctness, hydration, and cleanup.
 
+Queued native reorders have another independent 10,000-row comparison. One event queues two
+concise `toReversed()` setters, so the final order equals the committed order. Farm must validate
+that final permutation once, retain every DOM node, perform no intermediate DOM moves, and remain
+at least 2x faster than React and 1.25x faster than the equivalent block-bodied compiled control.
+Package tests also cover queued sorts, mixed sort/reverse chains, thousands of randomized batches,
+unsafe fallback, focus and selection, hydration, and cleanup.
+
 Native keyed-array sorting has its own 10,000-row comparison. Concise `toSorted()` is measured
 against bracketed React and an equivalent block-bodied compiled control. Both compiler modes must
 remain at least 4x faster than React and 1.25x faster than the compiled control. The report must
@@ -268,6 +275,9 @@ The default JSON report is `/tmp/farm-react-dashboard-benchmark.json`; change it
 - The reverse control compares concise native `toReversed()` with an equivalent block-bodied
   compiled update. Both paths move the same keyed DOM rows; the hint isolates the saved key,
   descriptor, binding, and generic LIS work.
+- The queued-reverse control executes two native reversals in one commit. Both controls end at the
+  same original order; the hinted path validates one final identity permutation and avoids the
+  complete keyed scan without exposing either intermediate order to the DOM.
 - The sort control compares concise native `toSorted()` with an equivalent block-bodied compiled
   update. Both paths run the same native sort and move the same keyed DOM rows; the hint isolates
   the saved key, descriptor, and binding work while retaining only the required LIS moves.

--- a/examples/react-compiler-dashboard/scripts/benchmark.mjs
+++ b/examples/react-compiler-dashboard/scripts/benchmark.mjs
@@ -1113,6 +1113,38 @@ async function measureTrial(browser, trial, compilerMode, port) {
           },
         );
 
+        const tableReverseQueued = await measureTable(
+          async () => ensure10000(),
+          async () => {
+            const rows = table.querySelectorAll("tbody tr");
+            const first = rows[0];
+            const last = rows[9_999];
+            await runTableAction(
+              () => tableButton("table-reverse-queued").click(),
+              () => {
+                const current = table.querySelectorAll("tbody tr");
+                return current[0] === first && current[9_999] === last;
+              },
+            );
+          },
+        );
+
+        const tableReverseQueuedSnapshot = await measureTable(
+          async () => ensure10000(),
+          async () => {
+            const rows = table.querySelectorAll("tbody tr");
+            const first = rows[0];
+            const last = rows[9_999];
+            await runTableAction(
+              () => tableButton("table-reverse-queued-snapshot").click(),
+              () => {
+                const current = table.querySelectorAll("tbody tr");
+                return current[0] === first && current[9_999] === last;
+              },
+            );
+          },
+        );
+
         const tableSort = await measureTable(
           async () => create10000(),
           async () => {
@@ -1534,6 +1566,8 @@ async function measureTrial(browser, trial, compilerMode, port) {
             positionReplace: tablePositionReplace,
             positionReplaceSnapshot: tablePositionReplaceSnapshot,
             reverse: tableReverse,
+            reverseQueued: tableReverseQueued,
+            reverseQueuedSnapshot: tableReverseQueuedSnapshot,
             reverseSnapshot: tableReverseSnapshot,
             sort: tableSort,
             sortSnapshot: tableSortSnapshot,
@@ -1662,6 +1696,8 @@ async function measureTrial(browser, trial, compilerMode, port) {
         positionReplace: timingSummary(result.table.positionReplace),
         positionReplaceSnapshot: timingSummary(result.table.positionReplaceSnapshot),
         reverse: timingSummary(result.table.reverse),
+        reverseQueued: timingSummary(result.table.reverseQueued),
+        reverseQueuedSnapshot: timingSummary(result.table.reverseQueuedSnapshot),
         reverseSnapshot: timingSummary(result.table.reverseSnapshot),
         sort: timingSummary(result.table.sort),
         sortSnapshot: timingSummary(result.table.sortSnapshot),
@@ -1774,6 +1810,8 @@ const tableMetrics = [
   "positionReplace",
   "positionReplaceSnapshot",
   "reverse",
+  "reverseQueued",
+  "reverseQueuedSnapshot",
   "reverseSnapshot",
   "sort",
   "sortSnapshot",
@@ -2327,6 +2365,29 @@ const keyedReorderRegressions = keyedReorderResults.filter(
     !Number.isFinite(snapshotSpeedup) ||
     snapshotSpeedup < keyedReorderMinimumSnapshotSpeedup,
 );
+// Two native reversals queued before one commit end in the original order. The composed hint
+// should validate that final permutation once, preserve every DOM node without moving it, and
+// stay ahead of React and the equivalent block-bodied compiled control at 10,000 rows.
+const keyedQueuedReorderMinimumSpeedup = 2;
+const keyedQueuedReorderMinimumSnapshotSpeedup = 1.25;
+const keyedQueuedReorderResults = ["static", "hybrid"].map((mode) => {
+  const reverseMedianMs = comparisons.table.reverseQueued[mode].medianMs;
+  const snapshotMedianMs = comparisons.table.reverseQueuedSnapshot[mode].medianMs;
+  return {
+    mode,
+    reverseMedianMs,
+    snapshotMedianMs,
+    snapshotSpeedup: snapshotMedianMs / reverseMedianMs,
+    speedup: comparisons.table.reverseQueued[`${mode}VsBaseline`].speedup,
+  };
+});
+const keyedQueuedReorderRegressions = keyedQueuedReorderResults.filter(
+  ({ snapshotSpeedup, speedup }) =>
+    !Number.isFinite(speedup) ||
+    speedup < keyedQueuedReorderMinimumSpeedup ||
+    !Number.isFinite(snapshotSpeedup) ||
+    snapshotSpeedup < keyedQueuedReorderMinimumSnapshotSpeedup,
+);
 // A direct native toSorted() exposes a permutation while preserving every keyed row object. The
 // hinted path validates that permutation by item identity, uses LIS to move only the required DOM
 // nodes, and avoids key, descriptor, and binding reads. Compare it with React and the equivalent
@@ -2511,6 +2572,7 @@ const passed =
   keyedPositionRegressions.length === 0 &&
   keyedRangeRemovalRegressions.length === 0 &&
   keyedReorderRegressions.length === 0 &&
+  keyedQueuedReorderRegressions.length === 0 &&
   keyedSortRegressions.length === 0 &&
   keyedFilterRegressions.length === 0 &&
   keyedIdentityRegressions.length === 0 &&
@@ -2648,6 +2710,13 @@ const report = {
     regressions: keyedReorderRegressions,
     results: keyedReorderResults,
     status: keyedReorderRegressions.length === 0 ? "PASS" : "FAIL",
+  },
+  keyedQueuedReorderHintGate: {
+    minimumSnapshotSpeedup: keyedQueuedReorderMinimumSnapshotSpeedup,
+    minimumSpeedup: keyedQueuedReorderMinimumSpeedup,
+    regressions: keyedQueuedReorderRegressions,
+    results: keyedQueuedReorderResults,
+    status: keyedQueuedReorderRegressions.length === 0 ? "PASS" : "FAIL",
   },
   keyedSortHintGate: {
     minimumSnapshotSpeedup: keyedSortMinimumSnapshotSpeedup,

--- a/examples/react-compiler-dashboard/scripts/benchmark.mjs
+++ b/examples/react-compiler-dashboard/scripts/benchmark.mjs
@@ -386,6 +386,13 @@ async function measureTrial(browser, trial, compilerMode, port) {
         await ensureLive();
 
         const rowCount = () => table.querySelectorAll("tbody tr").length;
+        const rowsMatch = (current, previous) => {
+          if (current.length !== previous.length) return false;
+          for (let index = 0; index < current.length; index += 1) {
+            if (current[index] !== previous[index]) return false;
+          }
+          return true;
+        };
         const tableRevision = () => Number(table.dataset.revision);
         const tableButton = (action) => requireButton(table, `[data-action="${action}"]`);
         const runTableAction = async (action, condition) => {
@@ -1117,14 +1124,9 @@ async function measureTrial(browser, trial, compilerMode, port) {
           async () => ensure10000(),
           async () => {
             const rows = table.querySelectorAll("tbody tr");
-            const first = rows[0];
-            const last = rows[9_999];
             await runTableAction(
               () => tableButton("table-reverse-queued").click(),
-              () => {
-                const current = table.querySelectorAll("tbody tr");
-                return current[0] === first && current[9_999] === last;
-              },
+              () => rowsMatch(table.querySelectorAll("tbody tr"), rows),
             );
           },
         );
@@ -1133,14 +1135,9 @@ async function measureTrial(browser, trial, compilerMode, port) {
           async () => ensure10000(),
           async () => {
             const rows = table.querySelectorAll("tbody tr");
-            const first = rows[0];
-            const last = rows[9_999];
             await runTableAction(
               () => tableButton("table-reverse-queued-snapshot").click(),
-              () => {
-                const current = table.querySelectorAll("tbody tr");
-                return current[0] === first && current[9_999] === last;
-              },
+              () => rowsMatch(table.querySelectorAll("tbody tr"), rows),
             );
           },
         );

--- a/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
+++ b/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
@@ -787,6 +787,34 @@ export function StandardTableBenchmark() {
           Reverse rows (snapshot control)
         </button>
         <button
+          data-action="table-reverse-queued"
+          type="button"
+          onClick={() => {
+            setRows((current) => current.toReversed());
+            setRows((current) => current.toReversed());
+            setOperation("reverse rows twice in one commit");
+            setRevision((value) => value + 1);
+          }}
+        >
+          Reverse rows twice
+        </button>
+        <button
+          data-action="table-reverse-queued-snapshot"
+          type="button"
+          onClick={() => {
+            setRows((current) => {
+              return current.toReversed();
+            });
+            setRows((current) => {
+              return current.toReversed();
+            });
+            setOperation("reverse rows twice (snapshot control)");
+            setRevision((value) => value + 1);
+          }}
+        >
+          Reverse rows twice (snapshot control)
+        </button>
+        <button
           data-action="table-sort"
           type="button"
           onClick={() => {

--- a/packages/farm-react/README.md
+++ b/packages/farm-react/README.md
@@ -379,14 +379,17 @@ setItems((current) => current.toReversed());
 ```
 
 Farm preserves the method lookup, call result, and errors, then records metadata only for the native
-method on a committed ordinary array. The runtime verifies equal lengths and every reversed item
-identity before moving the existing keyed elements with the minimum `n - 1` connected DOM moves.
-It does not reread row keys, descriptors, or bindings and does not run the generic LIS calculation.
-Index-aware or collection-reading rows, arguments, computed or chained calls, block-bodied
-updaters, custom methods, sparse or subclassed behavior, queued uncommitted reversals, nested or
-React-owned rows, and failed checks keep complete keyed reconciliation. Reports expose the site
-count as `keyedArrayReorderHints`, and modules without one omit the reorder runtime. Farm does not
-polyfill `Array.prototype.toReversed`.
+method on an ordinary array whose chain starts at the committed collection. One direct reverse
+verifies equal lengths and every reversed item identity before moving the existing keyed elements
+with the minimum `n - 1` connected DOM moves. It does not reread row keys, descriptors, or bindings
+and does not run the generic LIS calculation. Consecutive concise native `toReversed()` and
+`toSorted()` setters queued before one flush compose into one final validated permutation. The
+runtime skips intermediate DOM states and uses LIS once for that final order; two reversals that
+cancel perform no DOM moves. Index-aware or collection-reading rows, arguments, computed or chained
+calls, block-bodied updaters, custom methods, sparse or subclassed behavior, an unhinted or
+structural intermediate update, nested or React-owned rows, and failed checks keep complete keyed
+reconciliation. Reports expose the site count as `keyedArrayReorderHints`, and modules without one
+omit the reorder runtime. Farm does not polyfill `Array.prototype.toReversed`.
 
 A direct native immutable sort can use the same optional reorder runtime:
 
@@ -397,14 +400,16 @@ setLabels((current) => current.toSorted());
 
 Farm recognizes a concise functional setter with no comparator or an inline synchronous comparator
 from the compiler-safe expression subset. It preserves the original method lookup, comparator,
-stable native result, and errors. After the native sort runs, the runtime validates a committed
-ordinary dense array, equal lengths, and a unique one-to-one item-identity permutation. It then
-uses LIS to move only `n - LIS` keyed DOM nodes without rereading row keys, descriptors, or
-bindings. The native sorting work itself is unchanged.
+stable native result, and errors. After the native sort runs, the runtime validates an ordinary
+dense array whose reorder chain starts at the committed collection, equal lengths, and a unique
+one-to-one item-identity permutation. It then uses LIS to move only `n - LIS` keyed DOM nodes
+without rereading row keys, descriptors, or bindings. Multiple concise native sorts and reverses
+queued in one flush share the original committed token and reconcile only their final permutation.
+The native sorting work itself is unchanged.
 
 Index-aware or collection-reading rows, referenced comparators, block-bodied updaters, computed or
-chained calls, custom methods, sparse or subclassed arrays, duplicate item identities, queued
-uncommitted sorts, nested or React-owned rows, and failed checks keep complete keyed
+chained calls, custom methods, sparse or subclassed arrays, duplicate item identities, unhinted or
+structural intermediate updates, nested or React-owned rows, and failed checks keep complete keyed
 reconciliation. Reports expose the site count as `keyedArraySortHints`; sort shares the optional
 reorder runtime, and Farm does not polyfill `Array.prototype.toSorted`.
 

--- a/packages/farm-react/RUNTIME_SIZE_RESULTS.json
+++ b/packages/farm-react/RUNTIME_SIZE_RESULTS.json
@@ -145,14 +145,14 @@
         "brotli": 51795
       },
       "compilerOn": {
-        "raw": 235470,
-        "gzip": 72115,
-        "brotli": 61762
+        "raw": 235627,
+        "gzip": 72157,
+        "brotli": 61790
       },
       "compilerPremium": {
-        "raw": 42623,
-        "gzip": 12057,
-        "brotli": 9967
+        "raw": 42780,
+        "gzip": 12099,
+        "brotli": 9995
       }
     },
     "keyedSort": {
@@ -162,14 +162,14 @@
         "brotli": 51829
       },
       "compilerOn": {
-        "raw": 235612,
-        "gzip": 72172,
-        "brotli": 61898
+        "raw": 235760,
+        "gzip": 72207,
+        "brotli": 61868
       },
       "compilerPremium": {
-        "raw": 42736,
-        "gzip": 12095,
-        "brotli": 10069
+        "raw": 42884,
+        "gzip": 12130,
+        "brotli": 10039
       }
     },
     "keyedSlice": {
@@ -213,16 +213,16 @@
         "brotli": 51666
       },
       "full": {
-        "raw": 287010,
-        "gzip": 81533,
-        "brotli": 69607
+        "raw": 287017,
+        "gzip": 81538,
+        "brotli": 69552
       },
       "coreOnly": {
         "raw": 204922,
         "gzip": 63685,
         "brotli": 54902
       },
-      "fullRuntimePremiumGzip": 21614,
+      "fullRuntimePremiumGzip": 21619,
       "coreRuntimePremiumGzip": 3766,
       "gzipReductionPercent": 82.6
     }

--- a/packages/farm-react/RUNTIME_SIZE_RESULTS.md
+++ b/packages/farm-react/RUNTIME_SIZE_RESULTS.md
@@ -32,11 +32,11 @@ is enforced on every pull request instead of serving only as a manually recorded
 | Keyed rows with known-position hints              |          60,076 B |         72,344 B |         12,268 B |
 | Keyed rows with batch-position hints              |          60,091 B |         72,534 B |         12,443 B |
 | Keyed rows with exact-window hints                |          60,124 B |         74,297 B |         14,173 B |
-| Keyed rows with reverse hints                     |          60,058 B |         72,115 B |         12,057 B |
-| Keyed rows with sort hints                        |          60,077 B |         72,172 B |         12,095 B |
+| Keyed rows with reverse hints                     |          60,058 B |         72,157 B |         12,099 B |
+| Keyed rows with sort hints                        |          60,077 B |         72,207 B |         12,130 B |
 | Keyed rows with rolling-window hints              |          60,108 B |         73,177 B |         13,069 B |
 
-The isolated compatibility runtime contributes 21,614 B gzip over the React control. The
+The isolated compatibility runtime contributes 21,619 B gzip over the React control. The
 compiler-selected core contributes 3,766 B, an **82.6% reduction**. This comparison uses the same
 hand-authored compiled definition and changes only the runtime entry used to create it.
 
@@ -48,7 +48,7 @@ reuses the filter removal capability. Position-only, batch-position, exact-windo
 rolling-window modules select separate hint runtimes only when the compiler emits those update
 shapes. Reverse and sort share the optional reorder capability; the direct and isolated core
 results remain byte-for-byte unchanged. Over the ordinary keyed fixture, position pays 1,074 B
-gzip, batch-position pays 1,249 B, exact-window pays 2,979 B, reverse pays 863 B, sort pays 901 B,
+gzip, batch-position pays 1,249 B, exact-window pays 2,979 B, reverse pays 905 B, sort pays 936 B,
 slice pays 1,028 B, and rolling-window pays 1,875 B. The exact-window figure includes fresh-key
 replacement, atomic same-key binding refresh, fixed- and variable-length window-local keyed reuse
 with LIS movement, queued same-key window composition, disjoint queued fresh-key replacement, and

--- a/packages/farm-react/src/__tests__/compiler-keyed-array-sort-hints.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-keyed-array-sort-hints.test.ts
@@ -52,6 +52,33 @@ describe("React AOT keyed-array sort hints", () => {
     expect(result.code).not.toContain("keyedRowsEveryHintedRuntimeFeature");
   });
 
+  it("emits every native reorder in one queued sort and reverse chain", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Table() {
+        const [rows, setRows] = useState([
+          { id: "a", rank: 2, label: "Alpha" },
+          { id: "b", rank: 1, label: "Beta" },
+        ]);
+        return <section>
+          <button onClick={() => {
+            setRows((current) => current.toSorted((left, right) => left.rank - right.rank));
+            setRows((current) => current.toReversed());
+            setRows((current) => current.toReversed());
+            setRows((current) => current.toSorted((left, right) => right.rank - left.rank));
+          }}>Reorder</button>
+          <ul>{rows.map((row) => <li key={row.id}>{row.label}</li>)}</ul>
+        </section>;
+      }
+    `);
+
+    expect(result.optimizations.keyedArraySortHints).toBe(2);
+    expect(result.optimizations.keyedArrayReorderHints).toBe(2);
+    expect(result.code).toContain("createCompilerKeyedArraySort");
+    expect(result.code).toContain("createCompilerKeyedArrayReorder");
+    expect(result.code).toContain("keyedRowsReorderHintedRuntimeFeature");
+  });
+
   it.each([
     {
       name: "an index-dependent row",

--- a/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-reorder-hints.test.tsx
+++ b/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-reorder-hints.test.tsx
@@ -65,6 +65,7 @@ function createReorderHarness(initialItems: Item[], readsCollection = false) {
   };
   let reverse: () => void = () => undefined;
   let queueTwo: () => void = () => undefined;
+  let plainThenReverse: () => void = () => undefined;
   let customReverse: () => void = () => undefined;
   const Table = createCompiledComponent({
     displayName: "ReorderTable",
@@ -75,6 +76,10 @@ function createReorderHarness(initialItems: Item[], readsCollection = false) {
       reverse = () => state[0].set((previous) => hintedReverse(previous as Item[]));
       queueTwo = () => {
         state[0].set((previous) => hintedReverse(previous as Item[]));
+        state[0].set((previous) => hintedReverse(previous as Item[]));
+      };
+      plainThenReverse = () => {
+        state[0].set((previous) => [...(previous as Item[])]);
         state[0].set((previous) => hintedReverse(previous as Item[]));
       };
       customReverse = () =>
@@ -137,6 +142,7 @@ function createReorderHarness(initialItems: Item[], readsCollection = false) {
     Table,
     counters,
     customReverse: () => customReverse(),
+    plainThenReverse: () => plainThenReverse(),
     queueTwo: () => queueTwo(),
     reverse: () => reverse(),
   };
@@ -184,7 +190,41 @@ describe("compiled keyed-array reorder hints", () => {
     },
   );
 
-  it("falls back safely for custom methods, queued hints, and collection-reading bindings", async () => {
+  it("composes queued reverses as one validated final permutation", async () => {
+    const initialItems: Item[] = [
+      { id: "a", label: "Alpha" },
+      { id: "b", label: "Beta" },
+      { id: "c", label: "Gamma" },
+    ];
+    const harness = createReorderHarness(initialItems);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Table />));
+    const rows = [...container.querySelectorAll("li")];
+    const list = container.querySelector("ul")!;
+    const insertBefore = vi.spyOn(list, "insertBefore");
+    harness.counters.keys = 0;
+    harness.counters.descriptors = 0;
+    harness.counters.bindings = 0;
+
+    await act(async () => {
+      harness.queueTwo();
+      await flushCompilerUpdates();
+    });
+
+    expect(itemLabels(container)).toEqual(["Alpha", "Beta", "Gamma"]);
+    expect([...container.querySelectorAll("li")]).toEqual(rows);
+    expect(insertBefore).not.toHaveBeenCalled();
+    expect(harness.counters.executions).toBe(1);
+    expect(harness.counters.renders).toBe(1);
+    expect(harness.counters.keys).toBe(0);
+    expect(harness.counters.descriptors).toBe(0);
+    expect(harness.counters.bindings).toBe(0);
+  });
+
+  it("falls back safely for custom methods, unhinted chains, and collection-reading bindings", async () => {
     const initialItems: Item[] = [
       { id: "a", label: "Alpha" },
       { id: "b", label: "Beta" },
@@ -204,19 +244,19 @@ describe("compiled keyed-array reorder hints", () => {
     expect(itemLabels(customContainer)).toEqual(["Gamma", "Beta", "Alpha"]);
     expect(custom.counters.keys).toBeGreaterThan(0);
 
-    const queued = createReorderHarness(initialItems);
-    const queuedContainer = document.createElement("div");
-    document.body.append(queuedContainer);
-    const queuedRoot = createRoot(queuedContainer);
-    roots.push(queuedRoot);
-    await act(async () => queuedRoot.render(<queued.Table />));
-    queued.counters.keys = 0;
+    const unhinted = createReorderHarness(initialItems);
+    const unhintedContainer = document.createElement("div");
+    document.body.append(unhintedContainer);
+    const unhintedRoot = createRoot(unhintedContainer);
+    roots.push(unhintedRoot);
+    await act(async () => unhintedRoot.render(<unhinted.Table />));
+    unhinted.counters.keys = 0;
     await act(async () => {
-      queued.queueTwo();
+      unhinted.plainThenReverse();
       await flushCompilerUpdates();
     });
-    expect(itemLabels(queuedContainer)).toEqual(["Alpha", "Beta", "Gamma"]);
-    expect(queued.counters.keys).toBeGreaterThan(0);
+    expect(itemLabels(unhintedContainer)).toEqual(["Gamma", "Beta", "Alpha"]);
+    expect(unhinted.counters.keys).toBeGreaterThan(0);
 
     const dependent = createReorderHarness(initialItems, true);
     const dependentContainer = document.createElement("div");
@@ -318,7 +358,7 @@ describe("compiled keyed-array reorder hints", () => {
     expect([input.selectionStart, input.selectionEnd]).toEqual([1, 3]);
   });
 
-  it("matches normal React through 2,000 randomized reversals", async () => {
+  it("matches normal React through 2,000 randomized queued reversal batches", async () => {
     const initialItems = Array.from(
       { length: 64 },
       (_, index): Item => ({ id: `row-${index}`, label: `Row ${index}` }),
@@ -348,11 +388,12 @@ describe("compiled keyed-array reorder hints", () => {
       compiledRoot.render(<compiled.Table />);
       reactRoot.render(<NormalTable />);
     });
+    compiled.counters.keys = 0;
 
     let seed = 0x9e3779b9;
     for (let update = 0; update < 2_000; update += 1) {
       seed = (Math.imul(seed, 1_664_525) + 1_013_904_223) >>> 0;
-      const repetitions = (seed & 3) + 1;
+      const repetitions = 2 + (seed % 3);
       await act(async () => {
         for (let count = 0; count < repetitions; count += 1) {
           compiled.reverse();
@@ -366,6 +407,7 @@ describe("compiled keyed-array reorder hints", () => {
     }
     expect(itemLabels(compiledContainer)).toEqual(itemLabels(reactContainer));
     expect(compiled.counters.executions).toBe(1);
+    expect(compiled.counters.keys).toBe(0);
   }, 15_000);
 
   it("supports StrictMode hydration and ignores a flush after unmount", async () => {
@@ -399,7 +441,7 @@ describe("compiled keyed-array reorder hints", () => {
     document.body.append(unmountContainer);
     const unmountRoot = createRoot(unmountContainer);
     await act(async () => unmountRoot.render(<unmounted.Table />));
-    unmounted.reverse();
+    unmounted.queueTwo();
     await act(async () => unmountRoot.unmount());
     await flushCompilerUpdates();
     expect(unmountContainer.childElementCount).toBe(0);

--- a/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-sort-hints.test.tsx
+++ b/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-sort-hints.test.tsx
@@ -5,6 +5,7 @@ import { renderToString } from "react-dom/server";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createCompiledComponent,
+  createCompilerKeyedArrayReorder,
   createCompilerKeyedArraySort,
   type CompilerKeyedRowElement,
 } from "../compiler-runtime";
@@ -48,6 +49,10 @@ function hintedSort(previous: Item[], compare?: (left: Item, right: Item) => num
   return createCompilerKeyedArraySort(source, source.toSorted, compare) as Item[];
 }
 
+function hintedReverse(previous: Item[]): Item[] {
+  return createCompilerKeyedArrayReorder(previous, previous.toReversed) as Item[];
+}
+
 function rowDescriptor(item: Item): CompilerKeyedRowElement {
   return {
     kind: "element",
@@ -67,7 +72,11 @@ function createSortHarness(initialItems: Item[], readsCollection = false) {
     bindings: 0,
   };
   let sort: (compare: (left: Item, right: Item) => number) => void = () => undefined;
+  let queueSorts: (compares: Array<(left: Item, right: Item) => number>) => void = () => undefined;
   let queueTwo: () => void = () => undefined;
+  let plainThenSort: () => void = () => undefined;
+  let reverseThenSort: () => void = () => undefined;
+  let sortThenReverse: () => void = () => undefined;
   let customSort: () => void = () => undefined;
   let mismatchedSort: () => void = () => undefined;
   const Table = createCompiledComponent({
@@ -77,6 +86,11 @@ function createSortHarness(initialItems: Item[], readsCollection = false) {
       counters.executions += 1;
       const items = () => state[0].get() as Item[];
       sort = (compare) => state[0].set((previous) => hintedSort(previous as Item[], compare));
+      queueSorts = (compares) => {
+        for (const compare of compares) {
+          state[0].set((previous) => hintedSort(previous as Item[], compare));
+        }
+      };
       queueTwo = () => {
         state[0].set((previous) =>
           hintedSort(previous as Item[], (left, right) => left.rank - right.rank),
@@ -84,6 +98,24 @@ function createSortHarness(initialItems: Item[], readsCollection = false) {
         state[0].set((previous) =>
           hintedSort(previous as Item[], (left, right) => right.rank - left.rank),
         );
+      };
+      plainThenSort = () => {
+        state[0].set((previous) => [...(previous as Item[])]);
+        state[0].set((previous) =>
+          hintedSort(previous as Item[], (left, right) => left.rank - right.rank),
+        );
+      };
+      reverseThenSort = () => {
+        state[0].set((previous) => hintedReverse(previous as Item[]));
+        state[0].set((previous) =>
+          hintedSort(previous as Item[], (left, right) => left.rank - right.rank),
+        );
+      };
+      sortThenReverse = () => {
+        state[0].set((previous) =>
+          hintedSort(previous as Item[], (left, right) => left.rank - right.rank),
+        );
+        state[0].set((previous) => hintedReverse(previous as Item[]));
       };
       customSort = () =>
         state[0].set((previous) => {
@@ -156,8 +188,12 @@ function createSortHarness(initialItems: Item[], readsCollection = false) {
     counters,
     customSort: () => customSort(),
     mismatchedSort: () => mismatchedSort(),
+    plainThenSort: () => plainThenSort(),
+    queueSorts: (compares: Array<(left: Item, right: Item) => number>) => queueSorts(compares),
     queueTwo: () => queueTwo(),
+    reverseThenSort: () => reverseThenSort(),
     sort: (compare: (left: Item, right: Item) => number) => sort(compare),
+    sortThenReverse: () => sortThenReverse(),
   };
 }
 
@@ -225,13 +261,78 @@ describe("compiled keyed-array sort hints", () => {
     },
   );
 
-  it("falls back for custom methods, queued sorts, changed identities, and collection bindings", async () => {
+  it("composes queued sorts as one validated final permutation", async () => {
     const initialItems: Item[] = [
       { id: "a", label: "Alpha", rank: 3 },
       { id: "b", label: "Beta", rank: 1 },
       { id: "c", label: "Gamma", rank: 2 },
     ];
-    for (const operation of ["custom", "queued", "mismatched", "dependent"] as const) {
+    const target = [initialItems[0], initialItems[2], initialItems[1]];
+    const harness = createSortHarness(initialItems);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Table />));
+    const rows = new Map(
+      [...container.querySelectorAll("li")].map((row) => [row.getAttribute("data-key"), row]),
+    );
+    const list = container.querySelector("ul")!;
+    const insertBefore = vi.spyOn(list, "insertBefore");
+    harness.counters.keys = 0;
+    harness.counters.descriptors = 0;
+    harness.counters.bindings = 0;
+
+    await act(async () => {
+      harness.queueTwo();
+      await flushCompilerUpdates();
+    });
+
+    expect(itemLabels(container)).toEqual(target.map((item) => item.label));
+    expect(container.querySelector('[data-key="a"]')).toBe(rows.get("a"));
+    expect(container.querySelector('[data-key="b"]')).toBe(rows.get("b"));
+    expect(container.querySelector('[data-key="c"]')).toBe(rows.get("c"));
+    expect(insertBefore).toHaveBeenCalledTimes(1);
+    expect(harness.counters.executions).toBe(1);
+    expect(harness.counters.renders).toBe(1);
+    expect(harness.counters.keys).toBe(0);
+    expect(harness.counters.descriptors).toBe(0);
+    expect(harness.counters.bindings).toBe(0);
+  });
+
+  it("composes mixed native sort and reverse setters", async () => {
+    const initialItems: Item[] = [
+      { id: "a", label: "Alpha", rank: 3 },
+      { id: "b", label: "Beta", rank: 1 },
+      { id: "c", label: "Gamma", rank: 2 },
+    ];
+    for (const operation of ["reverse-sort", "sort-reverse"] as const) {
+      const harness = createSortHarness(initialItems);
+      const container = document.createElement("div");
+      document.body.append(container);
+      const root = createRoot(container);
+      roots.push(root);
+      await act(async () => root.render(<harness.Table />));
+      harness.counters.keys = 0;
+      await act(async () => {
+        if (operation === "reverse-sort") harness.reverseThenSort();
+        else harness.sortThenReverse();
+        await flushCompilerUpdates();
+      });
+      expect(itemLabels(container)).toEqual(
+        operation === "reverse-sort" ? ["Beta", "Gamma", "Alpha"] : ["Alpha", "Gamma", "Beta"],
+      );
+      expect(harness.counters.keys).toBe(0);
+    }
+  });
+
+  it("falls back for custom methods, unhinted chains, changed identities, and collection bindings", async () => {
+    const initialItems: Item[] = [
+      { id: "a", label: "Alpha", rank: 3 },
+      { id: "b", label: "Beta", rank: 1 },
+      { id: "c", label: "Gamma", rank: 2 },
+    ];
+    for (const operation of ["custom", "unhinted", "mismatched", "dependent"] as const) {
       const harness = createSortHarness(initialItems, operation === "dependent");
       const container = document.createElement("div");
       document.body.append(container);
@@ -241,7 +342,7 @@ describe("compiled keyed-array sort hints", () => {
       harness.counters.keys = 0;
       await act(async () => {
         if (operation === "custom") harness.customSort();
-        else if (operation === "queued") harness.queueTwo();
+        else if (operation === "unhinted") harness.plainThenSort();
         else if (operation === "mismatched") harness.mismatchedSort();
         else harness.sort((left, right) => left.rank - right.rank);
         await flushCompilerUpdates();
@@ -285,16 +386,20 @@ describe("compiled keyed-array sort hints", () => {
       { id: "b", label: "Beta", rank: 1 },
       { id: "c", label: "Gamma", rank: 2 },
     ];
-    let sort = () => undefined;
+    let sortTwice = () => undefined;
     const FormRows = createCompiledComponent({
       displayName: "SortFormRows",
       initialize: () => [initialItems],
       render(_props: Record<string, never>, state, blocks) {
         const items = () => state[0].get() as Item[];
-        sort = () =>
+        sortTwice = () => {
           state[0].set((previous) =>
             hintedSort(previous as Item[], (left, right) => left.rank - right.rank),
           );
+          state[0].set((previous) =>
+            hintedSort(previous as Item[], (left, right) => left.rank - right.rank),
+          );
+        };
         return (
           <section>
             <blocks.KeyedRows
@@ -340,7 +445,7 @@ describe("compiled keyed-array sort hints", () => {
     input.setSelectionRange(1, 3);
 
     await act(async () => {
-      sort();
+      sortTwice();
       await flushCompilerUpdates();
     });
 
@@ -355,11 +460,15 @@ describe("compiled keyed-array sort hints", () => {
       (_, index): Item => ({ id: `row-${index}`, label: `Row ${index}`, rank: index }),
     );
     const compiled = createSortHarness(initialItems);
-    let sortReact: (compare: (left: Item, right: Item) => number) => void = () => undefined;
+    let queueReactSorts: (compares: Array<(left: Item, right: Item) => number>) => void = () =>
+      undefined;
     function NormalTable() {
       const [items, setItems] = useState(initialItems);
-      sortReact = (compare) =>
-        setItems((previous) => (previous as SortableArray).toSorted(compare));
+      queueReactSorts = (compares) => {
+        for (const compare of compares) {
+          setItems((previous) => (previous as SortableArray).toSorted(compare));
+        }
+      };
       return (
         <ul>
           {items.map((item) => (
@@ -380,18 +489,24 @@ describe("compiled keyed-array sort hints", () => {
       compiledRoot.render(<compiled.Table />);
       reactRoot.render(<NormalTable />);
     });
+    compiled.counters.keys = 0;
 
     let seed = 0x51f15e;
     for (let update = 0; update < 2_000; update += 1) {
-      const ranks = new Map<string, number>();
-      for (const item of initialItems) {
-        seed = (Math.imul(seed, 1_664_525) + 1_013_904_223) >>> 0;
-        ranks.set(item.id, seed);
+      seed = (Math.imul(seed, 1_664_525) + 1_013_904_223) >>> 0;
+      const repetitions = 2 + (seed % 3);
+      const compares: Array<(left: Item, right: Item) => number> = [];
+      for (let repetition = 0; repetition < repetitions; repetition += 1) {
+        const ranks = new Map<string, number>();
+        for (const item of initialItems) {
+          seed = (Math.imul(seed, 1_664_525) + 1_013_904_223) >>> 0;
+          ranks.set(item.id, seed);
+        }
+        compares.push((left, right) => ranks.get(left.id)! - ranks.get(right.id)!);
       }
-      const compare = (left: Item, right: Item) => ranks.get(left.id)! - ranks.get(right.id)!;
       await act(async () => {
-        compiled.sort(compare);
-        sortReact(compare);
+        compiled.queueSorts(compares);
+        queueReactSorts(compares);
         await flushCompilerUpdates();
       });
       if (update % 100 === 0) {
@@ -400,6 +515,7 @@ describe("compiled keyed-array sort hints", () => {
     }
     expect(itemLabels(compiledContainer)).toEqual(itemLabels(reactContainer));
     expect(compiled.counters.executions).toBe(1);
+    expect(compiled.counters.keys).toBe(0);
   }, 20_000);
 
   it("supports StrictMode hydration and ignores a flush after unmount", async () => {
@@ -424,6 +540,7 @@ describe("compiled keyed-array sort hints", () => {
     const beta = container.querySelector('[data-key="b"]');
     await act(async () => {
       hydration.sort(compare);
+      hydration.sort(compare);
       await flushCompilerUpdates();
     });
     expect(itemLabels(container)).toEqual(["Beta", "Gamma", "Alpha"]);
@@ -434,6 +551,7 @@ describe("compiled keyed-array sort hints", () => {
     document.body.append(unmountContainer);
     const unmountRoot = createRoot(unmountContainer);
     await act(async () => unmountRoot.render(<unmounted.Table />));
+    unmounted.sort(compare);
     unmounted.sort(compare);
     await act(async () => unmountRoot.unmount());
     await flushCompilerUpdates();

--- a/packages/farm-react/src/compiler-runtime.tsx
+++ b/packages/farm-react/src/compiler-runtime.tsx
@@ -72,7 +72,7 @@ interface CompilerKeyedArrayWindowReplaceHint {
 }
 
 interface CompilerKeyedArrayReorderHint {
-  readonly kind: "reverse" | "sort";
+  readonly kind: "permutation" | "reverse";
   readonly sourceToken: object;
   readonly sourceLength: number;
   readonly resultLength: number;
@@ -985,7 +985,6 @@ export function createCompilerKeyedArrayReorder(previous: unknown, method: unkno
     if (
       !previousTarget ||
       !valueTarget ||
-      !COMPILER_KEYED_COMMITTED_COLLECTIONS.has(previousTarget) ||
       !Array.isArray(previous) ||
       !Array.isArray(value) ||
       Object.getPrototypeOf(previous) !== NATIVE_ARRAY_PROTOTYPE ||
@@ -996,10 +995,22 @@ export function createCompilerKeyedArrayReorder(previous: unknown, method: unkno
       return value;
     }
 
-    const sourceToken = compilerKeyedCollectionToken(previousTarget);
+    const committedSource = COMPILER_KEYED_COMMITTED_COLLECTIONS.has(previousTarget);
+    const previousUpdate = committedSource
+      ? undefined
+      : COMPILER_KEYED_ARRAY_REORDERS.get(previousTarget);
+    if (
+      !committedSource &&
+      (!previousUpdate ||
+        previousUpdate.sourceLength !== previous.length ||
+        previousUpdate.resultLength !== previous.length)
+    ) {
+      return value;
+    }
+    const sourceToken = previousUpdate?.sourceToken || compilerKeyedCollectionToken(previousTarget);
     if (!sourceToken) return value;
     COMPILER_KEYED_ARRAY_REORDERS.set(valueTarget, {
-      kind: "reverse",
+      kind: previousUpdate ? "permutation" : "reverse",
       sourceToken,
       sourceLength: previous.length,
       resultLength: value.length,
@@ -1028,7 +1039,6 @@ export function createCompilerKeyedArraySort(
     if (
       !previousTarget ||
       !valueTarget ||
-      !COMPILER_KEYED_COMMITTED_COLLECTIONS.has(previousTarget) ||
       !Array.isArray(previous) ||
       !Array.isArray(value) ||
       Object.getPrototypeOf(previous) !== NATIVE_ARRAY_PROTOTYPE ||
@@ -1044,10 +1054,22 @@ export function createCompilerKeyedArraySort(
       if (!(index in previous)) return value;
     }
 
-    const sourceToken = compilerKeyedCollectionToken(previousTarget);
+    const committedSource = COMPILER_KEYED_COMMITTED_COLLECTIONS.has(previousTarget);
+    const previousUpdate = committedSource
+      ? undefined
+      : COMPILER_KEYED_ARRAY_REORDERS.get(previousTarget);
+    if (
+      !committedSource &&
+      (!previousUpdate ||
+        previousUpdate.sourceLength !== previous.length ||
+        previousUpdate.resultLength !== previous.length)
+    ) {
+      return value;
+    }
+    const sourceToken = previousUpdate?.sourceToken || compilerKeyedCollectionToken(previousTarget);
     if (!sourceToken) return value;
     COMPILER_KEYED_ARRAY_REORDERS.set(valueTarget, {
-      kind: "sort",
+      kind: "permutation",
       sourceToken,
       sourceLength: previous.length,
       resultLength: value.length,
@@ -5299,7 +5321,7 @@ function reconcileCompilerKeyedArrayReorder(
   if (!update || !Array.isArray(finalValue)) return undefined;
 
   const previousInstances = [...instances.values()];
-  if (update.kind === "sort") {
+  if (update.kind === "permutation") {
     const instancesByItem = new Map<unknown, CompilerKeyedRowInstance>();
     try {
       for (let sourceIndex = 0; sourceIndex < previousInstances.length; sourceIndex += 1) {


### PR DESCRIPTION
## Problem

Farm already lowers concise native `toReversed()` and `toSorted()` setters, but only an update whose immediate source was committed could use the reorder fast path. A second native reorder queued before the compiler microtask therefore lost the hint and forced complete keyed reconciliation, even though every operation preserved length and item identity.

## Root cause

Reorder metadata was tied only to the immediate committed array. It did not carry the original committed collection token across an uncommitted native reorder result, so the runtime could not prove that the final array was a permutation of the mounted keyed rows.

## Change

- carry the original committed token through consecutive native `toReversed()` and `toSorted()` results;
- classify queued chains as a generic final permutation while retaining the smaller specialized path for one direct reverse;
- validate the final value as an exact, unique item-identity permutation of the committed rows, then run LIS once and skip every intermediate DOM order;
- preserve a cancelling double reverse with zero DOM moves;
- add compiler, runtime, randomized differential, Strict Mode hydration, focus/selection, unmount, mixed sort/reverse, and unsafe-fallback coverage;
- add a 10,000-row queued-reorder benchmark and independent persistence gate;
- document the behavior, safety limits, runtime-size cost, and reproducible browser result.

## Safety and compatibility

The optimization is accepted only for ordinary native arrays, native `toReversed()`/`toSorted()` methods, equal lengths, the original committed token, and a one-to-one final item-identity permutation. Custom or computed methods, sparse/subclassed arrays, unhinted or structural intermediate updates, duplicate or changed identities, index/collection-dependent rows, React-owned/nested rows, unrelated dirty dependencies, and failed runtime validation keep complete React-compatible keyed reconciliation before any DOM mutation.

A single direct reverse still uses its existing `n - 1` connected-move path. Queued sort/reverse chains use the existing generic permutation/LIS path. React 18 and 19 compatibility passes. Direct and ordinary keyed bundles remain byte-for-byte unchanged; the optional reverse fixture adds 42 B gzip and sort adds 35 B.

## Verification

- `pnpm --filter @farm.js/react test` — 637 passed, 3 skipped; stress suites 3 passed
- focused compiler/runtime reorder and sort suites — 31 passed, 2 stress-only skipped
- `pnpm --filter @farm.js/react type-check`
- `pnpm --filter @farm.js/react build`
- `pnpm --filter @farm.js/react test:compat` — React 18.3.1 and 19.2.8
- `pnpm --filter @farm.js/react test:runtime-size`
- `pnpm --filter farm-react-compiler-dashboard-example type-check`
- `pnpm --filter farm-react-compiler-dashboard-example build`
- full bracketed production-browser benchmark after review fix — PASS for correctness, all 10,000 queued-reorder row identities, general performance, scalability, every existing optimization gate, and the queued-reorder gate
  - static: 5.90 ms vs React 54.45 ms and compiled control 12.30 ms — 9.23x / 2.08x
  - hybrid: 7.00 ms vs React 54.45 ms and compiled control 14.70 ms — 7.78x / 2.10x
- `pnpm --dir docs exec farm generate --check`
- `pnpm docs:check-navigation`
- `pnpm docs:build`
- focused formatting, lint, syntax, and `git diff --check`
- GitHub Actions — Linux Node 20/22/24, Windows Node 24, React 18/19, examples, framework E2E, Postgres, and lint all passed

## Documentation and release

Updates the React renderer guide, package README, maintained compiler-dashboard example, benchmark methodology/result, and persisted runtime-size report. No version or release metadata is changed.
