### PR TITLE
perf(react): compile native reorder pipelines

### DIFF
--- a/docs/src/app/docs/renderers/react/page.md
+++ b/docs/src/app/docs/renderers/react/page.md
@@ -1182,13 +1182,14 @@ then applies one LIS-based reconciliation. A cancelling
 `current.toReversed().toReversed()` pipeline therefore performs no DOM moves.
 
 The first proof requires compiler-owned host rows whose render and key do not observe the index.
-Arguments to `toReversed()`, referenced comparators, computed methods, chains containing another
-method, block-bodied updaters, subclassed or sparse behavior, collection-reading bindings, custom
-methods, an unhinted or structural update between reorder setters, React-owned rows, nested host
-blocks, row conditionals, unrelated dirty dependencies, and any identity mismatch use complete
-keyed reconciliation. No option or component is added. Reports count every compiled reverse step
-as a `keyedArrayReorderHints` entry; modules without one do not retain the optional reorder runtime.
-The application runtime must provide `Array.prototype.toReversed`; Farm does not polyfill it.
+Arguments to `toReversed()`, referenced comparators, computed methods, chains containing a method
+other than `toSorted()` or `toReversed()`, block-bodied updaters, subclassed or sparse
+behavior, collection-reading bindings, custom methods, an unhinted or structural update between
+reorder setters, React-owned rows, nested host blocks, row conditionals, unrelated dirty
+dependencies, and any identity mismatch use complete keyed reconciliation. No option or component
+is added. Reports count every compiled reverse step as a `keyedArrayReorderHints` entry; modules
+without one do not retain the optional reorder runtime. The application runtime must provide
+`Array.prototype.toReversed`; Farm does not polyfill it.
 
 #### Keyed array sort hints
 

--- a/docs/src/app/docs/renderers/react/page.md
+++ b/docs/src/app/docs/renderers/react/page.md
@@ -375,10 +375,10 @@ exact retained interval after runtime validation.
 `keyedArrayPositionHints` counts compiler-proven native keyed-array insertions, single or
 contiguous-range removals, single-row replacements, and exact-window replacements with a guarded
 position.
-`keyedArrayReorderHints` counts direct native keyed-array reversals whose complete permutation is
-known at build time.
-`keyedArraySortHints` counts direct native keyed-array sorts whose resulting permutation can be
-validated without rebuilding keyed rows.
+`keyedArrayReorderHints` counts native keyed-array reverse steps whose complete permutation can be
+validated, including steps in a supported reorder-only pipeline.
+`keyedArraySortHints` counts native keyed-array sort steps whose resulting permutation can be
+validated without rebuilding keyed rows, including steps in a supported reorder-only pipeline.
 `keyedArrayRollingWindowHints` counts direct keyed-array updates that retain a proven sliced tail
 and append an incoming suffix.
 `selected` is `true` when an annotation explicitly requested compilation. Module paths are relative
@@ -1168,14 +1168,27 @@ once. Intermediate orders never reach the DOM. The final generic path uses LIS, 
 reversals that cancel preserve every row without a DOM move. A single direct reverse keeps the
 smaller specialized `n - 1` move path described above.
 
+The same proof also works when two or more native reorder operations are chained inside one concise
+functional setter:
+
+```tsx
+setItems((current) => current.toSorted((left, right) => left.rank - right.rank).toReversed());
+```
+
+Farm prepares this pipeline at build time and evaluates each property lookup, inline comparator,
+and native call in its original JavaScript order. The intermediate arrays do not reach the DOM.
+The runtime validates only the final identity permutation against the committed collection and
+then applies one LIS-based reconciliation. A cancelling
+`current.toReversed().toReversed()` pipeline therefore performs no DOM moves.
+
 The first proof requires compiler-owned host rows whose render and key do not observe the index.
-Arguments, computed or chained calls, block-bodied updaters, subclassed or sparse behavior,
-collection-reading bindings, custom methods, an unhinted or structural update between reorder
-setters, React-owned rows, nested host blocks, row conditionals, unrelated dirty dependencies, and
-any identity mismatch use complete keyed reconciliation. No option or component is added. Reports
-expose emitted sites as `keyedArrayReorderHints`; modules without one do not retain the optional
-reorder runtime. The application runtime must provide `Array.prototype.toReversed`; Farm does not
-polyfill it.
+Arguments to `toReversed()`, referenced comparators, computed methods, chains containing another
+method, block-bodied updaters, subclassed or sparse behavior, collection-reading bindings, custom
+methods, an unhinted or structural update between reorder setters, React-owned rows, nested host
+blocks, row conditionals, unrelated dirty dependencies, and any identity mismatch use complete
+keyed reconciliation. No option or component is added. Reports count every compiled reverse step
+as a `keyedArrayReorderHints` entry; modules without one do not retain the optional reorder runtime.
+The application runtime must provide `Array.prototype.toReversed`; Farm does not polyfill it.
 
 #### Keyed array sort hints
 
@@ -1196,18 +1209,19 @@ At commit time, Farm verifies an ordinary dense array whose reorder chain starts
 collection, the native `toSorted()` method, equal lengths, and a one-to-one identity match between
 the committed and final items. It then computes the longest increasing subsequence of the resulting
 permutation and moves only the rows outside that subsequence. Consecutive concise native sorts and
-reverses queued before one flush share this final reconciliation. Keys, descriptors, and bindings
-are not reread, the owner component does not rerun, and existing elements, handlers, form state,
-focus, and text selection remain attached to their rows.
+reverses queued before one flush, or chained in one concise updater, share this final
+reconciliation. Keys, descriptors, and bindings are not reread, the owner component does not rerun,
+and existing elements, handlers, form state, focus, and text selection remain attached to their
+rows.
 
 This proof requires compiler-owned host rows whose render and key do not observe the row index.
-Referenced comparators, block-bodied updaters, computed or chained calls, custom methods, sparse or
-subclassed arrays, duplicate item identities, collection-reading bindings, an unhinted or
-structural update between queued sorts, React-owned rows, nested host blocks, row conditionals,
-unrelated dirty dependencies, and failed validation keep complete keyed
-reconciliation. Reports expose emitted sites as
-`keyedArraySortHints`. Sort shares the optional reorder runtime, and Farm does not polyfill
-`Array.prototype.toSorted`.
+Referenced comparators, block-bodied updaters, computed methods, custom methods, sparse or subclassed
+arrays, duplicate item identities, collection-reading bindings, an unhinted or structural update
+between queued sorts, React-owned rows, nested host blocks, row conditionals, unrelated dirty
+dependencies, and failed validation keep complete keyed reconciliation. Native
+sort/reverse-only chains are supported; other chained calls fall back. Reports count each compiled
+sort step as a `keyedArraySortHints` entry. Sort shares the optional reorder runtime, and Farm does
+not polyfill `Array.prototype.toSorted`.
 
 #### Keyed array filter hints
 

--- a/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
+++ b/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
@@ -60,8 +60,8 @@ for a queued final permutation, native sort and reverse composition in both orde
 fallback after an unhinted intermediate update, focus and selection preservation, Strict Mode
 hydration, and unmount-before-flush cleanup. Two independent 2,000-commit differential suites,
 each queuing two to four reverses or randomized sorts, match normal React with zero row-key reads.
-The complete 637-test package suite, isolated stress suite, and packaged React 18.3.1 and 19.2.8
-compatibility runs pass.
+For that queued-setter measurement, the then-current complete 637-test package suite, isolated
+stress suite, and packaged React 18.3.1 and 19.2.8 compatibility runs passed.
 
 The optional reverse fixture grows by 42 B gzip to a 12,099 B compiler premium; the sort fixture
 grows by 35 B gzip to 12,130 B. Direct and ordinary keyed fixtures remain byte-for-byte unchanged,

--- a/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
+++ b/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
@@ -2,6 +2,38 @@
 
 Date: 2026-08-29
 
+## Native reorder pipelines in one setter — 2026-09-05
+
+The 10,000-row table now measures two native `toReversed()` calls chained inside one concise
+functional setter. Both calls execute, but their final order equals the committed order. The
+compiler lowers each lookup and call in source order, carries one committed source token through
+both immutable results, validates the final identity permutation once, retains every keyed DOM
+node, and performs no DOM moves. The equivalent block-bodied updater remains the compiled fallback
+control.
+
+| Mode   | React median | Reorder pipeline | Compiled control | vs React | vs control |
+| ------ | -----------: | ---------------: | ---------------: | -------: | ---------: |
+| Static |      50.85 ms |          5.60 ms |         12.80 ms |    9.08x |      2.29x |
+| Hybrid |      50.85 ms |          5.60 ms |         13.00 ms |    9.08x |      2.32x |
+
+The independent gate requires at least 2x versus bracketed React and 1.25x versus the compiled
+control in both modes. The full production run passed that gate, all 10,000-row DOM identity
+assertions, zero-owner-execution checks, the general performance and scalability gates, and every
+older optimization gate without lowering a threshold. Both compiler reports emitted five
+`keyedArrayReorderHints` steps: one direct reverse, two queued setters, and both calls in this
+pipeline.
+
+Compiler tests cover mixed sort/reverse pipelines, default sorting, and rejected unsafe syntax.
+Runtime tests compare 2,000 deterministic two-to-four-step pipelines with normal React, preserve
+DOM identity without row-key reads, and prove fallback for custom or unhinted methods. The complete
+645-test package suite, isolated stress suite, and packaged React 18.3.1 and 19.2.8 compatibility
+runs pass.
+
+No runtime implementation or runtime feature selection changed. Every persisted runtime-size
+fixture remains byte-for-byte unchanged, and the compiler-selected core still removes 82.6% of the
+complete compatibility-runtime premium. The recorded run used Chrome 152.0.7977.82, Node.js
+23.11.0, and Apple M1 macOS arm64.
+
 ## Queued native reorder composition — 2026-09-05
 
 The 10,000-row table now has a separate workload that queues two concise native `toReversed()`

--- a/examples/react-compiler-dashboard/README.md
+++ b/examples/react-compiler-dashboard/README.md
@@ -199,6 +199,13 @@ at least 2x faster than React and 1.25x faster than the equivalent block-bodied 
 Package tests also cover queued sorts, mixed sort/reverse chains, thousands of randomized batches,
 unsafe fallback, focus and selection, hydration, and cleanup.
 
+Native reorder pipelines have a separate 10,000-row comparison. One functional setter evaluates
+`current.toReversed().toReversed()`, so the final order again equals the committed order without
+using two queued React updates. Farm must preserve both native calls, validate the final permutation
+once, retain every DOM node, and remain at least 2x faster than React and 1.25x faster than the
+equivalent block-bodied compiled control. Package tests compile mixed sort/reverse pipelines and
+compare 2,000 deterministic two-to-four-step pipelines with normal React.
+
 Native keyed-array sorting has its own 10,000-row comparison. Concise `toSorted()` is measured
 against bracketed React and an equivalent block-bodied compiled control. Both compiler modes must
 remain at least 4x faster than React and 1.25x faster than the compiled control. The report must
@@ -278,6 +285,9 @@ The default JSON report is `/tmp/farm-react-dashboard-benchmark.json`; change it
 - The queued-reverse control executes two native reversals in one commit. Both controls end at the
   same original order; the hinted path validates one final identity permutation and avoids the
   complete keyed scan without exposing either intermediate order to the DOM.
+- The reorder-pipeline control executes two native reversals inside one functional setter. Its
+  block-bodied equivalent stays on complete reconciliation, isolating the build-time lowering of
+  native sort/reverse-only call chains.
 - The sort control compares concise native `toSorted()` with an equivalent block-bodied compiled
   update. Both paths run the same native sort and move the same keyed DOM rows; the hint isolates
   the saved key, descriptor, and binding work while retaining only the required LIS moves.

--- a/examples/react-compiler-dashboard/scripts/benchmark.mjs
+++ b/examples/react-compiler-dashboard/scripts/benchmark.mjs
@@ -1142,6 +1142,28 @@ async function measureTrial(browser, trial, compilerMode, port) {
           },
         );
 
+        const tableReversePipeline = await measureTable(
+          async () => ensure10000(),
+          async () => {
+            const rows = table.querySelectorAll("tbody tr");
+            await runTableAction(
+              () => tableButton("table-reverse-pipeline").click(),
+              () => rowsMatch(table.querySelectorAll("tbody tr"), rows),
+            );
+          },
+        );
+
+        const tableReversePipelineSnapshot = await measureTable(
+          async () => ensure10000(),
+          async () => {
+            const rows = table.querySelectorAll("tbody tr");
+            await runTableAction(
+              () => tableButton("table-reverse-pipeline-snapshot").click(),
+              () => rowsMatch(table.querySelectorAll("tbody tr"), rows),
+            );
+          },
+        );
+
         const tableSort = await measureTable(
           async () => create10000(),
           async () => {
@@ -1563,6 +1585,8 @@ async function measureTrial(browser, trial, compilerMode, port) {
             positionReplace: tablePositionReplace,
             positionReplaceSnapshot: tablePositionReplaceSnapshot,
             reverse: tableReverse,
+            reversePipeline: tableReversePipeline,
+            reversePipelineSnapshot: tableReversePipelineSnapshot,
             reverseQueued: tableReverseQueued,
             reverseQueuedSnapshot: tableReverseQueuedSnapshot,
             reverseSnapshot: tableReverseSnapshot,
@@ -1693,6 +1717,8 @@ async function measureTrial(browser, trial, compilerMode, port) {
         positionReplace: timingSummary(result.table.positionReplace),
         positionReplaceSnapshot: timingSummary(result.table.positionReplaceSnapshot),
         reverse: timingSummary(result.table.reverse),
+        reversePipeline: timingSummary(result.table.reversePipeline),
+        reversePipelineSnapshot: timingSummary(result.table.reversePipelineSnapshot),
         reverseQueued: timingSummary(result.table.reverseQueued),
         reverseQueuedSnapshot: timingSummary(result.table.reverseQueuedSnapshot),
         reverseSnapshot: timingSummary(result.table.reverseSnapshot),
@@ -1807,6 +1833,8 @@ const tableMetrics = [
   "positionReplace",
   "positionReplaceSnapshot",
   "reverse",
+  "reversePipeline",
+  "reversePipelineSnapshot",
   "reverseQueued",
   "reverseQueuedSnapshot",
   "reverseSnapshot",
@@ -2385,6 +2413,29 @@ const keyedQueuedReorderRegressions = keyedQueuedReorderResults.filter(
     !Number.isFinite(snapshotSpeedup) ||
     snapshotSpeedup < keyedQueuedReorderMinimumSnapshotSpeedup,
 );
+// Two native reversals inside one functional setter also end in the original order. The compiler
+// should preserve the full pipeline metadata, validate its final permutation once, and stay ahead
+// of React and the equivalent block-bodied compiled control at 10,000 rows.
+const keyedReorderPipelineMinimumSpeedup = 2;
+const keyedReorderPipelineMinimumSnapshotSpeedup = 1.25;
+const keyedReorderPipelineResults = ["static", "hybrid"].map((mode) => {
+  const reverseMedianMs = comparisons.table.reversePipeline[mode].medianMs;
+  const snapshotMedianMs = comparisons.table.reversePipelineSnapshot[mode].medianMs;
+  return {
+    mode,
+    reverseMedianMs,
+    snapshotMedianMs,
+    snapshotSpeedup: snapshotMedianMs / reverseMedianMs,
+    speedup: comparisons.table.reversePipeline[`${mode}VsBaseline`].speedup,
+  };
+});
+const keyedReorderPipelineRegressions = keyedReorderPipelineResults.filter(
+  ({ snapshotSpeedup, speedup }) =>
+    !Number.isFinite(speedup) ||
+    speedup < keyedReorderPipelineMinimumSpeedup ||
+    !Number.isFinite(snapshotSpeedup) ||
+    snapshotSpeedup < keyedReorderPipelineMinimumSnapshotSpeedup,
+);
 // A direct native toSorted() exposes a permutation while preserving every keyed row object. The
 // hinted path validates that permutation by item identity, uses LIS to move only the required DOM
 // nodes, and avoids key, descriptor, and binding reads. Compare it with React and the equivalent
@@ -2570,6 +2621,7 @@ const passed =
   keyedRangeRemovalRegressions.length === 0 &&
   keyedReorderRegressions.length === 0 &&
   keyedQueuedReorderRegressions.length === 0 &&
+  keyedReorderPipelineRegressions.length === 0 &&
   keyedSortRegressions.length === 0 &&
   keyedFilterRegressions.length === 0 &&
   keyedIdentityRegressions.length === 0 &&
@@ -2714,6 +2766,13 @@ const report = {
     regressions: keyedQueuedReorderRegressions,
     results: keyedQueuedReorderResults,
     status: keyedQueuedReorderRegressions.length === 0 ? "PASS" : "FAIL",
+  },
+  keyedReorderPipelineHintGate: {
+    minimumSnapshotSpeedup: keyedReorderPipelineMinimumSnapshotSpeedup,
+    minimumSpeedup: keyedReorderPipelineMinimumSpeedup,
+    regressions: keyedReorderPipelineRegressions,
+    results: keyedReorderPipelineResults,
+    status: keyedReorderPipelineRegressions.length === 0 ? "PASS" : "FAIL",
   },
   keyedSortHintGate: {
     minimumSnapshotSpeedup: keyedSortMinimumSnapshotSpeedup,

--- a/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
+++ b/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
@@ -815,6 +815,30 @@ export function StandardTableBenchmark() {
           Reverse rows twice (snapshot control)
         </button>
         <button
+          data-action="table-reverse-pipeline"
+          type="button"
+          onClick={() => {
+            setRows((current) => current.toReversed().toReversed());
+            setOperation("reverse rows twice in one setter");
+            setRevision((value) => value + 1);
+          }}
+        >
+          Reverse pipeline
+        </button>
+        <button
+          data-action="table-reverse-pipeline-snapshot"
+          type="button"
+          onClick={() => {
+            setRows((current) => {
+              return current.toReversed().toReversed();
+            });
+            setOperation("reverse rows twice in one setter (snapshot control)");
+            setRevision((value) => value + 1);
+          }}
+        >
+          Reverse pipeline (snapshot control)
+        </button>
+        <button
           data-action="table-sort"
           type="button"
           onClick={() => {

--- a/packages/farm-react/README.md
+++ b/packages/farm-react/README.md
@@ -385,11 +385,20 @@ with the minimum `n - 1` connected DOM moves. It does not reread row keys, descr
 and does not run the generic LIS calculation. Consecutive concise native `toReversed()` and
 `toSorted()` setters queued before one flush compose into one final validated permutation. The
 runtime skips intermediate DOM states and uses LIS once for that final order; two reversals that
-cancel perform no DOM moves. Index-aware or collection-reading rows, arguments, computed or chained
-calls, block-bodied updaters, custom methods, sparse or subclassed behavior, an unhinted or
+cancel perform no DOM moves. A single concise updater may also chain two or more native reorder
+operations:
+
+```tsx
+setItems((current) => current.toSorted((left, right) => left.rank - right.rank).toReversed());
+```
+
+Farm evaluates every lookup and call in JavaScript order, carries the same committed token through
+the pipeline, and reconciles only its final result. Index-aware or collection-reading rows,
+arguments to `toReversed()`, referenced comparators, computed methods, chains containing another
+method, block-bodied updaters, custom methods, sparse or subclassed behavior, an unhinted or
 structural intermediate update, nested or React-owned rows, and failed checks keep complete keyed
-reconciliation. Reports expose the site count as `keyedArrayReorderHints`, and modules without one
-omit the reorder runtime. Farm does not polyfill `Array.prototype.toReversed`.
+reconciliation. Reports count each compiled reverse step as a `keyedArrayReorderHints` entry, and
+modules without one omit the reorder runtime. Farm does not polyfill `Array.prototype.toReversed`.
 
 A direct native immutable sort can use the same optional reorder runtime:
 
@@ -404,14 +413,15 @@ stable native result, and errors. After the native sort runs, the runtime valida
 dense array whose reorder chain starts at the committed collection, equal lengths, and a unique
 one-to-one item-identity permutation. It then uses LIS to move only `n - LIS` keyed DOM nodes
 without rereading row keys, descriptors, or bindings. Multiple concise native sorts and reverses
-queued in one flush share the original committed token and reconcile only their final permutation.
-The native sorting work itself is unchanged.
+queued in one flush, or chained in one concise updater, share the original committed token and
+reconcile only their final permutation. The native sorting work itself is unchanged.
 
 Index-aware or collection-reading rows, referenced comparators, block-bodied updaters, computed or
-chained calls, custom methods, sparse or subclassed arrays, duplicate item identities, unhinted or
-structural intermediate updates, nested or React-owned rows, and failed checks keep complete keyed
-reconciliation. Reports expose the site count as `keyedArraySortHints`; sort shares the optional
-reorder runtime, and Farm does not polyfill `Array.prototype.toSorted`.
+unsupported chained calls, custom methods, sparse or subclassed arrays, duplicate item identities,
+unhinted or structural intermediate updates, nested or React-owned rows, and failed checks keep
+complete keyed reconciliation. Reports count each compiled sort step as a `keyedArraySortHints`
+entry; sort shares the optional reorder runtime, and Farm does not polyfill
+`Array.prototype.toSorted`.
 
 Concise immutable filters on a direct keyed array can carry removal positions into the same
 optional runtime:
@@ -718,8 +728,8 @@ reasons aggregated by count. Its summary and per-module `optimizations` also rep
 contiguous-range removal, single-row replacement, or exact-window replacement sites, including
 guarded compiler-safe runtime positions;
 and
-`keyedArrayReorderHints`, the number of compiler-proven direct native keyed-array reverse sites; and
-`keyedArraySortHints`, the number of compiler-proven direct native keyed-array sort sites; and
+`keyedArrayReorderHints`, the number of compiler-proven native keyed-array reverse steps; and
+`keyedArraySortHints`, the number of compiler-proven native keyed-array sort steps; and
 `keyedArrayRollingWindowHints`, the number of compiler-proven retained-tail plus incoming-suffix
 sites; and
 `keyedArraySliceHints`, the number of compiler-proven direct keyed-array slice sites with literal or

--- a/packages/farm-react/README.md
+++ b/packages/farm-react/README.md
@@ -394,11 +394,12 @@ setItems((current) => current.toSorted((left, right) => left.rank - right.rank).
 
 Farm evaluates every lookup and call in JavaScript order, carries the same committed token through
 the pipeline, and reconciles only its final result. Index-aware or collection-reading rows,
-arguments to `toReversed()`, referenced comparators, computed methods, chains containing another
-method, block-bodied updaters, custom methods, sparse or subclassed behavior, an unhinted or
-structural intermediate update, nested or React-owned rows, and failed checks keep complete keyed
-reconciliation. Reports count each compiled reverse step as a `keyedArrayReorderHints` entry, and
-modules without one omit the reorder runtime. Farm does not polyfill `Array.prototype.toReversed`.
+arguments to `toReversed()`, referenced comparators, computed methods, chains containing a method
+other than `toSorted()` or `toReversed()`, block-bodied updaters, custom methods, sparse or
+subclassed behavior, an unhinted or structural intermediate update, nested or React-owned rows, and
+failed checks keep complete keyed reconciliation. Reports count each compiled reverse step as a
+`keyedArrayReorderHints` entry, and modules without one omit the reorder runtime. Farm does not
+polyfill `Array.prototype.toReversed`.
 
 A direct native immutable sort can use the same optional reorder runtime:
 

--- a/packages/farm-react/src/__tests__/compiler-keyed-array-sort-hints.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-keyed-array-sort-hints.test.ts
@@ -79,6 +79,94 @@ describe("React AOT keyed-array sort hints", () => {
     expect(result.code).toContain("keyedRowsReorderHintedRuntimeFeature");
   });
 
+  it("lowers every step in one native sort and reverse pipeline", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Table() {
+        const [rows, setRows] = useState([
+          { id: "a", rank: 2, label: "Alpha" },
+          { id: "b", rank: 1, label: "Beta" },
+        ]);
+        return <section>
+          <button onClick={() => setRows((current) =>
+            current
+              .toSorted((left, right) => left.rank - right.rank)
+              .toReversed()
+              .toSorted((left, right) => right.rank - left.rank)
+          )}>Reorder</button>
+          <ul>{rows.map((row) => <li key={row.id}>{row.label}</li>)}</ul>
+        </section>;
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Table"]);
+    expect(result.optimizations.keyedArraySortHints).toBe(2);
+    expect(result.optimizations.keyedArrayReorderHints).toBe(1);
+    expect(result.code.match(/createCompilerKeyedArraySort\(/g)).toHaveLength(2);
+    expect(result.code.match(/createCompilerKeyedArrayReorder\(/g)).toHaveLength(1);
+    expect(result.code).toContain("keyedRowsReorderHintedRuntimeFeature");
+  });
+
+  it("supports a reverse-first pipeline and the native default comparator", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Table() {
+        const [rows, setRows] = useState(["beta", "alpha"]);
+        return <section>
+          <button onClick={() => setRows((current) =>
+            current.toReversed().toSorted().toReversed()
+          )}>Reorder</button>
+          <ul>{rows.map((row) => <li key={row}>{row}</li>)}</ul>
+        </section>;
+      }
+    `);
+
+    expect(result.optimizations.keyedArraySortHints).toBe(1);
+    expect(result.optimizations.keyedArrayReorderHints).toBe(2);
+    expect(result.code.match(/createCompilerKeyedArraySort\(/g)).toHaveLength(1);
+    expect(result.code.match(/createCompilerKeyedArrayReorder\(/g)).toHaveLength(2);
+  });
+
+  it.each([
+    {
+      name: "a referenced comparator",
+      declaration: "const compare = (left, right) => left.rank - right.rank;",
+      update: "current.toSorted(compare).toReversed()",
+    },
+    {
+      name: "a computed outer method",
+      update: 'current.toSorted((left, right) => left.rank - right.rank)["toReversed"]()',
+    },
+    {
+      name: "a non-reorder intermediate method",
+      update: "current.slice().toSorted((left, right) => left.rank - right.rank).toReversed()",
+    },
+    {
+      name: "an invalid reverse argument",
+      update: "current.toSorted((left, right) => left.rank - right.rank).toReversed(true)",
+    },
+  ])(
+    "keeps a pipeline with $name off the reorder fast path",
+    async ({ declaration = "", update }) => {
+      const result = await compile(`
+      import { useState } from "react";
+      export function Table() {
+        const [rows, setRows] = useState([{ id: "a", rank: 1, label: "Alpha" }]);
+        ${declaration}
+        return <section>
+          <button onClick={() => setRows((current) => ${update})}>Reorder</button>
+          <ul>{rows.map((row) => <li key={row.id}>{row.label}</li>)}</ul>
+        </section>;
+      }
+    `);
+
+      expect(result.optimizations.keyedArraySortHints).toBe(0);
+      expect(result.optimizations.keyedArrayReorderHints).toBe(0);
+      expect(result.code).not.toContain("createCompilerKeyedArraySort");
+      expect(result.code).not.toContain("createCompilerKeyedArrayReorder");
+    },
+  );
+
   it.each([
     {
       name: "an index-dependent row",

--- a/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-sort-hints.test.tsx
+++ b/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-sort-hints.test.tsx
@@ -24,6 +24,13 @@ type SortableArray = Item[] & {
   toSorted(compare?: (left: Item, right: Item) => number): Item[];
 };
 
+type ReorderPipelineOperation =
+  | { readonly kind: "reverse" }
+  | {
+      readonly compare: (left: Item, right: Item) => number;
+      readonly kind: "sort";
+    };
+
 const roots: Root[] = [];
 const stressIt = process.env.FARM_REACT_STRESS === "1" ? it : it.skip;
 
@@ -77,7 +84,11 @@ function createSortHarness(initialItems: Item[], readsCollection = false) {
   let plainThenSort: () => void = () => undefined;
   let reverseThenSort: () => void = () => undefined;
   let sortThenReverse: () => void = () => undefined;
+  let reverseThenSortPipeline: () => void = () => undefined;
+  let sortThenReversePipeline: () => void = () => undefined;
+  let reorderPipeline: (operations: readonly ReorderPipelineOperation[]) => void = () => undefined;
   let customSort: () => void = () => undefined;
+  let customSortThenReversePipeline: () => void = () => undefined;
   let mismatchedSort: () => void = () => undefined;
   const Table = createCompiledComponent({
     displayName: "SortTable",
@@ -117,6 +128,25 @@ function createSortHarness(initialItems: Item[], readsCollection = false) {
         );
         state[0].set((previous) => hintedReverse(previous as Item[]));
       };
+      reverseThenSortPipeline = () =>
+        state[0].set((previous) =>
+          hintedSort(hintedReverse(previous as Item[]), (left, right) => left.rank - right.rank),
+        );
+      sortThenReversePipeline = () =>
+        state[0].set((previous) =>
+          hintedReverse(hintedSort(previous as Item[], (left, right) => left.rank - right.rank)),
+        );
+      reorderPipeline = (operations) =>
+        state[0].set((previous) => {
+          let next = previous as Item[];
+          for (const operation of operations) {
+            next =
+              operation.kind === "reverse"
+                ? hintedReverse(next)
+                : hintedSort(next, operation.compare);
+          }
+          return next;
+        });
       customSort = () =>
         state[0].set((previous) => {
           const source = previous as Item[];
@@ -128,6 +158,19 @@ function createSortHarness(initialItems: Item[], readsCollection = false) {
             method,
             (left: Item, right: Item) => left.rank - right.rank,
           );
+        });
+      customSortThenReversePipeline = () =>
+        state[0].set((previous) => {
+          const source = previous as Item[];
+          const custom = function (this: Item[], compare: (left: Item, right: Item) => number) {
+            return [...this].sort(compare);
+          };
+          const sorted = createCompilerKeyedArraySort(
+            source,
+            custom,
+            (left: Item, right: Item) => left.rank - right.rank,
+          ) as Item[];
+          return hintedReverse(sorted);
         });
       mismatchedSort = () =>
         state[0].set((previous) => {
@@ -187,12 +230,17 @@ function createSortHarness(initialItems: Item[], readsCollection = false) {
     Table,
     counters,
     customSort: () => customSort(),
+    customSortThenReversePipeline: () => customSortThenReversePipeline(),
     mismatchedSort: () => mismatchedSort(),
     plainThenSort: () => plainThenSort(),
     queueSorts: (compares: Array<(left: Item, right: Item) => number>) => queueSorts(compares),
     queueTwo: () => queueTwo(),
+    reorderPipeline: (operations: readonly ReorderPipelineOperation[]) =>
+      reorderPipeline(operations),
+    reverseThenSortPipeline: () => reverseThenSortPipeline(),
     reverseThenSort: () => reverseThenSort(),
     sort: (compare: (left: Item, right: Item) => number) => sort(compare),
+    sortThenReversePipeline: () => sortThenReversePipeline(),
     sortThenReverse: () => sortThenReverse(),
   };
 }
@@ -326,13 +374,59 @@ describe("compiled keyed-array sort hints", () => {
     }
   });
 
+  it("composes a native sort and reverse pipeline inside one setter", async () => {
+    const initialItems: Item[] = [
+      { id: "a", label: "Alpha", rank: 3 },
+      { id: "b", label: "Beta", rank: 1 },
+      { id: "c", label: "Gamma", rank: 2 },
+    ];
+    for (const operation of ["reverse-sort", "sort-reverse"] as const) {
+      const harness = createSortHarness(initialItems);
+      const container = document.createElement("div");
+      document.body.append(container);
+      const root = createRoot(container);
+      roots.push(root);
+      await act(async () => root.render(<harness.Table />));
+      const rows = new Map(
+        [...container.querySelectorAll("li")].map((row) => [row.getAttribute("data-key"), row]),
+      );
+      harness.counters.keys = 0;
+      harness.counters.descriptors = 0;
+      harness.counters.bindings = 0;
+
+      await act(async () => {
+        if (operation === "reverse-sort") harness.reverseThenSortPipeline();
+        else harness.sortThenReversePipeline();
+        await flushCompilerUpdates();
+      });
+
+      expect(itemLabels(container)).toEqual(
+        operation === "reverse-sort" ? ["Beta", "Gamma", "Alpha"] : ["Alpha", "Gamma", "Beta"],
+      );
+      for (const [key, row] of rows) {
+        expect(container.querySelector(`[data-key="${key}"]`)).toBe(row);
+      }
+      expect(harness.counters.executions).toBe(1);
+      expect(harness.counters.renders).toBe(1);
+      expect(harness.counters.keys).toBe(0);
+      expect(harness.counters.descriptors).toBe(0);
+      expect(harness.counters.bindings).toBe(0);
+    }
+  });
+
   it("falls back for custom methods, unhinted chains, changed identities, and collection bindings", async () => {
     const initialItems: Item[] = [
       { id: "a", label: "Alpha", rank: 3 },
       { id: "b", label: "Beta", rank: 1 },
       { id: "c", label: "Gamma", rank: 2 },
     ];
-    for (const operation of ["custom", "unhinted", "mismatched", "dependent"] as const) {
+    for (const operation of [
+      "custom",
+      "custom-pipeline",
+      "unhinted",
+      "mismatched",
+      "dependent",
+    ] as const) {
       const harness = createSortHarness(initialItems, operation === "dependent");
       const container = document.createElement("div");
       document.body.append(container);
@@ -342,6 +436,7 @@ describe("compiled keyed-array sort hints", () => {
       harness.counters.keys = 0;
       await act(async () => {
         if (operation === "custom") harness.customSort();
+        else if (operation === "custom-pipeline") harness.customSortThenReversePipeline();
         else if (operation === "unhinted") harness.plainThenSort();
         else if (operation === "mismatched") harness.mismatchedSort();
         else harness.sort((left, right) => left.rank - right.rank);
@@ -380,26 +475,22 @@ describe("compiled keyed-array sort hints", () => {
     ).toThrow(error);
   });
 
-  it("preserves focused controlled-input identity and selection while sorting", async () => {
+  it("preserves focused controlled-input identity and selection through a reorder pipeline", async () => {
     const initialItems: Item[] = [
       { id: "a", label: "Alpha", rank: 3 },
       { id: "b", label: "Beta", rank: 1 },
       { id: "c", label: "Gamma", rank: 2 },
     ];
-    let sortTwice = () => undefined;
+    let reorderPipeline = () => undefined;
     const FormRows = createCompiledComponent({
       displayName: "SortFormRows",
       initialize: () => [initialItems],
       render(_props: Record<string, never>, state, blocks) {
         const items = () => state[0].get() as Item[];
-        sortTwice = () => {
+        reorderPipeline = () =>
           state[0].set((previous) =>
-            hintedSort(previous as Item[], (left, right) => left.rank - right.rank),
+            hintedReverse(hintedSort(previous as Item[], (left, right) => left.rank - right.rank)),
           );
-          state[0].set((previous) =>
-            hintedSort(previous as Item[], (left, right) => left.rank - right.rank),
-          );
-        };
         return (
           <section>
             <blocks.KeyedRows
@@ -445,7 +536,7 @@ describe("compiled keyed-array sort hints", () => {
     input.setSelectionRange(1, 3);
 
     await act(async () => {
-      sortTwice();
+      reorderPipeline();
       await flushCompilerUpdates();
     });
 
@@ -518,13 +609,90 @@ describe("compiled keyed-array sort hints", () => {
     expect(compiled.counters.keys).toBe(0);
   }, 20_000);
 
+  it("matches normal React through 2,000 randomized native reorder pipelines", async () => {
+    const initialItems = Array.from(
+      { length: 64 },
+      (_, index): Item => ({ id: `row-${index}`, label: `Row ${index}`, rank: index }),
+    );
+    const compiled = createSortHarness(initialItems);
+    let runReactPipeline: (operations: readonly ReorderPipelineOperation[]) => void = () =>
+      undefined;
+    function NormalTable() {
+      const [items, setItems] = useState(initialItems);
+      runReactPipeline = (operations) => {
+        setItems((previous) => {
+          let next = previous as SortableArray;
+          for (const operation of operations) {
+            next = (
+              operation.kind === "reverse" ? next.toReversed() : next.toSorted(operation.compare)
+            ) as SortableArray;
+          }
+          return next;
+        });
+      };
+      return (
+        <ul>
+          {items.map((item) => (
+            <li data-key={item.id} key={item.id}>
+              {item.label}
+            </li>
+          ))}
+        </ul>
+      );
+    }
+    const compiledContainer = document.createElement("div");
+    const reactContainer = document.createElement("div");
+    document.body.append(compiledContainer, reactContainer);
+    const compiledRoot = createRoot(compiledContainer);
+    const reactRoot = createRoot(reactContainer);
+    roots.push(compiledRoot, reactRoot);
+    await act(async () => {
+      compiledRoot.render(<compiled.Table />);
+      reactRoot.render(<NormalTable />);
+    });
+    compiled.counters.keys = 0;
+
+    let seed = 0x4f1bbcdc;
+    for (let update = 0; update < 2_000; update += 1) {
+      seed = (Math.imul(seed, 1_664_525) + 1_013_904_223) >>> 0;
+      const stepCount = 2 + (seed % 3);
+      const operations: ReorderPipelineOperation[] = [];
+      for (let step = 0; step < stepCount; step += 1) {
+        seed = (Math.imul(seed, 1_664_525) + 1_013_904_223) >>> 0;
+        if ((seed & 1) === 0) {
+          operations.push({ kind: "reverse" });
+          continue;
+        }
+        const ranks = new Map<string, number>();
+        for (const item of initialItems) {
+          seed = (Math.imul(seed, 1_664_525) + 1_013_904_223) >>> 0;
+          ranks.set(item.id, seed);
+        }
+        operations.push({
+          compare: (left, right) => ranks.get(left.id)! - ranks.get(right.id)!,
+          kind: "sort",
+        });
+      }
+      await act(async () => {
+        compiled.reorderPipeline(operations);
+        runReactPipeline(operations);
+        await flushCompilerUpdates();
+      });
+      if (update % 100 === 0) {
+        expect(itemLabels(compiledContainer)).toEqual(itemLabels(reactContainer));
+      }
+    }
+    expect(itemLabels(compiledContainer)).toEqual(itemLabels(reactContainer));
+    expect(compiled.counters.executions).toBe(1);
+    expect(compiled.counters.keys).toBe(0);
+  }, 20_000);
+
   it("supports StrictMode hydration and ignores a flush after unmount", async () => {
     const items: Item[] = [
       { id: "a", label: "Alpha", rank: 3 },
       { id: "b", label: "Beta", rank: 1 },
       { id: "c", label: "Gamma", rank: 2 },
     ];
-    const compare = (left: Item, right: Item) => left.rank - right.rank;
     const hydration = createSortHarness(items);
     const container = document.createElement("div");
     container.innerHTML = renderToString(<hydration.Table />);
@@ -539,11 +707,10 @@ describe("compiled keyed-array sort hints", () => {
     await act(async () => flushCompilerUpdates());
     const beta = container.querySelector('[data-key="b"]');
     await act(async () => {
-      hydration.sort(compare);
-      hydration.sort(compare);
+      hydration.sortThenReversePipeline();
       await flushCompilerUpdates();
     });
-    expect(itemLabels(container)).toEqual(["Beta", "Gamma", "Alpha"]);
+    expect(itemLabels(container)).toEqual(["Alpha", "Gamma", "Beta"]);
     expect(container.querySelector('[data-key="b"]')).toBe(beta);
 
     const unmounted = createSortHarness(items);
@@ -551,8 +718,7 @@ describe("compiled keyed-array sort hints", () => {
     document.body.append(unmountContainer);
     const unmountRoot = createRoot(unmountContainer);
     await act(async () => unmountRoot.render(<unmounted.Table />));
-    unmounted.sort(compare);
-    unmounted.sort(compare);
+    unmounted.reverseThenSortPipeline();
     await act(async () => unmountRoot.unmount());
     await flushCompilerUpdates();
     expect(unmountContainer.childElementCount).toBe(0);

--- a/packages/farm-react/src/compiler.ts
+++ b/packages/farm-react/src/compiler.ts
@@ -1881,6 +1881,154 @@ function rewriteKeyedArrayReorderHints(
   };
 }
 
+interface KeyedArrayReorderPipelineStep {
+  readonly kind: "reverse" | "sort";
+  readonly comparator?: t.ArrowFunctionExpression | t.FunctionExpression;
+}
+
+function keyedArrayReorderPipeline(
+  expression: t.Expression,
+  parameterName: string,
+  safeGlobals: ReadonlySet<string>,
+): readonly KeyedArrayReorderPipelineStep[] | undefined {
+  const outerSteps: KeyedArrayReorderPipelineStep[] = [];
+  let current = expression;
+  while (
+    t.isCallExpression(current) &&
+    t.isMemberExpression(current.callee) &&
+    !current.callee.computed &&
+    t.isIdentifier(current.callee.property) &&
+    t.isExpression(current.callee.object)
+  ) {
+    const methodName = current.callee.property.name;
+    if (methodName === "toReversed") {
+      if (current.arguments.length !== 0) return undefined;
+      outerSteps.push({ kind: "reverse" });
+    } else if (methodName === "toSorted") {
+      if (current.arguments.length > 1) return undefined;
+      const comparator = current.arguments[0];
+      if (
+        comparator &&
+        !t.isArrowFunctionExpression(comparator) &&
+        !t.isFunctionExpression(comparator)
+      ) {
+        return undefined;
+      }
+      if (comparator && validateCollectionCallback(comparator, "toSorted", safeGlobals)) {
+        return undefined;
+      }
+      outerSteps.push({ kind: "sort", ...(comparator ? { comparator } : {}) });
+    } else {
+      return undefined;
+    }
+    current = current.callee.object;
+  }
+  if (!t.isIdentifier(current, { name: parameterName }) || outerSteps.length < 2) {
+    return undefined;
+  }
+  return outerSteps.reverse();
+}
+
+function rewriteKeyedArrayReorderPipelineHints(
+  root: t.JSXElement,
+  hintedStateIndices: ReadonlySet<number>,
+  statesBySetter: ReadonlyMap<string, StateBinding>,
+  reorderHelperIdentifier: t.Identifier,
+  sortHelperIdentifier: t.Identifier,
+  safeGlobals: ReadonlySet<string>,
+): {
+  root: t.JSXElement;
+  reorderCount: number;
+  sortCount: number;
+  stateIndices: ReadonlySet<number>;
+} {
+  if (hintedStateIndices.size === 0) {
+    return {
+      root: t.cloneNode(root, true),
+      reorderCount: 0,
+      sortCount: 0,
+      stateIndices: new Set(),
+    };
+  }
+  const file = expressionFile(t.cloneNode(root, true));
+  const stateIndices = new Set<number>();
+  let reorderCount = 0;
+  let sortCount = 0;
+  traverse(file, {
+    CallExpression(path) {
+      const callee = path.get("callee");
+      if (!callee.isIdentifier() || callee.scope.hasBinding(callee.node.name)) return;
+      const state = statesBySetter.get(callee.node.name);
+      if (!state || !hintedStateIndices.has(state.index) || path.node.arguments.length !== 1) {
+        return;
+      }
+      const updater = path.node.arguments[0];
+      if (
+        !t.isArrowFunctionExpression(updater) ||
+        updater.async ||
+        updater.generator ||
+        updater.params.length !== 1 ||
+        !t.isIdentifier(updater.params[0]) ||
+        !t.isExpression(updater.body)
+      ) {
+        return;
+      }
+      const steps = keyedArrayReorderPipeline(updater.body, updater.params[0].name, safeGlobals);
+      if (!steps) return;
+
+      const previous = t.cloneNode(updater.params[0]);
+      const statements: t.Statement[] = [];
+      let value: t.Expression = t.cloneNode(previous);
+      for (const step of steps) {
+        const methodName = step.kind === "reverse" ? "toReversed" : "toSorted";
+        const method = path.scope.generateUidIdentifier(
+          step.kind === "reverse" ? "farmToReversed" : "farmToSorted",
+        );
+        const result = path.scope.generateUidIdentifier("farmReordered");
+        statements.push(
+          t.variableDeclaration("const", [
+            t.variableDeclarator(
+              t.cloneNode(method),
+              t.memberExpression(t.cloneNode(value), t.identifier(methodName)),
+            ),
+          ]),
+          t.variableDeclaration("const", [
+            t.variableDeclarator(
+              t.cloneNode(result),
+              t.callExpression(
+                t.cloneNode(
+                  step.kind === "reverse" ? reorderHelperIdentifier : sortHelperIdentifier,
+                ),
+                [
+                  t.cloneNode(value),
+                  t.cloneNode(method),
+                  ...(step.comparator ? [t.cloneNode(step.comparator, true)] : []),
+                ],
+              ),
+            ),
+          ]),
+        );
+        value = t.cloneNode(result);
+        if (step.kind === "reverse") reorderCount += 1;
+        else sortCount += 1;
+      }
+      statements.push(t.returnStatement(t.cloneNode(value)));
+      path.node.arguments[0] = t.arrowFunctionExpression(
+        [t.cloneNode(previous)],
+        t.blockStatement(statements),
+      );
+      stateIndices.add(state.index);
+      path.skip();
+    },
+  });
+  return {
+    root: (file.program.body[0] as t.ExpressionStatement).expression as t.JSXElement,
+    reorderCount,
+    sortCount,
+    stateIndices,
+  };
+}
+
 function rewriteKeyedArraySortHints(
   root: t.JSXElement,
   hintedStateIndices: ReadonlySet<number>,
@@ -7344,14 +7492,53 @@ function compileCandidate(
       compilerUsage.keyedArrayWindowReplaceHints += positionHintedRoot.windowReplaceCount;
     }
   }
+  const reorderPipelineHintedRoot = rewriteKeyedArrayReorderPipelineHints(
+    expandedReactiveRoot,
+    shiftedIndexIndependentStateIndices,
+    statesBySetter,
+    keyedArrayReorderIdentifier,
+    keyedArraySortIdentifier,
+    safeGlobals,
+  );
+  let appliedPipelineReorderHints = 0;
+  let appliedPipelineSortHints = 0;
+  let appliedPipelineHintedStateIndices: ReadonlySet<number> = new Set();
+  if (reorderPipelineHintedRoot.reorderCount > 0 || reorderPipelineHintedRoot.sortCount > 0) {
+    const hintedBlockAnalysis = analyzeComposableBlocks(
+      reorderPipelineHintedRoot.root,
+      reactiveByValue,
+      safeGlobals,
+      listNames,
+      allowedComponentNames,
+    );
+    const hintedAnalysis = analyzeHostTree(
+      reorderPipelineHintedRoot.root,
+      reactiveByValue,
+      safeGlobals,
+      hintedBlockAnalysis.conditionalExpressions || new Set<t.Expression>(),
+      hintedBlockAnalysis.keyedExpressions || new Set<t.Expression>(),
+      hintedBlockAnalysis.ownedElements || new Set<t.JSXElement>(),
+      hintedBlockAnalysis.componentElements || new Set<t.JSXElement>(),
+    );
+    if (!hintedBlockAnalysis.reason && !hintedAnalysis.reason) {
+      expandedReactiveRoot = reorderPipelineHintedRoot.root;
+      blockAnalysis = hintedBlockAnalysis;
+      analysis = hintedAnalysis;
+      appliedPipelineReorderHints = reorderPipelineHintedRoot.reorderCount;
+      appliedPipelineSortHints = reorderPipelineHintedRoot.sortCount;
+      appliedPipelineHintedStateIndices = reorderPipelineHintedRoot.stateIndices;
+      optimizationCounts.keyedArrayReorderHints += reorderPipelineHintedRoot.reorderCount;
+      optimizationCounts.keyedArraySortHints += reorderPipelineHintedRoot.sortCount;
+    }
+  }
   const reorderHintedRoot = rewriteKeyedArrayReorderHints(
     expandedReactiveRoot,
     shiftedIndexIndependentStateIndices,
     statesBySetter,
     keyedArrayReorderIdentifier,
   );
-  let appliedKeyedArrayReorderHints = 0;
-  let appliedReorderHintedStateIndices: ReadonlySet<number> = new Set();
+  let appliedKeyedArrayReorderHints = appliedPipelineReorderHints;
+  let appliedReorderHintedStateIndices: ReadonlySet<number> = appliedPipelineHintedStateIndices;
   if (reorderHintedRoot.count > 0) {
     const hintedBlockAnalysis = analyzeComposableBlocks(
       reorderHintedRoot.root,
@@ -7373,8 +7560,11 @@ function compileCandidate(
       expandedReactiveRoot = reorderHintedRoot.root;
       blockAnalysis = hintedBlockAnalysis;
       analysis = hintedAnalysis;
-      appliedKeyedArrayReorderHints = reorderHintedRoot.count;
-      appliedReorderHintedStateIndices = reorderHintedRoot.stateIndices;
+      appliedKeyedArrayReorderHints += reorderHintedRoot.count;
+      appliedReorderHintedStateIndices = new Set([
+        ...appliedReorderHintedStateIndices,
+        ...reorderHintedRoot.stateIndices,
+      ]);
       optimizationCounts.keyedArrayReorderHints += reorderHintedRoot.count;
     }
   }
@@ -7385,8 +7575,8 @@ function compileCandidate(
     keyedArraySortIdentifier,
     safeGlobals,
   );
-  let appliedKeyedArraySortHints = 0;
-  let appliedSortHintedStateIndices: ReadonlySet<number> = new Set();
+  let appliedKeyedArraySortHints = appliedPipelineSortHints;
+  let appliedSortHintedStateIndices: ReadonlySet<number> = appliedPipelineHintedStateIndices;
   if (sortHintedRoot.count > 0) {
     const hintedBlockAnalysis = analyzeComposableBlocks(
       sortHintedRoot.root,
@@ -7408,8 +7598,11 @@ function compileCandidate(
       expandedReactiveRoot = sortHintedRoot.root;
       blockAnalysis = hintedBlockAnalysis;
       analysis = hintedAnalysis;
-      appliedKeyedArraySortHints = sortHintedRoot.count;
-      appliedSortHintedStateIndices = sortHintedRoot.stateIndices;
+      appliedKeyedArraySortHints += sortHintedRoot.count;
+      appliedSortHintedStateIndices = new Set([
+        ...appliedSortHintedStateIndices,
+        ...sortHintedRoot.stateIndices,
+      ]);
       optimizationCounts.keyedArraySortHints += sortHintedRoot.count;
     }
   }


### PR DESCRIPTION
## Problem

Farm can already carry native keyed-array reorder metadata across multiple functional setters queued before one compiler flush. The equivalent expression inside one concise setter still falls back:

```tsx
setRows((current) =>
  current.toSorted((left, right) => left.rank - right.rank).toReversed(),
);
```

That forces complete keyed reconciliation even though every intermediate operation is a native identity-preserving permutation.

## Root cause

The compiler recognizes only a direct `toSorted()` or `toReversed()` call whose receiver is the updater parameter. It does not model a linear native reorder call chain, so the outer call prevents every step from receiving the existing metadata helper.

## Change

- Parse concise functional-updater chains containing two or more `toSorted()` and `toReversed()` calls.
- Lower each method lookup and call in source order through the existing sort/reorder metadata helpers.
- Reuse the existing committed-token propagation and one final LIS reconciliation; no runtime abstraction or public option is added.
- Count each lowered sort/reverse step in the existing compiler report fields.
- Add a 10,000-row production benchmark and compiled fallback control for two cancelling reversals inside one setter.

## Safety and compatibility

The compiler requires compiler-owned, index-independent keyed host rows, a concise updater, noncomputed native method names, and inline synchronous comparators from the existing safe expression subset. A chain containing another method, a referenced comparator, an argument to `toReversed()`, or unsupported updater syntax stays on normal React.

Generated code preserves property lookup, comparator evaluation, native calls, returned values, and thrown errors. The runtime records metadata only for ordinary dense arrays and exact native methods. Custom methods, sparse or subclassed arrays, changed identities, duplicate identities, ambiguous ownership, or failed validation use complete keyed reconciliation before any DOM mutation.

This is React-renderer-only experimental compiler behavior. React 18.3.1 and 19.2.8 compatibility pass. No runtime implementation or feature selection changed; every persisted runtime-size fixture is byte-for-byte unchanged and disabled builds retain no new browser runtime cost.

## Verification

- `pnpm --filter @farm.js/react type-check`
- `pnpm --filter @farm.js/react test` — 645 tests passed; 3 isolated stress tests passed
- `pnpm --filter @farm.js/react test:compat` — React 18.3.1 and 19.2.8 passed
- `pnpm --filter @farm.js/react test:runtime-size` — all persisted budgets passed; 82.6% core-runtime reduction preserved
- `pnpm --filter farm-react-compiler-dashboard-example type-check`
- `FARM_REACT_COMPILER=true FARM_REACTIVITY=hybrid pnpm --filter farm-react-compiler-dashboard-example build`
- `FARM_EXPERIMENT_BROWSER_PATH='/Applications/Google Chrome.app/Contents/MacOS/Google Chrome' pnpm --filter farm-react-compiler-dashboard-example benchmark`
  - correctness, general performance, scalability, and every existing optimization gate: PASS
  - pipeline static: 5.60 ms vs React 50.85 ms and compiled control 12.80 ms — 9.08x / 2.29x
  - pipeline hybrid: 5.60 ms vs React 50.85 ms and compiled control 13.00 ms — 9.08x / 2.32x
  - compiler report: 5 reverse steps, including both pipeline calls
- `pnpm --dir docs exec farm generate --check`
- `pnpm docs:check-navigation`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm docs:build`
- focused `oxfmt`, `oxlint`, `node --check`, and `git diff --check`

The runtime differential suite includes 2,000 deterministic updates, each with two to four randomized native sort/reverse steps, compared with normal React. It also covers DOM identity, zero key/descriptor/binding rereads, custom-method fallback, focused input selection, Strict Mode hydration, and unmount-before-flush cleanup.

Environment: Chrome 152.0.7977.82, Node.js 23.11.0, Apple M1 macOS arm64.

## Documentation and release

Updated the React renderer docs, package README, dashboard benchmark guide, executable example, benchmark gate, and persisted benchmark results. No release, template, or generated-route changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Compiles chained `toSorted()` and `toReversed()` calls inside one concise functional setter, so native reorder pipelines no longer fall back to complete keyed reconciliation.

**Safety and compatibility**
- Unsupported chains, custom methods, sparse/subclassed arrays, and mismatched identities stay on normal React.
- No runtime abstraction or option added; runtime-size fixtures unchanged.
- Each compiled step is reported as `keyedArrayReorderHints` or `keyedArraySortHints`.

**Benchmark and tests**
- New 10,000-row benchmark: 5.60 ms vs 50.85 ms React and 12.80 ms compiled control.
- 645 package tests, stress suite, and React 18.3.1/19.2.8 compatibility pass.
- Docs, README, and benchmark gate updated.

<sup>Written for commit 727550f2eb112b1058c204f81b8d84fe1cb35c29. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/731?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

