### PR TITLE
fix(config): reject unsafe application base paths

### DIFF
--- a/docs/src/app/docs/configuration/page.md
+++ b/docs/src/app/docs/configuration/page.md
@@ -273,6 +273,21 @@ mount, and shortcut together.
 | experimental  | Auditing or enabling opt-in rendering experiments such as isolated hydration.     |
 | openapi       | Publishing API reference docs.                                                    |
 
+## Application base path
+
+Set `basePath` when the complete application is mounted below the origin root. Farm applies the
+canonical path consistently to routes, links, assets, and runtime endpoints:
+
+```ts title="farm.config.ts"
+export default defineConfig({
+  basePath: "/console",
+});
+```
+
+Farm accepts a leading-slash or bare pathname and removes duplicate and trailing slashes. It rejects
+URLs, query strings, hashes, backslashes, control characters, and `.` or `..` segments because a
+browser could otherwise resolve a different path than Farm's server router.
+
 ## Trailing slashes
 
 Application page URLs omit a trailing slash by default. Set `trailingSlash: true` to generate

--- a/packages/farm/src/__tests__/base-path.test.ts
+++ b/packages/farm/src/__tests__/base-path.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { applyFarmBasePath, stripFarmBasePath } from "../base-path";
+import { FarmApp } from "../app";
 
 describe("Farm base paths", () => {
   it("applies the base path only to app-relative hrefs", () => {
@@ -12,5 +13,12 @@ describe("Farm base paths", () => {
     expect(stripFarmBasePath("/console/reports", "/console")).toBe("/reports");
     expect(stripFarmBasePath("/console", "/console")).toBe("/");
     expect(stripFarmBasePath("/reports", "/console")).toBe("/reports");
+  });
+
+  it("uses the canonical base path for direct FarmApp theme cookies", () => {
+    const config = new FarmApp({ basePath: " docs//guides/ ", theme: {} }).getConfig();
+
+    expect(config.basePath).toBe("/docs/guides");
+    expect(config.theme.cookiePath).toBe("/docs/guides");
   });
 });

--- a/packages/farm/src/__tests__/config.test.ts
+++ b/packages/farm/src/__tests__/config.test.ts
@@ -50,6 +50,34 @@ describe("config helpers", () => {
     expect(defineFarmConfig(config)).toBe(config);
   });
 
+  it("canonicalizes the application basePath", async () => {
+    await expect(
+      resolveConfig({ basePath: " docs//guides/ ", theme: {} }, "production"),
+    ).resolves.toMatchObject({
+      basePath: "/docs/guides",
+      theme: { cookiePath: "/docs/guides" },
+    });
+    await expect(resolveConfig({ basePath: "/" }, "production")).resolves.toMatchObject({
+      basePath: "/",
+    });
+  });
+
+  it("rejects application base paths that browsers reinterpret", async () => {
+    for (const basePath of [
+      "/docs/../admin",
+      "/docs/%2e%2e/admin",
+      "/docs/%2e%2e%2fadmin",
+      "/%2F%2Fevil.example/docs",
+      "/docs?preview=1",
+      "/docs#preview",
+      "/docs\\admin",
+      "https://example.com/docs",
+      "//example.com/docs",
+    ]) {
+      await expect(resolveConfig({ basePath }, "production")).rejects.toThrow("Farm basePath");
+    }
+  });
+
   it("preserves a configured cache adapter and namespace", async () => {
     const adapter = {
       name: "test-cache",

--- a/packages/farm/src/app.ts
+++ b/packages/farm/src/app.ts
@@ -33,6 +33,7 @@ import type { ResolvedFarmI18nConfig } from "./i18n/types";
 import { configureFarmCache } from "./cache";
 import { resolveFarmAuthConfig, type ResolvedFarmAuthConfig } from "./auth-config";
 import { resolveFarmPerformanceConfig, type ResolvedFarmPerformanceConfig } from "./preload";
+import { normalizeFarmConfigBasePath } from "./base-path";
 import { resolveFarmSecurityConfig, type ResolvedFarmSecurityConfig } from "./security";
 import { resolveFarmThemeConfig } from "./theme/config";
 import { _setDefaultFarmThemeConfig } from "./theme/server";
@@ -145,6 +146,7 @@ export class FarmApp {
 
   private normalizeConfig(config: FarmConfig): NormalizedFarmConfig {
     const root = config.root || process.cwd();
+    const basePath = normalizeFarmConfigBasePath(config.basePath);
 
     return {
       root,
@@ -152,7 +154,7 @@ export class FarmApp {
       extends: config.extends || [],
       layers: [...(config.layers || [])],
       outDir: config.outDir || "dist",
-      basePath: config.basePath || "/",
+      basePath,
       trailingSlash: config.trailingSlash ?? false,
       renderer: resolveFarmRenderer(config.renderer),
       preset: config.preset ?? "node-server",
@@ -174,7 +176,7 @@ export class FarmApp {
       security: resolveFarmSecurityConfig(config.security),
       images: resolveFarmImageConfig(config.images),
       performance: resolveFarmPerformanceConfig(config.performance),
-      theme: resolveFarmThemeConfig(config.theme, config.basePath || "/"),
+      theme: resolveFarmThemeConfig(config.theme, basePath),
       i18n: isResolvedI18nConfig(config.i18n)
         ? config.i18n
         : resolveFarmI18nConfig(config.i18n, {

--- a/packages/farm/src/base-path.ts
+++ b/packages/farm/src/base-path.ts
@@ -38,5 +38,49 @@ export function stripFarmBasePath(pathname: string, basePath = getFarmBasePath()
 
 export function normalizeFarmBasePath(basePath: string | undefined): string {
   if (!basePath || basePath === "/") return "";
-  return `/${basePath}`.replace(/\/{2,}/g, "/").replace(/\/+$/, "");
+
+  const hasUnstableCharacters = (candidate: string) =>
+    candidate.includes("\\") ||
+    Array.from(candidate).some((character) => {
+      const code = character.charCodeAt(0);
+      return code <= 31 || (code >= 127 && code <= 159);
+    });
+
+  if (hasUnstableCharacters(basePath)) {
+    throw new Error("Farm basePath cannot contain backslashes or control characters.");
+  }
+
+  const pathname = basePath.trim();
+  if (!pathname || pathname === "/") return "";
+  if (pathname.includes("?") || pathname.includes("#")) {
+    throw new Error("Farm basePath cannot contain a query string or hash.");
+  }
+  if (pathname.startsWith("//") || /^[a-z][a-z\d+.-]*:\/\//i.test(pathname)) {
+    throw new Error('Farm basePath must be a pathname such as "/docs", not a URL.');
+  }
+
+  for (const segment of pathname.split("/")) {
+    let decoded = segment;
+    try {
+      decoded = decodeURIComponent(segment);
+    } catch {
+      // Malformed escapes remain literal in URL pathnames and cannot be dot segments.
+    }
+    if (hasUnstableCharacters(decoded)) {
+      throw new Error("Farm basePath cannot contain backslashes or control characters.");
+    }
+    if (decoded.includes("/")) {
+      throw new Error("Farm basePath cannot contain percent-encoded path separators.");
+    }
+    if (decoded === "." || decoded === "..") {
+      throw new Error('Farm basePath cannot contain "." or ".." path segments.');
+    }
+  }
+
+  return `/${pathname}`.replace(/\/{2,}/g, "/").replace(/\/+$/, "");
+}
+
+/** Normalize a configured application base path while preserving `/` for root. */
+export function normalizeFarmConfigBasePath(basePath: string | undefined): string {
+  return normalizeFarmBasePath(basePath) || "/";
 }

--- a/packages/farm/src/config.ts
+++ b/packages/farm/src/config.ts
@@ -51,6 +51,7 @@ import {
 import path from "path";
 import { logger } from "./utils";
 import { normalizeFarmDeploymentId } from "./deployment";
+import { normalizeFarmConfigBasePath } from "./base-path";
 import { resolveFarmDevtoolsConfig, type ResolvedFarmDevtoolsConfig } from "./devtools-config";
 import {
   resolveFarmDevIndicatorsConfig,
@@ -946,6 +947,7 @@ export async function resolveConfig(
       process.env.CF_PAGES_COMMIT_SHA ||
       (mode === "production" ? await generateBuildId() : "development"),
   );
+  const basePath = normalizeFarmConfigBasePath(userConfig.basePath);
 
   const resolved: ResolvedFarmConfig = {
     [FARM_RESOLVED_CUSTOM_CONTEXT]: typeof userConfig.context === "function",
@@ -954,7 +956,7 @@ export async function resolveConfig(
     extends: userConfig.extends || [],
     layers: layerResolution.layers,
     outDir: userConfig.outDir || "dist",
-    basePath: userConfig.basePath || "/",
+    basePath,
     renderer: resolveFarmRenderer(userConfig.renderer),
     preset: deploy.preset || "node-server",
     deploy,
@@ -991,7 +993,7 @@ export async function resolveConfig(
     routeRules,
     images: resolveFarmImageConfig(userConfig.images),
     performance: resolveFarmPerformanceConfig(userConfig.performance),
-    theme: resolveFarmThemeConfig(userConfig.theme, userConfig.basePath || "/"),
+    theme: resolveFarmThemeConfig(userConfig.theme, basePath),
     publicDir: userConfig.publicDir || "public",
     i18n: resolveFarmI18nConfig(userConfig.i18n, { root, mode }),
     openapi: {


### PR DESCRIPTION
## Problem

Application base paths accepted traversal, encoded traversal, URL, network-path, query, fragment, backslash, and control-character forms. These values could be normalized differently by browsers, proxies, and framework internals.

## Root cause

Base-path normalization only added and removed slashes; it did not validate the value as a safe application pathname.

## Change

Centralize Farm config base-path normalization, reject unsafe forms (including decoded dot segments), and canonicalize safe repeated/trailing slashes. Preserve `/` as the root base path.

## Safety and compatibility

Normal paths continue to work and canonicalize deterministically. Invalid values now fail during configuration with an actionable error instead of reaching routing or deployment output.

## Verification

- `pnpm --filter @farm.js/core exec vitest run src/__tests__/config.test.ts src/__tests__/base-path.test.ts`
- `pnpm --filter @farm.js/core type-check`
- Focused oxfmt and oxlint checks

The added unsafe-path cases fail against `main`, which accepts them.

## Documentation and release

Updated the configuration documentation with accepted and rejected base-path forms.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects unsafe application base paths so a `basePath` can no longer be interpreted differently by browsers, proxies, and Farm internals. Previously accepted traversal, encoded dot segments, URLs, network paths, query strings, hashes, backslashes, and control characters now fail configuration with an actionable error.

**Validation and normalization**
- Accepts leading-slash or bare pathnames and removes duplicate and trailing slashes.
- Preserves `/` as the root base path and applies the canonical path to routes, assets, and theme cookie paths.
- Centralizes canonicalization in `normalizeFarmConfigBasePath`, shared by `resolveConfig` and `FarmApp`.

**Breaking changes**
- Configurations that passed unsafe base paths must be updated to a clean pathname.
- Docs now list accepted and rejected forms.

<sup>Written for commit 142869eff1d38935e2ac3575b21d9bd50e7fe7a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/743?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

