### PR TITLE
fix(cache): isolate fills across reconfiguration

### DIFF
--- a/docs/src/app/docs/cache-ppr/page.md
+++ b/docs/src/app/docs/cache-ppr/page.md
@@ -35,6 +35,10 @@ export default defineConfig({
 The adapter is selected once. Routes, queries, endpoints, server functions, ISR, and PPR continue
 using Farm cache keys and invalidation helpers; application handlers do not import a Redis client.
 
+If framework configuration is reloaded or a test calls `configureFarmCache()` again, Farm starts a
+new cache generation. A fill that began under the previous adapter or namespace can still return to
+its original caller, but it cannot populate the newly configured cache.
+
 When a shared adapter is present, Farm uses it as the authoritative cache instead of adding an
 incoherent process-local front cache.
 

--- a/packages/farm/src/__tests__/cache.test.ts
+++ b/packages/farm/src/__tests__/cache.test.ts
@@ -388,6 +388,116 @@ describe("server cache primitives", () => {
     expect(cache.get("products")).toEqual({ calls: 2 });
   });
 
+  it("does not write an in-flight fill into a reconfigured adapter or namespace", async () => {
+    const firstAdapter = new TestSharedCacheAdapter();
+    const secondAdapter = new TestSharedCacheAdapter();
+    const releaseLease = vi.spyOn(firstAdapter, "releaseLease");
+    const cache = new FarmDataCache({ adapter: firstAdapter, namespace: "first" });
+    let finishFill!: () => void;
+    const fillGate = new Promise<void>((resolve) => {
+      finishFill = resolve;
+    });
+    let started = false;
+
+    const pending = cache.getOrSet("products", async () => {
+      started = true;
+      await fillGate;
+      return { source: "first" };
+    });
+
+    await vi.waitFor(() => expect(started).toBe(true));
+    cache.configure({ adapter: secondAdapter, namespace: "second" });
+    finishFill();
+
+    await expect(pending).resolves.toEqual({ source: "first" });
+    await expect(secondAdapter.get("second:entry:products")).resolves.toBeNull();
+    expect(releaseLease).toHaveBeenCalledWith("first:lease:products", "lease-1");
+
+    await cache.getOrSet("products", async () => ({ source: "second" }));
+    await expect(secondAdapter.get("second:entry:products")).resolves.toMatchObject({
+      value: { source: "second" },
+    });
+  });
+
+  it("does not return an entry from an adapter retired during lookup", async () => {
+    const firstAdapter = new TestSharedCacheAdapter();
+    const secondAdapter = new TestSharedCacheAdapter();
+    let releaseLookup!: () => void;
+    let markLookupStarted!: () => void;
+    const lookupGate = new Promise<void>((resolve) => {
+      releaseLookup = resolve;
+    });
+    const lookupStarted = new Promise<void>((resolve) => {
+      markLookupStarted = resolve;
+    });
+    vi.spyOn(firstAdapter, "get").mockImplementation(async () => {
+      markLookupStarted();
+      await lookupGate;
+      return {
+        key: "products",
+        value: { source: "first" },
+        tags: [],
+        createdAt: Date.now(),
+      };
+    });
+    const cache = new FarmDataCache({ adapter: firstAdapter, namespace: "first" });
+    const producer = vi.fn(async () => ({ source: "second" }));
+    const pending = cache.getOrSet("products", producer);
+
+    await lookupStarted;
+    cache.configure({ adapter: secondAdapter, namespace: "second" });
+    releaseLookup();
+
+    await expect(pending).resolves.toEqual({ source: "second" });
+    expect(producer).toHaveBeenCalledOnce();
+    await expect(secondAdapter.get("second:entry:products")).resolves.toMatchObject({
+      value: { source: "second" },
+    });
+  });
+
+  it("stops waiting on a retired adapter without reacquiring its lease", async () => {
+    const firstAdapter = new TestSharedCacheAdapter();
+    const secondAdapter = new TestSharedCacheAdapter();
+    const acquireLease = vi.spyOn(firstAdapter, "acquireLease");
+    await firstAdapter.acquireLease("first:lease:products");
+    let getCalls = 0;
+    let releaseWaitLookup!: () => void;
+    let markWaitLookupStarted!: () => void;
+    const waitLookupGate = new Promise<void>((resolve) => {
+      releaseWaitLookup = resolve;
+    });
+    const waitLookupStarted = new Promise<void>((resolve) => {
+      markWaitLookupStarted = resolve;
+    });
+    vi.spyOn(firstAdapter, "get").mockImplementation(async () => {
+      getCalls++;
+      if (getCalls === 1) return null;
+      markWaitLookupStarted();
+      await waitLookupGate;
+      return {
+        key: "products",
+        value: { source: "first" },
+        tags: [],
+        createdAt: Date.now(),
+      };
+    });
+    const cache = new FarmDataCache({
+      adapter: firstAdapter,
+      namespace: "first",
+      lease: { pollIntervalMs: 1, waitTimeoutMs: 100 },
+    });
+    const producer = vi.fn(async () => ({ source: "second" }));
+    const pending = cache.getOrSet("products", producer);
+
+    await waitLookupStarted;
+    cache.configure({ adapter: secondAdapter, namespace: "second" });
+    releaseWaitLookup();
+
+    await expect(pending).resolves.toEqual({ source: "second" });
+    expect(producer).toHaveBeenCalledOnce();
+    expect(acquireLease).toHaveBeenCalledTimes(2);
+  });
+
   it("does not make a local value fresh when its tag is invalidated during generation", async () => {
     const cache = new FarmDataCache();
     let finishGeneration!: () => void;

--- a/packages/farm/src/cache.ts
+++ b/packages/farm/src/cache.ts
@@ -249,6 +249,11 @@ export class FarmDataCache {
   }
 
   configure(config: FarmCacheUserConfig = {}): void {
+    this.generation++;
+    this.entries.clear();
+    this.inflight.clear();
+    this.invalidatedTagVersions.clear();
+    this.version = 0;
     this.adapter = config.adapter;
     this.namespace = normalizeCacheNamespace(config.namespace || "farm");
     this.local = !config.adapter;
@@ -269,12 +274,6 @@ export class FarmDataCache {
               "cache.lease.pollIntervalMs",
             ),
           };
-    if (!this.local) {
-      this.entries.clear();
-      this.inflight.clear();
-      this.invalidatedTagVersions.clear();
-      this.version = 0;
-    }
   }
 
   get adapterName(): string {
@@ -342,14 +341,19 @@ export class FarmDataCache {
       return this.local ? undefined : this.getEntry<T>(key, options);
     }
 
-    const entry = await this.adapter.get<T>(this.createAdapterKey(key));
+    const generation = this.generation;
+    const adapter = this.adapter;
+    const namespace = this.namespace;
+    const entry = await adapter.get<T>(`${namespace}:entry:${key}`);
+    if (generation !== this.generation) return undefined;
     if (!entry) {
       emitFarmEvent({ type: "cache.miss", key });
       return undefined;
     }
 
     assertFarmCacheEntry(entry, key);
-    const stale = await this.isAdapterEntryStale(entry, options.now);
+    const stale = await this.isAdapterEntryStale(entry, options.now, adapter, namespace);
+    if (generation !== this.generation) return undefined;
     if (stale) {
       emitFarmEvent({
         type: "cache.stale",
@@ -619,42 +623,85 @@ export class FarmDataCache {
     tags: readonly string[],
     generation: number,
   ): Promise<T> {
-    const leaseKey = `${this.namespace}:lease:${key}`;
+    const adapter = this.adapter;
+    const namespace = this.namespace;
+    const lease = { ...this.lease };
+    const leaseKey = `${namespace}:lease:${key}`;
     let leaseToken: string | null | undefined;
 
-    if (this.adapter?.acquireLease && this.adapter.releaseLease && this.lease.enabled) {
-      leaseToken = await this.adapter.acquireLease(leaseKey, this.lease.ttlMs);
+    if (adapter?.acquireLease && adapter.releaseLease && lease.enabled) {
+      leaseToken = await adapter.acquireLease(leaseKey, lease.ttlMs);
       if (!leaseToken) {
-        const shared = await this.waitForAdapterEntry<T>(key);
+        const shared = await this.waitForAdapterEntry<T>(
+          key,
+          adapter,
+          namespace,
+          lease,
+          generation,
+        );
         if (shared) {
           emitFarmEvent({ type: "cache.dedupe", key });
           return shared.value;
         }
-        leaseToken = await this.adapter.acquireLease(leaseKey, this.lease.ttlMs);
+        if (generation === this.generation) {
+          leaseToken = await adapter.acquireLease(leaseKey, lease.ttlMs);
+        }
       }
     }
 
     try {
       const initialCreatedVersion = this.version;
-      const initialTagVersions = await this.getAdapterTagVersions(tags);
+      const initialTagVersions = await this.getAdapterTagVersions(tags, adapter, namespace);
       const value = await producer();
       if (generation === this.generation) {
         await this.writeAsync(key, value, options, initialTagVersions, initialCreatedVersion);
       }
       return value;
     } finally {
-      if (leaseToken && this.adapter?.releaseLease) {
-        await this.adapter.releaseLease(leaseKey, leaseToken);
+      if (leaseToken && adapter?.releaseLease) {
+        await adapter.releaseLease(leaseKey, leaseToken);
       }
     }
   }
 
-  private async waitForAdapterEntry<T>(key: string): Promise<FarmCacheEntry<T> | undefined> {
-    const deadline = Date.now() + this.lease.waitTimeoutMs;
+  private async waitForAdapterEntry<T>(
+    key: string,
+    adapter: FarmCacheAdapter,
+    namespace: string,
+    lease: typeof this.lease,
+    generation: number,
+  ): Promise<FarmCacheEntry<T> | undefined> {
+    const deadline = Date.now() + lease.waitTimeoutMs;
     while (Date.now() < deadline) {
-      await delay(this.lease.pollIntervalMs);
-      const entry = await this.getEntryAsync<T>(key);
-      if (entry) return entry;
+      await delay(lease.pollIntervalMs);
+      if (generation !== this.generation) return undefined;
+      const entry = await adapter.get<T>(`${namespace}:entry:${key}`);
+      if (generation !== this.generation) return undefined;
+      if (!entry) {
+        emitFarmEvent({ type: "cache.miss", key });
+        continue;
+      }
+      assertFarmCacheEntry(entry, key);
+      const stale = await this.isAdapterEntryStale(entry, Date.now(), adapter, namespace);
+      if (generation !== this.generation) return undefined;
+      if (stale) {
+        emitFarmEvent({
+          type: "cache.stale",
+          key,
+          tags: [...entry.tags],
+          revalidate: entry.revalidate,
+        });
+        emitFarmEvent({ type: "cache.miss", key, reason: "stale" });
+      } else {
+        emitFarmEvent({
+          type: "cache.hit",
+          key,
+          tags: [...entry.tags],
+          revalidate: entry.revalidate,
+          stale: false,
+        });
+        return { ...entry, key };
+      }
     }
     return undefined;
   }
@@ -718,12 +765,14 @@ export class FarmDataCache {
 
   private async getAdapterTagVersions(
     tags: readonly string[],
+    adapter = this.adapter,
+    namespace = this.namespace,
   ): Promise<Readonly<Record<string, number>>> {
-    if (!this.adapter?.getTagVersions || tags.length === 0) return {};
+    if (!adapter?.getTagVersions || tags.length === 0) return {};
 
     const normalized = tags.map(normalizeCacheTag);
-    const physicalTags = normalized.map((tag) => this.createAdapterTag(tag));
-    const versions = await this.adapter.getTagVersions(physicalTags);
+    const physicalTags = normalized.map((tag) => `${namespace}:tag:${tag}`);
+    const versions = await adapter.getTagVersions(physicalTags);
     return Object.fromEntries(
       normalized.map((tag, index) => [
         tag,
@@ -732,7 +781,12 @@ export class FarmDataCache {
     );
   }
 
-  private async isAdapterEntryStale(entry: FarmCacheEntry, now = Date.now()): Promise<boolean> {
+  private async isAdapterEntryStale(
+    entry: FarmCacheEntry,
+    now = Date.now(),
+    adapter = this.adapter,
+    namespace = this.namespace,
+  ): Promise<boolean> {
     if (
       typeof entry.revalidate === "number" &&
       entry.revalidate >= 0 &&
@@ -741,7 +795,7 @@ export class FarmDataCache {
       return true;
     }
 
-    const currentVersions = await this.getAdapterTagVersions(entry.tags);
+    const currentVersions = await this.getAdapterTagVersions(entry.tags, adapter, namespace);
     for (const tag of entry.tags) {
       if (
         normalizeAdapterVersion(currentVersions[tag]) >


### PR DESCRIPTION
## Problem

An in-flight cache fill could complete after cache reconfiguration and write its old result through the new adapter or namespace. Waiters could likewise observe a fill using mixed configuration.

## Root cause

The fill path read mutable adapter and namespace fields after asynchronous work rather than retaining the configuration that started the operation.

## Change

Give each configuration a generation, capture the adapter/namespace/lease for a fill, suppress writes after a generation change, and release the captured adapter lease. Waiters poll the captured context and stop when reconfiguration invalidates it.

## Safety and compatibility

Completed values still return to the caller that computed them, but stale work cannot populate a newly configured cache. Normal fills and cache observability events remain unchanged.

## Verification

- `pnpm --filter @farm.js/core exec vitest run src/__tests__/cache.test.ts`
- `pnpm --filter @farm.js/core type-check`
- Focused oxfmt and oxlint checks

The deferred-fill regression fails against `main`, where the old result is written after switching adapters and namespaces.

## Documentation and release

Updated the cache documentation with reconfiguration behavior for in-flight fills.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race condition where an in-flight cache fill could write its old result through a newly configured adapter or namespace after `configure()` runs.

- Captures the adapter, namespace, and lease settings when a fill starts so the fill never uses mixed configuration.
- Bumps a generation on reconfiguration; in-flight fills suppress writes, stop waiters, and release the captured adapter lease.
- The completed value still returns to the original caller, but it cannot populate the newly configured cache.
- Adds regression tests for fills across adapter and namespace switches, retired adapter lookups, and waiters on a retired adapter.
- Updates the cache documentation with reconfiguration behavior for in-flight fills.

<sup>Written for commit b442ec40eaa78537033737711ab23c5ce0bc45e6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/748?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

