### PR TITLE
perf(react): compose same-key map reorder pipelines

### DIFF
--- a/docs/src/app/docs/renderers/react/page.md
+++ b/docs/src/app/docs/renderers/react/page.md
@@ -1210,6 +1210,45 @@ reorder step in its existing hint counter; modules without those steps do not re
 runtimes. The application runtime must provide `Array.prototype.toReversed`; Farm does not polyfill
 it.
 
+#### Same-key map and reorder pipelines
+
+A common data-table update changes one row and immediately restores a sorted order:
+
+```tsx
+setItems((current) =>
+  current
+    .map((item) => (item.id === editedId ? { ...item, rank: nextRank, label: nextLabel } : item))
+    .toSorted((left, right) => left.rank - right.rank),
+);
+```
+
+For a concise functional setter, Farm can prepare the safe same-key `map()` and the following
+native `toSorted()` or `toReversed()` calls as one update pipeline. JavaScript still performs the
+map and reorder normally. The compiler records only enough provenance to prove that the final
+array came from the currently committed keyed rows.
+
+Before changing the DOM, the runtime verifies ordinary dense arrays, exact native methods, the
+committed collection token, equal lengths, a unique one-to-one source-item match, and the key of
+every replacement item. It prepares all changed binding values and DOM targets first, runs one LIS
+reconciliation for the final order, and patches bindings only for rows whose item identity changed.
+Unchanged rows need no second key or binding read. Existing row elements, delegated handlers,
+controlled inputs, focus, and text selection stay attached to their keys. Multiple supported
+map-and-reorder setters queued before one compiler flush compose against the same committed
+collection and expose only the final state.
+
+The initial proof accepts one inline, synchronous, compiler-safe map callback that returns the
+original item on one conditional branch and an object-spread replacement on the other. It requires
+compiler-owned host rows whose render and key do not observe the index. Referenced or block-bodied
+callbacks, unconditional replacements, changed or duplicate keys, `thisArg`, structural methods in
+the same chain, computed or custom methods, sparse or subclassed arrays, collection-reading
+bindings, React-owned rows, nested host blocks, row conditionals, unrelated dirty dependencies, or
+failed runtime validation use complete keyed reconciliation before any fast-path DOM write.
+
+No API or option is added. Reports count the prepared map and reorder calls through the existing
+`keyedMapUpdateHints`, `keyedArraySortHints`, and `keyedArrayReorderHints` fields. Modules that do
+not contain a supported map-and-reorder pipeline do not retain its optional runtime. Farm does not
+polyfill `Array.prototype.toSorted` or `Array.prototype.toReversed`.
+
 #### Keyed array sort hints
 
 A direct native immutable sort can reuse every keyed row while changing only its DOM position:
@@ -2068,6 +2107,11 @@ The package and example test suites verify more than generated code:
   React; targeted tests cover filter/slice/reorder pipelines, queued filter-then-sort updates,
   surviving controlled-input focus and selection, exact DOM identity, custom-method and identity
   fallback, StrictMode hydration, and unmount-before-flush cleanup;
+- 2,000 deterministic same-key edits followed by native sorting match normal React; targeted tests
+  require one changed-row binding read, preserve every keyed DOM node, compose queued map/sort and
+  map/sort/reverse pipelines, dispatch moved-row events with the newest item and index, preserve
+  controlled-input focus and selection, and cover changed-key and custom-method fallback, Strict
+  Mode hydration, and unmount-before-flush cleanup;
 - 1,000 deterministic exact-position insertions, single and contiguous-range removals, single-row
   replacements, and exact-window replacements match normal React; compiler tests cover guarded
   runtime positions plus literal and compiler-safe runtime delete counts, while targeted removal

--- a/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
+++ b/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
@@ -2,6 +2,39 @@
 
 Date: 2026-08-29
 
+## Same-key map composed with native reorder — 2026-09-07
+
+The 10,000-row table now measures a concise functional setter that replaces one row through
+`map()` and then restores amount order with native `toSorted()`. The compiler carries each mapped
+replacement back to its committed source row, so the runtime validates only the replacement key,
+prepares its changed bindings, and runs one LIS for the final permutation. Every unchanged row
+keeps its DOM node without another key, descriptor, or binding read. The equivalent block-bodied
+updater remains the complete-reconciliation control.
+
+| Mode   | React median | Map + reorder | Compiled control | vs React | vs control |
+| ------ | -----------: | ------------: | ---------------: | -------: | ---------: |
+| Static |    176.60 ms |      33.70 ms |         46.40 ms |    5.24x |      1.38x |
+| Hybrid |    176.60 ms |      32.20 ms |         42.80 ms |    5.48x |      1.33x |
+
+The new gate requires at least 4x versus bracketed React and 1.2x versus the compiled control in
+both modes, and passed without lowering either threshold. The run also proved that all 10,000
+original row nodes survived, and passed every value assertion, zero-owner-execution check, the
+general regression gate, every existing keyed optimization gate, the 8x
+optimization-persistence floor, and normalized scalability checks.
+
+Compiler tests accept one safe conditional object-spread map followed by native sort/reverse
+suffixes and reject referenced or unconditional mappers, structural calls in the same chain, and
+map calls after reordering. Runtime coverage checks queued map/sort/reverse composition, changed-key
+and custom-method fallback before DOM writes, delegated events, controlled-input focus and
+selection, Strict Mode hydration, unmount-before-flush cleanup, and 2,000 deterministic updates
+against normal React. The stress comparison completed in 24.88 seconds after replacement-lineage
+reuse, compared with 48.49 seconds for the earlier all-key-validation implementation on the same
+machine.
+
+The new map-reorder runtime is selected only for modules that emit the composed hint, and the size
+suite verifies that reorder-only applications do not retain it. The recorded browser run used
+Chrome 152.0.7977.82, Node.js 23.11.0, and Apple M1 macOS arm64.
+
 ## Structural prefixes composed with native reorders — 2026-09-06
 
 The 10,000-row table now measures one concise setter that filters one row and then executes two

--- a/examples/react-compiler-dashboard/README.md
+++ b/examples/react-compiler-dashboard/README.md
@@ -214,6 +214,16 @@ React and 1.25x faster than the compiled control. Package tests also cover filte
 composition, queued filter-then-sort updates, 2,000 randomized removals, controlled-input focus and
 selection, hydration, cleanup, and conservative fallback.
 
+Same-key map-and-reorder pipelines have their own 10,000-row comparison. One concise setter
+reprices a single row through `map()` and immediately restores amount order with `toSorted()`; the
+block-bodied form performs the same JavaScript and DOM-visible work through complete compiled
+reconciliation. Both compiler modes must remain at least 4x faster than React and 1.2x faster than
+that compiled control. The assertion retains all 10,000 row elements, moves the edited row to its
+exact final position, and verifies its text and amount. Package tests separately cover queued
+edits, map/sort/reverse composition, changed-key and custom-method fallback, delegated events,
+controlled-input focus and selection, 2,000 differential updates, Strict Mode hydration, and
+unmount-before-flush cleanup.
+
 Native keyed-array sorting has its own 10,000-row comparison. Concise `toSorted()` is measured
 against bracketed React and an equivalent block-bodied compiled control. Both compiler modes must
 remain at least 4x faster than React and 1.25x faster than the compiled control. The report must
@@ -296,6 +306,10 @@ The default JSON report is `/tmp/farm-react-dashboard-benchmark.json`; change it
 - The reorder-pipeline control executes two native reversals inside one functional setter. Its
   block-bodied equivalent stays on complete reconciliation, isolating the build-time lowering of
   native sort/reverse-only call chains.
+- The map-reorder control changes one item identity and then sorts the same keyed rows. Its
+  block-bodied equivalent rereads the complete keyed snapshot; the hinted path isolates the saved
+  descriptor and unchanged-binding work while both paths run the same native map, sort, and LIS
+  movement.
 - The sort control compares concise native `toSorted()` with an equivalent block-bodied compiled
   update. Both paths run the same native sort and move the same keyed DOM rows; the hint isolates
   the saved key, descriptor, and binding work while retaining only the required LIS moves.

--- a/examples/react-compiler-dashboard/scripts/benchmark.mjs
+++ b/examples/react-compiler-dashboard/scripts/benchmark.mjs
@@ -1198,6 +1198,40 @@ async function measureTrial(browser, trial, compilerMode, port) {
             ),
         );
 
+        const measureMapReorderPipeline = async (action) => {
+          const rows = [...table.querySelectorAll("tbody tr")];
+          const target = rows.find(
+            (row) => Number(row.getAttribute("data-row-id")) % 10_000 === 5_001,
+          );
+          if (!target) throw new Error("Map-reorder target row is missing.");
+          await runTableAction(action, () => {
+            const nextRows = table.querySelectorAll("tbody tr");
+            return (
+              nextRows.length === 10_000 &&
+              nextRows[0] === target &&
+              rows.every((row) => row.isConnected) &&
+              target.querySelector("td:nth-child(2)")?.textContent?.endsWith(" repriced") === true &&
+              target.querySelector("td:nth-child(4)")?.textContent === "$-1"
+            );
+          });
+        };
+
+        const tableMapReorderPipeline = await measureTable(
+          async () => create10000(),
+          async () =>
+            measureMapReorderPipeline(() =>
+              tableButton("table-map-reorder-pipeline").click(),
+            ),
+        );
+
+        const tableMapReorderPipelineSnapshot = await measureTable(
+          async () => create10000(),
+          async () =>
+            measureMapReorderPipeline(() =>
+              tableButton("table-map-reorder-pipeline-snapshot").click(),
+            ),
+        );
+
         const tableSort = await measureTable(
           async () => create10000(),
           async () => {
@@ -1592,6 +1626,8 @@ async function measureTrial(browser, trial, compilerMode, port) {
             executionsAdded: Number(tableExecutions.textContent) - initialTableExecutions,
             filterReorderPipeline: tableFilterReorderPipeline,
             filterReorderPipelineSnapshot: tableFilterReorderPipelineSnapshot,
+            mapReorderPipeline: tableMapReorderPipeline,
+            mapReorderPipelineSnapshot: tableMapReorderPipelineSnapshot,
             mapLookup: tableMapLookup,
             membership: tableMembership,
             prepend: tablePrepend,
@@ -1714,6 +1750,8 @@ async function measureTrial(browser, trial, compilerMode, port) {
         executionsAdded: result.table.executionsAdded,
         filterReorderPipeline: timingSummary(result.table.filterReorderPipeline),
         filterReorderPipelineSnapshot: timingSummary(result.table.filterReorderPipelineSnapshot),
+        mapReorderPipeline: timingSummary(result.table.mapReorderPipeline),
+        mapReorderPipelineSnapshot: timingSummary(result.table.mapReorderPipelineSnapshot),
         mapLookup: timingSummary(result.table.mapLookup),
         membership: timingSummary(result.table.membership),
         prepend: timingSummary(result.table.prepend),
@@ -1886,6 +1924,8 @@ const tableMetrics = [
   "denseMapLookup",
   "filterReorderPipeline",
   "filterReorderPipelineSnapshot",
+  "mapReorderPipeline",
+  "mapReorderPipelineSnapshot",
   "snapshotMembership",
   "snapshotMapLookup",
   "slicePrefix",
@@ -2499,6 +2539,29 @@ const keyedStructuralReorderRegressions = keyedStructuralReorderResults.filter(
     !Number.isFinite(snapshotSpeedup) ||
     snapshotSpeedup < keyedStructuralReorderMinimumSnapshotSpeedup,
 );
+// Editing one same-key row and immediately sorting it should reuse all keyed DOM rows, patch only
+// the changed bindings, and run one LIS against the final order. Compare the concise hinted setter
+// with React and the equivalent block-bodied compiled control at 10,000 rows.
+const keyedMapReorderMinimumSpeedup = 4;
+const keyedMapReorderMinimumSnapshotSpeedup = 1.2;
+const keyedMapReorderResults = ["static", "hybrid"].map((mode) => {
+  const pipelineMedianMs = comparisons.table.mapReorderPipeline[mode].medianMs;
+  const snapshotMedianMs = comparisons.table.mapReorderPipelineSnapshot[mode].medianMs;
+  return {
+    mode,
+    pipelineMedianMs,
+    snapshotMedianMs,
+    snapshotSpeedup: snapshotMedianMs / pipelineMedianMs,
+    speedup: comparisons.table.mapReorderPipeline[`${mode}VsBaseline`].speedup,
+  };
+});
+const keyedMapReorderRegressions = keyedMapReorderResults.filter(
+  ({ snapshotSpeedup, speedup }) =>
+    !Number.isFinite(speedup) ||
+    speedup < keyedMapReorderMinimumSpeedup ||
+    !Number.isFinite(snapshotSpeedup) ||
+    snapshotSpeedup < keyedMapReorderMinimumSnapshotSpeedup,
+);
 // A direct native toSorted() exposes a permutation while preserving every keyed row object. The
 // hinted path validates that permutation by item identity, uses LIS to move only the required DOM
 // nodes, and avoids key, descriptor, and binding reads. Compare it with React and the equivalent
@@ -2686,6 +2749,7 @@ const passed =
   keyedQueuedReorderRegressions.length === 0 &&
   keyedReorderPipelineRegressions.length === 0 &&
   keyedStructuralReorderRegressions.length === 0 &&
+  keyedMapReorderRegressions.length === 0 &&
   keyedSortRegressions.length === 0 &&
   keyedFilterRegressions.length === 0 &&
   keyedIdentityRegressions.length === 0 &&
@@ -2844,6 +2908,13 @@ const report = {
     regressions: keyedStructuralReorderRegressions,
     results: keyedStructuralReorderResults,
     status: keyedStructuralReorderRegressions.length === 0 ? "PASS" : "FAIL",
+  },
+  keyedMapReorderHintGate: {
+    minimumSnapshotSpeedup: keyedMapReorderMinimumSnapshotSpeedup,
+    minimumSpeedup: keyedMapReorderMinimumSpeedup,
+    regressions: keyedMapReorderRegressions,
+    results: keyedMapReorderResults,
+    status: keyedMapReorderRegressions.length === 0 ? "PASS" : "FAIL",
   },
   keyedSortHintGate: {
     minimumSnapshotSpeedup: keyedSortMinimumSnapshotSpeedup,

--- a/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
+++ b/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
@@ -871,6 +871,44 @@ export function StandardTableBenchmark() {
           Filter + reorder pipeline (snapshot control)
         </button>
         <button
+          data-action="table-map-reorder-pipeline"
+          type="button"
+          onClick={() => {
+            setRows((current) =>
+              current
+                .map((row) =>
+                  row.id % 10_000 === 5_001
+                    ? { ...row, amount: -1, label: `${row.label} repriced` }
+                    : row,
+                )
+                .toSorted((left, right) => left.amount - right.amount || left.id - right.id),
+            );
+            setOperation("reprice and sort one row");
+            setRevision((value) => value + 1);
+          }}
+        >
+          Reprice + sort one row
+        </button>
+        <button
+          data-action="table-map-reorder-pipeline-snapshot"
+          type="button"
+          onClick={() => {
+            setRows((current) => {
+              return current
+                .map((row) =>
+                  row.id % 10_000 === 5_001
+                    ? { ...row, amount: -1, label: `${row.label} repriced` }
+                    : row,
+                )
+                .toSorted((left, right) => left.amount - right.amount || left.id - right.id);
+            });
+            setOperation("reprice and sort one row (snapshot control)");
+            setRevision((value) => value + 1);
+          }}
+        >
+          Reprice + sort one row (snapshot control)
+        </button>
+        <button
           data-action="table-sort"
           type="button"
           onClick={() => {

--- a/packages/farm-react/README.md
+++ b/packages/farm-react/README.md
@@ -416,6 +416,28 @@ reorder fall back. Reports count each compiled step in the existing filter, slic
 counter, and modules without those operations omit their optional runtimes. Farm does not polyfill
 `Array.prototype.toReversed`.
 
+A compiler-safe same-key map may also precede the native reorder suffix:
+
+```tsx
+setItems((current) =>
+  current
+    .map((item) => (item.id === editedId ? { ...item, rank: nextRank } : item))
+    .toSorted((left, right) => left.rank - right.rank),
+);
+```
+
+Farm executes the native map and reorder calls normally, verifies the committed token, dense-array
+shape, a one-to-one source-item match, and every replacement key before touching the DOM, then runs
+one LIS and patches bindings only for changed item identities. Unchanged rows need no second key or
+binding read. Queued supported map-and-reorder setters compose against the same committed rows. The
+initial proof requires an inline synchronous
+conditional mapper that returns either the original item or an object-spread replacement, plus
+index-independent compiler-owned host rows. Changed keys, referenced or block-bodied callbacks,
+unconditional replacements, `thisArg`, structural calls in the same chain, computed or custom
+methods, sparse or subclassed arrays, collection-reading bindings, nested or React-owned rows, and
+failed checks use complete keyed reconciliation. Reports use the existing map, sort, and reorder
+hint counters, and unrelated modules do not retain this optional runtime.
+
 A direct native immutable sort can use the same optional reorder runtime:
 
 ```tsx

--- a/packages/farm-react/RUNTIME_SIZE_RESULTS.json
+++ b/packages/farm-react/RUNTIME_SIZE_RESULTS.json
@@ -26,14 +26,14 @@
         "brotli": 51897
       },
       "compilerOn": {
-        "raw": 232521,
-        "gzip": 71373,
-        "brotli": 61227
+        "raw": 232658,
+        "gzip": 71404,
+        "brotli": 61097
       },
       "compilerPremium": {
-        "raw": 39402,
-        "gzip": 11194,
-        "brotli": 9330
+        "raw": 39539,
+        "gzip": 11225,
+        "brotli": 9200
       }
     },
     "keyedAppend": {
@@ -43,14 +43,14 @@
         "brotli": 51772
       },
       "compilerOn": {
-        "raw": 233836,
-        "gzip": 71690,
-        "brotli": 61478
+        "raw": 233983,
+        "gzip": 71716,
+        "brotli": 61486
       },
       "compilerPremium": {
-        "raw": 40935,
-        "gzip": 11605,
-        "brotli": 9706
+        "raw": 41082,
+        "gzip": 11631,
+        "brotli": 9714
       }
     },
     "keyedFilter": {
@@ -60,14 +60,14 @@
         "brotli": 51833
       },
       "compilerOn": {
-        "raw": 235714,
-        "gzip": 72258,
-        "brotli": 61962
+        "raw": 235919,
+        "gzip": 72289,
+        "brotli": 61957
       },
       "compilerPremium": {
-        "raw": 42834,
-        "gzip": 12170,
-        "brotli": 10129
+        "raw": 43039,
+        "gzip": 12201,
+        "brotli": 10124
       }
     },
     "keyedPrepend": {
@@ -77,14 +77,14 @@
         "brotli": 51826
       },
       "compilerOn": {
-        "raw": 235346,
-        "gzip": 72055,
-        "brotli": 61743
+        "raw": 235483,
+        "gzip": 72086,
+        "brotli": 61715
       },
       "compilerPremium": {
-        "raw": 42444,
-        "gzip": 11968,
-        "brotli": 9917
+        "raw": 42581,
+        "gzip": 11999,
+        "brotli": 9889
       }
     },
     "keyedPosition": {
@@ -94,14 +94,14 @@
         "brotli": 51741
       },
       "compilerOn": {
-        "raw": 236197,
-        "gzip": 72344,
-        "brotli": 61968
+        "raw": 236334,
+        "gzip": 72378,
+        "brotli": 62052
       },
       "compilerPremium": {
-        "raw": 43299,
-        "gzip": 12268,
-        "brotli": 10227
+        "raw": 43436,
+        "gzip": 12302,
+        "brotli": 10311
       }
     },
     "keyedBatchPosition": {
@@ -111,14 +111,14 @@
         "brotli": 51753
       },
       "compilerOn": {
-        "raw": 237445,
-        "gzip": 72534,
-        "brotli": 62149
+        "raw": 237582,
+        "gzip": 72567,
+        "brotli": 62221
       },
       "compilerPremium": {
-        "raw": 44528,
-        "gzip": 12443,
-        "brotli": 10396
+        "raw": 44665,
+        "gzip": 12476,
+        "brotli": 10468
       }
     },
     "keyedWindowPosition": {
@@ -128,14 +128,14 @@
         "brotli": 51793
       },
       "compilerOn": {
-        "raw": 243233,
-        "gzip": 74297,
-        "brotli": 63756
+        "raw": 243370,
+        "gzip": 74328,
+        "brotli": 63836
       },
       "compilerPremium": {
-        "raw": 50242,
-        "gzip": 14173,
-        "brotli": 11963
+        "raw": 50379,
+        "gzip": 14204,
+        "brotli": 12043
       }
     },
     "keyedReorder": {
@@ -145,14 +145,31 @@
         "brotli": 51795
       },
       "compilerOn": {
-        "raw": 235627,
-        "gzip": 72157,
-        "brotli": 61790
+        "raw": 235870,
+        "gzip": 72278,
+        "brotli": 61907
       },
       "compilerPremium": {
-        "raw": 42780,
-        "gzip": 12099,
-        "brotli": 9995
+        "raw": 43023,
+        "gzip": 12220,
+        "brotli": 10112
+      }
+    },
+    "keyedMapReorder": {
+      "compilerOff": {
+        "raw": 192928,
+        "gzip": 60110,
+        "brotli": 51734
+      },
+      "compilerOn": {
+        "raw": 239547,
+        "gzip": 73253,
+        "brotli": 62736
+      },
+      "compilerPremium": {
+        "raw": 46619,
+        "gzip": 13143,
+        "brotli": 11002
       }
     },
     "keyedSort": {
@@ -162,14 +179,14 @@
         "brotli": 51829
       },
       "compilerOn": {
-        "raw": 235760,
-        "gzip": 72207,
-        "brotli": 61868
+        "raw": 236003,
+        "gzip": 72332,
+        "brotli": 61941
       },
       "compilerPremium": {
-        "raw": 42884,
-        "gzip": 12130,
-        "brotli": 10039
+        "raw": 43127,
+        "gzip": 12255,
+        "brotli": 10112
       }
     },
     "keyedSlice": {
@@ -179,14 +196,14 @@
         "brotli": 51855
       },
       "compilerOn": {
-        "raw": 235766,
-        "gzip": 72297,
-        "brotli": 61949
+        "raw": 235971,
+        "gzip": 72315,
+        "brotli": 62027
       },
       "compilerPremium": {
-        "raw": 42895,
-        "gzip": 12222,
-        "brotli": 10094
+        "raw": 43100,
+        "gzip": 12240,
+        "brotli": 10172
       }
     },
     "keyedRollingWindow": {
@@ -196,14 +213,14 @@
         "brotli": 51859
       },
       "compilerOn": {
-        "raw": 239845,
-        "gzip": 73177,
-        "brotli": 62691
+        "raw": 240050,
+        "gzip": 73237,
+        "brotli": 62753
       },
       "compilerPremium": {
-        "raw": 46916,
-        "gzip": 13069,
-        "brotli": 10832
+        "raw": 47121,
+        "gzip": 13129,
+        "brotli": 10894
       }
     },
     "isolatedRuntime": {
@@ -213,18 +230,18 @@
         "brotli": 51666
       },
       "full": {
-        "raw": 287017,
-        "gzip": 81538,
-        "brotli": 69552
+        "raw": 290969,
+        "gzip": 82543,
+        "brotli": 70368
       },
       "coreOnly": {
         "raw": 204922,
         "gzip": 63685,
         "brotli": 54902
       },
-      "fullRuntimePremiumGzip": 21619,
+      "fullRuntimePremiumGzip": 22624,
       "coreRuntimePremiumGzip": 3766,
-      "gzipReductionPercent": 82.6
+      "gzipReductionPercent": 83.4
     }
   }
 }

--- a/packages/farm-react/fixtures/runtime-size/keyed-map-reorder.tsx
+++ b/packages/farm-react/fixtures/runtime-size/keyed-map-reorder.tsx
@@ -1,0 +1,39 @@
+import { useState } from "react";
+import { createRoot } from "react-dom/client";
+
+interface Row {
+  id: number;
+  label: string;
+  rank: number;
+}
+
+export function MapReorderTable() {
+  const [rows, setRows] = useState<Row[]>([
+    { id: 1, label: "Alpha", rank: 1 },
+    { id: 2, label: "Beta", rank: 2 },
+  ]);
+  return (
+    <main>
+      <button
+        onClick={() =>
+          setRows((current) =>
+            current
+              .map((row) => (row.id === 1 ? { ...row, rank: 3 } : row))
+              .toSorted((left, right) => left.rank - right.rank),
+          )
+        }
+      >
+        Edit and sort
+      </button>
+      <ul>
+        {rows.map((row) => (
+          <li key={row.id}>
+            {row.label}: {row.rank}
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}
+
+createRoot(document.body).render(<MapReorderTable />);

--- a/packages/farm-react/scripts/benchmark-runtime-size.mjs
+++ b/packages/farm-react/scripts/benchmark-runtime-size.mjs
@@ -67,6 +67,8 @@ const [
   keyedWindowPositionOn,
   keyedReorderOff,
   keyedReorderOn,
+  keyedMapReorderOff,
+  keyedMapReorderOn,
   keyedSortOff,
   keyedSortOn,
   keyedRollingWindowOff,
@@ -95,6 +97,8 @@ const [
   bundle("keyed-window-position.tsx", true),
   bundle("keyed-reorder.tsx", false),
   bundle("keyed-reorder.tsx", true),
+  bundle("keyed-map-reorder.tsx", false),
+  bundle("keyed-map-reorder.tsx", true),
   bundle("keyed-sort.tsx", false),
   bundle("keyed-sort.tsx", true),
   bundle("keyed-rolling-window.tsx", false),
@@ -218,6 +222,18 @@ if (
   !keyedReorderOn.code.includes("reorderIndexIndependent")
 ) {
   throw new Error("Keyed reorder fixture did not retain its isolated reorder-hint runtime.");
+}
+if (
+  !keyedMapReorderOn.code.includes("FarmCompiledKeyedRows") ||
+  !keyedMapReorderOn.code.includes("keyed-rows:map-reorder-hinted") ||
+  !keyedMapReorderOn.code.includes("reorderIndexIndependent")
+) {
+  throw new Error(
+    `Keyed map-reorder fixture did not retain its isolated runtime: rows=${keyedMapReorderOn.code.includes("FarmCompiledKeyedRows")}, feature=${keyedMapReorderOn.code.includes("keyed-rows:map-reorder-hinted")}, proof=${keyedMapReorderOn.code.includes("reorderIndexIndependent")}.`,
+  );
+}
+if (keyedReorderOn.code.includes("keyed-rows:map-reorder-hinted")) {
+  throw new Error("Reorder-only fixture retained the optional map-reorder runtime.");
 }
 if (
   !keyedSortOn.code.includes("FarmCompiledKeyedRows") ||
@@ -413,6 +429,23 @@ const results = {
         brotli: keyedReorderOn.brotli - keyedReorderOff.brotli,
       },
     },
+    keyedMapReorder: {
+      compilerOff: {
+        raw: keyedMapReorderOff.raw,
+        gzip: keyedMapReorderOff.gzip,
+        brotli: keyedMapReorderOff.brotli,
+      },
+      compilerOn: {
+        raw: keyedMapReorderOn.raw,
+        gzip: keyedMapReorderOn.gzip,
+        brotli: keyedMapReorderOn.brotli,
+      },
+      compilerPremium: {
+        raw: keyedMapReorderOn.raw - keyedMapReorderOff.raw,
+        gzip: keyedMapReorderOn.gzip - keyedMapReorderOff.gzip,
+        brotli: keyedMapReorderOn.brotli - keyedMapReorderOff.brotli,
+      },
+    },
     keyedSort: {
       compilerOff: {
         raw: keyedSortOff.raw,
@@ -534,6 +567,13 @@ if (checkOnly) {
       maximum:
         (reference.fixtures.keyedReorder?.compilerPremium.gzip ??
           results.fixtures.keyedReorder.compilerPremium.gzip) + 256,
+    },
+    {
+      name: "keyed map-reorder compiler premium",
+      current: results.fixtures.keyedMapReorder.compilerPremium.gzip,
+      maximum:
+        (reference.fixtures.keyedMapReorder?.compilerPremium.gzip ??
+          results.fixtures.keyedMapReorder.compilerPremium.gzip) + 256,
     },
     {
       name: "keyed sort compiler premium",

--- a/packages/farm-react/src/__tests__/compiler-keyed-array-sort-hints.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-keyed-array-sort-hints.test.ts
@@ -163,6 +163,147 @@ describe("React AOT keyed-array sort hints", () => {
     expect(result.code).toContain("keyedRowsEveryHintedRuntimeFeature");
   });
 
+  it("lowers a same-key map followed by a native sort as one reorder pipeline", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Table({ editedId, nextRank }) {
+        const [rows, setRows] = useState([
+          { id: "a", label: "Alpha", rank: 1 },
+          { id: "b", label: "Beta", rank: 2 },
+        ]);
+        return <section>
+          <button onClick={() => setRows((current) => current
+            .map((row) => row.id === editedId ? { ...row, rank: nextRank } : row)
+            .toSorted((left, right) => left.rank - right.rank)
+          )}>Edit and sort</button>
+          <ul>{rows.map((row) => <li key={row.id}>{row.label}: {row.rank}</li>)}</ul>
+        </section>;
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Table"]);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.optimizations.keyedMapUpdateHints).toBe(1);
+    expect(result.optimizations.keyedArraySortHints).toBe(1);
+    expect(result.code).toContain("createCompilerKeyedArrayMapPipeline");
+    expect(result.code).toContain("createCompilerKeyedArrayMapReorder");
+    expect(result.code).toContain("keyedRowsMapReorderHintedRuntimeFeature");
+    expect(result.code).toContain("reorderIndexIndependent");
+    expect(result.code).not.toContain("createCompilerKeyedMapUpdate");
+    expect(result.code).not.toContain("createCompilerKeyedArraySort");
+  });
+
+  it("keeps each reorder step in a mapped sort and reverse pipeline", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Table({ editedId }) {
+        const [rows, setRows] = useState([
+          { id: "a", label: "Alpha", rank: 1 },
+          { id: "b", label: "Beta", rank: 2 },
+        ]);
+        return <section>
+          <button onClick={() => setRows((current) => current
+            .map((row) => row.id === editedId ? { ...row, rank: row.rank + 1 } : row)
+            .toSorted((left, right) => left.rank - right.rank)
+            .toReversed()
+          )}>Edit and reorder</button>
+          <ul>{rows.map((row) => <li key={row.id}>{row.label}</li>)}</ul>
+        </section>;
+      }
+    `);
+
+    expect(result.optimizations.keyedMapUpdateHints).toBe(1);
+    expect(result.optimizations.keyedArraySortHints).toBe(1);
+    expect(result.optimizations.keyedArrayReorderHints).toBe(1);
+    expect(result.code.match(/createCompilerKeyedArrayMapReorder/g)).toHaveLength(4);
+  });
+
+  it("does not lower map and reorder pipelines for host-backed keyed rows", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Table({ editedId, nextRank }) {
+        const [rows, setRows] = useState([
+          { id: "a", label: "Alpha", rank: 1, visible: true },
+          { id: "b", label: "Beta", rank: 2, visible: false },
+        ]);
+        return <section>
+          <button onClick={() => setRows((current) => current
+            .map((row) => row.id === editedId ? { ...row, rank: nextRank } : row)
+            .toSorted((left, right) => left.rank - right.rank)
+          )}>Edit and sort</button>
+          <ul>{rows.map((row) => (
+            <li key={row.id}>
+              <span>{row.label}: {row.rank}</span>
+              <div>{row.visible && <strong>{row.label}</strong>}</div>
+            </li>
+          ))}</ul>
+        </section>;
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Table"]);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.code).toContain("keyedRowsHostRuntimeFeature");
+    expect(result.optimizations.keyedMapUpdateHints).toBe(0);
+    expect(result.optimizations.keyedArraySortHints).toBe(0);
+    expect(result.code).not.toContain("createCompilerKeyedArrayMapPipeline");
+    expect(result.code).not.toContain("createCompilerKeyedArrayMapReorder");
+  });
+
+  it.each([
+    {
+      name: "an unconditional replacement",
+      pipeline:
+        "current.map((row) => ({ ...row, rank: row.rank + 1 })).toSorted((a, b) => a.rank - b.rank)",
+    },
+    {
+      name: "a referenced mapper",
+      declaration: "const updateRow = (row) => row.id === editedId ? { ...row, rank: 0 } : row;",
+      pipeline: "current.map(updateRow).toSorted((a, b) => a.rank - b.rank)",
+    },
+    {
+      name: "a block-bodied mapper",
+      pipeline:
+        "current.map((row) => { return row.id === editedId ? { ...row, rank: 0 } : row; }).toSorted((a, b) => a.rank - b.rank)",
+    },
+    {
+      name: "a map thisArg",
+      pipeline:
+        "current.map((row) => row.id === editedId ? { ...row, rank: 0 } : row, null).toSorted((a, b) => a.rank - b.rank)",
+    },
+    {
+      name: "a computed map method",
+      pipeline:
+        'current["map"]((row) => row.id === editedId ? { ...row, rank: 0 } : row).toSorted((a, b) => a.rank - b.rank)',
+    },
+    {
+      name: "a structural step after map",
+      pipeline:
+        "current.map((row) => row.id === editedId ? { ...row, rank: 0 } : row).filter((row) => row.rank > 0).toSorted((a, b) => a.rank - b.rank)",
+    },
+    {
+      name: "a map after reorder",
+      pipeline:
+        "current.toSorted((a, b) => a.rank - b.rank).map((row) => row.id === editedId ? { ...row, rank: 0 } : row)",
+    },
+  ])("keeps $name on complete reconciliation", async ({ declaration = "", pipeline }) => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Table({ editedId }) {
+        const [rows, setRows] = useState([{ id: "a", rank: 1 }]);
+        ${declaration}
+        return <section>
+          <button onClick={() => setRows((current) => ${pipeline})}>Update</button>
+          <ul>{rows.map((row) => <li key={row.id}>{row.rank}</li>)}</ul>
+        </section>;
+      }
+    `);
+
+    expect(result.optimizations.keyedArraySortHints).toBe(0);
+    expect(result.code).not.toContain("createCompilerKeyedArrayMapPipeline");
+    expect(result.code).not.toContain("keyedRowsMapReorderHintedRuntimeFeature");
+  });
+
   it.each([
     {
       name: "a referenced comparator",

--- a/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-map-reorder-hints.test.tsx
+++ b/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-map-reorder-hints.test.tsx
@@ -1,0 +1,610 @@
+import React, { StrictMode, useState } from "react";
+import { act } from "react";
+import { createRoot, hydrateRoot, type Root } from "react-dom/client";
+import { renderToString } from "react-dom/server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createCompiledComponent,
+  createCompilerKeyedArrayMapPipeline,
+  createCompilerKeyedArrayMapReorder,
+  type CompilerKeyedRowElement,
+} from "../compiler-runtime";
+
+declare global {
+  var IS_REACT_ACT_ENVIRONMENT: boolean;
+}
+
+interface Item {
+  id: string;
+  label: string;
+  rank: number;
+}
+
+const roots: Root[] = [];
+const stressIt = process.env.FARM_REACT_STRESS === "1" ? it : it.skip;
+
+beforeEach(() => {
+  globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+afterEach(async () => {
+  await act(async () => {
+    for (const root of roots.splice(0)) root.unmount();
+  });
+  document.body.replaceChildren();
+  vi.restoreAllMocks();
+});
+
+async function flushCompilerUpdates(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+function hintedMap(
+  items: Item[],
+  callback: (item: Item, index: number, items: Item[]) => Item,
+): Item[] {
+  return createCompilerKeyedArrayMapPipeline(items, items.map, callback) as Item[];
+}
+
+function hintedSort(items: Item[]): Item[] {
+  return createCompilerKeyedArrayMapReorder(
+    items,
+    items.toSorted,
+    (left: Item, right: Item) => left.rank - right.rank,
+  ) as Item[];
+}
+
+function hintedReverse(items: Item[]): Item[] {
+  return createCompilerKeyedArrayMapReorder(items, items.toReversed) as Item[];
+}
+
+function mappedSort(items: Item[], id: string, rank: number, label?: string): Item[] {
+  return hintedSort(
+    hintedMap(items, (item) =>
+      item.id === id ? { ...item, rank, ...(label === undefined ? {} : { label }) } : item,
+    ),
+  );
+}
+
+function rowDescriptor(item: Item): CompilerKeyedRowElement {
+  return {
+    kind: "element",
+    tag: "li",
+    attributes: [{ name: "data-key", value: item.id }],
+    styles: [],
+    children: [`${item.label}:${item.rank}`],
+  };
+}
+
+function labels(container: Element): string[] {
+  return [...container.querySelectorAll("li")].map((row) => row.textContent || "");
+}
+
+function createHarness(initialItems: Item[]) {
+  const counters = {
+    bindings: 0,
+    descriptors: 0,
+    executions: 0,
+    keys: 0,
+    renders: 0,
+  };
+  let editAndSort: (id: string, rank: number, label?: string) => void = () => undefined;
+  let editSortReverse: (id: string, rank: number) => void = () => undefined;
+  let queueEdits: (edits: readonly { id: string; rank: number; label?: string }[]) => void = () =>
+    undefined;
+  let invalidateKey: () => void = () => undefined;
+  let customMap: () => void = () => undefined;
+  const Table = createCompiledComponent({
+    displayName: "MapReorderTable",
+    initialize: () => [initialItems],
+    render(_props: Record<string, never>, state, blocks) {
+      counters.executions += 1;
+      const items = () => state[0].get() as Item[];
+      editAndSort = (id, rank, label) =>
+        state[0].set((previous) => mappedSort(previous as Item[], id, rank, label));
+      editSortReverse = (id, rank) =>
+        state[0].set((previous) => hintedReverse(mappedSort(previous as Item[], id, rank)));
+      queueEdits = (edits) => {
+        for (const edit of edits) {
+          state[0].set((previous) =>
+            mappedSort(previous as Item[], edit.id, edit.rank, edit.label),
+          );
+        }
+      };
+      invalidateKey = () =>
+        state[0].set((previous) =>
+          hintedSort(
+            hintedMap(previous as Item[], (item) =>
+              item.id === "b" ? { ...item, id: "replacement", label: "Replacement" } : item,
+            ),
+          ),
+        );
+      customMap = () =>
+        state[0].set((previous) => {
+          const source = previous as Item[];
+          const map = function (
+            this: Item[],
+            callback: (item: Item, index: number, items: Item[]) => Item,
+          ) {
+            return Array.prototype.map.call(this, callback);
+          };
+          const mapped = createCompilerKeyedArrayMapPipeline(source, map, (item: Item) =>
+            item.id === "a" ? { ...item, label: "Custom" } : item,
+          ) as Item[];
+          return createCompilerKeyedArrayMapReorder(
+            mapped,
+            mapped.toSorted,
+            (left: Item, right: Item) => left.rank - right.rank,
+          );
+        });
+      return (
+        <section>
+          <blocks.KeyedRows
+            collectionDependency={0}
+            dependencies={[0]}
+            id={0}
+            items={items}
+            reorderIndexIndependent
+            structureDependencies={[0]}
+            render={() => {
+              counters.renders += 1;
+              return (
+                <ul>
+                  {items().map((item) => (
+                    <li data-key={item.id} key={item.id}>
+                      {item.label}:{item.rank}
+                    </li>
+                  ))}
+                </ul>
+              );
+            }}
+            rowKey={(item) => {
+              counters.keys += 1;
+              return (item as Item).id;
+            }}
+            create={(item) => {
+              counters.descriptors += 1;
+              return rowDescriptor(item as Item);
+            }}
+            bindings={[
+              {
+                kind: "text",
+                path: [],
+                read: (item) => {
+                  counters.bindings += 1;
+                  const row = item as Item;
+                  return [`${row.label}:${row.rank}`];
+                },
+              },
+            ]}
+          />
+        </section>
+      );
+    },
+    bindings: [{ kind: "block", id: 0, dependencies: [0] }],
+  });
+  return {
+    Table,
+    counters,
+    customMap: () => customMap(),
+    editAndSort: (id: string, rank: number, label?: string) => editAndSort(id, rank, label),
+    editSortReverse: (id: string, rank: number) => editSortReverse(id, rank),
+    invalidateKey: () => invalidateKey(),
+    queueEdits: (edits: readonly { id: string; rank: number; label?: string }[]) =>
+      queueEdits(edits),
+  };
+}
+
+describe("compiled keyed-array map and reorder hints", () => {
+  it("patches one changed row and reorders the existing DOM in one transaction", async () => {
+    const harness = createHarness([
+      { id: "a", label: "Alpha", rank: 1 },
+      { id: "b", label: "Beta", rank: 2 },
+      { id: "c", label: "Gamma", rank: 3 },
+    ]);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Table />));
+    const rows = new Map(
+      [...container.querySelectorAll("li")].map((row) => [row.dataset.key, row]),
+    );
+    harness.counters.bindings = 0;
+    harness.counters.descriptors = 0;
+    harness.counters.keys = 0;
+
+    await act(async () => {
+      harness.editAndSort("a", 4, "Alpha edited");
+      await flushCompilerUpdates();
+    });
+
+    expect(labels(container)).toEqual(["Beta:2", "Gamma:3", "Alpha edited:4"]);
+    for (const [key, row] of rows) {
+      expect(container.querySelector(`[data-key="${key}"]`)).toBe(row);
+    }
+    expect(harness.counters.executions).toBe(1);
+    expect(harness.counters.renders).toBe(1);
+    expect(harness.counters.keys).toBe(1);
+    expect(harness.counters.descriptors).toBe(0);
+    expect(harness.counters.bindings).toBe(1);
+  });
+
+  it("composes map, sort, and reverse steps without rerunning the owner", async () => {
+    const harness = createHarness([
+      { id: "a", label: "Alpha", rank: 1 },
+      { id: "b", label: "Beta", rank: 2 },
+      { id: "c", label: "Gamma", rank: 3 },
+    ]);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Table />));
+
+    await act(async () => {
+      harness.editSortReverse("b", 5);
+      await flushCompilerUpdates();
+    });
+
+    expect(labels(container)).toEqual(["Beta:5", "Gamma:3", "Alpha:1"]);
+    expect(harness.counters.executions).toBe(1);
+  });
+
+  it("composes queued mapped reorders against the last committed rows", async () => {
+    const harness = createHarness([
+      { id: "a", label: "Alpha", rank: 1 },
+      { id: "b", label: "Beta", rank: 2 },
+      { id: "c", label: "Gamma", rank: 3 },
+    ]);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Table />));
+
+    await act(async () => {
+      harness.queueEdits([
+        { id: "a", rank: 6, label: "Alpha newest" },
+        { id: "c", rank: 0, label: "Gamma newest" },
+      ]);
+      await flushCompilerUpdates();
+    });
+
+    expect(labels(container)).toEqual(["Gamma newest:0", "Beta:2", "Alpha newest:6"]);
+    expect(harness.counters.executions).toBe(1);
+  });
+
+  it("falls back before DOM writes for custom map methods and changed keys", async () => {
+    const harness = createHarness([
+      { id: "a", label: "Alpha", rank: 2 },
+      { id: "b", label: "Beta", rank: 1 },
+    ]);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Table />));
+    const bindingsBeforeFallback = harness.counters.bindings;
+    await act(async () => {
+      harness.customMap();
+      await flushCompilerUpdates();
+    });
+    expect(labels(container)).toEqual(["Beta:1", "Custom:2"]);
+    expect(harness.counters.bindings - bindingsBeforeFallback).toBe(2);
+
+    await act(async () => {
+      harness.invalidateKey();
+      await flushCompilerUpdates();
+    });
+    expect(labels(container)).toEqual(["Replacement:1", "Custom:2"]);
+  });
+
+  it("reads accessor-backed source items only through the native map before falling back", async () => {
+    const alpha: Item = { id: "a", label: "Alpha", rank: 2 };
+    const initialItems: Item[] = [alpha, { id: "b", label: "Beta", rank: 1 }];
+    let reads = 0;
+    Object.defineProperty(initialItems, 0, {
+      configurable: true,
+      enumerable: true,
+      get() {
+        reads += 1;
+        return alpha;
+      },
+    });
+    const harness = createHarness(initialItems);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Table />));
+    reads = 0;
+    harness.counters.bindings = 0;
+
+    await act(async () => {
+      harness.editAndSort("b", 3, "Beta newest");
+      await flushCompilerUpdates();
+    });
+
+    expect(reads).toBe(1);
+    expect(labels(container)).toEqual(["Alpha:2", "Beta newest:3"]);
+    expect(harness.counters.bindings).toBe(2);
+  });
+
+  it("preserves focus and selection while a controlled row moves", async () => {
+    const initialItems: Item[] = [
+      { id: "a", label: "Alpha", rank: 1 },
+      { id: "b", label: "Beta", rank: 2 },
+      { id: "c", label: "Gamma", rank: 3 },
+    ];
+    let update = () => undefined;
+    const Form = createCompiledComponent({
+      displayName: "MapReorderForm",
+      initialize: () => [initialItems],
+      render(_props: Record<string, never>, state, blocks) {
+        const items = () => state[0].get() as Item[];
+        update = () =>
+          state[0].set((previous) => mappedSort(previous as Item[], "b", 5, "Beta newest"));
+        return (
+          <section>
+            <blocks.KeyedRows
+              collectionDependency={0}
+              dependencies={[0]}
+              id={0}
+              items={items}
+              reorderIndexIndependent
+              structureDependencies={[0]}
+              render={() => (
+                <div>
+                  {items().map((item) => (
+                    <input data-key={item.id} key={item.id} readOnly value={item.label} />
+                  ))}
+                </div>
+              )}
+              rowKey={(item) => (item as Item).id}
+              create={(item) => ({
+                kind: "element",
+                tag: "input",
+                attributes: [
+                  { name: "data-key", value: (item as Item).id },
+                  { name: "readOnly", value: true },
+                  { name: "value", value: (item as Item).label },
+                ],
+                styles: [],
+                children: [],
+              })}
+              bindings={[
+                {
+                  kind: "attribute",
+                  name: "value",
+                  path: [],
+                  read: (item) => (item as Item).label,
+                },
+              ]}
+            />
+          </section>
+        );
+      },
+      bindings: [{ kind: "block", id: 0, dependencies: [0] }],
+    });
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<Form />));
+    const input = container.querySelector('[data-key="b"]') as HTMLInputElement;
+    input.focus();
+    input.setSelectionRange(1, 3);
+
+    await act(async () => {
+      update();
+      await flushCompilerUpdates();
+    });
+
+    expect(container.querySelector('[data-key="b"]')).toBe(input);
+    expect(input.value).toBe("Beta newest");
+    expect(document.activeElement).toBe(input);
+    expect([input.selectionStart, input.selectionEnd]).toEqual([1, 3]);
+  });
+
+  it("dispatches a moved row event with the newest item and index", async () => {
+    const calls: string[] = [];
+    let update = () => undefined;
+    const Interactive = createCompiledComponent({
+      displayName: "MapReorderInteractive",
+      initialize: () => [
+        [
+          { id: "a", label: "Alpha", rank: 1 },
+          { id: "b", label: "Beta", rank: 2 },
+        ],
+      ],
+      render(_props: Record<string, never>, state, blocks) {
+        const items = () => state[0].get() as Item[];
+        update = () =>
+          state[0].set((previous) => mappedSort(previous as Item[], "b", 0, "Beta newest"));
+        return (
+          <section>
+            <blocks.KeyedRows
+              collectionDependency={0}
+              dependencies={[0]}
+              events={[
+                {
+                  name: "onClick",
+                  invoke: (item, index) => calls.push(`${(item as Item).label}:${index}`),
+                },
+              ]}
+              id={0}
+              items={items}
+              reorderIndexIndependent
+              structureDependencies={[0]}
+              render={(rowEvent) => (
+                <ul onClick={() => calls.push("bubble")}>
+                  {items().map((item, index) => (
+                    <li data-key={item.id} key={item.id}>
+                      <span>
+                        {item.label}:{item.rank}
+                      </span>
+                      <button onClick={rowEvent(item, index, 0)} type="button">
+                        Select
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              )}
+              rowKey={(item) => (item as Item).id}
+              create={(item) => ({
+                kind: "element",
+                tag: "li",
+                attributes: [{ name: "data-key", value: (item as Item).id }],
+                styles: [],
+                children: [
+                  {
+                    kind: "element",
+                    tag: "span",
+                    attributes: [],
+                    styles: [],
+                    children: [`${(item as Item).label}:${(item as Item).rank}`],
+                  },
+                  {
+                    kind: "element",
+                    tag: "button",
+                    attributes: [{ name: "type", value: "button" }],
+                    styles: [],
+                    children: ["Select"],
+                  },
+                ],
+              })}
+              bindings={[
+                {
+                  kind: "text",
+                  path: [0],
+                  read: (item) => {
+                    const row = item as Item;
+                    return [`${row.label}:${row.rank}`];
+                  },
+                },
+              ]}
+            />
+          </section>
+        );
+      },
+      bindings: [{ kind: "block", id: 0, dependencies: [0] }],
+    });
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<Interactive />));
+
+    await act(async () => {
+      update();
+      await flushCompilerUpdates();
+    });
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>('[data-key="b"] button')!.click();
+    });
+
+    expect(labels(container)).toEqual(["Beta newest:0Select", "Alpha:1Select"]);
+    expect(calls).toEqual(["Beta newest:0", "bubble"]);
+  });
+
+  stressIt(
+    "matches React through 2,000 deterministic mapped reorder updates",
+    async () => {
+      const initialItems = Array.from(
+        { length: 501 },
+        (_, index): Item => ({ id: `row-${index}`, label: `Row ${index}`, rank: index }),
+      );
+      const harness = createHarness(initialItems);
+      let updateReact: (id: string, rank: number, label: string) => void = () => undefined;
+      function Normal() {
+        const [items, setItems] = useState(initialItems);
+        updateReact = (id, rank, label) =>
+          setItems((previous) =>
+            previous
+              .map((item) => (item.id === id ? { ...item, rank, label } : item))
+              .toSorted((left, right) => left.rank - right.rank),
+          );
+        return (
+          <ol>
+            {items.map((item) => (
+              <li data-key={item.id} key={item.id}>
+                {item.label}:{item.rank}
+              </li>
+            ))}
+          </ol>
+        );
+      }
+      const compiledContainer = document.createElement("div");
+      const reactContainer = document.createElement("div");
+      document.body.append(compiledContainer, reactContainer);
+      const compiledRoot = createRoot(compiledContainer);
+      const reactRoot = createRoot(reactContainer);
+      roots.push(compiledRoot, reactRoot);
+      await act(async () => {
+        compiledRoot.render(<harness.Table />);
+        reactRoot.render(<Normal />);
+      });
+
+      let seed = 0x84f2d31b;
+      for (let update = 0; update < 2_000; update += 1) {
+        seed = (Math.imul(seed, 1_664_525) + 1_013_904_223) >>> 0;
+        const index = seed % initialItems.length;
+        const id = `row-${index}`;
+        const rank = (seed ^ (seed >>> 16)) % 4_003;
+        const label = `Updated ${update}`;
+        await act(async () => {
+          harness.editAndSort(id, rank, label);
+          updateReact(id, rank, label);
+          await flushCompilerUpdates();
+        });
+        expect(labels(compiledContainer)).toEqual(labels(reactContainer));
+      }
+      expect(harness.counters.executions).toBe(1);
+    },
+    120_000,
+  );
+
+  it("hydrates in StrictMode and drops a queued update after unmount", async () => {
+    const initialItems: Item[] = [
+      { id: "a", label: "Alpha", rank: 1 },
+      { id: "b", label: "Beta", rank: 2 },
+      { id: "c", label: "Gamma", rank: 3 },
+    ];
+    const hydration = createHarness(initialItems);
+    const container = document.createElement("div");
+    container.innerHTML = renderToString(<hydration.Table />);
+    document.body.append(container);
+    const recoverable: unknown[] = [];
+    let root!: Root;
+    await act(async () => {
+      root = hydrateRoot(
+        container,
+        <StrictMode>
+          <hydration.Table />
+        </StrictMode>,
+        { onRecoverableError: (error) => recoverable.push(error) },
+      );
+    });
+    roots.push(root);
+    await act(async () => {
+      hydration.editAndSort("a", 5, "Alpha hydrated");
+      await flushCompilerUpdates();
+    });
+    expect(labels(container)).toEqual(["Beta:2", "Gamma:3", "Alpha hydrated:5"]);
+    expect(recoverable).toEqual([]);
+
+    const unmounted = createHarness(initialItems);
+    const unmountContainer = document.createElement("div");
+    document.body.append(unmountContainer);
+    const unmountRoot = createRoot(unmountContainer);
+    await act(async () => unmountRoot.render(<unmounted.Table />));
+    act(() => {
+      unmounted.editAndSort("b", 8, "Never committed");
+      unmountRoot.unmount();
+    });
+    await flushCompilerUpdates();
+    expect(unmountContainer.innerHTML).toBe("");
+  });
+});

--- a/packages/farm-react/src/compiler-runtime.tsx
+++ b/packages/farm-react/src/compiler-runtime.tsx
@@ -76,7 +76,16 @@ interface CompilerKeyedArrayReorderHint {
   readonly sourceToken: object;
   readonly sourceLength: number;
   readonly resultLength: number;
+  readonly mapped?: boolean;
+  readonly mappedItemSources?: ReadonlyMap<unknown, unknown>;
   readonly structuralUpdate?: CompilerKeyedArrayFilterHint;
+}
+
+interface CompilerKeyedArrayMapPipelineHint {
+  readonly sourceToken: object;
+  readonly sourceLength: number;
+  readonly resultLength: number;
+  readonly mappedItemSources: ReadonlyMap<unknown, unknown>;
 }
 
 type CompilerKeyedCollectionKind = "set" | "map";
@@ -131,6 +140,10 @@ const COMPILER_KEYED_ARRAY_REORDERS = /* @__PURE__ */ new WeakMap<
   object,
   CompilerKeyedArrayReorderHint
 >();
+const COMPILER_KEYED_ARRAY_MAP_PIPELINES = /* @__PURE__ */ new WeakMap<
+  object,
+  CompilerKeyedArrayMapPipelineHint
+>();
 const COMPILER_KEYED_COLLECTION_DRAFTS = /* @__PURE__ */ new WeakMap<
   object,
   CompilerKeyedCollectionDraft
@@ -143,6 +156,7 @@ const COMPILER_KEYED_COMMITTED_COLLECTIONS = /* @__PURE__ */ new WeakSet<object>
 const NATIVE_ARRAY_PROTOTYPE = Array.prototype;
 const NATIVE_ARRAY_ITERATOR = Array.prototype[Symbol.iterator];
 const NATIVE_ARRAY_FILTER = Array.prototype.filter;
+const NATIVE_ARRAY_MAP = Array.prototype.map;
 const NATIVE_ARRAY_SLICE = Array.prototype.slice;
 const NATIVE_ARRAY_TO_SPLICED = (
   Array.prototype as unknown as { toSpliced?: (...args: readonly unknown[]) => unknown }
@@ -534,6 +548,142 @@ export function createCompilerKeyedMapUpdate(
       changedIndices,
       ...(previousUpdate ? { previous: previousUpdate } : {}),
     });
+  }
+  return value;
+}
+
+/** @internal Executes a proven native map at the start of a keyed reorder pipeline. */
+export function createCompilerKeyedArrayMapPipeline(
+  previous: unknown,
+  method: unknown,
+  callback: unknown,
+): unknown {
+  const value = NATIVE_REFLECT_APPLY(
+    method as (...values: readonly unknown[]) => unknown,
+    previous,
+    [callback],
+  );
+
+  try {
+    const previousTarget = compilerObject(previous);
+    const valueTarget = compilerObject(value);
+    if (
+      !previousTarget ||
+      !valueTarget ||
+      !Array.isArray(previous) ||
+      !Array.isArray(value) ||
+      Object.getPrototypeOf(previous) !== NATIVE_ARRAY_PROTOTYPE ||
+      Object.getPrototypeOf(value) !== NATIVE_ARRAY_PROTOTYPE ||
+      method !== NATIVE_ARRAY_MAP ||
+      typeof callback !== "function" ||
+      value.length !== previous.length
+    ) {
+      return value;
+    }
+
+    const committedSource = COMPILER_KEYED_COMMITTED_COLLECTIONS.has(previousTarget);
+    const previousReorder = committedSource
+      ? undefined
+      : COMPILER_KEYED_ARRAY_REORDERS.get(previousTarget);
+    if (
+      !committedSource &&
+      (!previousReorder ||
+        !previousReorder.mapped ||
+        previousReorder.resultLength !== previous.length)
+    ) {
+      return value;
+    }
+    const sourceToken =
+      previousReorder?.sourceToken || compilerKeyedCollectionToken(previousTarget);
+    if (!sourceToken) return value;
+    const previousMappedItemSources = previousReorder?.mappedItemSources;
+    const mappedItemSources = new Map<unknown, unknown>();
+    for (let index = 0; index < value.length; index += 1) {
+      const previousDescriptor = Object.getOwnPropertyDescriptor(previous, index);
+      const mappedDescriptor = Object.getOwnPropertyDescriptor(value, index);
+      if (
+        !previousDescriptor ||
+        !("value" in previousDescriptor) ||
+        !mappedDescriptor ||
+        !("value" in mappedDescriptor)
+      ) {
+        return value;
+      }
+      const previousItem = previousDescriptor.value;
+      const sourceItem = previousMappedItemSources?.has(previousItem)
+        ? previousMappedItemSources.get(previousItem)
+        : previousItem;
+      const mappedItem = mappedDescriptor.value;
+      if (!Object.is(mappedItem, sourceItem)) mappedItemSources.set(mappedItem, sourceItem);
+    }
+    COMPILER_KEYED_ARRAY_MAP_PIPELINES.set(valueTarget, {
+      sourceToken,
+      sourceLength: previousReorder?.sourceLength || previous.length,
+      resultLength: value.length,
+      mappedItemSources,
+    });
+  } catch {
+    // Metadata must never change the result of a successful native update.
+  }
+  return value;
+}
+
+/** @internal Executes a native reorder after a proven same-key map pipeline. */
+export function createCompilerKeyedArrayMapReorder(
+  previous: unknown,
+  method: unknown,
+  ...args: readonly unknown[]
+): unknown {
+  const value = NATIVE_REFLECT_APPLY(
+    method as (...values: readonly unknown[]) => unknown,
+    previous,
+    args,
+  );
+
+  try {
+    const previousTarget = compilerObject(previous);
+    const valueTarget = compilerObject(value);
+    if (
+      !previousTarget ||
+      !valueTarget ||
+      !Array.isArray(previous) ||
+      !Array.isArray(value) ||
+      Object.getPrototypeOf(previous) !== NATIVE_ARRAY_PROTOTYPE ||
+      Object.getPrototypeOf(value) !== NATIVE_ARRAY_PROTOTYPE ||
+      value.length !== previous.length ||
+      (method !== NATIVE_ARRAY_TO_REVERSED && method !== NATIVE_ARRAY_TO_SORTED) ||
+      (method === NATIVE_ARRAY_TO_REVERSED && args.length !== 0) ||
+      (method === NATIVE_ARRAY_TO_SORTED &&
+        (args.length > 1 ||
+          (args.length === 1 && args[0] !== undefined && typeof args[0] !== "function")))
+    ) {
+      return value;
+    }
+    for (let index = 0; index < previous.length; index += 1) {
+      if (
+        !Object.prototype.hasOwnProperty.call(previous, index) ||
+        !Object.prototype.hasOwnProperty.call(value, index)
+      ) {
+        return value;
+      }
+    }
+
+    const mapPipeline = COMPILER_KEYED_ARRAY_MAP_PIPELINES.get(previousTarget);
+    const previousReorder = mapPipeline
+      ? undefined
+      : COMPILER_KEYED_ARRAY_REORDERS.get(previousTarget);
+    const source = mapPipeline || (previousReorder?.mapped ? previousReorder : undefined);
+    if (!source || source.resultLength !== previous.length) return value;
+    COMPILER_KEYED_ARRAY_REORDERS.set(valueTarget, {
+      kind: "permutation",
+      sourceToken: source.sourceToken,
+      sourceLength: source.sourceLength,
+      resultLength: value.length,
+      mapped: true,
+      mappedItemSources: source.mappedItemSources,
+    });
+  } catch {
+    // Metadata must never change the result of a successful native update.
   }
   return value;
 }
@@ -4535,6 +4685,11 @@ const keyedReorderUpdateRuntime: KeyedUpdateRuntime = {
   reorder: reconcileCompilerKeyedArrayReorder,
 };
 
+const keyedMapReorderUpdateRuntime: KeyedUpdateRuntime = {
+  ...keyedUpdateRuntime,
+  reorder: reconcileCompilerKeyedArrayReorderWithMap,
+};
+
 const keyedCompleteUpdateRuntime: KeyedUpdateRuntime = {
   ...keyedFilterPrependUpdateRuntime,
   rollingWindow: reconcileCompilerKeyedArrayRollingWindow,
@@ -4543,7 +4698,7 @@ const keyedCompleteUpdateRuntime: KeyedUpdateRuntime = {
 const keyedEveryUpdateRuntime: KeyedUpdateRuntime = {
   ...keyedCompleteUpdateRuntime,
   position: reconcileCompilerKeyedArrayPosition,
-  reorder: reconcileCompilerKeyedArrayReorderWithStructural,
+  reorder: reconcileCompilerKeyedArrayReorderWithMapAndStructural,
 };
 
 const keyedBatchEveryUpdateRuntime: KeyedUpdateRuntime = {
@@ -4630,6 +4785,102 @@ function reconcileCompilerKeyedMapUpdate(
     conditionalChanges,
     fallback: false,
   };
+}
+
+function reconcileCompilerKeyedArrayMapReorder(
+  props: CompilerKeyedRowsBlockProps,
+  dirtyState: ReadonlySet<number>,
+  collectionToken: object | undefined,
+  instances: ReadonlyMap<string, CompilerKeyedRowInstance>,
+  root: Element,
+  reactOwnedRows: boolean,
+  preparedReorder?: CompilerPreparedKeyedArrayReorder,
+): ReadonlyMap<string, CompilerKeyedRowInstance> | undefined {
+  if (
+    reactOwnedRows ||
+    props.hostBlocks ||
+    (props.conditionals?.length || 0) > 0 ||
+    !props.reorderIndexIndependent ||
+    props.collectionDependency === undefined
+  ) {
+    return undefined;
+  }
+  const collectionDependency = props.collectionDependency;
+  if (props.bindings.some((binding) => binding.dependencies?.includes(collectionDependency))) {
+    return undefined;
+  }
+  const dependencies = props.dependencies || props.structureDependencies;
+  const relevantDirty = (dependencies || []).filter((index) => dirtyState.has(index));
+  if (relevantDirty.length !== 1 || relevantDirty[0] !== collectionDependency) {
+    return undefined;
+  }
+
+  const finalValue = preparedReorder?.value ?? props.items();
+  const update =
+    preparedReorder?.update ||
+    compilerKeyedArrayReorder(finalValue, collectionToken, instances.size);
+  if (
+    !update?.mapped ||
+    !update.mappedItemSources ||
+    update.structuralUpdate ||
+    !Array.isArray(finalValue)
+  ) {
+    return undefined;
+  }
+
+  const previousInstances = [...instances.values()];
+  const prepared = (() => {
+    try {
+      const instancesByItem = new Map<unknown, CompilerKeyedRowInstance>();
+      for (let sourceIndex = 0; sourceIndex < previousInstances.length; sourceIndex += 1) {
+        const instance = previousInstances[sourceIndex];
+        if (instance.index !== sourceIndex || instancesByItem.has(instance.item)) return undefined;
+        instancesByItem.set(instance.item, instance);
+      }
+
+      const nextInstances: CompilerKeyedRowInstance[] = [];
+      const sequence: number[] = [];
+      const changed: Array<{
+        bindingUpdates: CompilerPreparedKeyedRowBindingUpdate[];
+        instance: CompilerKeyedRowInstance;
+        item: unknown;
+        index: number;
+      }> = [];
+      for (let targetIndex = 0; targetIndex < finalValue.length; targetIndex += 1) {
+        const item = finalValue[targetIndex];
+        const sourceItem = update.mappedItemSources.has(item)
+          ? update.mappedItemSources.get(item)
+          : item;
+        const instance = instancesByItem.get(sourceItem);
+        if (!instance) return undefined;
+        instancesByItem.delete(sourceItem);
+        nextInstances.push(instance);
+        sequence.push(instance.index);
+        if (!Object.is(instance.item, item)) {
+          if (keyedRowIdentity(props.rowKey(item, targetIndex)) !== instance.key) return undefined;
+          const bindingUpdates = prepareKeyedRowBindingUpdates(props, instance, item, targetIndex);
+          if (!bindingUpdates) return undefined;
+          changed.push({ bindingUpdates, instance, item, index: targetIndex });
+        }
+      }
+      if (instancesByItem.size > 0) return undefined;
+      return { changed, nextInstances, sequence };
+    } catch {
+      return undefined;
+    }
+  })();
+  if (!prepared) return undefined;
+
+  reorderCompilerKeyedRows(root, prepared.nextInstances, prepared.sequence, null);
+  for (const { bindingUpdates, instance, item, index } of prepared.changed) {
+    applyPreparedKeyedRowBindingUpdates(props, instance, bindingUpdates);
+    instance.item = item;
+    instance.index = index;
+  }
+  for (let index = 0; index < prepared.nextInstances.length; index += 1) {
+    prepared.nextInstances[index].index = index;
+  }
+  return new Map(prepared.nextInstances.map((instance) => [instance.key, instance]));
 }
 
 function reconcileCompilerKeyedArrayAppend(
@@ -5431,6 +5682,7 @@ function reconcileCompilerKeyedArrayStructuralReorder(
   instances: ReadonlyMap<string, CompilerKeyedRowInstance>,
   root: Element,
   reactOwnedRows: boolean,
+  preparedReorder?: CompilerPreparedKeyedArrayReorder,
 ): ReadonlyMap<string, CompilerKeyedRowInstance> | undefined {
   if (
     reactOwnedRows ||
@@ -5452,8 +5704,10 @@ function reconcileCompilerKeyedArrayStructuralReorder(
     return undefined;
   }
 
-  const finalValue = props.items();
-  const update = compilerKeyedArrayReorder(finalValue, collectionToken, instances.size);
+  const finalValue = preparedReorder?.value ?? props.items();
+  const update =
+    preparedReorder?.update ||
+    compilerKeyedArrayReorder(finalValue, collectionToken, instances.size);
   if (!update?.structuralUpdate || !Array.isArray(finalValue)) return undefined;
   const survivorResult = compilerKeyedArrayFilterSurvivorsFromUpdate(
     update.structuralUpdate,
@@ -5547,6 +5801,7 @@ function reconcileCompilerKeyedArrayReorder(
   instances: ReadonlyMap<string, CompilerKeyedRowInstance>,
   root: Element,
   reactOwnedRows: boolean,
+  preparedReorder?: CompilerPreparedKeyedArrayReorder,
 ): ReadonlyMap<string, CompilerKeyedRowInstance> | undefined {
   if (
     reactOwnedRows ||
@@ -5567,9 +5822,11 @@ function reconcileCompilerKeyedArrayReorder(
     return undefined;
   }
 
-  const finalValue = props.items();
-  const update = compilerKeyedArrayReorder(finalValue, collectionToken, instances.size);
-  if (!update || update.structuralUpdate || !Array.isArray(finalValue)) {
+  const finalValue = preparedReorder?.value ?? props.items();
+  const update =
+    preparedReorder?.update ||
+    compilerKeyedArrayReorder(finalValue, collectionToken, instances.size);
+  if (!update || update.mapped || update.structuralUpdate || !Array.isArray(finalValue)) {
     return undefined;
   }
 
@@ -5660,12 +5917,76 @@ function reconcileCompilerKeyedArrayReorder(
   return new Map(previousInstances.map((instance) => [instance.key, instance]));
 }
 
-function reconcileCompilerKeyedArrayReorderWithStructural(
+interface CompilerPreparedKeyedArrayReorder {
+  readonly update: CompilerKeyedArrayReorderHint | undefined;
+  readonly value: unknown;
+}
+
+function prepareCompilerKeyedArrayReorder(
+  args: Parameters<typeof reconcileCompilerKeyedArrayReorder>,
+): CompilerPreparedKeyedArrayReorder | undefined {
+  const [props, dirtyState, collectionToken, instances, , reactOwnedRows] = args;
+  if (
+    reactOwnedRows ||
+    props.hostBlocks ||
+    (props.conditionals?.length || 0) > 0 ||
+    !props.reorderIndexIndependent ||
+    props.collectionDependency === undefined
+  ) {
+    return undefined;
+  }
+  const collectionDependency = props.collectionDependency;
+  if (props.bindings.some((binding) => binding.dependencies?.includes(collectionDependency))) {
+    return undefined;
+  }
+  const dependencies = props.dependencies || props.structureDependencies;
+  const relevantDirty = (dependencies || []).filter((index) => dirtyState.has(index));
+  if (relevantDirty.length !== 1 || relevantDirty[0] !== collectionDependency) {
+    return undefined;
+  }
+
+  const value = props.items();
+  return {
+    update: compilerKeyedArrayReorder(value, collectionToken, instances.size),
+    value,
+  };
+}
+
+function callPreparedCompilerKeyedArrayReorder(
+  reconcile: typeof reconcileCompilerKeyedArrayReorder,
+  args: Parameters<typeof reconcileCompilerKeyedArrayReorder>,
+  prepared: CompilerPreparedKeyedArrayReorder,
+): ReadonlyMap<string, CompilerKeyedRowInstance> | undefined {
+  return reconcile(args[0], args[1], args[2], args[3], args[4], args[5], prepared);
+}
+
+function reconcileCompilerKeyedArrayReorderWithMap(
   ...args: Parameters<typeof reconcileCompilerKeyedArrayReorder>
 ): ReadonlyMap<string, CompilerKeyedRowInstance> | undefined {
-  return (
-    reconcileCompilerKeyedArrayStructuralReorder(...args) ||
-    reconcileCompilerKeyedArrayReorder(...args)
+  const prepared = prepareCompilerKeyedArrayReorder(args);
+  if (!prepared) return undefined;
+  return callPreparedCompilerKeyedArrayReorder(
+    prepared.update?.mapped
+      ? reconcileCompilerKeyedArrayMapReorder
+      : reconcileCompilerKeyedArrayReorder,
+    args,
+    prepared,
+  );
+}
+
+function reconcileCompilerKeyedArrayReorderWithMapAndStructural(
+  ...args: Parameters<typeof reconcileCompilerKeyedArrayReorder>
+): ReadonlyMap<string, CompilerKeyedRowInstance> | undefined {
+  const prepared = prepareCompilerKeyedArrayReorder(args);
+  if (!prepared) return undefined;
+  return callPreparedCompilerKeyedArrayReorder(
+    prepared.update?.mapped
+      ? reconcileCompilerKeyedArrayMapReorder
+      : prepared.update?.structuralUpdate
+        ? reconcileCompilerKeyedArrayStructuralReorder
+        : reconcileCompilerKeyedArrayReorder,
+    args,
+    prepared,
   );
 }
 
@@ -7508,6 +7829,15 @@ export const keyedRowsReorderHintedRuntimeFeature: CompilerRuntimeFeature = {
   create: (owner) => ({
     KeyedRows: createKeyedRowsBlockComponent(owner, {
       keyedUpdates: keyedReorderUpdateRuntime,
+    }),
+  }),
+};
+
+export const keyedRowsMapReorderHintedRuntimeFeature: CompilerRuntimeFeature = {
+  name: "keyed-rows:map-reorder-hinted",
+  create: (owner) => ({
+    KeyedRows: createKeyedRowsBlockComponent(owner, {
+      keyedUpdates: keyedMapReorderUpdateRuntime,
     }),
   }),
 };

--- a/packages/farm-react/src/compiler.ts
+++ b/packages/farm-react/src/compiler.ts
@@ -371,6 +371,7 @@ type CompilerRuntimeFeatureName =
   | "keyed-rows-batch-position-hinted"
   | "keyed-rows-window-position-hinted"
   | "keyed-rows-reorder-hinted"
+  | "keyed-rows-map-reorder-hinted"
   | "keyed-rows-all-hinted"
   | "keyed-rows-every-hinted"
   | "keyed-rows-batch-every-hinted"
@@ -432,6 +433,7 @@ const COMPILER_RUNTIME_FEATURE_EXPORTS: Record<CompilerRuntimeFeatureName, strin
   "keyed-rows-batch-position-hinted": "keyedRowsBatchPositionHintedRuntimeFeature",
   "keyed-rows-window-position-hinted": "keyedRowsWindowPositionHintedRuntimeFeature",
   "keyed-rows-reorder-hinted": "keyedRowsReorderHintedRuntimeFeature",
+  "keyed-rows-map-reorder-hinted": "keyedRowsMapReorderHintedRuntimeFeature",
   "keyed-rows-all-hinted": "keyedRowsAllHintedRuntimeFeature",
   "keyed-rows-every-hinted": "keyedRowsEveryHintedRuntimeFeature",
   "keyed-rows-batch-every-hinted": "keyedRowsBatchEveryHintedRuntimeFeature",
@@ -497,6 +499,7 @@ function runtimeFeaturesForPlans(
   keyedArrayBatchInsertHints: boolean,
   keyedArrayWindowReplaceHints: boolean,
   keyedArrayReorderHints: boolean,
+  keyedArrayMapReorderHints: boolean,
   keyedArrayRollingWindowHints: boolean,
 ): CompilerRuntimeFeatureName[] {
   const features = new Set<CompilerRuntimeFeatureName>();
@@ -538,17 +541,19 @@ function runtimeFeaturesForPlans(
             ? "-all-hinted"
             : keyedArrayPositionHints
               ? "-position-hinted"
-              : keyedArrayReorderHints
-                ? "-reorder-hinted"
-                : keyedArrayFilterHints && keyedArrayPrependHints
-                  ? "-filter-prepend-hinted"
-                  : keyedArrayFilterHints
-                    ? "-filter-hinted"
-                    : keyedArrayPrependHints
-                      ? "-prepend-hinted"
-                      : keyedMapUpdateHints
-                        ? "-hinted"
-                        : "";
+              : keyedArrayMapReorderHints && keyedRowsFeature === "keyed-rows"
+                ? "-map-reorder-hinted"
+                : keyedArrayReorderHints
+                  ? "-reorder-hinted"
+                  : keyedArrayFilterHints && keyedArrayPrependHints
+                    ? "-filter-prepend-hinted"
+                    : keyedArrayFilterHints
+                      ? "-filter-hinted"
+                      : keyedArrayPrependHints
+                        ? "-prepend-hinted"
+                        : keyedMapUpdateHints
+                          ? "-hinted"
+                          : "";
     features.add(`${keyedRowsFeature}${hintSuffix}` as CompilerRuntimeFeatureName);
   }
   return [...features].sort();
@@ -1887,6 +1892,10 @@ type KeyedArrayReorderPipelineStep =
       readonly predicate: t.ArrowFunctionExpression;
     }
   | {
+      readonly callback: t.ArrowFunctionExpression;
+      readonly kind: "map";
+    }
+  | {
       readonly bounds: readonly t.Expression[];
       readonly kind: "slice";
     }
@@ -1911,7 +1920,23 @@ function keyedArrayReorderPipeline(
     t.isExpression(current.callee.object)
   ) {
     const methodName = current.callee.property.name;
-    if (methodName === "filter") {
+    if (methodName === "map") {
+      if (current.arguments.length !== 1) return undefined;
+      const callback = current.arguments[0];
+      if (
+        !t.isArrowFunctionExpression(callback) ||
+        callback.async ||
+        callback.generator ||
+        callback.params.length === 0 ||
+        callback.params.length > 3 ||
+        callback.params.some((parameter) => !t.isIdentifier(parameter)) ||
+        !t.isExpression(callback.body) ||
+        !isSafeKeyedMapResult(callback.body, callback.params[0] as t.Identifier, safeGlobals)
+      ) {
+        return undefined;
+      }
+      outerSteps.push({ callback, kind: "map" });
+    } else if (methodName === "filter") {
       if (current.arguments.length !== 1) return undefined;
       const predicate = current.arguments[0];
       if (
@@ -1964,11 +1989,16 @@ function keyedArrayReorderPipeline(
     return undefined;
   }
   const steps = outerSteps.reverse();
+  let mapSteps = 0;
   let structuralSteps = 0;
   let reorderSteps = 0;
   let reachedReorder = false;
-  for (const step of steps) {
-    if (step.kind === "filter" || step.kind === "slice") {
+  for (let index = 0; index < steps.length; index += 1) {
+    const step = steps[index];
+    if (step.kind === "map") {
+      if (index !== 0 || reachedReorder || structuralSteps > 0) return undefined;
+      mapSteps += 1;
+    } else if (step.kind === "filter" || step.kind === "slice") {
       if (reachedReorder) return undefined;
       structuralSteps += 1;
     } else {
@@ -1976,7 +2006,10 @@ function keyedArrayReorderPipeline(
       reorderSteps += 1;
     }
   }
-  if (reorderSteps < 1 || (structuralSteps < 1 && reorderSteps < 2)) return undefined;
+  if (mapSteps > 1 || (mapSteps > 0 && structuralSteps > 0)) return undefined;
+  if (reorderSteps < 1) return undefined;
+  if (mapSteps === 1 && reorderSteps >= 1) return steps;
+  if (structuralSteps < 1 && reorderSteps < 2) return undefined;
   return steps;
 }
 
@@ -1985,14 +2018,20 @@ function rewriteKeyedArrayReorderPipelineHints(
   hintedStateIndices: ReadonlySet<number>,
   statesBySetter: ReadonlyMap<string, StateBinding>,
   filterHelperIdentifier: t.Identifier,
+  mapHelperIdentifier: t.Identifier,
+  mapReorderHelperIdentifier: t.Identifier,
   reorderHelperIdentifier: t.Identifier,
   structuralReorderHelperIdentifier: t.Identifier,
   sliceHelperIdentifier: t.Identifier,
   sortHelperIdentifier: t.Identifier,
   structuralSortHelperIdentifier: t.Identifier,
   safeGlobals: ReadonlySet<string>,
+  allowMapPipelines: boolean,
 ): {
   filterCount: number;
+  mapCount: number;
+  mapReorderCount: number;
+  mapSortCount: number;
   root: t.JSXElement;
   reorderCount: number;
   sliceCount: number;
@@ -2005,6 +2044,9 @@ function rewriteKeyedArrayReorderPipelineHints(
     return {
       root: t.cloneNode(root, true),
       filterCount: 0,
+      mapCount: 0,
+      mapReorderCount: 0,
+      mapSortCount: 0,
       reorderCount: 0,
       sliceCount: 0,
       sortCount: 0,
@@ -2016,6 +2058,9 @@ function rewriteKeyedArrayReorderPipelineHints(
   const file = expressionFile(t.cloneNode(root, true));
   const stateIndices = new Set<number>();
   let filterCount = 0;
+  let mapCount = 0;
+  let mapReorderCount = 0;
+  let mapSortCount = 0;
   let reorderCount = 0;
   let sliceCount = 0;
   let sortCount = 0;
@@ -2045,49 +2090,63 @@ function rewriteKeyedArrayReorderPipelineHints(
       const structuralPipeline = steps.some(
         (step) => step.kind === "filter" || step.kind === "slice",
       );
+      const mapPipeline = steps.some((step) => step.kind === "map");
+      if (mapPipeline && !allowMapPipelines) return;
 
       const previous = t.cloneNode(updater.params[0]);
       const statements: t.Statement[] = [];
       let value: t.Expression = t.cloneNode(previous);
       for (const step of steps) {
         const methodName =
-          step.kind === "filter"
-            ? "filter"
-            : step.kind === "slice"
-              ? "slice"
-              : step.kind === "reverse"
-                ? "toReversed"
-                : "toSorted";
+          step.kind === "map"
+            ? "map"
+            : step.kind === "filter"
+              ? "filter"
+              : step.kind === "slice"
+                ? "slice"
+                : step.kind === "reverse"
+                  ? "toReversed"
+                  : "toSorted";
         const method = path.scope.generateUidIdentifier(
           step.kind === "filter"
             ? "farmFilter"
-            : step.kind === "slice"
-              ? "farmSlice"
-              : step.kind === "reverse"
-                ? "farmToReversed"
-                : "farmToSorted",
+            : step.kind === "map"
+              ? "farmMap"
+              : step.kind === "slice"
+                ? "farmSlice"
+                : step.kind === "reverse"
+                  ? "farmToReversed"
+                  : "farmToSorted",
         );
         const result = path.scope.generateUidIdentifier("farmPipelineValue");
         const helper =
-          step.kind === "filter"
-            ? filterHelperIdentifier
-            : step.kind === "slice"
-              ? sliceHelperIdentifier
-              : step.kind === "reverse"
-                ? structuralPipeline
-                  ? structuralReorderHelperIdentifier
-                  : reorderHelperIdentifier
-                : structuralPipeline
-                  ? structuralSortHelperIdentifier
-                  : sortHelperIdentifier;
+          step.kind === "map"
+            ? mapHelperIdentifier
+            : step.kind === "filter"
+              ? filterHelperIdentifier
+              : step.kind === "slice"
+                ? sliceHelperIdentifier
+                : step.kind === "reverse"
+                  ? mapPipeline
+                    ? mapReorderHelperIdentifier
+                    : structuralPipeline
+                      ? structuralReorderHelperIdentifier
+                      : reorderHelperIdentifier
+                  : mapPipeline
+                    ? mapReorderHelperIdentifier
+                    : structuralPipeline
+                      ? structuralSortHelperIdentifier
+                      : sortHelperIdentifier;
         const args =
-          step.kind === "filter"
-            ? [t.cloneNode(step.predicate, true)]
-            : step.kind === "slice"
-              ? step.bounds.map((bound) => t.cloneNode(bound, true))
-              : step.kind === "sort" && step.comparator
-                ? [t.cloneNode(step.comparator, true)]
-                : [];
+          step.kind === "map"
+            ? [t.cloneNode(step.callback, true)]
+            : step.kind === "filter"
+              ? [t.cloneNode(step.predicate, true)]
+              : step.kind === "slice"
+                ? step.bounds.map((bound) => t.cloneNode(bound, true))
+                : step.kind === "sort" && step.comparator
+                  ? [t.cloneNode(step.comparator, true)]
+                  : [];
         statements.push(
           t.variableDeclaration("const", [
             t.variableDeclarator(
@@ -2107,13 +2166,16 @@ function rewriteKeyedArrayReorderPipelineHints(
           ]),
         );
         value = t.cloneNode(result);
-        if (step.kind === "filter") filterCount += 1;
+        if (step.kind === "map") mapCount += 1;
+        else if (step.kind === "filter") filterCount += 1;
         else if (step.kind === "slice") sliceCount += 1;
         else if (step.kind === "reverse") {
           reorderCount += 1;
+          if (mapPipeline) mapReorderCount += 1;
           if (structuralPipeline) structuralReorderCount += 1;
         } else {
           sortCount += 1;
+          if (mapPipeline) mapSortCount += 1;
           if (structuralPipeline) structuralSortCount += 1;
         }
       }
@@ -2129,6 +2191,9 @@ function rewriteKeyedArrayReorderPipelineHints(
   return {
     root: (file.program.body[0] as t.ExpressionStatement).expression as t.JSXElement,
     filterCount,
+    mapCount,
+    mapReorderCount,
+    mapSortCount,
     reorderCount,
     sliceCount,
     sortCount,
@@ -7106,6 +7171,8 @@ function compileCandidate(
   keyedMapUpdateIdentifier: t.Identifier,
   keyedArrayAppendIdentifier: t.Identifier,
   keyedArrayFilterIdentifier: t.Identifier,
+  keyedArrayMapPipelineIdentifier: t.Identifier,
+  keyedArrayMapReorderIdentifier: t.Identifier,
   keyedArrayPrependIdentifier: t.Identifier,
   keyedArrayPositionIdentifier: t.Identifier,
   keyedArrayBatchInsertIdentifier: t.Identifier,
@@ -7137,6 +7204,9 @@ function compileCandidate(
   },
   compilerUsage: {
     keyedArrayBatchInsertHints: number;
+    keyedArrayMapReorderHints: number;
+    keyedArrayMapSortHints: number;
+    keyedArrayMapUpdateHints: number;
     keyedArrayStructuralReorderHints: number;
     keyedArrayStructuralSortHints: number;
     keyedArrayWindowReplaceHints: number;
@@ -7610,14 +7680,22 @@ function compileCandidate(
     shiftedIndexIndependentStateIndices,
     statesBySetter,
     keyedArrayFilterIdentifier,
+    keyedArrayMapPipelineIdentifier,
+    keyedArrayMapReorderIdentifier,
     keyedArrayReorderIdentifier,
     keyedArrayStructuralReorderIdentifier,
     keyedArraySliceIdentifier,
     keyedArraySortIdentifier,
     keyedArrayStructuralSortIdentifier,
     safeGlobals,
+    (blockAnalysis.plans || []).every(
+      (plan) =>
+        plan.kind !== "keyed-rows" ||
+        (plan.conditionals.length === 0 && !plan.descriptorBlocks?.size),
+    ),
   );
   let appliedPipelineFilterHints = 0;
+  let appliedPipelineMapHints = 0;
   let appliedPipelineReorderHints = 0;
   let appliedPipelineSliceHints = 0;
   let appliedPipelineSortHints = 0;
@@ -7649,17 +7727,23 @@ function compileCandidate(
       blockAnalysis = hintedBlockAnalysis;
       analysis = hintedAnalysis;
       appliedPipelineFilterHints = reorderPipelineHintedRoot.filterCount;
+      appliedPipelineMapHints = reorderPipelineHintedRoot.mapCount;
+      appliedKeyedMapUpdateHints += reorderPipelineHintedRoot.mapCount;
       appliedPipelineReorderHints = reorderPipelineHintedRoot.reorderCount;
       appliedPipelineSliceHints = reorderPipelineHintedRoot.sliceCount;
       appliedPipelineSortHints = reorderPipelineHintedRoot.sortCount;
       appliedPipelineHintedStateIndices = reorderPipelineHintedRoot.stateIndices;
       optimizationCounts.keyedArrayFilterHints += reorderPipelineHintedRoot.filterCount;
+      optimizationCounts.keyedMapUpdateHints += reorderPipelineHintedRoot.mapCount;
       optimizationCounts.keyedArrayReorderHints += reorderPipelineHintedRoot.reorderCount;
       optimizationCounts.keyedArraySliceHints += reorderPipelineHintedRoot.sliceCount;
       optimizationCounts.keyedArraySortHints += reorderPipelineHintedRoot.sortCount;
       compilerUsage.keyedArrayStructuralReorderHints +=
         reorderPipelineHintedRoot.structuralReorderCount;
       compilerUsage.keyedArrayStructuralSortHints += reorderPipelineHintedRoot.structuralSortCount;
+      compilerUsage.keyedArrayMapUpdateHints += reorderPipelineHintedRoot.mapCount;
+      compilerUsage.keyedArrayMapReorderHints += reorderPipelineHintedRoot.mapReorderCount;
+      compilerUsage.keyedArrayMapSortHints += reorderPipelineHintedRoot.mapSortCount;
     }
   }
   const reorderHintedRoot = rewriteKeyedArrayReorderHints(
@@ -7915,6 +7999,7 @@ function compileCandidate(
     appliedKeyedArrayBatchInsertHints > 0,
     appliedKeyedArrayWindowReplaceHints > 0,
     appliedKeyedArrayReorderHints > 0 || appliedKeyedArraySortHints > 0,
+    appliedPipelineMapHints > 0,
     appliedKeyedArrayRollingWindowHints > 0,
   );
   markShortCircuitBindings(analysis.bindings || []);
@@ -8126,6 +8211,9 @@ export async function compileReactModule(
   };
   const compilerUsage = {
     keyedArrayBatchInsertHints: 0,
+    keyedArrayMapReorderHints: 0,
+    keyedArrayMapSortHints: 0,
+    keyedArrayMapUpdateHints: 0,
     keyedArrayStructuralReorderHints: 0,
     keyedArrayStructuralSortHints: 0,
     keyedArrayWindowReplaceHints: 0,
@@ -8175,6 +8263,12 @@ export async function compileReactModule(
         );
         const keyedArrayFilterIdentifier = programPath.scope.generateUidIdentifier(
           "createCompilerKeyedArrayFilter",
+        );
+        const keyedArrayMapPipelineIdentifier = programPath.scope.generateUidIdentifier(
+          "createCompilerKeyedArrayMapPipeline",
+        );
+        const keyedArrayMapReorderIdentifier = programPath.scope.generateUidIdentifier(
+          "createCompilerKeyedArrayMapReorder",
         );
         const keyedArrayPrependIdentifier = programPath.scope.generateUidIdentifier(
           "createCompilerKeyedArrayPrepend",
@@ -8236,6 +8330,8 @@ export async function compileReactModule(
             keyedMapUpdateIdentifier,
             keyedArrayAppendIdentifier,
             keyedArrayFilterIdentifier,
+            keyedArrayMapPipelineIdentifier,
+            keyedArrayMapReorderIdentifier,
             keyedArrayPrependIdentifier,
             keyedArrayPositionIdentifier,
             keyedArrayBatchInsertIdentifier,
@@ -8278,11 +8374,23 @@ export async function compileReactModule(
                   createComponentIdentifier,
                   t.identifier("createCompiledComponentWithFeatures"),
                 ),
-                ...(optimizationCounts.keyedMapUpdateHints > 0
+                ...(optimizationCounts.keyedMapUpdateHints > compilerUsage.keyedArrayMapUpdateHints
                   ? [
                       t.importSpecifier(
                         keyedMapUpdateIdentifier,
                         t.identifier("createCompilerKeyedMapUpdate"),
+                      ),
+                    ]
+                  : []),
+                ...(compilerUsage.keyedArrayMapUpdateHints > 0
+                  ? [
+                      t.importSpecifier(
+                        keyedArrayMapPipelineIdentifier,
+                        t.identifier("createCompilerKeyedArrayMapPipeline"),
+                      ),
+                      t.importSpecifier(
+                        keyedArrayMapReorderIdentifier,
+                        t.identifier("createCompilerKeyedArrayMapReorder"),
                       ),
                     ]
                   : []),
@@ -8337,7 +8445,8 @@ export async function compileReactModule(
                     ]
                   : []),
                 ...(optimizationCounts.keyedArrayReorderHints >
-                compilerUsage.keyedArrayStructuralReorderHints
+                compilerUsage.keyedArrayStructuralReorderHints +
+                  compilerUsage.keyedArrayMapReorderHints
                   ? [
                       t.importSpecifier(
                         keyedArrayReorderIdentifier,
@@ -8354,7 +8463,7 @@ export async function compileReactModule(
                     ]
                   : []),
                 ...(optimizationCounts.keyedArraySortHints >
-                compilerUsage.keyedArrayStructuralSortHints
+                compilerUsage.keyedArrayStructuralSortHints + compilerUsage.keyedArrayMapSortHints
                   ? [
                       t.importSpecifier(
                         keyedArraySortIdentifier,


### PR DESCRIPTION
## Problem

A common keyed-table update replaces one row with `map()` and immediately restores order with native `toSorted()` or `toReversed()`. Farm could optimize the map or the reorder in isolation, but the composed expression lost provenance between those steps and used complete keyed reconciliation. That reread every row key and binding even though only one same-key row changed.

## Root cause

The compiler only recognized structural-prefix reorder pipelines and direct native reorders. The runtime had no proof connecting a replacement object produced by a safe map callback to its committed keyed-row instance, so it could not safely combine binding patches with one final LIS reorder.

## Change

- Recognize one inline synchronous conditional map callback that returns either the original item or an object-spread replacement, followed by native `toSorted()` and/or `toReversed()` suffixes.
- Execute every native method normally while recording replacement-to-source lineage and committed collection provenance.
- Validate the final one-to-one source match and replacement keys, prepare changed bindings before DOM mutation, run one LIS for the final order, and patch only changed row identities.
- Compose multiple queued supported setters against the last committed rows.
- Add existing-counter observability, a tree-shakeable map/reorder runtime feature, a runtime-size fixture, a 10,000-row browser comparison, and renderer/example documentation.

## Safety and compatibility

There is no new public option or API. Unsupported syntax or failed runtime validation uses complete keyed reconciliation before any fast-path DOM write. This includes referenced, block-bodied, unconditional, computed, or custom mappers; `thisArg`; changed keys; sparse, accessor-backed, or subclassed arrays; structural calls in the same chain; React-owned rows; nested host blocks; row conditionals; index-sensitive rows; and unrelated dirty dependencies.

Map/reorder metadata lowering is emitted only when all keyed-row boundaries in the component use the compatible plain-row runtime. Host-backed or conditional keyed rows keep the original JavaScript expression and complete reconciliation, avoiding metadata work that their runtime cannot consume.

The fast path preserves keyed DOM identity, delegated event item/index data and bubbling, controlled-input focus and selection, native method execution/errors, Strict Mode hydration, queued updates, and unmount-before-flush cleanup. It is React-renderer-specific and remains behind the existing experimental compiler setting. Reorder-only modules do not retain the new runtime.

## Verification

- `pnpm --dir packages/farm-react exec vitest run src/__tests__/compiler-keyed-array-sort-hints.test.ts src/__tests__/compiler-runtime-keyed-array-map-reorder-hints.test.tsx` — 39 passed, 1 stress case skipped
- `FARM_REACT_STRESS=1 pnpm --dir packages/farm-react exec vitest run src/__tests__/compiler-runtime-keyed-array-map-reorder-hints.test.tsx` — 9 passed, including 2,000 differential updates against React
- Existing keyed append, batch, filter, prepend, reorder, slice, sort, structural, window, host, nested, recursive, and identity suites rerun sequentially — all passed
- `pnpm --filter @farm.js/react type-check`
- `pnpm --filter @farm.js/react build`
- `pnpm --filter @farm.js/react test:compat` — React 18.3.1 and 19.2.8 passed from the packed artifact
- `node packages/farm-react/scripts/benchmark-runtime-size.mjs --check` — passed; map/reorder premium 13,143 B gzip, reorder-only fixture excludes the feature
- `pnpm --dir examples/react-compiler-dashboard type-check`
- `pnpm --dir docs exec farm generate --check`
- `pnpm docs:check-navigation`
- `pnpm docs:build`
- Focused `oxfmt`, `oxlint`, and `git diff --check`

The final 10,000-row browser run passed overall correctness, the general performance gate, every keyed optimization gate, the existing 8x persistence floor, and scalability without reducing thresholds. It also verifies that all 10,000 pre-action row nodes survive. The new map/reorder gate measured:

- static: 33.70 ms versus React 176.60 ms and compiled control 46.40 ms — 5.24x / 1.38x
- hybrid: 32.20 ms versus React 176.60 ms and compiled control 42.80 ms — 5.48x / 1.33x

A broad parallel React test attempt completed 649 tests with 4 skips before 14 pre-existing heavy suites timed out and one worker hit temporary `ENOSPC`; every affected compiler suite was then rerun sequentially and passed without weakening timeouts.

## Documentation and release

Updated the React renderer docs, package README, compiler dashboard README, benchmark implementation, and reproducible benchmark results. No template, generated route, version, or release-flow change.
