### PR TITLE
fix(scripts): run package scripts through pnpm's shell emulator

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,5 @@
+# Scripts across the repo set variables with `VAR=value command` and
+# `${VAR:-default}`, which cmd.exe cannot run. The emulator interprets that
+# syntax the same way on every platform, so `pnpm docs:build` and the
+# deployment-preset examples work on Windows without rewriting each script.
+shell-emulator=true

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "build": "pnpm -r --filter \"./packages/*\" build",
     "dev": "turbo --filter \"./packages/*\" dev",
-    "test": "node --test scripts/pack-public-packages.test.js scripts/release-beta.test.js scripts/publish-beta.test.js scripts/run-prisma-generate.test.js && node scripts/test-packages.js",
+    "test": "node --test scripts/pack-public-packages.test.js scripts/release-beta.test.js scripts/publish-beta.test.js scripts/run-prisma-generate.test.js scripts/pnpm-script-shell.test.js && node scripts/test-packages.js",
     "test:farm": "pnpm --filter @farm.js/core test",
     "test:renderers": "node scripts/test-renderers.mjs",
     "test:ci": "node scripts/run-tests.js",

--- a/scripts/pnpm-script-shell.test.js
+++ b/scripts/pnpm-script-shell.test.js
@@ -29,6 +29,9 @@ function runScript(script, env = {}) {
       encoding: "utf8",
       shell: process.platform === "win32",
     });
+    if (result.error || result.stdout === null) {
+      throw new Error(`pnpm could not be spawned: ${result.error?.message ?? "no output"}`);
+    }
     return { status: result.status, stdout: result.stdout.trim(), stderr: result.stderr };
   } finally {
     fs.rmSync(dir, { recursive: true, force: true });
@@ -51,6 +54,14 @@ test("a ${VAR:-default} expansion falls back when the variable is unset", () => 
 
   assert.equal(result.status, 0, result.stderr);
   assert.equal(result.stdout, "fallback");
+});
+
+test("a ${VAR:-default} expansion leaves an empty string alone", () => {
+  // Pins the emulator's departure from bash so a change in pnpm is noticed.
+  const result = runScript(`PROBE_VAR=\${PROBE_VAR:-fallback} ${PRINT}`, { PROBE_VAR: "" });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout, "");
 });
 
 test("a ${VAR:-default} expansion keeps an explicit value", () => {

--- a/scripts/pnpm-script-shell.test.js
+++ b/scripts/pnpm-script-shell.test.js
@@ -1,0 +1,61 @@
+const assert = require("node:assert/strict");
+const { spawnSync } = require("node:child_process");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { test } = require("node:test");
+
+const repoRoot = path.resolve(__dirname, "..");
+
+/**
+ * Runs a package script through pnpm inside a throwaway package that carries
+ * the repository's .npmrc, so the test exercises the same script shell the
+ * workspace uses rather than whatever the host shell happens to be.
+ */
+function runScript(script, env = {}) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "farm-script-shell-"));
+  try {
+    fs.copyFileSync(path.join(repoRoot, ".npmrc"), path.join(dir, ".npmrc"));
+    fs.writeFileSync(
+      path.join(dir, "package.json"),
+      JSON.stringify({ name: "script-shell-probe", private: true, scripts: { probe: script } }),
+    );
+    const childEnv = { ...process.env, ...env };
+    // A caller passes `undefined` to leave the variable unset rather than empty.
+    for (const [key, value] of Object.entries(env)) if (value === undefined) delete childEnv[key];
+    const result = spawnSync("pnpm", ["run", "--silent", "probe"], {
+      cwd: dir,
+      env: childEnv,
+      encoding: "utf8",
+      shell: process.platform === "win32",
+    });
+    return { status: result.status, stdout: result.stdout.trim(), stderr: result.stderr };
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+const PRINT = 'node -e "process.stdout.write(String(process.env.PROBE_VAR))"';
+
+test("an inline environment prefix reaches the command", () => {
+  const result = runScript(`PROBE_VAR=inline ${PRINT}`);
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout, "inline");
+});
+
+test("a ${VAR:-default} expansion falls back when the variable is unset", () => {
+  // The emulator applies the default for an unset variable only; unlike bash it
+  // leaves an empty string alone. The repository relies on the unset case.
+  const result = runScript(`PROBE_VAR=\${PROBE_VAR:-fallback} ${PRINT}`, { PROBE_VAR: undefined });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout, "fallback");
+});
+
+test("a ${VAR:-default} expansion keeps an explicit value", () => {
+  const result = runScript(`PROBE_VAR=\${PROBE_VAR:-fallback} ${PRINT}`, { PROBE_VAR: "explicit" });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout, "explicit");
+});


### PR DESCRIPTION
## Problem

`pnpm docs:build` fails on Windows before the docs site is built:

```
> DATABASE_URL=${DATABASE_URL:-postgresql://user:password@localhost:5432/farmjs} node ../scripts/run-prisma-generate.mjs
'DATABASE_URL' is not recognized as an internal or external command
```

Fixes #733.

## Root cause

pnpm runs package scripts through `cmd.exe` on Windows. `VAR=value command` is a POSIX shell
prefix and `${VAR:-default}` is shell parameter expansion, so `cmd.exe` treats `DATABASE_URL=...`
as a program name. The docs `build` script has a second instance in `NODE_OPTIONS=... farm build`,
and the same form appears in `release:build`, the deployment-preset examples and the benchmarks.

## Change

Add `shell-emulator=true` to a repository `.npmrc`. pnpm then runs scripts through its JavaScript
shell emulator on every platform, which interprets variable prefixes and `${VAR:-default}`
expansion, so no script needs rewriting.

A regression test in `scripts/pnpm-script-shell.test.js` runs a probe script through pnpm inside a
throwaway package carrying the repository's `.npmrc`, and checks that an inline prefix reaches the
command and that a default expansion falls back when unset and keeps an explicit value. It is added
to the root `test` script.

## Safety and compatibility

The emulator applies on every platform, not only Windows. Tracked package scripts use `&&` chains,
variable prefixes and `test/*.test.mjs` globs, all of which run unchanged under it; the CLI, sentry
and core scripts were run to confirm. One semantic difference from bash: `${VAR:-default}` applies
the default when the variable is unset, not when it is set to an empty string. The repository
relies on the unset case, and the test documents the distinction.

## Verification

- `pnpm docs:build` on Windows (Prisma Client generated and the build completes; it failed before
  reaching `farm build` without the change)
- `node --test scripts/pnpm-script-shell.test.js` (3 tests passed; all 3 fail with `.npmrc` removed)
- `node --test scripts/pack-public-packages.test.js scripts/release-beta.test.js scripts/publish-beta.test.js scripts/run-prisma-generate.test.js scripts/pnpm-script-shell.test.js` (17 tests passed)
- `pnpm --filter @farm.js/cli test` (88 tests passed, exercises the `test/*.test.mjs` glob)
- `pnpm --filter @farm.js/sentry test` (47 tests passed)
- `pnpm --filter @farm.js/core type-check`
- `pnpm lint` at the root (0 errors)
- `pnpm docs:check-navigation`
- `git diff --check`

## Documentation and release

No documentation, release metadata or generated artifacts changed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `pnpm docs:build` failing on Windows, where `cmd.exe` can't run `VAR=value` prefixes or `${VAR:-default}` expansions used in package scripts. Setting `shell-emulator=true` in `.npmrc` makes pnpm run scripts with its own shell emulator on every platform.

**Bug Fixes**
- Adds a regression test in `scripts/pnpm-script-shell.test.js` that verifies prefixes and `${VAR:-default}` expansion semantics; it's now part of the root `test` script.
- The emulator differs from bash in one edge case: the default applies only when the variable is unset, not when empty, a behavior the repo relies on and the new tests pin.

<sup>Written for commit b8266add99b0086a9b722820684f7e7fe95d43d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/734?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

