### PR TITLE
fix(link): retry settled prefetch attempts

### DIFF
--- a/docs/src/app/docs/routing/page.md
+++ b/docs/src/app/docs/routing/page.md
@@ -120,7 +120,8 @@ handled by the browser instead of Farm's SPA router. Absolute URI schemes such a
 `sms:`, and same-origin `blob:` URLs are passed through unchanged and are never prefetched as app routes. Literal custom
 schemes such as `customapp:open` are validated from their URI grammar and work without registration.
 Viewport prefetch uses a short scroll guard and is cancelled if its link unmounts before the guard
-expires.
+expires. Intent prefetches are deduplicated while active; after an attempt settles, a later hover,
+focus, or touch can retry while successful route data remains deduplicated by the router cache.
 Internal `Link` hrefs stay app-relative: when `basePath: "/console"` is configured, `href="/about"`
 renders and navigates to `/console/about`. Do not add the base path to route hrefs yourself.
 For a reusable custom-scheme type, use ``ExternalHref<`customapp:${string}`>`` (or declaration-merge

--- a/packages/farm/src/__tests__/link.test.tsx
+++ b/packages/farm/src/__tests__/link.test.tsx
@@ -151,6 +151,30 @@ describe("Link", () => {
       vi.useRealTimers();
     });
 
+    it("allows a later intent to retry after prefetch settles", async () => {
+      vi.useFakeTimers();
+      prefetch.mockRejectedValueOnce(new Error("temporary prefetch failure"));
+      const el = render(
+        createElement(Link, { href: "/docs", prefetch: "intent", prefetchDelay: 10 }),
+      ) as HTMLAnchorElement;
+
+      act(() => {
+        el.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
+        vi.advanceTimersByTime(10);
+      });
+      await act(async () => {});
+
+      act(() => {
+        el.dispatchEvent(new MouseEvent("mouseout", { bubbles: true }));
+        el.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
+        vi.advanceTimersByTime(10);
+      });
+
+      expect(prefetch).toHaveBeenCalledTimes(2);
+      expect(prefetch).toHaveBeenLastCalledWith("/docs");
+      vi.useRealTimers();
+    });
+
     it("prefetch=intent cancels pending prefetch on blur", () => {
       vi.useFakeTimers();
       const el = render(

--- a/packages/farm/src/client/link.tsx
+++ b/packages/farm/src/client/link.tsx
@@ -335,7 +335,7 @@ function LinkInner<TRoute extends string = DefaultRouteHref, THref extends strin
 ) {
   const elementRef = useRef<HTMLAnchorElement | null>(null);
   const intentTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const hasPrefetched = useRef(false);
+  const activePrefetch = useRef<symbol | null>(null);
   const farm = useOptionalFarm();
 
   const { intent, viewport, render } = normalizePrefetch(prefetch);
@@ -351,15 +351,23 @@ function LinkInner<TRoute extends string = DefaultRouteHref, THref extends strin
   const isExternal = isExternalUrl(resolvedHref);
 
   const doPrefetch = useCallback(() => {
-    if (isExternal || hasPrefetched.current) return;
+    if (isExternal || activePrefetch.current) return;
     const router = getRouter();
     if (!router) return;
-    hasPrefetched.current = true;
-    router.prefetch(resolvedHref);
+    const token = Symbol(resolvedHref);
+    activePrefetch.current = token;
+    const reset = () => {
+      if (activePrefetch.current === token) activePrefetch.current = null;
+    };
+    try {
+      void router.prefetch(resolvedHref).then(reset, reset);
+    } catch {
+      reset();
+    }
   }, [resolvedHref, isExternal]);
 
   useEffect(() => {
-    hasPrefetched.current = false;
+    activePrefetch.current = null;
   }, [resolvedHref]);
 
   useEffect(() => {
@@ -382,7 +390,7 @@ function LinkInner<TRoute extends string = DefaultRouteHref, THref extends strin
     let timeoutId: ReturnType<typeof setTimeout> | null = null;
 
     const tryRenderPrefetch = () => {
-      if (cancelled || hasPrefetched.current) return;
+      if (cancelled || activePrefetch.current) return;
 
       const router = getRouter();
       if (!router) {
@@ -390,8 +398,7 @@ function LinkInner<TRoute extends string = DefaultRouteHref, THref extends strin
         return;
       }
 
-      hasPrefetched.current = true;
-      router.prefetch(resolvedHref);
+      doPrefetch();
     };
 
     tryRenderPrefetch();
@@ -402,7 +409,7 @@ function LinkInner<TRoute extends string = DefaultRouteHref, THref extends strin
         clearTimeout(timeoutId);
       }
     };
-  }, [render, isExternal, resolvedHref]);
+  }, [render, isExternal, resolvedHref, doPrefetch]);
 
   useEffect(() => {
     return () => {
@@ -421,7 +428,7 @@ function LinkInner<TRoute extends string = DefaultRouteHref, THref extends strin
   }, []);
 
   const scheduleIntentPrefetch = useCallback(() => {
-    if (isExternal || !intent || hasPrefetched.current) return;
+    if (isExternal || !intent || activePrefetch.current) return;
     cancelIntent();
     intentTimeoutRef.current = setTimeout(() => {
       intentTimeoutRef.current = null;


### PR DESCRIPTION
## Problem

A rejected link prefetch permanently marked that Link instance as prefetched. Later hover or focus intent could not retry even after a transient failure had cleared.

## Root cause

The component stored a one-way boolean before invoking the router and never reset it when the attempt settled.

## Change

Track only the active prefetch attempt and clear that token on resolution, rejection, or a synchronous throw. Concurrent intent remains deduplicated while later intent can retry; the router cache still owns successful-result deduplication.

## Safety and compatibility

Rendering and navigation behavior are unchanged. The change only permits a later retry after the previous attempt is no longer active.

## Verification

- `pnpm --filter @farm.js/core exec vitest run src/__tests__/link.test.tsx src/__tests__/client-router.test.ts`
- `pnpm --filter @farm.js/core type-check`
- Focused oxfmt and oxlint checks

The regression fails against `main`, where the second hover produces no second prefetch.

## Documentation and release

Updated the routing documentation with prefetch retry behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug where a rejected link prefetch permanently marked the Link as prefetched, preventing any retry on later hover or focus. Now the Link tracks only the active prefetch attempt and clears it when the attempt resolves, rejects, or throws synchronously, so later intent can retry while the router cache still deduplicates successful results. No rendering or navigation behavior changes. Updated routing docs to describe this retry behavior.

<sup>Written for commit 2948985d0852f9ac1777b55e8844023ae196265b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/749?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

