### PR TITLE
fix(routing): reject duplicate parameter names

### DIFF
--- a/docs/src/app/docs/routing/page.md
+++ b/docs/src/app/docs/routing/page.md
@@ -180,6 +180,9 @@ instead of aborting the request.
 A required or optional catch-all must be the final URL segment. Farm reports paths such as
 `docs/[...slug]/edit/page.tsx` during route discovery because the catch-all would otherwise consume
 the `edit` segment and make the route unreachable.
+
+Each dynamic segment in one route must have a unique parameter name. Farm rejects paths such as
+`teams/[id]/members/[id]/page.tsx` instead of silently replacing the outer `id` value.
 For navigation state, `router.isActive(pattern, pathname, { exact: false })` also matches
 descendants after dynamic segments, such as `/users/42/settings` for `/users/[id]`.
 

--- a/packages/farm/src/__tests__/api-route-manager.test.ts
+++ b/packages/farm/src/__tests__/api-route-manager.test.ts
@@ -79,6 +79,19 @@ describe("APIRouteManager", () => {
     );
   });
 
+  it("fails discovery for duplicate API parameter names", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "farm-api-route-"));
+    tempDirs.push(root);
+    const routeDir = path.join(root, "api", "teams", "[id]", "members", "[id]");
+    fs.mkdirSync(routeDir, { recursive: true });
+    fs.writeFileSync(path.join(routeDir, "route.ts"), "export const GET = () => new Response();\n");
+    const manager = new APIRouteManager(root, {
+      ssrLoadModule: async () => ({ GET: async () => new Response() }),
+    } as any);
+
+    await expect(manager.discoverRoutes()).rejects.toThrow('Duplicate route parameter "id"');
+  });
+
   it("ignores empty programmatic routes and preserves API-literal syntax", async () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), "farm-api-route-"));
     tempDirs.push(root);

--- a/packages/farm/src/__tests__/programmatic-routes.test.ts
+++ b/packages/farm/src/__tests__/programmatic-routes.test.ts
@@ -18,6 +18,7 @@ import {
   type InferProgrammaticRouteData,
   type ProgrammaticPageRoute,
 } from "../routes";
+import { parseProgrammaticRoutePath } from "../routes-shared";
 import { RouteManager } from "../routing/route-manager";
 import { createServerFn } from "../server-fn";
 import type { FarmConfig } from "../types";
@@ -54,6 +55,13 @@ function createConfig(root: string): Required<FarmConfig> {
 }
 
 describe("programmatic routes", () => {
+  it("validates parameters with the programmatic bracket syntax", () => {
+    expect(() => parseProgrammaticRoutePath("/teams/[user.id]/members/[user.id]")).toThrow(
+      'Duplicate route parameter "user.id"',
+    );
+    expect(() => parseProgrammaticRoutePath("/literal/:id/:id/*id/*id")).not.toThrow();
+  });
+
   it("owns typed named actions and resolves a default action", async () => {
     const update = createServerFn({
       input: z.object({ id: z.string(), name: z.string() }),
@@ -250,6 +258,42 @@ describe("programmatic routes", () => {
       "/blog/farm-router",
       "/blog/hello-world",
     ]);
+  });
+
+  it("rejects duplicate params in programmatic page routes", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "farm-programmatic-routes-"));
+    tempDirs.push(root);
+    const routesFile = path.join(root, "src", "farm.routes.js");
+    fs.mkdirSync(path.dirname(routesFile), { recursive: true });
+    fs.writeFileSync(routesFile, "export {};\n");
+    const manifest = defineRoutes(({ page }) => [
+      page("/teams/[user.id]/members/[user.id]", { component: () => null }),
+    ]);
+    const manager = new RouteManager(createConfig(root), {
+      config: { root },
+      ssrLoadModule: async () => ({ default: manifest }),
+    } as any);
+    manager.setRendererRuntime(createTestRendererRuntime() as any);
+
+    await expect(manager.discoverRoutes()).rejects.toThrow('Duplicate route parameter "user.id"');
+  });
+
+  it("rejects duplicate params in programmatic layout routes", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "farm-programmatic-routes-"));
+    tempDirs.push(root);
+    const routesFile = path.join(root, "src", "farm.routes.js");
+    fs.mkdirSync(path.dirname(routesFile), { recursive: true });
+    fs.writeFileSync(routesFile, "export {};\n");
+    const manifest = defineRoutes(({ layout }) => [
+      layout("/teams/[id]/members/[id]", { component: ({ children }) => children }),
+    ]);
+    const manager = new RouteManager(createConfig(root), {
+      config: { root },
+      ssrLoadModule: async () => ({ default: manifest }),
+    } as any);
+    manager.setRendererRuntime(createTestRendererRuntime() as any);
+
+    await expect(manager.discoverRoutes()).rejects.toThrow('Duplicate route parameter "id"');
   });
 
   it("rejects duplicate page routes across file and programmatic definitions", async () => {

--- a/packages/farm/src/__tests__/router.test.ts
+++ b/packages/farm/src/__tests__/router.test.ts
@@ -48,6 +48,15 @@ describe("createFarmRouter", () => {
     expect(buildFarmRoutePath("/docs/[...slug]/()", { slug: "guide" })).toBe("/docs/guide");
   });
 
+  it("rejects duplicate parameter names within a route", () => {
+    expect(() => createFarmRouter(["/teams/[id]/members/[id]"])).toThrow(
+      'Duplicate route parameter "id"',
+    );
+    expect(() => matchFarmRoute("/docs/:slug/*slug", "/docs/core/routing")).toThrow(
+      'Duplicate route parameter "slug"',
+    );
+  });
+
   it("rejects routes that differ only by parameter names", () => {
     expect(() => createFarmRouter(["/users/[id]", "/users/[slug]"])).toThrow(
       'Ambiguous route patterns "/users/[id]" and "/users/[slug]" match the same URLs.',

--- a/packages/farm/src/__tests__/utils.test.ts
+++ b/packages/farm/src/__tests__/utils.test.ts
@@ -122,6 +122,20 @@ describe("parseRoutePath", () => {
     );
   });
 
+  it("rejects duplicate parameter names in one file route", () => {
+    expect(() => parseRoutePath("teams/[id]/members/[id]/page.tsx")).toThrow(
+      'Duplicate route parameter "id"',
+    );
+    expect(() => parseRoutePath("docs/[section]/[...section]/page.tsx")).toThrow(
+      'Duplicate route parameter "section"',
+    );
+    for (const fileName of ["layout.tsx", "loading.tsx", "error.tsx"]) {
+      expect(() => parseRoutePath(`teams/[id]/members/[id]/${fileName}`)).toThrow(
+        'Duplicate route parameter "id"',
+      );
+    }
+  });
+
   it("should parse root page", () => {
     const result = parseRoutePath("page.tsx");
     expect(result.segments).toEqual([]);

--- a/packages/farm/src/api/route-manager.ts
+++ b/packages/farm/src/api/route-manager.ts
@@ -22,6 +22,7 @@ import {
 import { isFarmAPIRouteFileName } from "./route-files";
 import {
   AmbiguousRouteError,
+  assertUniqueRouteParameters,
   getRoutePatternShape,
   NonTerminalCatchAllRouteError,
 } from "../routing/specificity";
@@ -374,6 +375,7 @@ export class APIRouteManager {
   }
 
   private registerRouteShape(routePath: string, filePath: string, appDir: string): void {
+    assertUniqueRouteParameters(routePath, "api");
     const shape = getRoutePatternShape(routePath, "api");
     const existing = this.routeShapes.get(shape);
 

--- a/packages/farm/src/api/vite-plugin.ts
+++ b/packages/farm/src/api/vite-plugin.ts
@@ -36,7 +36,11 @@ import {
   resolveFarmServerConfig,
 } from "../server-http";
 import { createCliColors } from "../cli-colors";
-import { AmbiguousRouteError, getRoutePatternShape } from "../routing/specificity";
+import {
+  AmbiguousRouteError,
+  assertUniqueRouteParameters,
+  getRoutePatternShape,
+} from "../routing/specificity";
 
 export interface FarmApiPluginOptions {
   /** Source directory containing the api folder (default: 'src') */
@@ -98,6 +102,7 @@ export function farmApiPlugin(options: FarmApiPluginOptions = {}): Plugin {
   };
 
   const registerRouteShape = (routePath: string, filePath: string): void => {
+    assertUniqueRouteParameters(routePath, "api");
     const shape = getRoutePatternShape(routePath, "api");
     const existing = routeShapes.get(shape);
     if (existing && existing.routePath !== routePath) {

--- a/packages/farm/src/manifest/generator.ts
+++ b/packages/farm/src/manifest/generator.ts
@@ -14,7 +14,7 @@ import type {
 import { getClientModuleMetadata } from "../utils/client-component";
 import { toRootRelativeUrlPath } from "../utils";
 import { createFarmRouteRenderPlan } from "../navigation/render-plan";
-import { assertTerminalCatchAll } from "../routing/specificity";
+import { assertTerminalCatchAll, assertUniqueRouteParameters } from "../routing/specificity";
 
 function layoutAppliesToRoute(layoutPattern: string, routePattern: string): boolean {
   if (layoutPattern === "/") return true;
@@ -99,6 +99,7 @@ function parseRoutePath(filePath: string): {
       .join("/");
 
   assertTerminalCatchAll(pattern || "/");
+  assertUniqueRouteParameters(pattern || "/");
   return { segments, pattern: pattern || "/" };
 }
 

--- a/packages/farm/src/router.ts
+++ b/packages/farm/src/router.ts
@@ -1,6 +1,7 @@
 import {
   AmbiguousRouteError,
   assertTerminalCatchAll,
+  assertUniqueRouteParameters,
   compareRouteSpecificity,
   getRoutePatternShape,
   type RouteSegmentSpecificity,
@@ -196,6 +197,7 @@ function normalizeRouteInput<TMeta>(
 
 function parseRoutePattern(pattern: string): RouterSegment[] {
   assertTerminalCatchAll(pattern, "router");
+  assertUniqueRouteParameters(pattern, "router");
   return splitPathname(pattern)
     .filter((part) => !isRouteGroup(part))
     .map((part) => {

--- a/packages/farm/src/routes-shared.ts
+++ b/packages/farm/src/routes-shared.ts
@@ -1,4 +1,5 @@
 import type { ParsedRoute } from "./types";
+import { assertUniqueRouteParameters } from "./routing/specificity";
 
 export const PROGRAMMATIC_ROUTE_FILE_NAMES = [
   "farm.route.ts",
@@ -88,6 +89,7 @@ export function parseProgrammaticRoutePath(
 ): ParsedRoute {
   const fileName = type === "layout" ? "layout.tsx" : "page.tsx";
   const normalized = normalizeProgrammaticRoutePath(routePath);
+  assertUniqueRouteParameters(normalized);
   const filePath =
     normalized === "/" ? fileName : `${normalized.slice(1).replace(/\/+$/, "")}/${fileName}`;
 

--- a/packages/farm/src/routing/route-manager.ts
+++ b/packages/farm/src/routing/route-manager.ts
@@ -71,6 +71,7 @@ import { getFarmRendererComponentExtensions } from "../renderer";
 import type { ApplicationMetadataRouteKind } from "../metadata-route";
 import {
   AmbiguousRouteError,
+  assertUniqueRouteParameters,
   compareRouteSpecificity,
   getRoutePatternShape,
   type RouteSegmentSpecificity,
@@ -815,6 +816,7 @@ export class RouteManager {
   }
 
   private registerPageRoute(entry: RouteEntry): void {
+    assertUniqueRouteParameters(entry.pattern);
     const shape = getRoutePatternShape(entry.pattern);
     const existing = this.pageRouteShapes.get(shape);
 

--- a/packages/farm/src/routing/specificity.ts
+++ b/packages/farm/src/routing/specificity.ts
@@ -14,6 +14,13 @@ export class NonTerminalCatchAllRouteError extends TypeError {
   }
 }
 
+export class DuplicateRouteParameterError extends AmbiguousRouteError {
+  constructor(message: string) {
+    super(message);
+    this.name = "DuplicateRouteParameterError";
+  }
+}
+
 const SEGMENT_RANK: Record<RouteSegmentSpecificity, number> = {
   static: 4,
   dynamic: 3,
@@ -44,6 +51,29 @@ export function compareRouteSpecificity(
 export type RoutePatternSyntax = "page" | "router" | "api";
 
 const ROUTER_PARAMETER_NAME = "[A-Za-z0-9_$-]+";
+const PAGE_PARAMETER_PATTERN = /^(?:\[\[\.\.\.(.+)\]\]|\[\.\.\.(.+)\]|\[(.+)\])$/;
+const ROUTER_PARAMETER_PATTERN =
+  /^(?:\[\[\.\.\.([A-Za-z0-9_$-]+)\]\]|\[\.\.\.([A-Za-z0-9_$-]+)\]|\[([A-Za-z0-9_$-]+)\]|:([A-Za-z0-9_$-]+)|\*([A-Za-z0-9_$-]+)\??)$/;
+
+export function assertUniqueRouteParameters(
+  pattern: string,
+  syntax: RoutePatternSyntax = "page",
+): void {
+  const parameterPattern = syntax === "router" ? ROUTER_PARAMETER_PATTERN : PAGE_PARAMETER_PATTERN;
+  const names = new Set<string>();
+
+  for (const segment of splitRoutePattern(pattern, syntax)) {
+    const match = parameterPattern.exec(segment);
+    const name = match?.slice(1).find(Boolean);
+    if (!name) continue;
+    if (names.has(name)) {
+      throw new DuplicateRouteParameterError(
+        `Duplicate route parameter "${name}" in route "${pattern}". Each dynamic segment must use a unique name.`,
+      );
+    }
+    names.add(name);
+  }
+}
 
 function splitRoutePattern(pattern: string, syntax: RoutePatternSyntax): string[] {
   return pattern

--- a/packages/farm/src/utils.ts
+++ b/packages/farm/src/utils.ts
@@ -1,6 +1,6 @@
 import type { RouteSegment, ParsedRoute } from "./types";
 import path from "path";
-import { assertTerminalCatchAll } from "./routing/specificity";
+import { assertTerminalCatchAll, assertUniqueRouteParameters } from "./routing/specificity";
 import { decodeRouteSegment } from "./utils/decode";
 
 export function parseRoutePath(filePath: string): ParsedRoute {
@@ -11,6 +11,7 @@ export function parseRoutePath(filePath: string): ParsedRoute {
   const fileName = pathParts.pop() || "";
   const fileType = getRouteType(fileName);
   assertTerminalCatchAll(`/${pathParts.join("/")}`);
+  assertUniqueRouteParameters(`/${pathParts.join("/")}`);
 
   for (const part of pathParts) {
     // Route groups like `(marketing)` organize files without adding URL


### PR DESCRIPTION
## Problem

A route could declare the same parameter name more than once. Later captures overwrite earlier values, so the runtime params object cannot represent the route declaration faithfully.

## Root cause

Route validation checked segment shapes and specificity but not parameter-name uniqueness.

## Change

Add shared duplicate-parameter validation across file routes, API routes, programmatic bracket/colon/star patterns, and generated SPA manifest parsing.

## Safety and compatibility

Routes with unique parameter names are unchanged. Invalid duplicate declarations now fail at route construction with a direct error rather than silently losing a value. The validation is renderer-neutral.

## Verification

- `pnpm --filter @farm.js/core exec vitest run src/__tests__/utils.test.ts src/__tests__/router.test.ts src/__tests__/api-route-manager.test.ts src/__tests__/api-vite-plugin-hmr.test.ts src/__tests__/programmatic-routes.test.ts`
- `pnpm --filter @farm.js/core type-check`
- Focused oxfmt and oxlint checks

The duplicate dynamic and catch-all regressions fail against `main`, which accepts them.

## Documentation and release

Updated the routing documentation to require unique parameter names within a route.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects duplicate parameter names in routes so the runtime params object always matches the route declaration. Previously later captures overwrote earlier values; now invalid duplicates fail at construction with a clear error, while unique parameter routes behave unchanged.

**Details**
- Validation covers file routes, API routes, programmatic bracket/colon/star patterns, and SPA manifest parsing.
- Routing documentation now requires unique parameter names per route.

<sup>Written for commit 2626bfdf142c823bde0fb68072ac17d880c3542a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/747?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

