### PR TITLE
fix(routing): decode file route URL segments

### DIFF
--- a/docs/src/app/docs/routing/page.md
+++ b/docs/src/app/docs/routing/page.md
@@ -171,6 +171,10 @@ const href = router.build("/docs/[[...slug]]", {
 ```
 
 This returns `/docs/core/routing`. Optional catch-all params can be omitted, static routes win over dynamic routes, and route groups such as `(marketing)` do not appear in the URL.
+
+Route matching decodes each URL path segment once before comparing static names or exposing
+`params`. Route names remain literal (including `%`), and malformed percent escapes remain literal
+instead of aborting the request.
 For navigation state, `router.isActive(pattern, pathname, { exact: false })` also matches
 descendants after dynamic segments, such as `/users/42/settings` for `/users/[id]`.
 

--- a/packages/farm/src/__tests__/client-component.test.ts
+++ b/packages/farm/src/__tests__/client-component.test.ts
@@ -714,6 +714,10 @@ export function Chart() {}
     expect(source).toContain("const layouts = Array.isArray(window.__FARM_LAYOUTS__)");
     expect(source).toContain("? window.__FARM_LAYOUTS__");
     expect(source).toContain(": findLayouts(window.location.pathname);");
+    expect(source).toContain("const pathnameSegments = pathname === '/'");
+    expect(source).toContain("pathnameSegments[index] === segment");
+    expect(source).not.toContain("map(decodeRouteSegment).join('/')");
+    expect(source).toContain("return urlSegment === routeSegment.segment ? {} : null;");
     expect(source).toMatch(
       /tryHydrateImportedPage\(\s+pageContainer,[\s\S]*?layouts,[\s\S]*?layoutShouldHydrate,/,
     );

--- a/packages/farm/src/__tests__/universal-build-router-runtime.test.ts
+++ b/packages/farm/src/__tests__/universal-build-router-runtime.test.ts
@@ -415,5 +415,12 @@ describe("generateRuntimePathMatcherSource", () => {
     // The only decodeURIComponent left is the one inside the guard's try.
     expect(matcher.split("decodeURIComponent(").length - 1).toBe(1);
     expect(matcher).toContain("function decodeRouteSegment(segment)");
+    expect(matcher).toContain("segment !== decodeRouteSegment(pathnameSegment)");
+
+    const matchRuntimePathPattern = new Function(
+      matcher + "; return matchRuntimePathPattern;",
+    )() as (pattern: string, pathname: string) => Record<string, string> | null;
+    expect(matchRuntimePathPattern("/café", "/caf%C3%A9")).toEqual({});
+    expect(matchRuntimePathPattern("/a%20b", "/a%2520b")).toEqual({});
   });
 });

--- a/packages/farm/src/__tests__/utils.test.ts
+++ b/packages/farm/src/__tests__/utils.test.ts
@@ -161,6 +161,33 @@ describe("matchRoute", () => {
     expect(result.params).toEqual({ id: "123" });
   });
 
+  it("decodes dynamic, catch-all, and static URL segments", () => {
+    expect(
+      matchRoute("/users/hello%20farm", parseRoutePath("users/[id]/page.tsx").segments),
+    ).toEqual({ matches: true, params: { id: "hello farm" } });
+    expect(
+      matchRoute("/docs/guides/caf%C3%A9", parseRoutePath("docs/[...slug]/page.tsx").segments),
+    ).toEqual({ matches: true, params: { slug: "guides/café" } });
+    expect(matchRoute("/caf%C3%A9", parseRoutePath("café/page.tsx").segments)).toEqual({
+      matches: true,
+      params: {},
+    });
+    expect(matchRoutePrefix("/caf%C3%A9/menu", parseRoutePath("café/layout.tsx").segments)).toBe(
+      true,
+    );
+    expect(matchRoute("/a%2520b", parseRoutePath("a%20b/page.tsx").segments)).toEqual({
+      matches: true,
+      params: {},
+    });
+  });
+
+  it("keeps malformed URL segments literal while matching", () => {
+    expect(matchRoute("/users/%E0%A4%A", parseRoutePath("users/[id]/page.tsx").segments)).toEqual({
+      matches: true,
+      params: { id: "%E0%A4%A" },
+    });
+  });
+
   it("should match dynamic segments containing dots", () => {
     const segments = [
       { segment: "user", isDynamic: true, isOptional: false, isCatchAll: false },

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -1696,7 +1696,7 @@ function matchRuntimePathPattern(pattern, pathname) {
       continue;
     }
 
-    if (segment !== pathnameSegment) return null;
+    if (segment !== decodeRouteSegment(pathnameSegment)) return null;
     pathIndex++;
   }
 

--- a/packages/farm/src/utils.ts
+++ b/packages/farm/src/utils.ts
@@ -1,5 +1,6 @@
 import type { RouteSegment, ParsedRoute } from "./types";
 import path from "path";
+import { decodeRouteSegment } from "./utils/decode";
 
 export function parseRoutePath(filePath: string): ParsedRoute {
   const segments: RouteSegment[] = [];
@@ -91,7 +92,7 @@ export function matchRoute(
   url: string,
   segments: RouteSegment[],
 ): { params: Record<string, string>; matches: boolean } {
-  const urlParts = url.split("/").filter(Boolean);
+  const urlParts = url.split("/").filter(Boolean).map(decodeRouteSegment);
   const params: Record<string, string> = {};
   if (segments.length === 0) {
     return { params, matches: urlParts.length === 0 };
@@ -137,7 +138,7 @@ export function matchRoute(
 
 /** Match a route segment chain as an owner of the pathname or one of its descendants. */
 export function matchRoutePrefix(url: string, segments: RouteSegment[]): boolean {
-  const urlParts = url.split("/").filter(Boolean);
+  const urlParts = url.split("/").filter(Boolean).map(decodeRouteSegment);
   let urlIndex = 0;
 
   for (const segment of segments) {

--- a/packages/farm/src/vite.ts
+++ b/packages/farm/src/vite.ts
@@ -3679,9 +3679,17 @@ function matchSegment(urlSegment, routeSegment) {
   return { [routeSegment.segment]: urlSegment };
 }
 
+function decodeRouteSegment(segment) {
+  try {
+    return decodeURIComponent(segment);
+  } catch {
+    return segment;
+  }
+}
+
 function matchRoute(pathname, routeSegments) {
   const normalizedPath = pathname === '/' ? '' : pathname.replace(/^\\//, '').replace(/\\/$/, '');
-  const pathSegments = normalizedPath ? normalizedPath.split('/') : [];
+  const pathSegments = normalizedPath ? normalizedPath.split('/').map(decodeRouteSegment) : [];
   
   // Handle catch-all routes
   const hasCatchAll = routeSegments.some(s => s.isCatchAll);
@@ -3733,7 +3741,9 @@ function findLayouts(pathname) {
   pathname = stripFarmBasePath(pathname);
   const manifest = getManifest();
   const layouts = Object.values(manifest.layouts);
-  const normalizedPath = pathname === '/' ? '/' : pathname.replace(/\\/$/, '');
+  const pathnameSegments = pathname === '/'
+    ? []
+    : pathname.replace(/\\/$/, '').split('/').filter(Boolean).map(decodeRouteSegment);
   const matchingLayouts = [];
   
   for (const layout of layouts) {
@@ -3742,9 +3752,15 @@ function findLayouts(pathname) {
       matchingLayouts.push(layout);
       continue;
     }
-    // Check if pathname starts with layout pattern
-    if (normalizedPath.startsWith(layout.pattern) || 
-        normalizedPath === layout.pattern.replace(/\\/[^/]+$/, '')) {
+    const layoutSegments = layout.pattern.split('/').filter(Boolean);
+    const matchesLayout = layoutSegments.every(
+      (segment, index) => pathnameSegments[index] === segment
+    );
+    const matchesLayoutParent = pathnameSegments.length === layoutSegments.length - 1 &&
+      layoutSegments.slice(0, -1).every(
+        (segment, index) => pathnameSegments[index] === segment
+      );
+    if (matchesLayout || matchesLayoutParent) {
       matchingLayouts.push(layout);
     }
   }


### PR DESCRIPTION
## Problem

File-route matching compared raw URL pathname segments with decoded route filenames. Encoded parameters and Unicode static segments could therefore produce inconsistent values or fail to match between development and the generated production router.

## Root cause

The development matcher, Vite-generated matcher, and production runtime matcher split the pathname without applying the URL path-segment decoding step.

## Change

Decode each route segment through one guarded helper before static comparison or parameter capture, and apply the same behavior to development and production routing.

## Safety and compatibility

Malformed percent escapes remain non-fatal and fall through as their original segment. This is renderer-neutral and does not change the public routing API.

## Verification

- `pnpm --filter @farm.js/core exec vitest run src/__tests__/utils.test.ts src/__tests__/route-manager.test.ts src/__tests__/universal-build-router-runtime.test.ts src/__tests__/client-component.test.ts`
- `pnpm --filter @farm.js/core type-check`
- Focused oxfmt and oxlint checks

The added Unicode and encoded-parameter regressions fail against `main`, where segments stay raw.

## Documentation and release

Updated the routing documentation to state that URL segments are decoded before matching.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes file-route matching so URL segments are decoded before static comparison or parameter capture, preventing mismatches with encoded parameters and Unicode segment names in dev and production.

**Bug Fixes**

- Applies a guarded `decodeURIComponent` to each pathname segment in the dev matcher, Vite-generated matcher, and production runtime matcher.
- Malformed percent escapes stay literal instead of failing the request.
- Updates routing docs to note that URL segments are decoded before matching.

<sup>Written for commit 979e0122c3f81f439ce8e82c6334bc3dbdbed1c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/742?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

