### PR TITLE
fix(images): block DNS rebinding in remote fetches

### DIFF
--- a/docs/src/app/docs/images/page.md
+++ b/docs/src/app/docs/images/page.md
@@ -152,7 +152,7 @@ Pass a `loader` prop when an application already uses an image CDN. The loader r
 
 ## Security model
 
-The optimizer accepts only configured widths and qualities. It does not forward browser cookies or authorization headers, limits response bodies, checks file signatures instead of trusting `Content-Type`, revalidates redirect destinations, and blocks loopback, link-local, and private network targets.
+The optimizer accepts only configured widths and qualities. It does not forward browser cookies or authorization headers, limits response bodies, checks file signatures instead of trusting `Content-Type`, revalidates redirect destinations, and blocks loopback, link-local, and private network targets. On Node, Farm validates the DNS addresses used by the actual image connection so a hostname cannot switch to a private target between an earlier check and the fetch.
 Formats explicitly rejected with `q=0` are never emitted. Farm uses the configured format order to
 break equal-quality ties and keeps the source format when the client only sends wildcard ranges.
 

--- a/packages/farm/src/__tests__/image-server.test.ts
+++ b/packages/farm/src/__tests__/image-server.test.ts
@@ -1,7 +1,10 @@
 // @vitest-environment node
 
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
 import { describe, expect, it, vi } from "vitest";
 import { resolveFarmImageConfig } from "../image-config";
+import { createNodeImageFetcher } from "../image-sharp";
 import {
   createCloudflareImageTransformer,
   createFarmImageHandler,
@@ -141,6 +144,42 @@ describe("Farm image optimizer", () => {
 
     expect(unconfigured?.status).toBe(400);
     expect(privateAddress?.status).toBe(400);
+  });
+
+  it("blocks a private address resolved by the actual remote connection", async () => {
+    let requests = 0;
+    const server = createServer((_request, response) => {
+      requests++;
+      response.end(PNG);
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const port = (server.address() as AddressInfo).port;
+    const config = resolveFarmImageConfig({
+      remotePatterns: [{ protocol: "http", hostname: "images.example.test", pathname: "/**" }],
+    });
+    const validateRemoteUrl = vi.fn(async () => undefined);
+    const fetchRemote = createNodeImageFetcher(config, (_hostname, _options, callback) => {
+      callback(null, [{ address: "127.0.0.1", family: 4 }]);
+    });
+    const handler = createFarmImageHandler(config, {
+      fetchRemote,
+      transform: passthroughTransformer(),
+      validateRemoteUrl,
+    });
+
+    try {
+      const response = await handler(
+        new Request(optimizerUrl(`http://images.example.test:${port}/photo.png`)),
+      );
+
+      expect(validateRemoteUrl).toHaveBeenCalledOnce();
+      expect(response?.status).toBe(400);
+      expect(requests).toBe(0);
+    } finally {
+      await new Promise<void>((resolve, reject) =>
+        server.close((error) => (error ? reject(error) : resolve())),
+      );
+    }
   });
 
   it("revalidates every remote redirect", async () => {

--- a/packages/farm/src/__tests__/image-sharp.test.ts
+++ b/packages/farm/src/__tests__/image-sharp.test.ts
@@ -2,10 +2,43 @@
 
 import { imageSize } from "image-size";
 import sharp from "sharp";
-import { describe, expect, it } from "vitest";
-import { createSharpImageTransformer } from "../image-sharp";
+import { describe, expect, it, vi } from "vitest";
+import { createNodeImageFetcher, createSharpImageTransformer } from "../image-sharp";
+import { resolveFarmImageConfig } from "../image-config";
+
+const { requestMock } = vi.hoisted(() => ({ requestMock: vi.fn() }));
+
+vi.mock("node:http", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("node:http")>()),
+  request: requestMock,
+}));
 
 describe("Sharp image adapter", () => {
+  it("rejects invalid upstream status codes without constructing a Response", async () => {
+    const resume = vi.fn();
+    requestMock.mockImplementationOnce((_url, _options, onResponse) => {
+      return {
+        once: vi.fn(),
+        end() {
+          onResponse({ statusCode: 700, resume });
+        },
+      };
+    });
+    const fetchRemote = createNodeImageFetcher(
+      resolveFarmImageConfig({
+        remotePatterns: [{ protocol: "http", hostname: "images.example.test" }],
+      }),
+      (_hostname, _options, callback) => {
+        callback(null, [{ address: "203.0.113.1", family: 4 }]);
+      },
+    );
+
+    await expect(fetchRemote("http://images.example.test/photo.png")).rejects.toThrow(
+      "invalid HTTP status",
+    );
+    expect(resume).toHaveBeenCalledOnce();
+  });
+
   it("performs a real format conversion without enlarging the image", async () => {
     const source = await sharp({
       create: {

--- a/packages/farm/src/image-server.ts
+++ b/packages/farm/src/image-server.ts
@@ -27,6 +27,8 @@ export type FarmImageTransformer = (
 
 export interface CreateFarmImageHandlerOptions {
   fetch?: typeof globalThis.fetch;
+  /** Node-only fetcher that validates the DNS result used for remote connections. @internal */
+  fetchRemote?: typeof globalThis.fetch;
   transform: FarmImageTransformer;
   validateRemoteUrl?: (url: URL) => void | Promise<void>;
   onError?: (error: unknown, request: Request) => void;
@@ -108,6 +110,7 @@ export function createFarmImageHandler(
           requestUrl.origin,
           config,
           fetcher,
+          options.fetchRemote,
           options.validateRemoteUrl,
           request.signal,
         );
@@ -333,6 +336,7 @@ async function fetchImageSource(
   requestOrigin: string,
   config: ResolvedFarmImageConfig,
   fetcher: typeof globalThis.fetch,
+  fetchRemote: typeof globalThis.fetch | undefined,
   validateRemoteUrl: CreateFarmImageHandlerOptions["validateRemoteUrl"],
   signal: AbortSignal,
 ): Promise<{ response: Response; url: URL }> {
@@ -340,7 +344,8 @@ async function fetchImageSource(
 
   for (let redirectCount = 0; ; redirectCount += 1) {
     throwIfAborted(signal);
-    const response = await fetcher(currentUrl, {
+    const sourceFetcher = currentUrl.origin === requestOrigin ? fetcher : (fetchRemote ?? fetcher);
+    const response = await sourceFetcher(currentUrl, {
       method: "GET",
       redirect: "manual",
       signal,

--- a/packages/farm/src/image-sharp.ts
+++ b/packages/farm/src/image-sharp.ts
@@ -6,6 +6,15 @@ import {
   type FarmImageTransformer,
 } from "./image-server";
 
+type NodeImageDnsLookup = (
+  hostname: string,
+  options: { all: true; verbatim: true },
+  callback: (
+    error: NodeJS.ErrnoException | null,
+    addresses: Array<{ address: string; family: number }>,
+  ) => void,
+) => void;
+
 export function createSharpImageTransformer(): FarmImageTransformer {
   return async ({ source, sourceType, width, quality, accept, formats, signal }) => {
     // Sharp is an optional native runtime. Load it only when an image request
@@ -79,6 +88,116 @@ export function createNodeImageUrlValidator(config: ResolvedFarmImageConfig) {
       throw new FarmImageRequestError("PRIVATE_SOURCE", 400, "Private image source is not allowed");
     }
   };
+}
+
+/**
+ * Create a remote image fetcher whose socket lookup rejects private addresses.
+ * Validation and connection share this lookup, closing the DNS-rebinding gap
+ * left by resolving a hostname before a separate global fetch.
+ */
+export function createNodeImageFetcher(
+  config: ResolvedFarmImageConfig,
+  lookup?: NodeImageDnsLookup,
+): typeof globalThis.fetch {
+  if (config.dangerouslyAllowLocalIP) return globalThis.fetch.bind(globalThis);
+
+  return (async (input: RequestInfo | URL, init: RequestInit = {}) => {
+    const inputRequest = input instanceof Request ? input : undefined;
+    const url = input instanceof URL ? input : new URL(inputRequest?.url ?? String(input));
+    if (url.protocol !== "http:" && url.protocol !== "https:") {
+      throw new FarmImageRequestError("DISALLOWED_SOURCE", 400, "Unsupported image protocol");
+    }
+
+    const [{ request }, { Readable }, dns] = await Promise.all([
+      url.protocol === "https:" ? import("node:https") : import("node:http"),
+      import("node:stream"),
+      lookup ? Promise.resolve(null) : import("node:dns"),
+    ]);
+    const resolveHostname = lookup ?? (dns!.lookup as unknown as NodeImageDnsLookup);
+    const headers = new Headers(inputRequest?.headers);
+    new Headers(init.headers).forEach((value, name) => headers.set(name, value));
+    if (!headers.has("accept-encoding")) headers.set("accept-encoding", "identity");
+
+    return new Promise<Response>((resolve, reject) => {
+      const nodeRequest = request(
+        url,
+        {
+          method: init.method ?? inputRequest?.method ?? "GET",
+          headers: Object.fromEntries(headers.entries()),
+          signal: init.signal ?? inputRequest?.signal,
+          lookup(hostname, options, callback) {
+            resolveHostname(hostname, { all: true, verbatim: true }, (error, addresses) => {
+              if (error) {
+                callback(error, "", 4);
+                return;
+              }
+              if (
+                addresses.length === 0 ||
+                addresses.some(({ address }) => isPrivateImageAddress(address))
+              ) {
+                callback(
+                  new FarmImageRequestError(
+                    "PRIVATE_SOURCE",
+                    400,
+                    "Private image source is not allowed",
+                  ),
+                  "",
+                  4,
+                );
+                return;
+              }
+
+              if (options.all) {
+                (
+                  callback as unknown as (
+                    error: null,
+                    addresses: Array<{ address: string; family: number }>,
+                  ) => void
+                )(null, addresses);
+                return;
+              }
+              const address = addresses[0]!;
+              callback(null, address.address, address.family);
+            });
+          },
+        },
+        (nodeResponse) => {
+          const status = nodeResponse.statusCode ?? 500;
+          if (status < 200 || status > 599) {
+            nodeResponse.resume();
+            reject(
+              new FarmImageRequestError(
+                "UNSUPPORTED_IMAGE",
+                502,
+                "Image source returned an invalid HTTP status",
+              ),
+            );
+            return;
+          }
+          const responseHeaders = new Headers();
+          for (let index = 0; index < nodeResponse.rawHeaders.length; index += 2) {
+            responseHeaders.append(
+              nodeResponse.rawHeaders[index]!,
+              nodeResponse.rawHeaders[index + 1]!,
+            );
+          }
+          const body =
+            status === 204 || status === 205 || status === 304
+              ? null
+              : (Readable.toWeb(nodeResponse) as ReadableStream);
+          resolve(
+            new Response(body, {
+              status,
+              statusText: nodeResponse.statusMessage,
+              headers: responseHeaders,
+            }),
+          );
+        },
+      );
+      nodeRequest.once("error", reject);
+      nodeRequest.end();
+    });
+  }) as typeof globalThis.fetch;
 }
 
 function throwIfAborted(signal: AbortSignal): void {

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -4340,7 +4340,7 @@ ${integrationRuntimeImport}
       : `import { createCloudflareImageTransformer, createFarmImageHandler } from "@farm.js/core/image/server";`;
   const imageNodeRuntimeImport =
     imageRuntime === "node"
-      ? `import { createNodeImageUrlValidator, createSharpImageTransformer } from "@farm.js/core/image/sharp";`
+      ? `import { createNodeImageFetcher, createNodeImageUrlValidator, createSharpImageTransformer } from "@farm.js/core/image/sharp";`
       : "";
   const apiHandlerCode =
     apiRoutes.length > 0
@@ -4580,6 +4580,7 @@ const farmImageHandler = ${
 })`
         : `createFarmImageHandler(${JSON.stringify(config.images)}, {
   transform: createSharpImageTransformer(),
+  fetchRemote: createNodeImageFetcher(${JSON.stringify(config.images)}),
   validateRemoteUrl: createNodeImageUrlValidator(${JSON.stringify(config.images)}),
   onError(error) { console.error("[Farm Image]", error); },
 })`

--- a/packages/farm/src/vite.ts
+++ b/packages/farm/src/vite.ts
@@ -787,10 +787,11 @@ export function farmPlugin(
       const serverConfig = resolveFarmServerConfig(farmConfig.server);
       let imageHandler: FarmImageHandler | null = null;
       if (farmConfig.images.provider !== "none") {
-        const { createNodeImageUrlValidator, createSharpImageTransformer } =
+        const { createNodeImageFetcher, createNodeImageUrlValidator, createSharpImageTransformer } =
           await import("./image-sharp");
         imageHandler = createFarmImageHandler(farmConfig.images, {
           transform: createSharpImageTransformer(),
+          fetchRemote: createNodeImageFetcher(farmConfig.images),
           validateRemoteUrl: createNodeImageUrlValidator(farmConfig.images),
           onError(error) {
             logger.error(


### PR DESCRIPTION
## Problem

The image optimizer validated a remote hostname before calling the ordinary fetch implementation. DNS could resolve differently between validation and connection, allowing a permitted hostname to connect to a private address.

## Root cause

Address validation and socket creation performed separate DNS resolution with no binding between the checked addresses and the address used by the connection.

## Change

Add a Node image fetcher that resolves and validates all addresses at connection time, then connects through that same lookup result. Wire it into both Vite development and generated Nitro production handlers while retaining the existing URL allow-list validation.

## Safety and compatibility

The secure fetcher is limited to remote image requests; same-origin/local image handling remains unchanged. HTTPS retains the original hostname for TLS verification and SNI. Private or empty DNS results fail closed before a request is sent.

## Verification

- `pnpm --filter @farm.js/core exec vitest run src/__tests__/image-server.test.ts src/__tests__/image-sharp.test.ts`
- `pnpm --filter @farm.js/core type-check`
- `pnpm --filter @farm.js/core build`
- Focused oxfmt and oxlint checks

The regression uses a real local HTTP server and an injected connection-time lookup. It fails against `main`, which has no checked connection lookup.

## Documentation and release

Updated the image optimization documentation with connection-time DNS validation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Blocks DNS rebinding in remote image fetches by resolving and validating addresses at connection time.

- Adds a Node fetcher that uses the same DNS lookup result for validation and the socket connection.
- Wires it into both Vite development and Nitro production handlers; local and same-origin image handling is unchanged.
- HTTPS retains the original hostname for TLS verification and SNI.
- Private or empty DNS results fail closed before a request is sent; upstream status codes outside 200-599 are rejected with a 502.
- Updates image optimization documentation to describe connection-time DNS validation.

<sup>Written for commit 292e6fc1c2001879fed6e0e010604ed4073a2379. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/744?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

