### PR TITLE
fix(routing): reject non-terminal catch-all routes

### DIFF
--- a/docs/src/app/docs/routing/page.md
+++ b/docs/src/app/docs/routing/page.md
@@ -175,6 +175,10 @@ This returns `/docs/core/routing`. Optional catch-all params can be omitted, sta
 Route matching decodes each URL path segment once before comparing static names or exposing
 `params`. Route names remain literal (including `%`), and malformed percent escapes remain literal
 instead of aborting the request.
+
+A required or optional catch-all must be the final URL segment. Farm reports paths such as
+`docs/[...slug]/edit/page.tsx` during route discovery because the catch-all would otherwise consume
+the `edit` segment and make the route unreachable.
 For navigation state, `router.isActive(pattern, pathname, { exact: false })` also matches
 descendants after dynamic segments, such as `/users/42/settings` for `/users/[id]`.
 

--- a/packages/farm/src/__tests__/api-route-manager.test.ts
+++ b/packages/farm/src/__tests__/api-route-manager.test.ts
@@ -64,6 +64,21 @@ describe("APIRouteManager", () => {
     expect(error.message).toContain("/api/users/[slug]");
   });
 
+  it("fails discovery for a non-terminal API catch-all", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "farm-api-route-"));
+    tempDirs.push(root);
+    const routeDir = path.join(root, "api", "docs", "[...slug]", "edit");
+    fs.mkdirSync(routeDir, { recursive: true });
+    fs.writeFileSync(path.join(routeDir, "route.ts"), "export const GET = () => new Response();\n");
+    const manager = new APIRouteManager(root, {
+      ssrLoadModule: async () => ({ GET: async () => new Response() }),
+    } as any);
+
+    await expect(manager.discoverRoutes()).rejects.toThrow(
+      'Catch-all segment "[...slug]" must be the final segment',
+    );
+  });
+
   it("ignores empty programmatic routes and preserves API-literal syntax", async () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), "farm-api-route-"));
     tempDirs.push(root);

--- a/packages/farm/src/__tests__/router.test.ts
+++ b/packages/farm/src/__tests__/router.test.ts
@@ -35,6 +35,19 @@ describe("createFarmRouter", () => {
     });
   });
 
+  it("rejects non-terminal catch-all patterns", () => {
+    expect(() => createFarmRouter(["/docs/[...slug]/edit"])).toThrow(
+      'Catch-all segment "[...slug]" must be the final segment',
+    );
+    expect(() => matchFarmRoute("/docs/*slug/edit", "/docs/guide/edit")).toThrow(
+      'Catch-all segment "*slug" must be the final segment',
+    );
+    expect(() => buildFarmRoutePath("\\docs\\[...slug]\\edit", { slug: "guide" })).toThrow(
+      'Catch-all segment "[...slug]" must be the final segment',
+    );
+    expect(buildFarmRoutePath("/docs/[...slug]/()", { slug: "guide" })).toBe("/docs/guide");
+  });
+
   it("rejects routes that differ only by parameter names", () => {
     expect(() => createFarmRouter(["/users/[id]", "/users/[slug]"])).toThrow(
       'Ambiguous route patterns "/users/[id]" and "/users/[slug]" match the same URLs.',

--- a/packages/farm/src/__tests__/utils.test.ts
+++ b/packages/farm/src/__tests__/utils.test.ts
@@ -113,6 +113,15 @@ describe("parseRoutePath", () => {
     ]);
   });
 
+  it("rejects a catch-all directory before another route segment", () => {
+    expect(() => parseRoutePath("docs/[...slug]/edit/page.tsx")).toThrow(
+      'Catch-all segment "[...slug]" must be the final segment',
+    );
+    expect(() => parseRoutePath("docs/[[...slug]]/edit/page.tsx")).toThrow(
+      'Catch-all segment "[[...slug]]" must be the final segment',
+    );
+  });
+
   it("should parse root page", () => {
     const result = parseRoutePath("page.tsx");
     expect(result.segments).toEqual([]);

--- a/packages/farm/src/api/route-manager.ts
+++ b/packages/farm/src/api/route-manager.ts
@@ -20,7 +20,11 @@ import {
   type APIRouteMatch,
 } from "./runtime";
 import { isFarmAPIRouteFileName } from "./route-files";
-import { AmbiguousRouteError, getRoutePatternShape } from "../routing/specificity";
+import {
+  AmbiguousRouteError,
+  getRoutePatternShape,
+  NonTerminalCatchAllRouteError,
+} from "../routing/specificity";
 
 export interface APIRoute extends FarmRouteRuntimeConfig {
   path: string;
@@ -274,7 +278,8 @@ export class APIRouteManager {
     if (
       this.throwOnLoadError ||
       error instanceof APIRouteConflictError ||
-      error instanceof AmbiguousRouteError
+      error instanceof AmbiguousRouteError ||
+      error instanceof NonTerminalCatchAllRouteError
     ) {
       throw error;
     }

--- a/packages/farm/src/manifest/generator.ts
+++ b/packages/farm/src/manifest/generator.ts
@@ -14,6 +14,7 @@ import type {
 import { getClientModuleMetadata } from "../utils/client-component";
 import { toRootRelativeUrlPath } from "../utils";
 import { createFarmRouteRenderPlan } from "../navigation/render-plan";
+import { assertTerminalCatchAll } from "../routing/specificity";
 
 function layoutAppliesToRoute(layoutPattern: string, routePattern: string): boolean {
   if (layoutPattern === "/") return true;
@@ -97,6 +98,7 @@ function parseRoutePath(filePath: string): {
       })
       .join("/");
 
+  assertTerminalCatchAll(pattern || "/");
   return { segments, pattern: pattern || "/" };
 }
 

--- a/packages/farm/src/router.ts
+++ b/packages/farm/src/router.ts
@@ -1,5 +1,6 @@
 import {
   AmbiguousRouteError,
+  assertTerminalCatchAll,
   compareRouteSpecificity,
   getRoutePatternShape,
   type RouteSegmentSpecificity,
@@ -194,6 +195,7 @@ function normalizeRouteInput<TMeta>(
 }
 
 function parseRoutePattern(pattern: string): RouterSegment[] {
+  assertTerminalCatchAll(pattern, "router");
   return splitPathname(pattern)
     .filter((part) => !isRouteGroup(part))
     .map((part) => {

--- a/packages/farm/src/routing/specificity.ts
+++ b/packages/farm/src/routing/specificity.ts
@@ -7,6 +7,13 @@ export class AmbiguousRouteError extends Error {
   }
 }
 
+export class NonTerminalCatchAllRouteError extends TypeError {
+  constructor(message: string) {
+    super(message);
+    this.name = "NonTerminalCatchAllRouteError";
+  }
+}
+
 const SEGMENT_RANK: Record<RouteSegmentSpecificity, number> = {
   static: 4,
   dynamic: 3,
@@ -38,40 +45,63 @@ export type RoutePatternSyntax = "page" | "router" | "api";
 
 const ROUTER_PARAMETER_NAME = "[A-Za-z0-9_$-]+";
 
-/** Return the URL-matching shape of a route without its parameter names. */
-export function getRoutePatternShape(pattern: string, syntax: RoutePatternSyntax = "page"): string {
-  const segments = pattern
+function splitRoutePattern(pattern: string, syntax: RoutePatternSyntax): string[] {
+  return pattern
+    .replace(/\\/g, "/")
     .split("/")
     .filter(Boolean)
-    .filter((segment) => syntax === "api" || !/^\([^/]+\)$/.test(segment))
-    .map((segment) => {
-      const parameterName = syntax === "router" ? ROUTER_PARAMETER_NAME : ".+";
-      const supportsColonAndStar = syntax === "router";
-      if (
-        new RegExp(`^\\[\\[\\.\\.\\.${parameterName}\\]\\]$`).test(segment) ||
-        (supportsColonAndStar && new RegExp(`^\\*${parameterName}\\?$`).test(segment))
-      ) {
-        return "optional-catch-all";
-      }
-      if (
-        new RegExp(`^\\[\\.\\.\\.${parameterName}\\]$`).test(segment) ||
-        (supportsColonAndStar && new RegExp(`^\\*${parameterName}$`).test(segment))
-      ) {
-        return "catch-all";
-      }
-      if (
-        new RegExp(`^\\[${parameterName}\\]$`).test(segment) ||
-        (supportsColonAndStar && new RegExp(`^:${parameterName}$`).test(segment))
-      ) {
-        return "dynamic";
-      }
+    .filter((segment) =>
+      syntax === "api" ? true : !(segment.startsWith("(") && segment.endsWith(")")),
+    );
+}
 
-      try {
-        return `static:${decodeURIComponent(segment)}`;
-      } catch {
-        return `static:${segment}`;
-      }
-    });
+export function assertTerminalCatchAll(pattern: string, syntax: RoutePatternSyntax = "page"): void {
+  const segments = splitRoutePattern(pattern, syntax);
+  const parameterName = syntax === "router" ? ROUTER_PARAMETER_NAME : ".+";
+  const catchAllPattern = new RegExp(
+    syntax === "router"
+      ? `^(?:\\[\\[\\.\\.\\.${parameterName}\\]\\]|\\[\\.\\.\\.${parameterName}\\]|\\*${parameterName}\\??)$`
+      : `^(?:\\[\\[\\.\\.\\.${parameterName}\\]\\]|\\[\\.\\.\\.${parameterName}\\])$`,
+  );
+  const catchAllIndex = segments.findIndex((segment) => catchAllPattern.test(segment));
+  if (catchAllIndex >= 0 && catchAllIndex !== segments.length - 1) {
+    throw new NonTerminalCatchAllRouteError(
+      `Catch-all segment "${segments[catchAllIndex]}" must be the final segment in route "${pattern}".`,
+    );
+  }
+}
+
+/** Return the URL-matching shape of a route without its parameter names. */
+export function getRoutePatternShape(pattern: string, syntax: RoutePatternSyntax = "page"): string {
+  assertTerminalCatchAll(pattern, syntax);
+  const segments = splitRoutePattern(pattern, syntax).map((segment) => {
+    const parameterName = syntax === "router" ? ROUTER_PARAMETER_NAME : ".+";
+    const supportsColonAndStar = syntax === "router";
+    if (
+      new RegExp(`^\\[\\[\\.\\.\\.${parameterName}\\]\\]$`).test(segment) ||
+      (supportsColonAndStar && new RegExp(`^\\*${parameterName}\\?$`).test(segment))
+    ) {
+      return "optional-catch-all";
+    }
+    if (
+      new RegExp(`^\\[\\.\\.\\.${parameterName}\\]$`).test(segment) ||
+      (supportsColonAndStar && new RegExp(`^\\*${parameterName}$`).test(segment))
+    ) {
+      return "catch-all";
+    }
+    if (
+      new RegExp(`^\\[${parameterName}\\]$`).test(segment) ||
+      (supportsColonAndStar && new RegExp(`^:${parameterName}$`).test(segment))
+    ) {
+      return "dynamic";
+    }
+
+    try {
+      return `static:${decodeURIComponent(segment)}`;
+    } catch {
+      return `static:${segment}`;
+    }
+  });
 
   return segments.length === 0 ? "/" : JSON.stringify(segments);
 }

--- a/packages/farm/src/utils.ts
+++ b/packages/farm/src/utils.ts
@@ -1,5 +1,6 @@
 import type { RouteSegment, ParsedRoute } from "./types";
 import path from "path";
+import { assertTerminalCatchAll } from "./routing/specificity";
 import { decodeRouteSegment } from "./utils/decode";
 
 export function parseRoutePath(filePath: string): ParsedRoute {
@@ -9,6 +10,7 @@ export function parseRoutePath(filePath: string): ParsedRoute {
 
   const fileName = pathParts.pop() || "";
   const fileType = getRouteType(fileName);
+  assertTerminalCatchAll(`/${pathParts.join("/")}`);
 
   for (const part of pathParts) {
     // Route groups like `(marketing)` organize files without adding URL


### PR DESCRIPTION
## Problem

Farm accepted catch-all parameters followed by more route segments, even though a catch-all consumes the remainder of the pathname. These routes are ambiguous and can never expose a predictable parameter contract.

## Root cause

Route parsing classified catch-all segments but did not require them to be terminal.

## Change

Add one shared terminal catch-all assertion and apply it to file routes, API routes, programmatic router patterns, and generated SPA manifest parsing.

## Safety and compatibility

Valid terminal catch-all routes are unchanged. Invalid routes now fail early with a clear message instead of producing unreachable or ambiguous matches. The validation is renderer-neutral.

## Verification

- `pnpm --filter @farm.js/core exec vitest run src/__tests__/utils.test.ts src/__tests__/router.test.ts src/__tests__/api-route-manager.test.ts`
- `pnpm --filter @farm.js/core type-check`
- Focused oxfmt and oxlint checks

The new file and programmatic-route cases fail against `main`, which accepts non-terminal catch-alls.

## Documentation and release

Updated the routing documentation to require catch-all parameters to be the final segment.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects non-terminal catch-all routes so catch-all parameters can only be the final segment. Farm previously accepted routes like `/docs/[...slug]/edit`, which are unreachable because the catch-all consumes the rest of the pathname; these now fail early with a clear error instead of producing ambiguous matches. Valid terminal catch-all routes are unchanged.

- Applies the check to file routes, API routes, programmatic router patterns, and generated SPA manifest parsing.
- Updates routing docs to require catch-alls to be the final segment.
- Throws a dedicated `NonTerminalCatchAllRouteError` from route discovery and router pattern parsing.

<sup>Written for commit c4fb28e691188a45e4b64d48e640ec83bf0c6731. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/745?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

