### PR TITLE
perf(react): compose structural reorder pipelines

### DIFF
--- a/docs/src/app/docs/renderers/react/page.md
+++ b/docs/src/app/docs/renderers/react/page.md
@@ -376,9 +376,9 @@ exact retained interval after runtime validation.
 contiguous-range removals, single-row replacements, and exact-window replacements with a guarded
 position.
 `keyedArrayReorderHints` counts native keyed-array reverse steps whose complete permutation can be
-validated, including steps in a supported reorder-only pipeline.
+validated, including steps after a supported filter/slice prefix.
 `keyedArraySortHints` counts native keyed-array sort steps whose resulting permutation can be
-validated without rebuilding keyed rows, including steps in a supported reorder-only pipeline.
+validated without rebuilding keyed rows, including steps after a supported filter/slice prefix.
 `keyedArrayRollingWindowHints` counts direct keyed-array updates that retain a proven sliced tail
 and append an incoming suffix.
 `selected` is `true` when an annotation explicitly requested compilation. Module paths are relative
@@ -1181,15 +1181,34 @@ The runtime validates only the final identity permutation against the committed 
 then applies one LIS-based reconciliation. A cancelling
 `current.toReversed().toReversed()` pipeline therefore performs no DOM moves.
 
+A compiler-safe `filter()` or bounded `slice()` prefix may run before one or more native reorder
+steps in the same concise setter:
+
+```tsx
+setItems((current) =>
+  current
+    .filter((item) => item.visible)
+    .toSorted((left, right) => left.rank - right.rank)
+    .toReversed(),
+);
+```
+
+Farm executes every native method normally, carries the structural survivor proof into the final
+reorder result, and validates the complete operation before touching the DOM. It removes only
+rejected rows, uses LIS once for the surviving final order, and preserves every surviving element,
+handler, and form control without recreating descriptors or rereading bindings. A concise filter
+or slice setter followed by a concise reorder setter in the same batch uses the same proof.
+
 The first proof requires compiler-owned host rows whose render and key do not observe the index.
 Arguments to `toReversed()`, referenced comparators, computed methods, chains containing a method
-other than `toSorted()` or `toReversed()`, block-bodied updaters, subclassed or sparse
-behavior, collection-reading bindings, custom methods, an unhinted or structural update between
-reorder setters, React-owned rows, nested host blocks, row conditionals, unrelated dirty
-dependencies, and any identity mismatch use complete keyed reconciliation. No option or component
-is added. Reports count every compiled reverse step as a `keyedArrayReorderHints` entry; modules
-without one do not retain the optional reorder runtime. The application runtime must provide
-`Array.prototype.toReversed`; Farm does not polyfill it.
+outside the supported `filter()`/`slice()` prefix and `toSorted()`/`toReversed()` suffix,
+block-bodied updaters, subclassed or sparse behavior, collection-reading bindings, custom methods,
+structural calls after reordering, an unhinted intermediate update, React-owned rows, nested host
+blocks, row conditionals, unrelated dirty dependencies, and any identity mismatch use complete
+keyed reconciliation. No option or component is added. Reports count every compiled structural and
+reorder step in its existing hint counter; modules without those steps do not retain their optional
+runtimes. The application runtime must provide `Array.prototype.toReversed`; Farm does not polyfill
+it.
 
 #### Keyed array sort hints
 
@@ -1217,12 +1236,12 @@ rows.
 
 This proof requires compiler-owned host rows whose render and key do not observe the row index.
 Referenced comparators, block-bodied updaters, computed methods, custom methods, sparse or subclassed
-arrays, duplicate item identities, collection-reading bindings, an unhinted or structural update
-between queued sorts, React-owned rows, nested host blocks, row conditionals, unrelated dirty
-dependencies, and failed validation keep complete keyed reconciliation. Native
-sort/reverse-only chains are supported; other chained calls fall back. Reports count each compiled
-sort step as a `keyedArraySortHints` entry. Sort shares the optional reorder runtime, and Farm does
-not polyfill `Array.prototype.toSorted`.
+arrays, duplicate item identities, collection-reading bindings, an unhinted intermediate update,
+structural calls after reordering, React-owned rows, nested host blocks, row conditionals, unrelated
+dirty dependencies, and failed validation keep complete keyed reconciliation. Native sort/reverse
+chains may start with compiler-safe `filter()` and bounded `slice()` calls; other chained calls fall
+back. Reports count each compiled sort step as a `keyedArraySortHints` entry. Sort shares the
+optional reorder runtime, and Farm does not polyfill `Array.prototype.toSorted`.
 
 #### Keyed array filter hints
 
@@ -2045,6 +2064,10 @@ The package and example test suites verify more than generated code:
 - 2,000 deterministic randomized keyed-array removals match normal React; targeted tests require
   zero surviving descriptor and binding reads, preserve DOM identity, and cover queued filters,
   unhinted-chain fallback, collection-reading rows, StrictMode hydration, and unmount cleanup;
+- 2,000 deterministic randomized removals followed by native sorting and reversal match normal
+  React; targeted tests cover filter/slice/reorder pipelines, queued filter-then-sort updates,
+  surviving controlled-input focus and selection, exact DOM identity, custom-method and identity
+  fallback, StrictMode hydration, and unmount-before-flush cleanup;
 - 1,000 deterministic exact-position insertions, single and contiguous-range removals, single-row
   replacements, and exact-window replacements match normal React; compiler tests cover guarded
   runtime positions plus literal and compiler-safe runtime delete counts, while targeted removal

--- a/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
+++ b/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
@@ -2,6 +2,39 @@
 
 Date: 2026-08-29
 
+## Structural prefixes composed with native reorders — 2026-09-06
+
+The 10,000-row table now measures one concise setter that filters one row and then executes two
+native `toReversed()` calls. The final order matches the surviving source order, so the workload
+isolates structural composition from DOM movement. The compiler carries the filter survivor map
+through both immutable reorder results, validates every surviving item and key before writing,
+disconnects only the rejected row, preserves all 9,999 surviving DOM nodes, and skips map and LIS
+work when the final permutation keeps survivor order. The equivalent block-bodied updater remains
+the compiled fallback control.
+
+| Mode   | React median | Composed pipeline | Compiled control | vs React | vs control |
+| ------ | -----------: | ----------------: | ---------------: | -------: | ---------: |
+| Static |     92.85 ms |          23.10 ms |         32.40 ms |    4.02x |      1.40x |
+| Hybrid |     92.85 ms |          24.70 ms |         37.30 ms |    3.76x |      1.51x |
+
+The independent gate requires at least 2x versus bracketed React and 1.25x versus the compiled
+control in both modes. The full production run passed that gate, the general regression and
+scalability gates, every older optimization gate, all DOM identity assertions, and zero-owner-
+execution checks without lowering a threshold. Both compiler reports emitted two filter hints and
+seven reorder hints, including the filter/reorder pipeline.
+
+Compiler coverage accepts compiler-safe `filter()` and bounded `slice()` prefixes followed by
+native `toSorted()` and `toReversed()` suffixes, while rejecting structural calls after a reorder,
+referenced predicates, custom methods, and index-dependent rows. Runtime coverage preserves
+controlled-input focus and selection, proves atomic fallback before DOM writes, exercises queued
+updates, Strict Mode hydration, and unmount-before-flush cleanup, and compares 2,000 randomized
+filter/sort/reverse updates with normal React.
+
+The combined reconciler and structural metadata helpers live only in the every-hints runtime tier.
+The runtime-size guard passes: a reorder-only fixture remains 12,151 B gzip and the compiler-
+selected core removes 82.9% of the complete compatibility-runtime premium. The recorded run used
+Chrome 152.0.7977.82, Node.js 23.11.0, and Apple M1 macOS arm64.
+
 ## Native reorder pipelines in one setter — 2026-09-05
 
 The 10,000-row table now measures two native `toReversed()` calls chained inside one concise

--- a/examples/react-compiler-dashboard/README.md
+++ b/examples/react-compiler-dashboard/README.md
@@ -206,6 +206,14 @@ once, retain every DOM node, and remain at least 2x faster than React and 1.25x 
 equivalent block-bodied compiled control. Package tests compile mixed sort/reverse pipelines and
 compare 2,000 deterministic two-to-four-step pipelines with normal React.
 
+Structural reorder pipelines add an independent 10,000-row comparison. One concise setter filters
+one row and then evaluates two native reversals, while the block-bodied version remains the compiled
+fallback control. Farm must validate membership and final order before touching the DOM, preserve
+all 9,999 surviving row identities, remove only the rejected row, and remain at least 2x faster than
+React and 1.25x faster than the compiled control. Package tests also cover filter/slice/sort/reverse
+composition, queued filter-then-sort updates, 2,000 randomized removals, controlled-input focus and
+selection, hydration, cleanup, and conservative fallback.
+
 Native keyed-array sorting has its own 10,000-row comparison. Concise `toSorted()` is measured
 against bracketed React and an equivalent block-bodied compiled control. Both compiler modes must
 remain at least 4x faster than React and 1.25x faster than the compiled control. The report must

--- a/examples/react-compiler-dashboard/scripts/benchmark.mjs
+++ b/examples/react-compiler-dashboard/scripts/benchmark.mjs
@@ -135,8 +135,8 @@ async function inspectBuild(compilerMode) {
       "The compiler build did not emit a keyed-array append hint.",
     );
     assert(
-      compilerReport.summary.keyedArrayFilterHints > 0,
-      "The compiler build did not emit a keyed-array filter hint.",
+      compilerReport.summary.keyedArrayFilterHints >= 2,
+      "The compiler build did not emit both keyed-array filter hints.",
     );
     assert(
       compilerReport.summary.keyedArrayPrependHints > 0,
@@ -147,8 +147,8 @@ async function inspectBuild(compilerMode) {
       "The compiler build did not emit the keyed-array exact-position hints.",
     );
     assert(
-      compilerReport.summary.keyedArrayReorderHints > 0,
-      "The compiler build did not emit a keyed-array reorder hint.",
+      compilerReport.summary.keyedArrayReorderHints >= 7,
+      "The compiler build did not emit every keyed-array reorder pipeline step.",
     );
     assert(
       compilerReport.summary.keyedArraySortHints > 0,
@@ -1164,6 +1164,40 @@ async function measureTrial(browser, trial, compilerMode, port) {
           },
         );
 
+        const measureFilterReorderPipeline = async (action) => {
+          const rows = [...table.querySelectorAll("tbody tr")];
+          const survivors = rows.filter(
+            (row) => Number(row.getAttribute("data-row-id")) % 10_000 !== 5_001,
+          );
+          const removed = rows.filter(
+            (row) => Number(row.getAttribute("data-row-id")) % 10_000 === 5_001,
+          );
+          await runTableAction(action, () => {
+            const nextRows = table.querySelectorAll("tbody tr");
+            return (
+              nextRows.length === survivors.length &&
+              rowsMatch(nextRows, survivors) &&
+              removed.every((row) => !row.isConnected)
+            );
+          });
+        };
+
+        const tableFilterReorderPipeline = await measureTable(
+          async () => ensure10000(),
+          async () =>
+            measureFilterReorderPipeline(() =>
+              tableButton("table-filter-reorder-pipeline").click(),
+            ),
+        );
+
+        const tableFilterReorderPipelineSnapshot = await measureTable(
+          async () => ensure10000(),
+          async () =>
+            measureFilterReorderPipeline(() =>
+              tableButton("table-filter-reorder-pipeline-snapshot").click(),
+            ),
+        );
+
         const tableSort = await measureTable(
           async () => create10000(),
           async () => {
@@ -1556,6 +1590,8 @@ async function measureTrial(browser, trial, compilerMode, port) {
             denseMapLookup: tableDenseMapLookup,
             denseMembership: tableDenseMembership,
             executionsAdded: Number(tableExecutions.textContent) - initialTableExecutions,
+            filterReorderPipeline: tableFilterReorderPipeline,
+            filterReorderPipelineSnapshot: tableFilterReorderPipelineSnapshot,
             mapLookup: tableMapLookup,
             membership: tableMembership,
             prepend: tablePrepend,
@@ -1676,6 +1712,8 @@ async function measureTrial(browser, trial, compilerMode, port) {
         denseMapLookup: timingSummary(result.table.denseMapLookup),
         denseMembership: timingSummary(result.table.denseMembership),
         executionsAdded: result.table.executionsAdded,
+        filterReorderPipeline: timingSummary(result.table.filterReorderPipeline),
+        filterReorderPipelineSnapshot: timingSummary(result.table.filterReorderPipelineSnapshot),
         mapLookup: timingSummary(result.table.mapLookup),
         membership: timingSummary(result.table.membership),
         prepend: timingSummary(result.table.prepend),
@@ -1846,6 +1884,8 @@ const tableMetrics = [
   "mapLookup",
   "denseMembership",
   "denseMapLookup",
+  "filterReorderPipeline",
+  "filterReorderPipelineSnapshot",
   "snapshotMembership",
   "snapshotMapLookup",
   "slicePrefix",
@@ -2436,6 +2476,29 @@ const keyedReorderPipelineRegressions = keyedReorderPipelineResults.filter(
     !Number.isFinite(snapshotSpeedup) ||
     snapshotSpeedup < keyedReorderPipelineMinimumSnapshotSpeedup,
 );
+// Filtering followed by native reorder steps changes membership and order in one setter. The
+// hinted path must preserve every surviving row, remove rejected rows, and stay ahead of React and
+// the equivalent block-bodied compiled control at 10,000 rows.
+const keyedStructuralReorderMinimumSpeedup = 2;
+const keyedStructuralReorderMinimumSnapshotSpeedup = 1.25;
+const keyedStructuralReorderResults = ["static", "hybrid"].map((mode) => {
+  const pipelineMedianMs = comparisons.table.filterReorderPipeline[mode].medianMs;
+  const snapshotMedianMs = comparisons.table.filterReorderPipelineSnapshot[mode].medianMs;
+  return {
+    mode,
+    pipelineMedianMs,
+    snapshotMedianMs,
+    snapshotSpeedup: snapshotMedianMs / pipelineMedianMs,
+    speedup: comparisons.table.filterReorderPipeline[`${mode}VsBaseline`].speedup,
+  };
+});
+const keyedStructuralReorderRegressions = keyedStructuralReorderResults.filter(
+  ({ snapshotSpeedup, speedup }) =>
+    !Number.isFinite(speedup) ||
+    speedup < keyedStructuralReorderMinimumSpeedup ||
+    !Number.isFinite(snapshotSpeedup) ||
+    snapshotSpeedup < keyedStructuralReorderMinimumSnapshotSpeedup,
+);
 // A direct native toSorted() exposes a permutation while preserving every keyed row object. The
 // hinted path validates that permutation by item identity, uses LIS to move only the required DOM
 // nodes, and avoids key, descriptor, and binding reads. Compare it with React and the equivalent
@@ -2622,6 +2685,7 @@ const passed =
   keyedReorderRegressions.length === 0 &&
   keyedQueuedReorderRegressions.length === 0 &&
   keyedReorderPipelineRegressions.length === 0 &&
+  keyedStructuralReorderRegressions.length === 0 &&
   keyedSortRegressions.length === 0 &&
   keyedFilterRegressions.length === 0 &&
   keyedIdentityRegressions.length === 0 &&
@@ -2773,6 +2837,13 @@ const report = {
     regressions: keyedReorderPipelineRegressions,
     results: keyedReorderPipelineResults,
     status: keyedReorderPipelineRegressions.length === 0 ? "PASS" : "FAIL",
+  },
+  keyedStructuralReorderHintGate: {
+    minimumSnapshotSpeedup: keyedStructuralReorderMinimumSnapshotSpeedup,
+    minimumSpeedup: keyedStructuralReorderMinimumSpeedup,
+    regressions: keyedStructuralReorderRegressions,
+    results: keyedStructuralReorderResults,
+    status: keyedStructuralReorderRegressions.length === 0 ? "PASS" : "FAIL",
   },
   keyedSortHintGate: {
     minimumSnapshotSpeedup: keyedSortMinimumSnapshotSpeedup,

--- a/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
+++ b/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
@@ -839,6 +839,38 @@ export function StandardTableBenchmark() {
           Reverse pipeline (snapshot control)
         </button>
         <button
+          data-action="table-filter-reorder-pipeline"
+          type="button"
+          onClick={() => {
+            setRows((current) =>
+              current
+                .filter((item) => item.id % 10_000 !== 5_001)
+                .toReversed()
+                .toReversed(),
+            );
+            setOperation("filter and reorder rows in one setter");
+            setRevision((value) => value + 1);
+          }}
+        >
+          Filter + reorder pipeline
+        </button>
+        <button
+          data-action="table-filter-reorder-pipeline-snapshot"
+          type="button"
+          onClick={() => {
+            setRows((current) => {
+              return current
+                .filter((item) => item.id % 10_000 !== 5_001)
+                .toReversed()
+                .toReversed();
+            });
+            setOperation("filter and reorder rows (snapshot control)");
+            setRevision((value) => value + 1);
+          }}
+        >
+          Filter + reorder pipeline (snapshot control)
+        </button>
+        <button
           data-action="table-sort"
           type="button"
           onClick={() => {

--- a/packages/farm-react/README.md
+++ b/packages/farm-react/README.md
@@ -394,12 +394,27 @@ setItems((current) => current.toSorted((left, right) => left.rank - right.rank).
 
 Farm evaluates every lookup and call in JavaScript order, carries the same committed token through
 the pipeline, and reconciles only its final result. Index-aware or collection-reading rows,
-arguments to `toReversed()`, referenced comparators, computed methods, chains containing a method
-other than `toSorted()` or `toReversed()`, block-bodied updaters, custom methods, sparse or
-subclassed behavior, an unhinted or structural intermediate update, nested or React-owned rows, and
-failed checks keep complete keyed reconciliation. Reports count each compiled reverse step as a
-`keyedArrayReorderHints` entry, and modules without one omit the reorder runtime. Farm does not
-polyfill `Array.prototype.toReversed`.
+arguments to `toReversed()`, referenced comparators, computed methods, block-bodied updaters, custom
+methods, sparse or subclassed behavior, structural calls after reordering, an unhinted intermediate
+update, nested or React-owned rows, and failed checks keep complete keyed reconciliation.
+
+A compiler-safe `filter()` or bounded `slice()` prefix may precede the native reorder suffix:
+
+```tsx
+setItems((current) =>
+  current
+    .filter((item) => item.visible)
+    .toSorted((left, right) => left.rank - right.rank)
+    .toReversed(),
+);
+```
+
+Farm validates the complete survivor set and final order before the first DOM write, removes only
+rejected rows, and applies LIS once to the survivors. Concise filter/slice and reorder setters also
+compose when queued in that order before one flush. Unsupported calls or a structural call after a
+reorder fall back. Reports count each compiled step in the existing filter, slice, sort, or reverse
+counter, and modules without those operations omit their optional runtimes. Farm does not polyfill
+`Array.prototype.toReversed`.
 
 A direct native immutable sort can use the same optional reorder runtime:
 
@@ -419,10 +434,10 @@ reconcile only their final permutation. The native sorting work itself is unchan
 
 Index-aware or collection-reading rows, referenced comparators, block-bodied updaters, computed or
 unsupported chained calls, custom methods, sparse or subclassed arrays, duplicate item identities,
-unhinted or structural intermediate updates, nested or React-owned rows, and failed checks keep
-complete keyed reconciliation. Reports count each compiled sort step as a `keyedArraySortHints`
-entry; sort shares the optional reorder runtime, and Farm does not polyfill
-`Array.prototype.toSorted`.
+unhinted intermediate updates, structural calls after reordering, nested or React-owned rows, and
+failed checks keep complete keyed reconciliation. A compiler-safe filter/slice prefix is supported.
+Reports count each compiled sort step as a `keyedArraySortHints` entry; sort shares the optional
+reorder runtime, and Farm does not polyfill `Array.prototype.toSorted`.
 
 Concise immutable filters on a direct keyed array can carry removal positions into the same
 optional runtime:
@@ -723,7 +738,8 @@ reasons aggregated by count. Its summary and per-module `optimizations` also rep
 `keyedCollectionUpdateHints`, the number of compiler-proven native Set/Map mutation sites; and
 `keyedMapUpdateHints`, the number of compiler-proven direct keyed `map()` update sites; and
 `keyedArrayAppendHints`, the number of compiler-proven direct keyed-array append sites; and
-`keyedArrayFilterHints`, the number of compiler-proven direct keyed-array filter sites; and
+`keyedArrayFilterHints`, the number of compiler-proven keyed-array filter sites, including supported
+structural reorder pipelines; and
 `keyedArrayPrependHints`, the number of compiler-proven direct keyed-array prepend sites; and
 `keyedArrayPositionHints`, the number of compiler-proven native exact-position insertion, single or
 contiguous-range removal, single-row replacement, or exact-window replacement sites, including
@@ -733,8 +749,9 @@ and
 `keyedArraySortHints`, the number of compiler-proven native keyed-array sort steps; and
 `keyedArrayRollingWindowHints`, the number of compiler-proven retained-tail plus incoming-suffix
 sites; and
-`keyedArraySliceHints`, the number of compiler-proven direct keyed-array slice sites with literal or
-guarded compiler-safe runtime bounds. A custom project-relative `reportFile` also enables reporting.
+`keyedArraySliceHints`, the number of compiler-proven keyed-array slice sites with literal or guarded
+compiler-safe runtime bounds, including supported structural reorder pipelines. A custom
+project-relative `reportFile` also enables reporting.
 
 The runtime test compares the same counter interaction on both paths: ordinary React performs a
 second component render and commit, while the compiled component remains at one render and one

--- a/packages/farm-react/src/__tests__/compiler-keyed-array-sort-hints.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-keyed-array-sort-hints.test.ts
@@ -127,6 +127,42 @@ describe("React AOT keyed-array sort hints", () => {
     expect(result.code.match(/createCompilerKeyedArrayReorder\(/g)).toHaveLength(2);
   });
 
+  it("lowers a structural prefix followed by native reorder steps", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Table() {
+        const [rows, setRows] = useState([
+          { id: "a", rank: 2, visible: true, label: "Alpha" },
+          { id: "b", rank: 1, visible: false, label: "Beta" },
+          { id: "c", rank: 3, visible: true, label: "Gamma" },
+        ]);
+        return <section>
+          <button onClick={() => setRows((current) =>
+            current
+              .filter((row) => row.visible)
+              .slice(0, 2)
+              .toSorted((left, right) => left.rank - right.rank)
+              .toReversed()
+          )}>Keep and reorder</button>
+          <ul>{rows.map((row) => <li key={row.id}>{row.label}</li>)}</ul>
+        </section>;
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Table"]);
+    expect(result.optimizations.keyedArrayFilterHints).toBe(1);
+    expect(result.optimizations.keyedArraySliceHints).toBe(1);
+    expect(result.optimizations.keyedArraySortHints).toBe(1);
+    expect(result.optimizations.keyedArrayReorderHints).toBe(1);
+    expect(result.code.match(/createCompilerKeyedArrayFilter\(/g)).toHaveLength(1);
+    expect(result.code.match(/createCompilerKeyedArraySlice\(/g)).toHaveLength(1);
+    expect(result.code.match(/createCompilerKeyedArrayStructuralSort\(/g)).toHaveLength(1);
+    expect(result.code.match(/createCompilerKeyedArrayStructuralReorder\(/g)).toHaveLength(1);
+    expect(result.code).not.toContain("createCompilerKeyedArraySort");
+    expect(result.code).not.toContain("createCompilerKeyedArrayReorder");
+    expect(result.code).toContain("keyedRowsEveryHintedRuntimeFeature");
+  });
+
   it.each([
     {
       name: "a referenced comparator",
@@ -138,8 +174,18 @@ describe("React AOT keyed-array sort hints", () => {
       update: 'current.toSorted((left, right) => left.rank - right.rank)["toReversed"]()',
     },
     {
-      name: "a non-reorder intermediate method",
+      name: "a no-op slice without a structural hint",
       update: "current.slice().toSorted((left, right) => left.rank - right.rank).toReversed()",
+    },
+    {
+      name: "a structural method after reordering",
+      update:
+        "current.toSorted((left, right) => left.rank - right.rank).filter((row) => row.visible)",
+    },
+    {
+      name: "a referenced filter predicate",
+      declaration: "const visible = (row) => row.visible;",
+      update: "current.filter(visible).toReversed()",
     },
     {
       name: "an invalid reverse argument",
@@ -224,6 +270,31 @@ describe("React AOT keyed-array sort hints", () => {
     `);
 
     expect(result.optimizations.keyedArraySortHints).toBe(0);
+    expect(result.code).not.toContain("createCompilerKeyedArraySort");
+  });
+
+  it("keeps an index-dependent structural reorder on complete reconciliation", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Table() {
+        const [rows, setRows] = useState([
+          { id: "a", rank: 2, visible: true },
+          { id: "b", rank: 1, visible: false },
+        ]);
+        return <section>
+          <button onClick={() => setRows((current) =>
+            current
+              .filter((row) => row.visible)
+              .toSorted((left, right) => left.rank - right.rank)
+          )}>Keep and sort</button>
+          <ul>{rows.map((row, index) => <li key={row.id}>{index}: {row.id}</li>)}</ul>
+        </section>;
+      }
+    `);
+
+    expect(result.optimizations.keyedArrayFilterHints).toBe(0);
+    expect(result.optimizations.keyedArraySortHints).toBe(0);
+    expect(result.code).not.toContain("createCompilerKeyedArrayFilter");
     expect(result.code).not.toContain("createCompilerKeyedArraySort");
   });
 });

--- a/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-structural-reorder-hints.test.tsx
+++ b/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-structural-reorder-hints.test.tsx
@@ -1,0 +1,484 @@
+import React, { StrictMode, useState } from "react";
+import { act } from "react";
+import { createRoot, hydrateRoot, type Root } from "react-dom/client";
+import { renderToString } from "react-dom/server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createCompiledComponent,
+  createCompilerKeyedArrayFilter,
+  createCompilerKeyedArraySlice,
+  createCompilerKeyedArrayStructuralReorder,
+  createCompilerKeyedArrayStructuralSort,
+  type CompilerKeyedRowElement,
+} from "../compiler-runtime";
+
+declare global {
+  var IS_REACT_ACT_ENVIRONMENT: boolean;
+}
+
+interface Item {
+  id: string;
+  label: string;
+  rank: number;
+  visible: boolean;
+}
+
+const roots: Root[] = [];
+
+beforeEach(() => {
+  globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+afterEach(async () => {
+  await act(async () => {
+    for (const root of roots.splice(0)) root.unmount();
+  });
+  document.body.replaceChildren();
+});
+
+async function flushCompilerUpdates(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+function hintedFilter(items: Item[], predicate: (item: Item) => boolean): Item[] {
+  return createCompilerKeyedArrayFilter(items, items.filter, predicate) as Item[];
+}
+
+function hintedSlice(items: Item[], start: number, end?: number): Item[] {
+  return createCompilerKeyedArraySlice(
+    items,
+    items.slice,
+    ...([start, end].filter((value) => value !== undefined) as number[]),
+  ) as Item[];
+}
+
+function hintedSort(items: Item[], compare: (left: Item, right: Item) => number): Item[] {
+  return createCompilerKeyedArrayStructuralSort(items, items.toSorted, compare) as Item[];
+}
+
+function hintedReverse(items: Item[]): Item[] {
+  return createCompilerKeyedArrayStructuralReorder(items, items.toReversed) as Item[];
+}
+
+function rowDescriptor(item: Item): CompilerKeyedRowElement {
+  return {
+    kind: "element",
+    tag: "li",
+    attributes: [{ name: "data-key", value: item.id }],
+    styles: [],
+    children: [item.label],
+  };
+}
+
+function createHarness(initialItems: Item[]) {
+  const counters = {
+    bindings: 0,
+    descriptors: 0,
+    executions: 0,
+    keys: 0,
+    renders: 0,
+  };
+  let filterSortReverse: (removed: ReadonlySet<string>) => void = () => undefined;
+  let filterThenQueuedSort: (removed: ReadonlySet<string>) => void = () => undefined;
+  let filterSliceReverse: (removed: ReadonlySet<string>, limit: number) => void = () => undefined;
+  let invalidIdentity: () => void = () => undefined;
+  let customSortAfterFilter: (removed: ReadonlySet<string>) => void = () => undefined;
+  const Table = createCompiledComponent({
+    displayName: "StructuralReorderTable",
+    initialize: () => [initialItems],
+    render(_props: Record<string, never>, state, blocks) {
+      counters.executions += 1;
+      const items = () => state[0].get() as Item[];
+      filterSortReverse = (removed) =>
+        state[0].set((previous) =>
+          hintedReverse(
+            hintedSort(
+              hintedFilter(previous as Item[], (item) => !removed.has(item.id)),
+              (left, right) => left.rank - right.rank,
+            ),
+          ),
+        );
+      filterThenQueuedSort = (removed) => {
+        state[0].set((previous) =>
+          hintedFilter(previous as Item[], (item) => !removed.has(item.id)),
+        );
+        state[0].set((previous) =>
+          hintedSort(previous as Item[], (left, right) => right.rank - left.rank),
+        );
+      };
+      filterSliceReverse = (removed, limit) =>
+        state[0].set((previous) =>
+          hintedReverse(
+            hintedSlice(
+              hintedFilter(previous as Item[], (item) => !removed.has(item.id)),
+              0,
+              limit,
+            ),
+          ),
+        );
+      invalidIdentity = () =>
+        state[0].set((previous) => {
+          const next = hintedReverse(hintedFilter(previous as Item[], (item) => item.id !== "b"));
+          next[0] = { ...next[0], id: "replacement", label: "Replacement" };
+          return next;
+        });
+      customSortAfterFilter = (removed) =>
+        state[0].set((previous) => {
+          const filtered = hintedFilter(previous as Item[], (item) => !removed.has(item.id));
+          const custom = function (this: Item[], compare: (left: Item, right: Item) => number) {
+            return [...this].sort(compare);
+          };
+          return createCompilerKeyedArrayStructuralSort(
+            filtered,
+            custom,
+            (left: Item, right: Item) => left.rank - right.rank,
+          );
+        });
+      return (
+        <section>
+          <blocks.KeyedRows
+            collectionDependency={0}
+            dependencies={[0]}
+            filterIndexIndependent
+            id={0}
+            items={items}
+            reorderIndexIndependent
+            structureDependencies={[0]}
+            render={() => {
+              counters.renders += 1;
+              return (
+                <ul>
+                  {items().map((item) => (
+                    <li data-key={item.id} key={item.id}>
+                      {item.label}
+                    </li>
+                  ))}
+                </ul>
+              );
+            }}
+            rowKey={(item) => {
+              counters.keys += 1;
+              return (item as Item).id;
+            }}
+            create={(item) => {
+              counters.descriptors += 1;
+              return rowDescriptor(item as Item);
+            }}
+            bindings={[
+              {
+                kind: "text",
+                path: [],
+                read: (item) => {
+                  counters.bindings += 1;
+                  return [(item as Item).label];
+                },
+              },
+            ]}
+          />
+        </section>
+      );
+    },
+    bindings: [{ kind: "block", id: 0, dependencies: [0] }],
+  });
+  return {
+    Table,
+    counters,
+    customSortAfterFilter: (removed: ReadonlySet<string>) => customSortAfterFilter(removed),
+    filterSliceReverse: (removed: ReadonlySet<string>, limit: number) =>
+      filterSliceReverse(removed, limit),
+    filterSortReverse: (removed: ReadonlySet<string>) => filterSortReverse(removed),
+    filterThenQueuedSort: (removed: ReadonlySet<string>) => filterThenQueuedSort(removed),
+    invalidIdentity: () => invalidIdentity(),
+  };
+}
+
+function labels(container: Element): string[] {
+  return [...container.querySelectorAll("li")].map((row) => row.textContent || "");
+}
+
+describe("compiled keyed-array structural reorder hints", () => {
+  it("removes and reorders in one validated DOM transaction", async () => {
+    const items: Item[] = [
+      { id: "a", label: "Alpha", rank: 4, visible: true },
+      { id: "b", label: "Beta", rank: 1, visible: false },
+      { id: "c", label: "Gamma", rank: 3, visible: true },
+      { id: "d", label: "Delta", rank: 2, visible: true },
+    ];
+    const harness = createHarness(items);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Table />));
+    const alpha = container.querySelector('[data-key="a"]');
+    const gamma = container.querySelector('[data-key="c"]');
+    const delta = container.querySelector('[data-key="d"]');
+    const insertBefore = vi.spyOn(container.querySelector("ul")!, "insertBefore");
+    harness.counters.bindings = 0;
+    harness.counters.descriptors = 0;
+    harness.counters.keys = 0;
+
+    await act(async () => {
+      harness.filterSortReverse(new Set(["b"]));
+      await flushCompilerUpdates();
+    });
+
+    expect(labels(container)).toEqual(["Alpha", "Gamma", "Delta"]);
+    expect(container.querySelector('[data-key="a"]')).toBe(alpha);
+    expect(container.querySelector('[data-key="c"]')).toBe(gamma);
+    expect(container.querySelector('[data-key="d"]')).toBe(delta);
+    expect(container.querySelector('[data-key="b"]')).toBeNull();
+    expect(harness.counters.executions).toBe(1);
+    expect(harness.counters.renders).toBe(1);
+    expect(harness.counters.keys).toBe(3);
+    expect(harness.counters.descriptors).toBe(0);
+    expect(harness.counters.bindings).toBe(0);
+    expect(insertBefore).not.toHaveBeenCalled();
+  });
+
+  it("composes a queued filter with a following native sort", async () => {
+    const harness = createHarness([
+      { id: "a", label: "Alpha", rank: 2, visible: true },
+      { id: "b", label: "Beta", rank: 4, visible: true },
+      { id: "c", label: "Gamma", rank: 1, visible: true },
+    ]);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Table />));
+
+    await act(async () => {
+      harness.filterThenQueuedSort(new Set(["a"]));
+      await flushCompilerUpdates();
+    });
+
+    expect(labels(container)).toEqual(["Beta", "Gamma"]);
+    expect(harness.counters.executions).toBe(1);
+  });
+
+  it("composes filter, slice, and reverse metadata", async () => {
+    const harness = createHarness([
+      { id: "a", label: "Alpha", rank: 1, visible: true },
+      { id: "b", label: "Beta", rank: 2, visible: true },
+      { id: "c", label: "Gamma", rank: 3, visible: true },
+      { id: "d", label: "Delta", rank: 4, visible: true },
+    ]);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Table />));
+
+    await act(async () => {
+      harness.filterSliceReverse(new Set(["b"]), 2);
+      await flushCompilerUpdates();
+    });
+
+    expect(labels(container)).toEqual(["Gamma", "Alpha"]);
+    expect(harness.counters.executions).toBe(1);
+  });
+
+  it("falls back safely for custom methods and identity mismatches", async () => {
+    const items: Item[] = [
+      { id: "a", label: "Alpha", rank: 2, visible: true },
+      { id: "b", label: "Beta", rank: 1, visible: true },
+      { id: "c", label: "Gamma", rank: 3, visible: true },
+    ];
+    const harness = createHarness(items);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Table />));
+    await act(async () => {
+      harness.customSortAfterFilter(new Set(["c"]));
+      await flushCompilerUpdates();
+    });
+    expect(labels(container)).toEqual(["Beta", "Alpha"]);
+    expect(harness.counters.bindings).toBeGreaterThan(0);
+
+    await act(async () => {
+      harness.invalidIdentity();
+      await flushCompilerUpdates();
+    });
+    expect(labels(container)).toEqual(["Replacement"]);
+    expect(harness.counters.bindings).toBeGreaterThan(0);
+  });
+
+  it("preserves a surviving controlled input, focus, and selection", async () => {
+    const items: Item[] = [
+      { id: "a", label: "Alpha", rank: 3, visible: true },
+      { id: "b", label: "Beta", rank: 1, visible: true },
+      { id: "c", label: "Gamma", rank: 2, visible: true },
+    ];
+    let update = () => undefined;
+    const FormRows = createCompiledComponent({
+      displayName: "StructuralReorderFormRows",
+      initialize: () => [items],
+      render(_props: Record<string, never>, state, blocks) {
+        const rows = () => state[0].get() as Item[];
+        update = () =>
+          state[0].set((previous) =>
+            hintedReverse(hintedFilter(previous as Item[], (item) => item.id !== "a")),
+          );
+        return (
+          <section>
+            <blocks.KeyedRows
+              collectionDependency={0}
+              dependencies={[0]}
+              filterIndexIndependent
+              id={0}
+              items={rows}
+              reorderIndexIndependent
+              structureDependencies={[0]}
+              render={() => (
+                <div>
+                  {rows().map((item) => (
+                    <input data-key={item.id} key={item.id} readOnly value={item.label} />
+                  ))}
+                </div>
+              )}
+              rowKey={(item) => (item as Item).id}
+              create={(item) => ({
+                kind: "element",
+                tag: "input",
+                attributes: [
+                  { name: "data-key", value: (item as Item).id },
+                  { name: "readOnly", value: true },
+                  { name: "value", value: (item as Item).label },
+                ],
+                styles: [],
+                children: [],
+              })}
+              bindings={[]}
+            />
+          </section>
+        );
+      },
+      bindings: [{ kind: "block", id: 0, dependencies: [0] }],
+    });
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<FormRows />));
+    const input = container.querySelector('[data-key="b"]') as HTMLInputElement;
+    input.focus();
+    input.setSelectionRange(1, 3);
+
+    await act(async () => {
+      update();
+      await flushCompilerUpdates();
+    });
+
+    expect(container.querySelector('[data-key="b"]')).toBe(input);
+    expect(document.activeElement).toBe(input);
+    expect([input.selectionStart, input.selectionEnd]).toEqual([1, 3]);
+  });
+
+  it("matches React across 2,000 randomized removals plus reorderings", async () => {
+    const initialItems = Array.from(
+      { length: 2_001 },
+      (_, index): Item => ({
+        id: `row-${index}`,
+        label: `Row ${index}`,
+        rank: (index * 1_229) % 2_003,
+        visible: true,
+      }),
+    );
+    const harness = createHarness(initialItems);
+    let updateReact: (removed: ReadonlySet<string>) => void = () => undefined;
+    function Normal() {
+      const [items, setItems] = useState(initialItems);
+      updateReact = (removed) =>
+        setItems((previous) =>
+          previous
+            .filter((item) => !removed.has(item.id))
+            .toSorted((left, right) => left.rank - right.rank)
+            .toReversed(),
+        );
+      return (
+        <ol>
+          {items.map((item) => (
+            <li data-key={item.id} key={item.id}>
+              {item.label}
+            </li>
+          ))}
+        </ol>
+      );
+    }
+    const compiledContainer = document.createElement("div");
+    const reactContainer = document.createElement("div");
+    document.body.append(compiledContainer, reactContainer);
+    const compiledRoot = createRoot(compiledContainer);
+    const reactRoot = createRoot(reactContainer);
+    roots.push(compiledRoot, reactRoot);
+    await act(async () => {
+      compiledRoot.render(<harness.Table />);
+      reactRoot.render(<Normal />);
+    });
+
+    let seed = 0x7f4a7c15;
+    const active = initialItems.map((item) => item.id);
+    for (let batch = 0; batch < 100; batch += 1) {
+      const removed = new Set<string>();
+      for (let update = 0; update < 20; update += 1) {
+        seed = (Math.imul(seed, 1_664_525) + 1_013_904_223) >>> 0;
+        const index = seed % active.length;
+        const [id] = active.splice(index, 1);
+        removed.add(id);
+      }
+      await act(async () => {
+        harness.filterSortReverse(removed);
+        updateReact(removed);
+        await flushCompilerUpdates();
+      });
+      expect(labels(compiledContainer)).toEqual(labels(reactContainer));
+    }
+    expect(harness.counters.executions).toBe(1);
+  }, 20_000);
+
+  it("hydrates in StrictMode and drops a queued pipeline after unmount", async () => {
+    const items: Item[] = [
+      { id: "a", label: "Alpha", rank: 3, visible: true },
+      { id: "b", label: "Beta", rank: 1, visible: true },
+      { id: "c", label: "Gamma", rank: 2, visible: true },
+    ];
+    const hydration = createHarness(items);
+    const container = document.createElement("div");
+    container.innerHTML = renderToString(<hydration.Table />);
+    document.body.append(container);
+    const recoverable: unknown[] = [];
+    let root!: Root;
+    await act(async () => {
+      root = hydrateRoot(
+        container,
+        <StrictMode>
+          <hydration.Table />
+        </StrictMode>,
+        { onRecoverableError: (error) => recoverable.push(error) },
+      );
+    });
+    roots.push(root);
+    await act(async () => {
+      hydration.filterSortReverse(new Set(["b"]));
+      await flushCompilerUpdates();
+    });
+    expect(labels(container)).toEqual(["Alpha", "Gamma"]);
+    expect(recoverable).toEqual([]);
+
+    const unmounted = createHarness(items);
+    const unmountContainer = document.createElement("div");
+    document.body.append(unmountContainer);
+    const unmountRoot = createRoot(unmountContainer);
+    await act(async () => unmountRoot.render(<unmounted.Table />));
+    act(() => {
+      unmounted.filterSortReverse(new Set(["a"]));
+      unmountRoot.unmount();
+    });
+    await flushCompilerUpdates();
+    expect(unmountContainer.innerHTML).toBe("");
+  });
+});

--- a/packages/farm-react/src/compiler-runtime.tsx
+++ b/packages/farm-react/src/compiler-runtime.tsx
@@ -76,6 +76,7 @@ interface CompilerKeyedArrayReorderHint {
   readonly sourceToken: object;
   readonly sourceLength: number;
   readonly resultLength: number;
+  readonly structuralUpdate?: CompilerKeyedArrayFilterHint;
 }
 
 type CompilerKeyedCollectionKind = "set" | "map";
@@ -236,6 +237,21 @@ function compilerKeyedArrayFilterSurvivors(
   if (!target || !sourceToken || !Array.isArray(value)) return undefined;
   const update = COMPILER_KEYED_ARRAY_FILTERS.get(target);
   if (!update || update.sourceToken !== sourceToken) return undefined;
+  return compilerKeyedArrayFilterSurvivorsFromUpdate(
+    update,
+    sourceToken,
+    expectedLength,
+    value.length,
+  );
+}
+
+function compilerKeyedArrayFilterSurvivorsFromUpdate(
+  update: CompilerKeyedArrayFilterHint,
+  sourceToken: object | undefined,
+  expectedLength: number,
+  resultLength: number,
+): { readonly indices: readonly number[]; readonly keysStable: boolean } | undefined {
+  if (!sourceToken || update.sourceToken !== sourceToken) return undefined;
   const updates: CompilerKeyedArrayFilterHint[] = [];
   for (
     let current: CompilerKeyedArrayFilterHint | undefined = update;
@@ -279,7 +295,25 @@ function compilerKeyedArrayFilterSurvivors(
     if (current.resultLength !== current.sourceLength - removed.size) return undefined;
     survivors = survivors.filter((_sourceIndex, index) => !removed.has(index));
   }
-  return survivors.length === value.length ? { indices: survivors, keysStable } : undefined;
+  return survivors.length === resultLength ? { indices: survivors, keysStable } : undefined;
+}
+
+function compilerKeyedArrayFilterSource(
+  update: CompilerKeyedArrayFilterHint,
+  resultLength: number,
+): { readonly sourceLength: number; readonly sourceToken: object } | undefined {
+  if (update.resultLength !== resultLength) return undefined;
+  let current = update;
+  while (current.previous) {
+    if (
+      current.sourceToken !== current.previous.sourceToken ||
+      current.sourceLength !== current.previous.resultLength
+    ) {
+      return undefined;
+    }
+    current = current.previous;
+  }
+  return { sourceLength: current.sourceLength, sourceToken: current.sourceToken };
 }
 
 function compilerKeyedArrayPrependLength(
@@ -452,7 +486,7 @@ function compilerKeyedArrayReorder(
     !update ||
     update.sourceToken !== sourceToken ||
     update.sourceLength !== expectedLength ||
-    update.resultLength !== expectedLength ||
+    (!update.structuralUpdate && update.resultLength !== expectedLength) ||
     update.resultLength !== value.length
   ) {
     return undefined;
@@ -1078,6 +1112,107 @@ export function createCompilerKeyedArraySort(
     // Metadata must never change the result of a successful native update.
   }
   return value;
+}
+
+function recordCompilerKeyedArrayStructuralReorder(
+  previous: unknown,
+  value: unknown,
+  kind: CompilerKeyedArrayReorderHint["kind"],
+): unknown {
+  try {
+    const previousTarget = compilerObject(previous);
+    const valueTarget = compilerObject(value);
+    if (!previousTarget || !valueTarget || !Array.isArray(previous) || !Array.isArray(value)) {
+      return value;
+    }
+
+    const previousUpdate = COMPILER_KEYED_ARRAY_REORDERS.get(previousTarget);
+    const structuralUpdate =
+      previousUpdate?.structuralUpdate ||
+      (!previousUpdate ? COMPILER_KEYED_ARRAY_FILTERS.get(previousTarget) : undefined);
+    const structuralSource = structuralUpdate
+      ? compilerKeyedArrayFilterSource(structuralUpdate, previous.length)
+      : undefined;
+    if (
+      !structuralUpdate ||
+      !structuralSource ||
+      (previousUpdate && previousUpdate.resultLength !== previous.length)
+    ) {
+      return value;
+    }
+    const sourceToken = previousUpdate?.sourceToken || structuralSource?.sourceToken;
+    if (!sourceToken) return value;
+    COMPILER_KEYED_ARRAY_REORDERS.set(valueTarget, {
+      kind: previousUpdate ? "permutation" : kind,
+      sourceToken,
+      sourceLength: previousUpdate?.sourceLength || structuralSource.sourceLength,
+      resultLength: value.length,
+      structuralUpdate,
+    });
+  } catch {
+    // Metadata must never change the result of a successful native update.
+  }
+  return value;
+}
+
+/** @internal Executes a native reverse after a compiler-proven filter or slice pipeline. */
+export function createCompilerKeyedArrayStructuralReorder(
+  previous: unknown,
+  method: unknown,
+): unknown {
+  const value = NATIVE_REFLECT_APPLY(
+    method as (...values: readonly unknown[]) => unknown,
+    previous,
+    [],
+  );
+  try {
+    if (
+      !Array.isArray(previous) ||
+      !Array.isArray(value) ||
+      Object.getPrototypeOf(previous) !== NATIVE_ARRAY_PROTOTYPE ||
+      Object.getPrototypeOf(value) !== NATIVE_ARRAY_PROTOTYPE ||
+      method !== NATIVE_ARRAY_TO_REVERSED ||
+      value.length !== previous.length
+    ) {
+      return value;
+    }
+  } catch {
+    return value;
+  }
+  return recordCompilerKeyedArrayStructuralReorder(previous, value, "reverse");
+}
+
+/** @internal Executes a native sort after a compiler-proven filter or slice pipeline. */
+export function createCompilerKeyedArrayStructuralSort(
+  previous: unknown,
+  method: unknown,
+  ...args: readonly unknown[]
+): unknown {
+  const value = NATIVE_REFLECT_APPLY(
+    method as (...values: readonly unknown[]) => unknown,
+    previous,
+    args,
+  );
+  try {
+    if (
+      !Array.isArray(previous) ||
+      !Array.isArray(value) ||
+      Object.getPrototypeOf(previous) !== NATIVE_ARRAY_PROTOTYPE ||
+      Object.getPrototypeOf(value) !== NATIVE_ARRAY_PROTOTYPE ||
+      method !== NATIVE_ARRAY_TO_SORTED ||
+      args.length > 1 ||
+      (args.length === 1 && args[0] !== undefined && typeof args[0] !== "function") ||
+      value.length !== previous.length
+    ) {
+      return value;
+    }
+    for (let index = 0; index < previous.length; index += 1) {
+      if (!(index in previous)) return value;
+    }
+  } catch {
+    return value;
+  }
+  return recordCompilerKeyedArrayStructuralReorder(previous, value, "permutation");
 }
 
 /** @internal Preserves a proven native collection mutation while recording its executed key. */
@@ -4408,7 +4543,7 @@ const keyedCompleteUpdateRuntime: KeyedUpdateRuntime = {
 const keyedEveryUpdateRuntime: KeyedUpdateRuntime = {
   ...keyedCompleteUpdateRuntime,
   position: reconcileCompilerKeyedArrayPosition,
-  reorder: reconcileCompilerKeyedArrayReorder,
+  reorder: reconcileCompilerKeyedArrayReorderWithStructural,
 };
 
 const keyedBatchEveryUpdateRuntime: KeyedUpdateRuntime = {
@@ -5289,6 +5424,122 @@ function reconcileCompilerKeyedArrayPositionWithWindow(
   );
 }
 
+function reconcileCompilerKeyedArrayStructuralReorder(
+  props: CompilerKeyedRowsBlockProps,
+  dirtyState: ReadonlySet<number>,
+  collectionToken: object | undefined,
+  instances: ReadonlyMap<string, CompilerKeyedRowInstance>,
+  root: Element,
+  reactOwnedRows: boolean,
+): ReadonlyMap<string, CompilerKeyedRowInstance> | undefined {
+  if (
+    reactOwnedRows ||
+    props.hostBlocks ||
+    (props.conditionals?.length || 0) > 0 ||
+    !props.filterIndexIndependent ||
+    !props.reorderIndexIndependent ||
+    props.collectionDependency === undefined
+  ) {
+    return undefined;
+  }
+  const collectionDependency = props.collectionDependency;
+  if (props.bindings.some((binding) => binding.dependencies?.includes(collectionDependency))) {
+    return undefined;
+  }
+  const dependencies = props.dependencies || props.structureDependencies;
+  const relevantDirty = (dependencies || []).filter((index) => dirtyState.has(index));
+  if (relevantDirty.length !== 1 || relevantDirty[0] !== collectionDependency) {
+    return undefined;
+  }
+
+  const finalValue = props.items();
+  const update = compilerKeyedArrayReorder(finalValue, collectionToken, instances.size);
+  if (!update?.structuralUpdate || !Array.isArray(finalValue)) return undefined;
+  const survivorResult = compilerKeyedArrayFilterSurvivorsFromUpdate(
+    update.structuralUpdate,
+    collectionToken,
+    instances.size,
+    finalValue.length,
+  );
+  if (!survivorResult) return undefined;
+
+  const previousInstances = [...instances.values()];
+  const prepared = (() => {
+    try {
+      const survivors: CompilerKeyedRowInstance[] = [];
+      let previousSourceIndex = -1;
+      for (const sourceIndex of survivorResult.indices) {
+        const instance = previousInstances[sourceIndex];
+        if (sourceIndex <= previousSourceIndex || !instance || instance.index !== sourceIndex) {
+          return undefined;
+        }
+        previousSourceIndex = sourceIndex;
+        survivors.push(instance);
+      }
+
+      let preservesSurvivorOrder = true;
+      for (let targetIndex = 0; targetIndex < finalValue.length; targetIndex += 1) {
+        const item = finalValue[targetIndex];
+        const instance = survivors[targetIndex];
+        if (!Object.is(instance.item, item)) {
+          preservesSurvivorOrder = false;
+          break;
+        }
+        if (keyedRowIdentity(props.rowKey(item, targetIndex)) !== instance.key) return undefined;
+      }
+      if (preservesSurvivorOrder) {
+        return { nextInstances: survivors, sequence: undefined };
+      }
+
+      const survivorInstances = new Map<unknown, CompilerKeyedRowInstance>();
+      for (const instance of survivors) {
+        if (survivorInstances.has(instance.item)) return undefined;
+        survivorInstances.set(instance.item, instance);
+      }
+
+      const nextInstances: CompilerKeyedRowInstance[] = [];
+      const sequence: number[] = [];
+      for (let targetIndex = 0; targetIndex < finalValue.length; targetIndex += 1) {
+        const item = finalValue[targetIndex];
+        const instance = survivorInstances.get(item);
+        if (
+          !instance ||
+          !Object.is(instance.item, item) ||
+          keyedRowIdentity(props.rowKey(item, targetIndex)) !== instance.key
+        ) {
+          return undefined;
+        }
+        survivorInstances.delete(item);
+        nextInstances.push(instance);
+        sequence.push(instance.index);
+      }
+      if (survivorInstances.size > 0) return undefined;
+      return { nextInstances, sequence };
+    } catch {
+      return undefined;
+    }
+  })();
+  if (!prepared) return undefined;
+
+  let survivorCursor = 0;
+  for (let sourceIndex = 0; sourceIndex < previousInstances.length; sourceIndex += 1) {
+    if (survivorResult.indices[survivorCursor] === sourceIndex) {
+      survivorCursor += 1;
+      continue;
+    }
+    const instance = previousInstances[sourceIndex];
+    instance.scope?.cleanup();
+    instance.element.remove();
+  }
+  if (prepared.sequence) {
+    reorderCompilerKeyedRows(root, prepared.nextInstances, prepared.sequence, null);
+  }
+  for (let index = 0; index < prepared.nextInstances.length; index += 1) {
+    prepared.nextInstances[index].index = index;
+  }
+  return new Map(prepared.nextInstances.map((instance) => [instance.key, instance]));
+}
+
 function reconcileCompilerKeyedArrayReorder(
   props: CompilerKeyedRowsBlockProps,
   dirtyState: ReadonlySet<number>,
@@ -5318,7 +5569,9 @@ function reconcileCompilerKeyedArrayReorder(
 
   const finalValue = props.items();
   const update = compilerKeyedArrayReorder(finalValue, collectionToken, instances.size);
-  if (!update || !Array.isArray(finalValue)) return undefined;
+  if (!update || update.structuralUpdate || !Array.isArray(finalValue)) {
+    return undefined;
+  }
 
   const previousInstances = [...instances.values()];
   if (update.kind === "permutation") {
@@ -5405,6 +5658,15 @@ function reconcileCompilerKeyedArrayReorder(
     (activeElement as HTMLElement).focus({ preventScroll: true });
   }
   return new Map(previousInstances.map((instance) => [instance.key, instance]));
+}
+
+function reconcileCompilerKeyedArrayReorderWithStructural(
+  ...args: Parameters<typeof reconcileCompilerKeyedArrayReorder>
+): ReadonlyMap<string, CompilerKeyedRowInstance> | undefined {
+  return (
+    reconcileCompilerKeyedArrayStructuralReorder(...args) ||
+    reconcileCompilerKeyedArrayReorder(...args)
+  );
 }
 
 function reconcileCompilerKeyedArrayPrepend(
@@ -6581,8 +6843,14 @@ function createKeyedRowsBlockComponent(
           this.hasReactOwnedRows(),
         );
         if (reorderedInstances) {
+          const removedRows = reorderedInstances.size < this.instances.size;
           this.instances = new Map(reorderedInstances);
           this.rebuildElementIndex(this.instances);
+          if (removedRows) {
+            const keys = [...this.instances.keys()];
+            this.pruneEventHandlers(keys);
+            this.pruneConditionalListeners(keys);
+          }
           this.commitCurrentCollection(dirtyState);
           afterCommit?.();
           return;

--- a/packages/farm-react/src/compiler.ts
+++ b/packages/farm-react/src/compiler.ts
@@ -1881,10 +1881,20 @@ function rewriteKeyedArrayReorderHints(
   };
 }
 
-interface KeyedArrayReorderPipelineStep {
-  readonly kind: "reverse" | "sort";
-  readonly comparator?: t.ArrowFunctionExpression | t.FunctionExpression;
-}
+type KeyedArrayReorderPipelineStep =
+  | {
+      readonly kind: "filter";
+      readonly predicate: t.ArrowFunctionExpression;
+    }
+  | {
+      readonly bounds: readonly t.Expression[];
+      readonly kind: "slice";
+    }
+  | { readonly kind: "reverse" }
+  | {
+      readonly comparator?: t.ArrowFunctionExpression | t.FunctionExpression;
+      readonly kind: "sort";
+    };
 
 function keyedArrayReorderPipeline(
   expression: t.Expression,
@@ -1901,7 +1911,34 @@ function keyedArrayReorderPipeline(
     t.isExpression(current.callee.object)
   ) {
     const methodName = current.callee.property.name;
-    if (methodName === "toReversed") {
+    if (methodName === "filter") {
+      if (current.arguments.length !== 1) return undefined;
+      const predicate = current.arguments[0];
+      if (
+        !t.isArrowFunctionExpression(predicate) ||
+        predicate.async ||
+        predicate.generator ||
+        predicate.params.length !== 1 ||
+        !t.isIdentifier(predicate.params[0]) ||
+        !t.isExpression(predicate.body) ||
+        validateDerivedExpression(predicate.body, safeGlobals)
+      ) {
+        return undefined;
+      }
+      outerSteps.push({ kind: "filter", predicate });
+    } else if (methodName === "slice") {
+      if (current.arguments.length < 1 || current.arguments.length > 2) return undefined;
+      const bounds: t.Expression[] = [];
+      for (const argument of current.arguments) {
+        if (!t.isExpression(argument)) return undefined;
+        if (validateKeyedArrayPositionExpression(argument, safeGlobals) !== undefined) {
+          return undefined;
+        }
+        bounds.push(argument);
+      }
+      if (bounds.length === 1 && staticSliceIndex(bounds[0]) === 0) return undefined;
+      outerSteps.push({ bounds, kind: "slice" });
+    } else if (methodName === "toReversed") {
       if (current.arguments.length !== 0) return undefined;
       outerSteps.push({ kind: "reverse" });
     } else if (methodName === "toSorted") {
@@ -1926,34 +1963,64 @@ function keyedArrayReorderPipeline(
   if (!t.isIdentifier(current, { name: parameterName }) || outerSteps.length < 2) {
     return undefined;
   }
-  return outerSteps.reverse();
+  const steps = outerSteps.reverse();
+  let structuralSteps = 0;
+  let reorderSteps = 0;
+  let reachedReorder = false;
+  for (const step of steps) {
+    if (step.kind === "filter" || step.kind === "slice") {
+      if (reachedReorder) return undefined;
+      structuralSteps += 1;
+    } else {
+      reachedReorder = true;
+      reorderSteps += 1;
+    }
+  }
+  if (reorderSteps < 1 || (structuralSteps < 1 && reorderSteps < 2)) return undefined;
+  return steps;
 }
 
 function rewriteKeyedArrayReorderPipelineHints(
   root: t.JSXElement,
   hintedStateIndices: ReadonlySet<number>,
   statesBySetter: ReadonlyMap<string, StateBinding>,
+  filterHelperIdentifier: t.Identifier,
   reorderHelperIdentifier: t.Identifier,
+  structuralReorderHelperIdentifier: t.Identifier,
+  sliceHelperIdentifier: t.Identifier,
   sortHelperIdentifier: t.Identifier,
+  structuralSortHelperIdentifier: t.Identifier,
   safeGlobals: ReadonlySet<string>,
 ): {
+  filterCount: number;
   root: t.JSXElement;
   reorderCount: number;
+  sliceCount: number;
   sortCount: number;
+  structuralReorderCount: number;
+  structuralSortCount: number;
   stateIndices: ReadonlySet<number>;
 } {
   if (hintedStateIndices.size === 0) {
     return {
       root: t.cloneNode(root, true),
+      filterCount: 0,
       reorderCount: 0,
+      sliceCount: 0,
       sortCount: 0,
+      structuralReorderCount: 0,
+      structuralSortCount: 0,
       stateIndices: new Set(),
     };
   }
   const file = expressionFile(t.cloneNode(root, true));
   const stateIndices = new Set<number>();
+  let filterCount = 0;
   let reorderCount = 0;
+  let sliceCount = 0;
   let sortCount = 0;
+  let structuralReorderCount = 0;
+  let structuralSortCount = 0;
   traverse(file, {
     CallExpression(path) {
       const callee = path.get("callee");
@@ -1975,16 +2042,52 @@ function rewriteKeyedArrayReorderPipelineHints(
       }
       const steps = keyedArrayReorderPipeline(updater.body, updater.params[0].name, safeGlobals);
       if (!steps) return;
+      const structuralPipeline = steps.some(
+        (step) => step.kind === "filter" || step.kind === "slice",
+      );
 
       const previous = t.cloneNode(updater.params[0]);
       const statements: t.Statement[] = [];
       let value: t.Expression = t.cloneNode(previous);
       for (const step of steps) {
-        const methodName = step.kind === "reverse" ? "toReversed" : "toSorted";
+        const methodName =
+          step.kind === "filter"
+            ? "filter"
+            : step.kind === "slice"
+              ? "slice"
+              : step.kind === "reverse"
+                ? "toReversed"
+                : "toSorted";
         const method = path.scope.generateUidIdentifier(
-          step.kind === "reverse" ? "farmToReversed" : "farmToSorted",
+          step.kind === "filter"
+            ? "farmFilter"
+            : step.kind === "slice"
+              ? "farmSlice"
+              : step.kind === "reverse"
+                ? "farmToReversed"
+                : "farmToSorted",
         );
-        const result = path.scope.generateUidIdentifier("farmReordered");
+        const result = path.scope.generateUidIdentifier("farmPipelineValue");
+        const helper =
+          step.kind === "filter"
+            ? filterHelperIdentifier
+            : step.kind === "slice"
+              ? sliceHelperIdentifier
+              : step.kind === "reverse"
+                ? structuralPipeline
+                  ? structuralReorderHelperIdentifier
+                  : reorderHelperIdentifier
+                : structuralPipeline
+                  ? structuralSortHelperIdentifier
+                  : sortHelperIdentifier;
+        const args =
+          step.kind === "filter"
+            ? [t.cloneNode(step.predicate, true)]
+            : step.kind === "slice"
+              ? step.bounds.map((bound) => t.cloneNode(bound, true))
+              : step.kind === "sort" && step.comparator
+                ? [t.cloneNode(step.comparator, true)]
+                : [];
         statements.push(
           t.variableDeclaration("const", [
             t.variableDeclarator(
@@ -1995,22 +2098,24 @@ function rewriteKeyedArrayReorderPipelineHints(
           t.variableDeclaration("const", [
             t.variableDeclarator(
               t.cloneNode(result),
-              t.callExpression(
-                t.cloneNode(
-                  step.kind === "reverse" ? reorderHelperIdentifier : sortHelperIdentifier,
-                ),
-                [
-                  t.cloneNode(value),
-                  t.cloneNode(method),
-                  ...(step.comparator ? [t.cloneNode(step.comparator, true)] : []),
-                ],
-              ),
+              t.callExpression(t.cloneNode(helper), [
+                t.cloneNode(value),
+                t.cloneNode(method),
+                ...args,
+              ]),
             ),
           ]),
         );
         value = t.cloneNode(result);
-        if (step.kind === "reverse") reorderCount += 1;
-        else sortCount += 1;
+        if (step.kind === "filter") filterCount += 1;
+        else if (step.kind === "slice") sliceCount += 1;
+        else if (step.kind === "reverse") {
+          reorderCount += 1;
+          if (structuralPipeline) structuralReorderCount += 1;
+        } else {
+          sortCount += 1;
+          if (structuralPipeline) structuralSortCount += 1;
+        }
       }
       statements.push(t.returnStatement(t.cloneNode(value)));
       path.node.arguments[0] = t.arrowFunctionExpression(
@@ -2023,8 +2128,12 @@ function rewriteKeyedArrayReorderPipelineHints(
   });
   return {
     root: (file.program.body[0] as t.ExpressionStatement).expression as t.JSXElement,
+    filterCount,
     reorderCount,
+    sliceCount,
     sortCount,
+    structuralReorderCount,
+    structuralSortCount,
     stateIndices,
   };
 }
@@ -7002,7 +7111,9 @@ function compileCandidate(
   keyedArrayBatchInsertIdentifier: t.Identifier,
   keyedArrayWindowReplaceIdentifier: t.Identifier,
   keyedArrayReorderIdentifier: t.Identifier,
+  keyedArrayStructuralReorderIdentifier: t.Identifier,
   keyedArraySortIdentifier: t.Identifier,
+  keyedArrayStructuralSortIdentifier: t.Identifier,
   keyedArrayRollingWindowIdentifier: t.Identifier,
   keyedArraySliceIdentifier: t.Identifier,
   keyedCollectionUpdateIdentifier: t.Identifier,
@@ -7026,6 +7137,8 @@ function compileCandidate(
   },
   compilerUsage: {
     keyedArrayBatchInsertHints: number;
+    keyedArrayStructuralReorderHints: number;
+    keyedArrayStructuralSortHints: number;
     keyedArrayWindowReplaceHints: number;
   },
   useStateNames: ReadonlySet<string>,
@@ -7496,14 +7609,25 @@ function compileCandidate(
     expandedReactiveRoot,
     shiftedIndexIndependentStateIndices,
     statesBySetter,
+    keyedArrayFilterIdentifier,
     keyedArrayReorderIdentifier,
+    keyedArrayStructuralReorderIdentifier,
+    keyedArraySliceIdentifier,
     keyedArraySortIdentifier,
+    keyedArrayStructuralSortIdentifier,
     safeGlobals,
   );
+  let appliedPipelineFilterHints = 0;
   let appliedPipelineReorderHints = 0;
+  let appliedPipelineSliceHints = 0;
   let appliedPipelineSortHints = 0;
   let appliedPipelineHintedStateIndices: ReadonlySet<number> = new Set();
-  if (reorderPipelineHintedRoot.reorderCount > 0 || reorderPipelineHintedRoot.sortCount > 0) {
+  if (
+    reorderPipelineHintedRoot.filterCount > 0 ||
+    reorderPipelineHintedRoot.reorderCount > 0 ||
+    reorderPipelineHintedRoot.sliceCount > 0 ||
+    reorderPipelineHintedRoot.sortCount > 0
+  ) {
     const hintedBlockAnalysis = analyzeComposableBlocks(
       reorderPipelineHintedRoot.root,
       reactiveByValue,
@@ -7524,11 +7648,18 @@ function compileCandidate(
       expandedReactiveRoot = reorderPipelineHintedRoot.root;
       blockAnalysis = hintedBlockAnalysis;
       analysis = hintedAnalysis;
+      appliedPipelineFilterHints = reorderPipelineHintedRoot.filterCount;
       appliedPipelineReorderHints = reorderPipelineHintedRoot.reorderCount;
+      appliedPipelineSliceHints = reorderPipelineHintedRoot.sliceCount;
       appliedPipelineSortHints = reorderPipelineHintedRoot.sortCount;
       appliedPipelineHintedStateIndices = reorderPipelineHintedRoot.stateIndices;
+      optimizationCounts.keyedArrayFilterHints += reorderPipelineHintedRoot.filterCount;
       optimizationCounts.keyedArrayReorderHints += reorderPipelineHintedRoot.reorderCount;
+      optimizationCounts.keyedArraySliceHints += reorderPipelineHintedRoot.sliceCount;
       optimizationCounts.keyedArraySortHints += reorderPipelineHintedRoot.sortCount;
+      compilerUsage.keyedArrayStructuralReorderHints +=
+        reorderPipelineHintedRoot.structuralReorderCount;
+      compilerUsage.keyedArrayStructuralSortHints += reorderPipelineHintedRoot.structuralSortCount;
     }
   }
   const reorderHintedRoot = rewriteKeyedArrayReorderHints(
@@ -7613,8 +7744,9 @@ function compileCandidate(
     keyedArraySliceIdentifier,
     safeGlobals,
   );
-  let appliedKeyedArraySliceHints = 0;
-  let appliedSliceHintedStateIndices: ReadonlySet<number> = new Set();
+  let appliedKeyedArraySliceHints = appliedPipelineSliceHints;
+  let appliedSliceHintedStateIndices: ReadonlySet<number> =
+    appliedPipelineSliceHints > 0 ? appliedPipelineHintedStateIndices : new Set();
   if (sliceHintedRoot.count > 0) {
     const hintedBlockAnalysis = analyzeComposableBlocks(
       sliceHintedRoot.root,
@@ -7636,8 +7768,11 @@ function compileCandidate(
       expandedReactiveRoot = sliceHintedRoot.root;
       blockAnalysis = hintedBlockAnalysis;
       analysis = hintedAnalysis;
-      appliedKeyedArraySliceHints = sliceHintedRoot.count;
-      appliedSliceHintedStateIndices = sliceHintedRoot.stateIndices;
+      appliedKeyedArraySliceHints += sliceHintedRoot.count;
+      appliedSliceHintedStateIndices = new Set([
+        ...appliedSliceHintedStateIndices,
+        ...sliceHintedRoot.stateIndices,
+      ]);
       optimizationCounts.keyedArraySliceHints += sliceHintedRoot.count;
     }
   }
@@ -7648,8 +7783,9 @@ function compileCandidate(
     keyedArrayFilterIdentifier,
     safeGlobals,
   );
-  let appliedKeyedArrayFilterHints = 0;
-  let appliedFilterHintedStateIndices: ReadonlySet<number> = new Set();
+  let appliedKeyedArrayFilterHints = appliedPipelineFilterHints;
+  let appliedFilterHintedStateIndices: ReadonlySet<number> =
+    appliedPipelineFilterHints > 0 ? appliedPipelineHintedStateIndices : new Set();
   if (filterHintedRoot.count > 0) {
     const hintedBlockAnalysis = analyzeComposableBlocks(
       filterHintedRoot.root,
@@ -7671,8 +7807,11 @@ function compileCandidate(
       expandedReactiveRoot = filterHintedRoot.root;
       blockAnalysis = hintedBlockAnalysis;
       analysis = hintedAnalysis;
-      appliedKeyedArrayFilterHints = filterHintedRoot.count;
-      appliedFilterHintedStateIndices = filterHintedRoot.stateIndices;
+      appliedKeyedArrayFilterHints += filterHintedRoot.count;
+      appliedFilterHintedStateIndices = new Set([
+        ...appliedFilterHintedStateIndices,
+        ...filterHintedRoot.stateIndices,
+      ]);
       optimizationCounts.keyedArrayFilterHints += filterHintedRoot.count;
     }
   }
@@ -7987,6 +8126,8 @@ export async function compileReactModule(
   };
   const compilerUsage = {
     keyedArrayBatchInsertHints: 0,
+    keyedArrayStructuralReorderHints: 0,
+    keyedArrayStructuralSortHints: 0,
     keyedArrayWindowReplaceHints: 0,
   };
   const plugin = (): PluginObj => ({
@@ -8050,8 +8191,14 @@ export async function compileReactModule(
         const keyedArrayReorderIdentifier = programPath.scope.generateUidIdentifier(
           "createCompilerKeyedArrayReorder",
         );
+        const keyedArrayStructuralReorderIdentifier = programPath.scope.generateUidIdentifier(
+          "createCompilerKeyedArrayStructuralReorder",
+        );
         const keyedArraySortIdentifier = programPath.scope.generateUidIdentifier(
           "createCompilerKeyedArraySort",
+        );
+        const keyedArrayStructuralSortIdentifier = programPath.scope.generateUidIdentifier(
+          "createCompilerKeyedArrayStructuralSort",
         );
         const keyedArrayRollingWindowIdentifier = programPath.scope.generateUidIdentifier(
           "createCompilerKeyedArrayRollingWindow",
@@ -8094,7 +8241,9 @@ export async function compileReactModule(
             keyedArrayBatchInsertIdentifier,
             keyedArrayWindowReplaceIdentifier,
             keyedArrayReorderIdentifier,
+            keyedArrayStructuralReorderIdentifier,
             keyedArraySortIdentifier,
+            keyedArrayStructuralSortIdentifier,
             keyedArrayRollingWindowIdentifier,
             keyedArraySliceIdentifier,
             keyedCollectionUpdateIdentifier,
@@ -8187,7 +8336,8 @@ export async function compileReactModule(
                       ),
                     ]
                   : []),
-                ...(optimizationCounts.keyedArrayReorderHints > 0
+                ...(optimizationCounts.keyedArrayReorderHints >
+                compilerUsage.keyedArrayStructuralReorderHints
                   ? [
                       t.importSpecifier(
                         keyedArrayReorderIdentifier,
@@ -8195,11 +8345,28 @@ export async function compileReactModule(
                       ),
                     ]
                   : []),
-                ...(optimizationCounts.keyedArraySortHints > 0
+                ...(compilerUsage.keyedArrayStructuralReorderHints > 0
+                  ? [
+                      t.importSpecifier(
+                        keyedArrayStructuralReorderIdentifier,
+                        t.identifier("createCompilerKeyedArrayStructuralReorder"),
+                      ),
+                    ]
+                  : []),
+                ...(optimizationCounts.keyedArraySortHints >
+                compilerUsage.keyedArrayStructuralSortHints
                   ? [
                       t.importSpecifier(
                         keyedArraySortIdentifier,
                         t.identifier("createCompilerKeyedArraySort"),
+                      ),
+                    ]
+                  : []),
+                ...(compilerUsage.keyedArrayStructuralSortHints > 0
+                  ? [
+                      t.importSpecifier(
+                        keyedArrayStructuralSortIdentifier,
+                        t.identifier("createCompilerKeyedArrayStructuralSort"),
                       ),
                     ]
                   : []),


### PR DESCRIPTION
## Problem

A concise keyed-row update such as `current.filter(predicate).toSorted(compare)` executes two compiler-safe native operations, but the reorder result previously lost the filter survivor metadata. The runtime therefore could not prove the reduced collection against the committed rows and used complete React reconciliation.

## Root cause

Filter/slice hints and reorder hints were recorded independently. The reorder metadata required its result length to equal the committed collection length, so a structural prefix could not carry its source token or survivor positions across a later `toSorted()` or `toReversed()` call.

## Change

- Recognize compiler-safe `filter()` and bounded `slice()` prefixes followed by one or more native `toSorted()` / `toReversed()` suffixes in concise functional setters.
- Preserve JavaScript lookup and call order while lowering every pipeline step through native-method-validated helpers.
- Carry the original committed token and structural survivor chain through the reorder result.
- Validate the complete survivor chain, item identities, and row keys before any DOM write; remove rejected rows once and run one LIS pass only when the final survivors actually move.
- Use a linear validated path when the reorder suffix returns survivors in source order.
- Keep the combined reconciler and helpers in the every-hints runtime tier so reorder-only applications do not include them.
- Add the workload and an independent React/control gate to the production browser benchmark.

## Safety and compatibility

The fast path is limited to host-only keyed rows with compiler-proven index-independent filtering, reordering, and keys. Structural calls after a reorder, referenced predicates, custom/computed methods, sparse or subclassed arrays, identity/key mismatches, unrelated dirty state, collection-dependent row bindings, conditionals, and component/host-block rows retain complete React fallback.

All runtime proof completes before removals or moves. Native method lookup, invocation, results, and thrown errors remain observable in source order. Surviving DOM identity, focus, selection, queued updates, hydration, Strict Mode, and unmount cleanup are preserved. React 18.3.1 and 19.2.8 both pass the packaged compatibility suite. There is no public API or configuration change.

The runtime-size guard passes. The reorder-only fixture is 12,151 B gzip, below its persisted cap, and the compiler-selected core retains an 82.9% reduction from the complete compatibility-runtime premium.

## Verification

- `pnpm --filter @farm.js/react test` — 656 tests passed; the isolated stress suite also passed all 3 enabled stress tests.
- `pnpm --filter @farm.js/react test:compat` — React 18.3.1 and React 19.2.8 passed from the packed package.
- `pnpm --filter @farm.js/react test:runtime-size`
- `pnpm --filter @farm.js/react type-check`
- `pnpm --dir examples/react-compiler-dashboard type-check`
- `pnpm exec oxlint <changed JS/TS files>`
- `pnpm docs:check-navigation`
- `pnpm --dir docs exec farm generate --check`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm docs:build`
- `FARM_EXPERIMENT_BROWSER_PATH='/Applications/Google Chrome.app/Contents/MacOS/Google Chrome' pnpm --dir examples/react-compiler-dashboard benchmark`

The full bracketed Chrome 152 production run passed correctness and every existing performance gate without lowering a threshold. For the new 10,000-row case:

| Mode | Pipeline | React | Control | vs React | vs control |
| --- | ---: | ---: | ---: | ---: | ---: |
| Static | 23.10 ms | 92.85 ms | 32.40 ms | 4.02x | 1.40x |
| Hybrid | 24.70 ms | 92.85 ms | 37.30 ms | 3.76x | 1.51x |

Both compiler modes kept all 9,999 surviving DOM nodes and recorded zero owner component executions. The browser benchmark generated screenshots for compiler-off baseline A, static, hybrid, and compiler-off baseline B.

## Documentation and release

Updated the React renderer guide, package README, dashboard README, reproducible benchmark script, and persisted benchmark results. No template, generated artifact, package version, or release-flow change.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Composes compiler-safe `filter()`/`slice()` prefixes with native `toSorted()`/`toReversed()` suffixes in concise functional setters, so pipelines like `current.filter(...).toSorted(...)` no longer fall back to full React reconciliation. Previously the reorder result dropped filter survivor metadata and forced complete reconciliation; now the structural proof is carried through and validated before any DOM write.

- Preserves JavaScript lookup and call order while lowering each pipeline step through native-method-validated helpers.
- Removes rejected rows once and runs a single LIS pass only when the final survivors actually move; uses a linear path when they stay in source order.
- Validates the full survivor chain, item identities, and row keys before the first removal or move.
- Limits the fast path to host-only keyed rows with compiler-proven index-independent filtering, reordering, and keys; referenced predicates, custom methods, structural calls after reordering, and identity mismatches keep the React fallback.
- Keeps the combined reconciler and helpers in the every-hints runtime tier so reorder-only applications do not include them.
- Adds a 10,000-row benchmark workload and independent gate: 4.02x faster than React and 1.40x faster than the compiled control with zero owner component executions.
- Passes the runtime-size guard (reorder-only fixture stays at 12,151 B gzip) and the React 18.3.1/19.2.8 compatibility suite; no public API or config change.
- Updates docs, READMEs, and the benchmark script.

<sup>Written for commit 1eee28e147defad675678c4161d820af5be03629. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/740?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

