### PR TITLE
fix(workflows): align request body parsing across runtimes

### DIFF
--- a/docs/src/app/docs/cron/page.md
+++ b/docs/src/app/docs/cron/page.md
@@ -227,4 +227,8 @@ Farm's local `--cron` runner prevents overlap inside one development process. Th
 | Run short best-effort work after an HTTP response                                | [`after()`](/docs/after)                    |
 | Durable retries, long-running steps, queues, status, cancellation, or dashboards | [Jobs Integration](/docs/integrations/jobs) |
 
-The older `defineCron()` workflow-module API remains available for compatibility. New applications should use `cron` config plus an ordinary API route so local, deployment, security, and testing behavior share one model.
+The older `defineCron()` workflow-module API remains available for compatibility. Its HTTP trigger
+parses `application/json` and `application/*+json` bodies as JSON, wraps other non-empty bodies as
+`{ text }`, and rejects malformed JSON consistently in development and production. New applications
+should use `cron` config plus an ordinary API route so local, deployment, security, and testing
+behavior share one model.

--- a/packages/farm/src/__tests__/workflows.test.ts
+++ b/packages/farm/src/__tests__/workflows.test.ts
@@ -121,6 +121,66 @@ describe("Farm workflows", () => {
     expect(run).toHaveBeenCalledOnce();
   });
 
+  it("parses workflow bodies consistently by content type", async () => {
+    const workflow = {
+      id: "sync-users",
+      filePath: "/virtual/sync-users.ts",
+      routePath: "/api/_farm/workflows/sync-users",
+    };
+    const run = vi.fn(async (ctx) => ctx.payload);
+    const handler = createFarmWorkflowRequestHandler({
+      workflows: [workflow],
+      config: resolveWorkflowsConfig(undefined),
+      loadModule: async () => ({ default: { run } }),
+    });
+    const url = "https://example.com/api/_farm/workflows/sync-users";
+
+    const textResponse = await handler(
+      new Request(url, {
+        method: "POST",
+        headers: { "content-type": "text/plain" },
+        body: "refresh catalog",
+      }),
+    );
+    expect(textResponse?.status).toBe(200);
+    await expect(textResponse?.json()).resolves.toMatchObject({
+      result: { text: "refresh catalog" },
+    });
+
+    const vendorJsonResponse = await handler(
+      new Request(url, {
+        method: "POST",
+        headers: { "content-type": "application/farm+json; charset=utf-8" },
+        body: JSON.stringify({ cursor: "next" }),
+      }),
+    );
+    expect(vendorJsonResponse?.status).toBe(200);
+    await expect(vendorJsonResponse?.json()).resolves.toMatchObject({
+      result: { cursor: "next" },
+    });
+
+    const nonApplicationJsonResponse = await handler(
+      new Request(url, {
+        method: "POST",
+        headers: { "content-type": "text/event+json" },
+        body: JSON.stringify({ cursor: "text" }),
+      }),
+    );
+    await expect(nonApplicationJsonResponse?.json()).resolves.toMatchObject({
+      result: { text: '{"cursor":"text"}' },
+    });
+
+    const malformedResponse = await handler(
+      new Request(url, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: "{broken",
+      }),
+    );
+    expect(malformedResponse?.status).toBe(400);
+    expect(run).toHaveBeenCalledTimes(3);
+  });
+
   it("protects workflow metadata and supports GET scheduler payloads", async () => {
     const workflow = {
       id: "sync-users",
@@ -239,7 +299,72 @@ describe("Farm workflows", () => {
     expect(handlerSource).toContain("authorization.match(/^Bearer");
     expect(handlerSource).not.toContain('searchParams.get("secret")');
     expect(handlerSource).toContain("function decodeRouteSegment(segment)");
+    expect(handlerSource).toContain('contentType.startsWith("application/")');
+    expect(handlerSource).toContain('contentType.endsWith("+json")');
+    expect(handlerSource).toContain("return { text }");
     expect(handlerSource).not.toContain("decodeURIComponent(event.context.params");
+
+    const readPayloadStart = handlerSource.indexOf("async function readPayload(event)");
+    const readPayloadEnd = handlerSource.indexOf("\n\nexport default", readPayloadStart);
+    expect(readPayloadStart).toBeGreaterThan(-1);
+    expect(readPayloadEnd).toBeGreaterThan(readPayloadStart);
+    const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor;
+    const generatedReadPayload = (await AsyncFunction(
+      "readFarmRequestBody",
+      "getHeader",
+      "bodySizeLimit",
+      "searchParamsToObject",
+      `${handlerSource.slice(readPayloadStart, readPayloadEnd)}; return readPayload;`,
+    )(
+      async (request: Request) => new Uint8Array(await request.arrayBuffer()),
+      (event: { req: Request }, name: string) => event.req.headers.get(name),
+      1234,
+      (searchParams: URLSearchParams) => Object.fromEntries(searchParams),
+    )) as (event: { req: Request; url: URL }) => Promise<unknown>;
+    const generatedTextEvent = {
+      req: new Request("https://example.com/api/_farm/workflows/sync", {
+        method: "POST",
+        headers: { "content-type": "text/event+json" },
+        body: '{"cursor":"text"}',
+      }),
+      url: new URL("https://example.com/api/_farm/workflows/sync"),
+    };
+    await expect(generatedReadPayload(generatedTextEvent)).resolves.toEqual({
+      text: '{"cursor":"text"}',
+    });
+
+    const branchStart = handlerSource.indexOf("    let payload;", readPayloadEnd);
+    const branchEnd = handlerSource.indexOf("    const result = await runTask", branchStart);
+    expect(branchStart).toBeGreaterThan(readPayloadEnd);
+    expect(branchEnd).toBeGreaterThan(branchStart);
+    const executeGeneratedPayloadBranch = AsyncFunction(
+      "event",
+      "readPayload",
+      "createFarmRequestBodyErrorResponse",
+      "json",
+      `${handlerSource.slice(branchStart, branchEnd)}; return payload;`,
+    ) as (
+      event: { req: Request; url: URL },
+      readPayload: typeof generatedReadPayload,
+      createErrorResponse: (error: unknown) => Response | null,
+      json: (value: unknown, status?: number) => Response,
+    ) => Promise<unknown>;
+    const malformedEvent = {
+      req: new Request("https://example.com/api/_farm/workflows/sync", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: "{broken",
+      }),
+      url: new URL("https://example.com/api/_farm/workflows/sync"),
+    };
+    const malformedResponse = await executeGeneratedPayloadBranch(
+      malformedEvent,
+      generatedReadPayload,
+      () => null,
+      (value, status = 200) => Response.json(value, { status }),
+    );
+    expect(malformedResponse).toBeInstanceOf(Response);
+    expect((malformedResponse as Response).status).toBe(400);
   });
 
   it("emits only internal imports the production runtime actually exports", async () => {

--- a/packages/farm/src/workflows.ts
+++ b/packages/farm/src/workflows.ts
@@ -232,6 +232,9 @@ export function createFarmWorkflowRequestHandler(options: FarmWorkflowHTTPHandle
     } catch (error) {
       const response = createFarmRequestBodyErrorResponse(error);
       if (response) return response;
+      if (error instanceof SyntaxError) {
+        return Response.json({ error: "Invalid workflow request body." }, { status: 400 });
+      }
       throw error;
     }
     const module = await options.loadModule(workflow);
@@ -645,7 +648,14 @@ async function readPayload(event) {
   const bytes = await readFarmRequestBody(event.req, bodySizeLimit);
   const text = new TextDecoder().decode(bytes);
   if (!text) return {};
-  return JSON.parse(text);
+  const contentType = (getHeader(event, "content-type") || "").split(";", 1)[0].trim().toLowerCase();
+  if (
+    contentType === "application/json" ||
+    (contentType.startsWith("application/") && contentType.endsWith("+json"))
+  ) {
+    return JSON.parse(text);
+  }
+  return { text };
 }
 
 export default new H3()
@@ -710,16 +720,18 @@ async function readWorkflowPayload(request: Request, bodySizeLimit: number): Pro
   const bytes = await readFarmRequestBody(request, bodySizeLimit);
   const text = new TextDecoder().decode(bytes);
   if (!text) return {};
-  const contentType = request.headers.get("content-type") || "";
-  if (contentType.includes("application/json")) {
-    try {
-      return JSON.parse(text);
-    } catch {
-      return {};
-    }
+  const contentType = (request.headers.get("content-type") || "")
+    .split(";", 1)[0]
+    .trim()
+    .toLowerCase();
+  if (
+    contentType === "application/json" ||
+    (contentType.startsWith("application/") && contentType.endsWith("+json"))
+  ) {
+    return JSON.parse(text);
   }
 
-  return text ? { text } : {};
+  return { text };
 }
 
 function readScheduledTime(payload: unknown): number | string | undefined {


### PR DESCRIPTION
## Problem

Workflow endpoints parsed request bodies differently in Vite development and generated production output. Text payloads, vendor JSON media types, and malformed JSON could reach jobs with different values or status codes.

## Root cause

The two runtime implementations used different content-type checks and different malformed-JSON fallbacks.

## Change

Use the same contract in both paths: parse `application/json` and `application/*+json` as JSON, wrap other bodies as `{ text }`, treat empty bodies as `{}`, and return 400 for malformed JSON before executing a job.

## Safety and compatibility

The behavior remains web-platform based and preserves non-JSON content. No workflow job runs after an invalid JSON request.

## Verification

- `pnpm --filter @farm.js/core exec vitest run src/__tests__/workflow.test.ts`
- `pnpm --filter @farm.js/core type-check`
- Focused oxfmt and oxlint checks

The regressions fail against `main`, where malformed JSON can become an empty object and development/production parsing diverges.

## Documentation and release

Updated the workflow request-body behavior in the cron/workflow documentation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes workflow endpoints parse request bodies identically in Vite development and generated production output. Previously, text payloads, vendor JSON media types, and malformed JSON could reach a job with different values or status codes depending on the runtime.

**Behavior**
- Parse `application/json` and `application/*+json` bodies as JSON, wrap other bodies as `{ text }`, and treat empty bodies as `{}`.
- Malformed JSON now returns a 400 response before the job executes.
- No workflow job runs after an invalid JSON request.

<sup>Written for commit 173a08dd62dcf9465fd665cfbcfb03e13aeb9f88. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/746?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

