### PR TITLE
fix(middleware): retain guards when reload fails

### DIFF
--- a/docs/src/app/docs/middleware/page.md
+++ b/docs/src/app/docs/middleware/page.md
@@ -12,6 +12,10 @@ Run request behavior before routes, pass request-scoped data to pages, and short
 
 Farm runs middleware in development and production builds. For every request, Farm finds matching `farm.config.ts` middleware entries first, then matching `src/app/**/middleware.ts` files from the root segment down to the route segment.
 
+In development, a middleware edit is activated only after the complete middleware tree loads
+successfully. A syntax or import error is reported through Vite while the last valid tree remains
+active, so a broken hot update cannot silently remove authentication or other request guards.
+
 The chain stops when a middleware handler returns a Web `Response` or uses a short-circuit helper such as `ctx.redirect()`. Default Farm handlers call `await next()` to continue. A named request-first handler continues automatically when it returns `undefined`.
 
 Data and headers written during middleware are request-scoped:

--- a/packages/farm/src/__tests__/middleware.test.ts
+++ b/packages/farm/src/__tests__/middleware.test.ts
@@ -1739,6 +1739,84 @@ describe("Named request middleware", () => {
     }
   });
 
+  it("keeps the last valid middleware when an HMR reload fails", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "farm-middleware-reload-"));
+    const appDir = path.join(root, "src", "app");
+    const middlewareFile = path.join(appDir, "middleware.ts");
+    await fs.mkdir(appDir, { recursive: true });
+    await fs.writeFile(middlewareFile, "export {};\n");
+    const handler = vi.fn();
+    const viteServer = {
+      ssrLoadModule: vi
+        .fn()
+        .mockResolvedValueOnce({ default: handler })
+        .mockRejectedValueOnce(new SyntaxError("Unexpected token")),
+    };
+
+    try {
+      const manager = new MiddlewareManager(appDir, viteServer as never);
+      await manager.discover();
+      expect(manager.getMiddlewares()).toHaveLength(1);
+
+      await expect(manager.reload()).rejects.toThrow(`Failed to load middleware ${middlewareFile}`);
+      expect(manager.getMiddlewares()).toHaveLength(1);
+      expect(manager.getMiddlewares()[0]?.handlers).toEqual([handler]);
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("fails initial discovery when a middleware module cannot load", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "farm-middleware-invalid-"));
+    const appDir = path.join(root, "src", "app");
+    const middlewareFile = path.join(appDir, "middleware.ts");
+    await fs.mkdir(appDir, { recursive: true });
+    await fs.writeFile(middlewareFile, "export {};\n");
+    const viteServer = {
+      ssrLoadModule: vi.fn().mockRejectedValue(new SyntaxError("Unexpected token")),
+    };
+
+    try {
+      const manager = new MiddlewareManager(appDir, viteServer as never);
+      await expect(manager.discover()).rejects.toThrow(
+        `Failed to load middleware ${middlewareFile}`,
+      );
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("propagates initial discovery failures through the standalone Vite plugin", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "farm-middleware-plugin-invalid-"));
+    const middlewareFile = path.join(root, "src", "app", "middleware.ts");
+    await fs.mkdir(path.dirname(middlewareFile), { recursive: true });
+    await fs.writeFile(middlewareFile, "export {};\n");
+    const loadError = new SyntaxError("Unexpected token");
+    const server = {
+      config: { root },
+      ssrLoadModule: vi.fn().mockRejectedValue(loadError),
+      moduleGraph: { invalidateModule: vi.fn() },
+      ws: { send: vi.fn() },
+    };
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      const plugin = farmMiddlewarePlugin();
+      (plugin.configureServer as (server: any) => void)(server);
+
+      await expect((server as any).__farmMiddleware__.waitForDiscovery()).rejects.toThrow(
+        `Failed to load middleware ${middlewareFile}`,
+      );
+      expect((server as any).__farmMiddleware__.isReady()).toBe(false);
+      await expect(
+        (server as any).__farmMiddleware__.execute(createMockRequest("/"), createMockResponse()),
+      ).rejects.toThrow(`Failed to load middleware ${middlewareFile}`);
+    } finally {
+      errorSpy.mockRestore();
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("preserves Response short-circuiting", async () => {
     const normalized = normalizeMiddlewareModule(
       {

--- a/packages/farm/src/middleware/manager.ts
+++ b/packages/farm/src/middleware/manager.ts
@@ -167,10 +167,7 @@ export class MiddlewareManager {
   /**
    * Load a middleware file
    */
-  private async loadMiddleware(
-    filePath: string,
-    routePath: string,
-  ): Promise<DiscoveredMiddleware | null> {
+  private async loadMiddleware(filePath: string, routePath: string): Promise<DiscoveredMiddleware> {
     try {
       // Load the module
       let module: any;
@@ -183,10 +180,7 @@ export class MiddlewareManager {
 
       const normalized = normalizeMiddlewareModule(module, routePath);
       if (!normalized) {
-        logger.warn(
-          `Middleware file ${filePath} must export a default handler or a named middleware handler`,
-        );
-        return null;
+        throw new Error("must export a default handler or a named middleware handler");
       }
 
       return {
@@ -197,8 +191,7 @@ export class MiddlewareManager {
         source: "file",
       };
     } catch (error) {
-      logger.error(`Failed to load middleware ${filePath}: ${error}`);
-      return null;
+      throw new Error(`Failed to load middleware ${filePath}: ${error}`);
     }
   }
 

--- a/packages/farm/src/middleware/vite-plugin.ts
+++ b/packages/farm/src/middleware/vite-plugin.ts
@@ -38,8 +38,8 @@ export function farmMiddlewarePlugin(options: FarmMiddlewarePluginOptions = {}):
     enforce: "pre",
 
     configureServer(server) {
-      discoveryPromise = discover(server).catch((error) => {
-        discoveryComplete = true;
+      discoveryPromise = discover(server);
+      void discoveryPromise.catch((error) => {
         console.error("[FARM] Middleware discovery error:", error);
       });
 
@@ -49,7 +49,7 @@ export function farmMiddlewarePlugin(options: FarmMiddlewarePluginOptions = {}):
         _pathname?: string,
         sharedData?: Map<string, any>,
       ): Promise<boolean> => {
-        if (discoveryPromise && !discoveryComplete) {
+        if (discoveryPromise) {
           await discoveryPromise;
         }
 


### PR DESCRIPTION
## Problem

A middleware syntax/import failure during development reload could replace the active middleware set and temporarily remove application guards. The same failure during initial discovery could also be swallowed.

## Root cause

Middleware loading logged module and export failures and returned `null`. Discovery interpreted that as a successful scan and committed the incomplete result.

## Change

Treat middleware import failures and missing handlers as discovery failures. Discovery already commits its next middleware array atomically, so a failed reload now preserves the last valid set while an initial failure is surfaced.

## Safety and compatibility

Successful reload behavior is unchanged. The stricter error only applies to invalid middleware modules that could not safely run.

## Verification

- `pnpm --filter @farm.js/core exec vitest run src/__tests__/middleware.test.ts`
- `pnpm --filter @farm.js/core type-check`
- Focused oxfmt and oxlint checks

The new reload regression fails against `main`, where the loader swallows the failure and discovery replaces the valid middleware.

## Documentation and release

Updated the middleware documentation with the reload failure behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes middleware reload failures so a broken hot update no longer replaces the active middleware set and removes request guards.

- Middleware import failures and missing handlers now throw instead of logging and returning `null`, so discovery treats them as failures.
- A failed reload keeps the last valid middleware tree; an initial discovery failure surfaces instead of being swallowed.
- Updates the middleware docs to describe the reload failure behavior.

<sup>Written for commit 891054437401cdaeec1ef2067de2ceee3ea48254. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/741?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

