### PR TITLE
perf(react): compose consecutive map reorder pipelines

### DIFF
--- a/docs/src/app/docs/renderers/react/page.md
+++ b/docs/src/app/docs/renderers/react/page.md
@@ -1217,15 +1217,17 @@ A common data-table update changes one row and immediately restores a sorted ord
 ```tsx
 setItems((current) =>
   current
-    .map((item) => (item.id === editedId ? { ...item, rank: nextRank, label: nextLabel } : item))
+    .map((item) => (item.id === editedId ? { ...item, label: nextLabel } : item))
+    .map((item) => (item.id === editedId ? { ...item, rank: nextRank } : item))
     .toSorted((left, right) => left.rank - right.rank),
 );
 ```
 
-For a concise functional setter, Farm can prepare the safe same-key `map()` and the following
-native `toSorted()` or `toReversed()` calls as one update pipeline. JavaScript still performs the
-map and reorder normally. The compiler records only enough provenance to prove that the final
-array came from the currently committed keyed rows.
+For a concise functional setter, Farm can prepare one or more consecutive safe same-key `map()`
+calls and the following native `toSorted()` or `toReversed()` calls as one update pipeline.
+JavaScript still performs every map and reorder normally. After each map, the compiler runtime
+flattens replacement lineage back to the committed source row, so any number of accepted stages
+still needs one final keyed reconciliation rather than a growing chain of intermediate snapshots.
 
 Before changing the DOM, the runtime verifies ordinary dense arrays, exact native methods, the
 committed collection token, equal lengths, a unique one-to-one source-item match, and the key of
@@ -1236,7 +1238,7 @@ controlled inputs, focus, and text selection stay attached to their keys. Multip
 map-and-reorder setters queued before one compiler flush compose against the same committed
 collection and expose only the final state.
 
-The initial proof accepts one inline, synchronous, compiler-safe map callback that returns the
+The proof requires every map callback to be inline, synchronous, compiler-safe, and to return the
 original item on one conditional branch and an object-spread replacement on the other. It requires
 compiler-owned host rows whose render and key do not observe the index. Referenced or block-bodied
 callbacks, unconditional replacements, changed or duplicate keys, `thisArg`, structural methods in

--- a/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
+++ b/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
@@ -1,6 +1,43 @@
 # Complex dashboard and 21,000-row peak result
 
-Date: 2026-08-29
+Latest run: 2026-09-07
+
+## Consecutive same-key maps composed with native reorder — 2026-09-07
+
+The 10,000-row table now measures a concise functional setter that changes one row's label and
+amount in two consecutive native `map()` calls, then restores amount order with native
+`toSorted()`. Each accepted map flattens its replacements back to the committed source rows, so the
+runtime validates the final replacement key, prepares the final binding values once, and runs one
+LIS for the final permutation. The equivalent block-bodied updater remains the
+complete-reconciliation control.
+
+| Mode   | React median | Two maps + reorder | Compiled control | vs React | vs control |
+| ------ | -----------: | -----------------: | ---------------: | -------: | ---------: |
+| Static |    198.30 ms |           34.20 ms |         47.30 ms |    5.80x |      1.38x |
+| Hybrid |    198.30 ms |           34.20 ms |         46.10 ms |    5.80x |      1.35x |
+
+The independent gate requires at least 4x versus bracketed React and 1.2x versus the compiled
+control in both modes. It passed without lowering either threshold. The run also proved that all
+10,000 original row nodes stayed connected, the edited row retained its DOM identity after moving,
+the final label and amount were correct, and compiled owner executions remained zero.
+
+Every existing correctness and performance gate passed in the same run, including the general
+regression gate, the 8x optimization-persistence floor, normalized scalability, and the earlier
+single-map reorder gate. The single-map workload remained 5.23x faster than React in static mode
+and 5.28x in hybrid mode, with 1.41x versus its compiled control in both modes.
+
+Compiler tests accept consecutive safe conditional object-spread maps before native sort/reverse
+suffixes and keep structural calls, maps after reordering, and unsupported callbacks on complete
+reconciliation. Runtime coverage proves same-row and different-row lineage, one final patch per
+changed row, queued composition, changed-key and custom-method fallback, native errors, delegated
+events, controlled-input focus and selection, Strict Mode hydration, unmount-before-flush cleanup,
+and 2,000 deterministic two-map updates against normal React. That differential run completed in
+17.11 seconds on this machine.
+
+No public API or runtime feature is added. The existing optional map-reorder runtime grew by 15 B
+gzip to a 13,158 B compiler premium, while reorder-only modules still omit it and the core-only
+runtime retains its 83.4% reduction versus the complete compatibility runtime. The browser run used
+Chrome 152.0.7977.82, Node.js 23.11.0, and Apple M1 macOS arm64.
 
 ## Same-key map composed with native reorder — 2026-09-07
 

--- a/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
+++ b/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
@@ -13,8 +13,8 @@ complete-reconciliation control.
 
 | Mode   | React median | Two maps + reorder | Compiled control | vs React | vs control |
 | ------ | -----------: | -----------------: | ---------------: | -------: | ---------: |
-| Static |    205.25 ms |           29.70 ms |         39.90 ms |    6.91x |      1.34x |
-| Hybrid |    205.25 ms |           31.90 ms |         39.60 ms |    6.43x |      1.24x |
+| Static |    206.45 ms |           32.10 ms |         44.30 ms |    6.43x |      1.38x |
+| Hybrid |    206.45 ms |           32.40 ms |         44.30 ms |    6.37x |      1.37x |
 
 The independent gate requires at least 4x versus bracketed React and 1.2x versus the compiled
 control in both modes. It passed without lowering either threshold. The run also proved that all
@@ -25,8 +25,8 @@ assertion work is not included in the update measurement.
 
 Every existing correctness and performance gate passed in the same run, including the general
 regression gate, the 8x optimization-persistence floor, normalized scalability, and the earlier
-single-map reorder gate. In this latest run, the single-map workload was 5.99x faster than React in
-static mode and 5.89x in hybrid mode, with 1.33x and 1.39x versus its compiled control. The section
+single-map reorder gate. In this latest run, the single-map workload was 6.86x faster than React in
+static mode and 6.31x in hybrid mode, with 1.49x and 1.28x versus its compiled control. The section
 below preserves the measurements from the earlier run that introduced that workload.
 
 Compiler tests accept consecutive safe conditional object-spread maps before native sort/reverse
@@ -34,8 +34,7 @@ suffixes and keep structural calls, maps after reordering, and unsupported callb
 reconciliation. Runtime coverage proves same-row and different-row lineage, one final patch per
 changed row, queued composition, changed-key and custom-method fallback, native errors, delegated
 events, controlled-input focus and selection, Strict Mode hydration, unmount-before-flush cleanup,
-and 2,000 deterministic two-map updates against normal React. That differential run completed in
-17.11 seconds on this machine.
+and 2,000 deterministic two-map updates against normal React.
 
 No public API or runtime feature is added. The existing optional map-reorder runtime grew by 15 B
 gzip to a 13,158 B compiler premium, while reorder-only modules still omit it and the core-only

--- a/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
+++ b/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
@@ -13,18 +13,21 @@ complete-reconciliation control.
 
 | Mode   | React median | Two maps + reorder | Compiled control | vs React | vs control |
 | ------ | -----------: | -----------------: | ---------------: | -------: | ---------: |
-| Static |    198.30 ms |           34.20 ms |         47.30 ms |    5.80x |      1.38x |
-| Hybrid |    198.30 ms |           34.20 ms |         46.10 ms |    5.80x |      1.35x |
+| Static |    205.25 ms |           29.70 ms |         39.90 ms |    6.91x |      1.34x |
+| Hybrid |    205.25 ms |           31.90 ms |         39.60 ms |    6.43x |      1.24x |
 
 The independent gate requires at least 4x versus bracketed React and 1.2x versus the compiled
 control in both modes. It passed without lowering either threshold. The run also proved that all
-10,000 original row nodes stayed connected, the edited row retained its DOM identity after moving,
-the final label and amount were correct, and compiled owner executions remained zero.
+10,000 original row nodes stayed connected in the complete expected amount/id order, the edited
+row retained its DOM identity after moving, the final label and amount were correct, and compiled
+owner executions remained zero. The full permutation oracle runs after each latency sample, so its
+assertion work is not included in the update measurement.
 
 Every existing correctness and performance gate passed in the same run, including the general
 regression gate, the 8x optimization-persistence floor, normalized scalability, and the earlier
-single-map reorder gate. The single-map workload remained 5.23x faster than React in static mode
-and 5.28x in hybrid mode, with 1.41x versus its compiled control in both modes.
+single-map reorder gate. In this latest run, the single-map workload was 5.99x faster than React in
+static mode and 5.89x in hybrid mode, with 1.33x and 1.39x versus its compiled control. The section
+below preserves the measurements from the earlier run that introduced that workload.
 
 Compiler tests accept consecutive safe conditional object-spread maps before native sort/reverse
 suffixes and keep structural calls, maps after reordering, and unsupported callbacks on complete

--- a/examples/react-compiler-dashboard/README.md
+++ b/examples/react-compiler-dashboard/README.md
@@ -310,6 +310,9 @@ The default JSON report is `/tmp/farm-react-dashboard-benchmark.json`; change it
   block-bodied equivalent rereads the complete keyed snapshot; the hinted path isolates the saved
   descriptor and unchanged-binding work while both paths run the same native map, sort, and LIS
   movement.
+- The multi-map reorder control changes one row's label and amount in two consecutive native maps,
+  then sorts the same keyed rows. Its block-bodied equivalent keeps complete reconciliation, while
+  the hinted path proves one flattened source-row lineage and patches the final row once.
 - The sort control compares concise native `toSorted()` with an equivalent block-bodied compiled
   update. Both paths run the same native sort and move the same keyed DOM rows; the hint isolates
   the saved key, descriptor, and binding work while retaining only the required LIS moves.

--- a/examples/react-compiler-dashboard/scripts/benchmark.mjs
+++ b/examples/react-compiler-dashboard/scripts/benchmark.mjs
@@ -1198,7 +1198,11 @@ async function measureTrial(browser, trial, compilerMode, port) {
             ),
         );
 
-        const measureMapReorderPipeline = async (action) => {
+        const measureMapReorderPipeline = async (
+          action,
+          expectedLabelSuffix = " repriced",
+          expectedAmount = "$-1",
+        ) => {
           const rows = [...table.querySelectorAll("tbody tr")];
           const target = rows.find(
             (row) => Number(row.getAttribute("data-row-id")) % 10_000 === 5_001,
@@ -1210,8 +1214,10 @@ async function measureTrial(browser, trial, compilerMode, port) {
               nextRows.length === 10_000 &&
               nextRows[0] === target &&
               rows.every((row) => row.isConnected) &&
-              target.querySelector("td:nth-child(2)")?.textContent?.endsWith(" repriced") === true &&
-              target.querySelector("td:nth-child(4)")?.textContent === "$-1"
+              target
+                .querySelector("td:nth-child(2)")
+                ?.textContent?.endsWith(expectedLabelSuffix) === true &&
+              target.querySelector("td:nth-child(4)")?.textContent === expectedAmount
             );
           });
         };
@@ -1229,6 +1235,26 @@ async function measureTrial(browser, trial, compilerMode, port) {
           async () =>
             measureMapReorderPipeline(() =>
               tableButton("table-map-reorder-pipeline-snapshot").click(),
+            ),
+        );
+
+        const tableMultiMapReorderPipeline = await measureTable(
+          async () => create10000(),
+          async () =>
+            measureMapReorderPipeline(
+              () => tableButton("table-multi-map-reorder-pipeline").click(),
+              " reviewed",
+              "$-2",
+            ),
+        );
+
+        const tableMultiMapReorderPipelineSnapshot = await measureTable(
+          async () => create10000(),
+          async () =>
+            measureMapReorderPipeline(
+              () => tableButton("table-multi-map-reorder-pipeline-snapshot").click(),
+              " reviewed",
+              "$-2",
             ),
         );
 
@@ -1628,6 +1654,8 @@ async function measureTrial(browser, trial, compilerMode, port) {
             filterReorderPipelineSnapshot: tableFilterReorderPipelineSnapshot,
             mapReorderPipeline: tableMapReorderPipeline,
             mapReorderPipelineSnapshot: tableMapReorderPipelineSnapshot,
+            multiMapReorderPipeline: tableMultiMapReorderPipeline,
+            multiMapReorderPipelineSnapshot: tableMultiMapReorderPipelineSnapshot,
             mapLookup: tableMapLookup,
             membership: tableMembership,
             prepend: tablePrepend,
@@ -1752,6 +1780,10 @@ async function measureTrial(browser, trial, compilerMode, port) {
         filterReorderPipelineSnapshot: timingSummary(result.table.filterReorderPipelineSnapshot),
         mapReorderPipeline: timingSummary(result.table.mapReorderPipeline),
         mapReorderPipelineSnapshot: timingSummary(result.table.mapReorderPipelineSnapshot),
+        multiMapReorderPipeline: timingSummary(result.table.multiMapReorderPipeline),
+        multiMapReorderPipelineSnapshot: timingSummary(
+          result.table.multiMapReorderPipelineSnapshot,
+        ),
         mapLookup: timingSummary(result.table.mapLookup),
         membership: timingSummary(result.table.membership),
         prepend: timingSummary(result.table.prepend),
@@ -1926,6 +1958,8 @@ const tableMetrics = [
   "filterReorderPipelineSnapshot",
   "mapReorderPipeline",
   "mapReorderPipelineSnapshot",
+  "multiMapReorderPipeline",
+  "multiMapReorderPipelineSnapshot",
   "snapshotMembership",
   "snapshotMapLookup",
   "slicePrefix",
@@ -2562,6 +2596,29 @@ const keyedMapReorderRegressions = keyedMapReorderResults.filter(
     !Number.isFinite(snapshotSpeedup) ||
     snapshotSpeedup < keyedMapReorderMinimumSnapshotSpeedup,
 );
+// Multiple safe map stages should keep one flat source-row lineage and still reconcile only the
+// final permutation. Compare the concise two-map setter with React and its block-bodied compiled
+// control at 10,000 rows.
+const keyedMultiMapReorderMinimumSpeedup = 4;
+const keyedMultiMapReorderMinimumSnapshotSpeedup = 1.2;
+const keyedMultiMapReorderResults = ["static", "hybrid"].map((mode) => {
+  const pipelineMedianMs = comparisons.table.multiMapReorderPipeline[mode].medianMs;
+  const snapshotMedianMs = comparisons.table.multiMapReorderPipelineSnapshot[mode].medianMs;
+  return {
+    mode,
+    pipelineMedianMs,
+    snapshotMedianMs,
+    snapshotSpeedup: snapshotMedianMs / pipelineMedianMs,
+    speedup: comparisons.table.multiMapReorderPipeline[`${mode}VsBaseline`].speedup,
+  };
+});
+const keyedMultiMapReorderRegressions = keyedMultiMapReorderResults.filter(
+  ({ snapshotSpeedup, speedup }) =>
+    !Number.isFinite(speedup) ||
+    speedup < keyedMultiMapReorderMinimumSpeedup ||
+    !Number.isFinite(snapshotSpeedup) ||
+    snapshotSpeedup < keyedMultiMapReorderMinimumSnapshotSpeedup,
+);
 // A direct native toSorted() exposes a permutation while preserving every keyed row object. The
 // hinted path validates that permutation by item identity, uses LIS to move only the required DOM
 // nodes, and avoids key, descriptor, and binding reads. Compare it with React and the equivalent
@@ -2750,6 +2807,7 @@ const passed =
   keyedReorderPipelineRegressions.length === 0 &&
   keyedStructuralReorderRegressions.length === 0 &&
   keyedMapReorderRegressions.length === 0 &&
+  keyedMultiMapReorderRegressions.length === 0 &&
   keyedSortRegressions.length === 0 &&
   keyedFilterRegressions.length === 0 &&
   keyedIdentityRegressions.length === 0 &&
@@ -2915,6 +2973,13 @@ const report = {
     regressions: keyedMapReorderRegressions,
     results: keyedMapReorderResults,
     status: keyedMapReorderRegressions.length === 0 ? "PASS" : "FAIL",
+  },
+  keyedMultiMapReorderHintGate: {
+    minimumSnapshotSpeedup: keyedMultiMapReorderMinimumSnapshotSpeedup,
+    minimumSpeedup: keyedMultiMapReorderMinimumSpeedup,
+    regressions: keyedMultiMapReorderRegressions,
+    results: keyedMultiMapReorderResults,
+    status: keyedMultiMapReorderRegressions.length === 0 ? "PASS" : "FAIL",
   },
   keyedSortHintGate: {
     minimumSnapshotSpeedup: keyedSortMinimumSnapshotSpeedup,

--- a/examples/react-compiler-dashboard/scripts/benchmark.mjs
+++ b/examples/react-compiler-dashboard/scripts/benchmark.mjs
@@ -1198,64 +1198,110 @@ async function measureTrial(browser, trial, compilerMode, port) {
             ),
         );
 
+        const prepareMapReorderPipeline = async (expectedAmount) => {
+          await create10000();
+          const rows = [...table.querySelectorAll("tbody tr")];
+          const orderedRows = rows.map((row) => {
+            const id = Number(row.getAttribute("data-row-id"));
+            const amountText = row.querySelector("td:nth-child(4)")?.textContent;
+            const amount = Number(amountText?.slice(1));
+            if (!Number.isFinite(id) || !Number.isFinite(amount)) {
+              throw new Error("Map-reorder source row is invalid.");
+            }
+            return {
+              amount: id % 10_000 === 5_001 ? expectedAmount : amount,
+              id,
+              row,
+            };
+          });
+          orderedRows.sort((left, right) => left.amount - right.amount || left.id - right.id);
+          const target = orderedRows.find(({ id }) => id % 10_000 === 5_001)?.row;
+          if (!target) throw new Error("Map-reorder target row is missing.");
+          return { expectedRows: orderedRows.map(({ row }) => row), rows, target };
+        };
+
         const measureMapReorderPipeline = async (
           action,
+          prepared,
           expectedLabelSuffix = " repriced",
-          expectedAmount = "$-1",
+          expectedAmount = -1,
         ) => {
-          const rows = [...table.querySelectorAll("tbody tr")];
-          const target = rows.find(
-            (row) => Number(row.getAttribute("data-row-id")) % 10_000 === 5_001,
-          );
-          if (!target) throw new Error("Map-reorder target row is missing.");
+          if (!prepared) throw new Error("Map-reorder expectation is missing.");
+          const { expectedRows, rows, target } = prepared;
           await runTableAction(action, () => {
             const nextRows = table.querySelectorAll("tbody tr");
             return (
               nextRows.length === 10_000 &&
               nextRows[0] === target &&
-              rows.every((row) => row.isConnected) &&
               target
                 .querySelector("td:nth-child(2)")
                 ?.textContent?.endsWith(expectedLabelSuffix) === true &&
-              target.querySelector("td:nth-child(4)")?.textContent === expectedAmount
+              target.querySelector("td:nth-child(4)")?.textContent === `$${expectedAmount}`
             );
           });
+          return () => {
+            const nextRows = table.querySelectorAll("tbody tr");
+            if (
+              nextRows.length !== 10_000 ||
+              !rowsMatch(nextRows, expectedRows) ||
+              rows.some((row) => !row.isConnected)
+            ) {
+              throw new Error("Map-reorder rows do not match the complete expected permutation.");
+            }
+          };
         };
 
-        const tableMapReorderPipeline = await measureTable(
-          async () => create10000(),
-          async () =>
-            measureMapReorderPipeline(() =>
-              tableButton("table-map-reorder-pipeline").click(),
-            ),
+        const measureMapReorderTable = async (
+          action,
+          expectedAmount,
+          expectedLabelSuffix = " repriced",
+        ) => {
+          for (let sample = 0; sample < warmupSamples; sample += 1) {
+            const prepared = await prepareMapReorderPipeline(expectedAmount);
+            const verify = await measureMapReorderPipeline(
+              action,
+              prepared,
+              expectedLabelSuffix,
+              expectedAmount,
+            );
+            verify();
+          }
+          const timings = [];
+          for (let sample = 0; sample < tableSamples; sample += 1) {
+            const prepared = await prepareMapReorderPipeline(expectedAmount);
+            const startedAt = performance.now();
+            const verify = await measureMapReorderPipeline(
+              action,
+              prepared,
+              expectedLabelSuffix,
+              expectedAmount,
+            );
+            timings.push(performance.now() - startedAt);
+            verify();
+          }
+          return timings;
+        };
+
+        const tableMapReorderPipeline = await measureMapReorderTable(
+          () => tableButton("table-map-reorder-pipeline").click(),
+          -1,
         );
 
-        const tableMapReorderPipelineSnapshot = await measureTable(
-          async () => create10000(),
-          async () =>
-            measureMapReorderPipeline(() =>
-              tableButton("table-map-reorder-pipeline-snapshot").click(),
-            ),
+        const tableMapReorderPipelineSnapshot = await measureMapReorderTable(
+          () => tableButton("table-map-reorder-pipeline-snapshot").click(),
+          -1,
         );
 
-        const tableMultiMapReorderPipeline = await measureTable(
-          async () => create10000(),
-          async () =>
-            measureMapReorderPipeline(
-              () => tableButton("table-multi-map-reorder-pipeline").click(),
-              " reviewed",
-              "$-2",
-            ),
+        const tableMultiMapReorderPipeline = await measureMapReorderTable(
+          () => tableButton("table-multi-map-reorder-pipeline").click(),
+          -2,
+          " reviewed",
         );
 
-        const tableMultiMapReorderPipelineSnapshot = await measureTable(
-          async () => create10000(),
-          async () =>
-            measureMapReorderPipeline(
-              () => tableButton("table-multi-map-reorder-pipeline-snapshot").click(),
-              " reviewed",
-              "$-2",
-            ),
+        const tableMultiMapReorderPipelineSnapshot = await measureMapReorderTable(
+          () => tableButton("table-multi-map-reorder-pipeline-snapshot").click(),
+          -2,
+          " reviewed",
         );
 
         const tableSort = await measureTable(

--- a/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
+++ b/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
@@ -909,6 +909,42 @@ export function StandardTableBenchmark() {
           Reprice + sort one row (snapshot control)
         </button>
         <button
+          data-action="table-multi-map-reorder-pipeline"
+          type="button"
+          onClick={() => {
+            setRows((current) =>
+              current
+                .map((row) =>
+                  row.id % 10_000 === 5_001 ? { ...row, label: `${row.label} reviewed` } : row,
+                )
+                .map((row) => (row.id % 10_000 === 5_001 ? { ...row, amount: -2 } : row))
+                .toSorted((left, right) => left.amount - right.amount || left.id - right.id),
+            );
+            setOperation("review, reprice, and sort one row");
+            setRevision((value) => value + 1);
+          }}
+        >
+          Review + reprice + sort one row
+        </button>
+        <button
+          data-action="table-multi-map-reorder-pipeline-snapshot"
+          type="button"
+          onClick={() => {
+            setRows((current) => {
+              return current
+                .map((row) =>
+                  row.id % 10_000 === 5_001 ? { ...row, label: `${row.label} reviewed` } : row,
+                )
+                .map((row) => (row.id % 10_000 === 5_001 ? { ...row, amount: -2 } : row))
+                .toSorted((left, right) => left.amount - right.amount || left.id - right.id);
+            });
+            setOperation("review, reprice, and sort one row (snapshot control)");
+            setRevision((value) => value + 1);
+          }}
+        >
+          Review + reprice + sort one row (snapshot control)
+        </button>
+        <button
           data-action="table-sort"
           type="button"
           onClick={() => {

--- a/packages/farm-react/README.md
+++ b/packages/farm-react/README.md
@@ -421,20 +421,22 @@ A compiler-safe same-key map may also precede the native reorder suffix:
 ```tsx
 setItems((current) =>
   current
+    .map((item) => (item.id === editedId ? { ...item, label: nextLabel } : item))
     .map((item) => (item.id === editedId ? { ...item, rank: nextRank } : item))
     .toSorted((left, right) => left.rank - right.rank),
 );
 ```
 
-Farm executes the native map and reorder calls normally, verifies the committed token, dense-array
-shape, a one-to-one source-item match, and every replacement key before touching the DOM, then runs
-one LIS and patches bindings only for changed item identities. Unchanged rows need no second key or
-binding read. Queued supported map-and-reorder setters compose against the same committed rows. The
-initial proof requires an inline synchronous
-conditional mapper that returns either the original item or an object-spread replacement, plus
-index-independent compiler-owned host rows. Changed keys, referenced or block-bodied callbacks,
-unconditional replacements, `thisArg`, structural calls in the same chain, computed or custom
-methods, sparse or subclassed arrays, collection-reading bindings, nested or React-owned rows, and
+Farm executes every native map and reorder call normally and flattens accepted replacement lineage
+back to the committed source rows. It verifies the committed token, dense-array shape, a one-to-one
+source-item match, and every final replacement key before touching the DOM, then runs one LIS and
+patches each changed row once. Unchanged rows need no second key or binding read. Queued supported
+map-and-reorder setters compose against the same committed rows. Every accepted map requires an
+inline synchronous conditional mapper that returns either the original item or an object-spread
+replacement, plus index-independent compiler-owned host rows. Changed keys, referenced or
+block-bodied callbacks, unconditional replacements, `thisArg`, structural calls in the same chain,
+computed or custom methods, sparse or subclassed arrays, collection-reading bindings, nested or
+React-owned rows, and
 failed checks use complete keyed reconciliation. Reports use the existing map, sort, and reorder
 hint counters, and unrelated modules do not retain this optional runtime.
 

--- a/packages/farm-react/src/__tests__/compiler-keyed-array-sort-hints.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-keyed-array-sort-hints.test.ts
@@ -218,6 +218,37 @@ describe("React AOT keyed-array sort hints", () => {
     expect(result.code.match(/createCompilerKeyedArrayMapReorder/g)).toHaveLength(4);
   });
 
+  it("composes multiple safe maps before native reorder steps", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Table({ editedId, nextRank, nextLabel }) {
+        const [rows, setRows] = useState([
+          { id: "a", label: "Alpha", rank: 1 },
+          { id: "b", label: "Beta", rank: 2 },
+        ]);
+        return <section>
+          <button onClick={() => setRows((current) => current
+            .map((row) => row.id === editedId ? { ...row, label: nextLabel } : row)
+            .map((row) => row.id === editedId ? { ...row, rank: nextRank } : row)
+            .toSorted((left, right) => left.rank - right.rank)
+            .toReversed()
+          )}>Edit and reorder</button>
+          <ul>{rows.map((row) => <li key={row.id}>{row.label}: {row.rank}</li>)}</ul>
+        </section>;
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Table"]);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.optimizations.keyedMapUpdateHints).toBe(2);
+    expect(result.optimizations.keyedArraySortHints).toBe(1);
+    expect(result.optimizations.keyedArrayReorderHints).toBe(1);
+    expect(result.code.match(/createCompilerKeyedArrayMapPipeline\(/g)).toHaveLength(2);
+    expect(result.code.match(/createCompilerKeyedArrayMapReorder\(/g)).toHaveLength(2);
+    expect(result.code).toContain("keyedRowsMapReorderHintedRuntimeFeature");
+    expect(result.code).not.toContain("createCompilerKeyedMapUpdate");
+  });
+
   it("does not lower map and reorder pipelines for host-backed keyed rows", async () => {
     const result = await compile(`
       import { useState } from "react";
@@ -265,6 +296,11 @@ describe("React AOT keyed-array sort hints", () => {
       name: "a block-bodied mapper",
       pipeline:
         "current.map((row) => { return row.id === editedId ? { ...row, rank: 0 } : row; }).toSorted((a, b) => a.rank - b.rank)",
+    },
+    {
+      name: "an unsupported second mapper",
+      pipeline:
+        "current.map((row) => row.id === editedId ? { ...row, rank: 0 } : row).map((row) => ({ ...row, rank: row.rank + 1 })).toSorted((a, b) => a.rank - b.rank)",
     },
     {
       name: "a map thisArg",

--- a/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-map-reorder-hints.test.tsx
+++ b/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-map-reorder-hints.test.tsx
@@ -67,6 +67,15 @@ function mappedSort(items: Item[], id: string, rank: number, label?: string): It
   );
 }
 
+function multiMappedSort(items: Item[], id: string, rank: number, label: string): Item[] {
+  return hintedSort(
+    hintedMap(
+      hintedMap(items, (item) => (item.id === id ? { ...item, label } : item)),
+      (item) => (item.id === id ? { ...item, rank } : item),
+    ),
+  );
+}
+
 function rowDescriptor(item: Item): CompilerKeyedRowElement {
   return {
     kind: "element",
@@ -90,11 +99,14 @@ function createHarness(initialItems: Item[]) {
     renders: 0,
   };
   let editAndSort: (id: string, rank: number, label?: string) => void = () => undefined;
+  let editTwoAndSort: (labelId: string, rankId: string) => void = () => undefined;
+  let editTwiceAndSort: (id: string, rank: number, label: string) => void = () => undefined;
   let editSortReverse: (id: string, rank: number) => void = () => undefined;
-  let queueEdits: (edits: readonly { id: string; rank: number; label?: string }[]) => void = () =>
+  let queueEdits: (edits: readonly { id: string; rank: number; label: string }[]) => void = () =>
     undefined;
   let invalidateKey: () => void = () => undefined;
   let customMap: () => void = () => undefined;
+  let customSecondMap: () => void = () => undefined;
   const Table = createCompiledComponent({
     displayName: "MapReorderTable",
     initialize: () => [initialItems],
@@ -103,12 +115,25 @@ function createHarness(initialItems: Item[]) {
       const items = () => state[0].get() as Item[];
       editAndSort = (id, rank, label) =>
         state[0].set((previous) => mappedSort(previous as Item[], id, rank, label));
+      editTwoAndSort = (labelId, rankId) =>
+        state[0].set((previous) =>
+          hintedSort(
+            hintedMap(
+              hintedMap(previous as Item[], (item) =>
+                item.id === labelId ? { ...item, label: `${item.label} labeled` } : item,
+              ),
+              (item) => (item.id === rankId ? { ...item, rank: 4 } : item),
+            ),
+          ),
+        );
+      editTwiceAndSort = (id, rank, label) =>
+        state[0].set((previous) => multiMappedSort(previous as Item[], id, rank, label));
       editSortReverse = (id, rank) =>
         state[0].set((previous) => hintedReverse(mappedSort(previous as Item[], id, rank)));
       queueEdits = (edits) => {
         for (const edit of edits) {
           state[0].set((previous) =>
-            mappedSort(previous as Item[], edit.id, edit.rank, edit.label),
+            multiMappedSort(previous as Item[], edit.id, edit.rank, edit.label),
           );
         }
       };
@@ -135,6 +160,26 @@ function createHarness(initialItems: Item[]) {
           return createCompilerKeyedArrayMapReorder(
             mapped,
             mapped.toSorted,
+            (left: Item, right: Item) => left.rank - right.rank,
+          );
+        });
+      customSecondMap = () =>
+        state[0].set((previous) => {
+          const first = hintedMap(previous as Item[], (item) =>
+            item.id === "a" ? { ...item, label: "First map" } : item,
+          );
+          const map = function (
+            this: Item[],
+            callback: (item: Item, index: number, items: Item[]) => Item,
+          ) {
+            return Array.prototype.map.call(this, callback);
+          };
+          const second = createCompilerKeyedArrayMapPipeline(first, map, (item: Item) =>
+            item.id === "b" ? { ...item, rank: 0 } : item,
+          ) as Item[];
+          return createCompilerKeyedArrayMapReorder(
+            second,
+            second.toSorted,
             (left: Item, right: Item) => left.rank - right.rank,
           );
         });
@@ -188,10 +233,14 @@ function createHarness(initialItems: Item[]) {
     Table,
     counters,
     customMap: () => customMap(),
+    customSecondMap: () => customSecondMap(),
     editAndSort: (id: string, rank: number, label?: string) => editAndSort(id, rank, label),
+    editTwoAndSort: (labelId: string, rankId: string) => editTwoAndSort(labelId, rankId),
+    editTwiceAndSort: (id: string, rank: number, label: string) =>
+      editTwiceAndSort(id, rank, label),
     editSortReverse: (id: string, rank: number) => editSortReverse(id, rank),
     invalidateKey: () => invalidateKey(),
-    queueEdits: (edits: readonly { id: string; rank: number; label?: string }[]) =>
+    queueEdits: (edits: readonly { id: string; rank: number; label: string }[]) =>
       queueEdits(edits),
   };
 }
@@ -252,7 +301,74 @@ describe("compiled keyed-array map and reorder hints", () => {
     expect(harness.counters.executions).toBe(1);
   });
 
-  it("composes queued mapped reorders against the last committed rows", async () => {
+  it("composes multiple map stages and patches the final row only once", async () => {
+    const harness = createHarness([
+      { id: "a", label: "Alpha", rank: 1 },
+      { id: "b", label: "Beta", rank: 2 },
+      { id: "c", label: "Gamma", rank: 3 },
+    ]);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Table />));
+    const rows = new Map(
+      [...container.querySelectorAll("li")].map((row) => [row.dataset.key, row]),
+    );
+    harness.counters.bindings = 0;
+    harness.counters.descriptors = 0;
+    harness.counters.keys = 0;
+
+    await act(async () => {
+      harness.editTwiceAndSort("a", 4, "Alpha twice");
+      await flushCompilerUpdates();
+    });
+
+    expect(labels(container)).toEqual(["Beta:2", "Gamma:3", "Alpha twice:4"]);
+    for (const [key, row] of rows) {
+      expect(container.querySelector(`[data-key="${key}"]`)).toBe(row);
+    }
+    expect(harness.counters.executions).toBe(1);
+    expect(harness.counters.renders).toBe(1);
+    expect(harness.counters.keys).toBe(1);
+    expect(harness.counters.descriptors).toBe(0);
+    expect(harness.counters.bindings).toBe(1);
+  });
+
+  it("keeps source lineage for different rows changed by separate map stages", async () => {
+    const harness = createHarness([
+      { id: "a", label: "Alpha", rank: 1 },
+      { id: "b", label: "Beta", rank: 2 },
+      { id: "c", label: "Gamma", rank: 3 },
+    ]);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Table />));
+    const rows = new Map(
+      [...container.querySelectorAll("li")].map((row) => [row.dataset.key, row]),
+    );
+    harness.counters.bindings = 0;
+    harness.counters.descriptors = 0;
+    harness.counters.keys = 0;
+
+    await act(async () => {
+      harness.editTwoAndSort("c", "a");
+      await flushCompilerUpdates();
+    });
+
+    expect(labels(container)).toEqual(["Beta:2", "Gamma labeled:3", "Alpha:4"]);
+    for (const [key, row] of rows) {
+      expect(container.querySelector(`[data-key="${key}"]`)).toBe(row);
+    }
+    expect(harness.counters.executions).toBe(1);
+    expect(harness.counters.keys).toBe(2);
+    expect(harness.counters.descriptors).toBe(0);
+    expect(harness.counters.bindings).toBe(2);
+  });
+
+  it("composes queued multi-map reorders against the last committed rows", async () => {
     const harness = createHarness([
       { id: "a", label: "Alpha", rank: 1 },
       { id: "b", label: "Beta", rank: 2 },
@@ -299,6 +415,38 @@ describe("compiled keyed-array map and reorder hints", () => {
       await flushCompilerUpdates();
     });
     expect(labels(container)).toEqual(["Replacement:1", "Custom:2"]);
+  });
+
+  it("discards earlier map lineage when a later map method is custom", async () => {
+    const harness = createHarness([
+      { id: "a", label: "Alpha", rank: 2 },
+      { id: "b", label: "Beta", rank: 1 },
+    ]);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Table />));
+    harness.counters.bindings = 0;
+
+    await act(async () => {
+      harness.customSecondMap();
+      await flushCompilerUpdates();
+    });
+
+    expect(labels(container)).toEqual(["Beta:0", "First map:2"]);
+    expect(harness.counters.bindings).toBe(2);
+  });
+
+  it("preserves a native error thrown by a later map stage", () => {
+    const items: Item[] = [{ id: "a", label: "Alpha", rank: 1 }];
+    const first = hintedMap(items, (item) => item);
+
+    expect(() =>
+      hintedMap(first, () => {
+        throw new Error("second map failed");
+      }),
+    ).toThrow("second map failed");
   });
 
   it("reads accessor-backed source items only through the native map before falling back", async () => {
@@ -523,7 +671,8 @@ describe("compiled keyed-array map and reorder hints", () => {
         updateReact = (id, rank, label) =>
           setItems((previous) =>
             previous
-              .map((item) => (item.id === id ? { ...item, rank, label } : item))
+              .map((item) => (item.id === id ? { ...item, label } : item))
+              .map((item) => (item.id === id ? { ...item, rank } : item))
               .toSorted((left, right) => left.rank - right.rank),
           );
         return (
@@ -555,7 +704,7 @@ describe("compiled keyed-array map and reorder hints", () => {
         const rank = (seed ^ (seed >>> 16)) % 4_003;
         const label = `Updated ${update}`;
         await act(async () => {
-          harness.editAndSort(id, rank, label);
+          harness.editTwiceAndSort(id, rank, label);
           updateReact(id, rank, label);
           await flushCompilerUpdates();
         });
@@ -589,7 +738,7 @@ describe("compiled keyed-array map and reorder hints", () => {
     });
     roots.push(root);
     await act(async () => {
-      hydration.editAndSort("a", 5, "Alpha hydrated");
+      hydration.editTwiceAndSort("a", 5, "Alpha hydrated");
       await flushCompilerUpdates();
     });
     expect(labels(container)).toEqual(["Beta:2", "Gamma:3", "Alpha hydrated:5"]);

--- a/packages/farm-react/src/compiler-runtime.tsx
+++ b/packages/farm-react/src/compiler-runtime.tsx
@@ -552,7 +552,7 @@ export function createCompilerKeyedMapUpdate(
   return value;
 }
 
-/** @internal Executes a proven native map at the start of a keyed reorder pipeline. */
+/** @internal Executes a proven native map before the reorder suffix of a keyed pipeline. */
 export function createCompilerKeyedArrayMapPipeline(
   previous: unknown,
   method: unknown,
@@ -582,21 +582,21 @@ export function createCompilerKeyedArrayMapPipeline(
     }
 
     const committedSource = COMPILER_KEYED_COMMITTED_COLLECTIONS.has(previousTarget);
-    const previousReorder = committedSource
+    const previousMapPipeline = committedSource
       ? undefined
-      : COMPILER_KEYED_ARRAY_REORDERS.get(previousTarget);
-    if (
-      !committedSource &&
-      (!previousReorder ||
-        !previousReorder.mapped ||
-        previousReorder.resultLength !== previous.length)
-    ) {
+      : COMPILER_KEYED_ARRAY_MAP_PIPELINES.get(previousTarget);
+    const previousReorder =
+      committedSource || previousMapPipeline
+        ? undefined
+        : COMPILER_KEYED_ARRAY_REORDERS.get(previousTarget);
+    const previousSource =
+      previousMapPipeline || (previousReorder?.mapped ? previousReorder : undefined);
+    if (!committedSource && (!previousSource || previousSource.resultLength !== previous.length)) {
       return value;
     }
-    const sourceToken =
-      previousReorder?.sourceToken || compilerKeyedCollectionToken(previousTarget);
+    const sourceToken = previousSource?.sourceToken || compilerKeyedCollectionToken(previousTarget);
     if (!sourceToken) return value;
-    const previousMappedItemSources = previousReorder?.mappedItemSources;
+    const previousMappedItemSources = previousSource?.mappedItemSources;
     const mappedItemSources = new Map<unknown, unknown>();
     for (let index = 0; index < value.length; index += 1) {
       const previousDescriptor = Object.getOwnPropertyDescriptor(previous, index);
@@ -610,6 +610,8 @@ export function createCompilerKeyedArrayMapPipeline(
         return value;
       }
       const previousItem = previousDescriptor.value;
+      // Keep every replacement directly connected to the committed row instead of retaining a
+      // chain of intermediate map results.
       const sourceItem = previousMappedItemSources?.has(previousItem)
         ? previousMappedItemSources.get(previousItem)
         : previousItem;
@@ -618,7 +620,7 @@ export function createCompilerKeyedArrayMapPipeline(
     }
     COMPILER_KEYED_ARRAY_MAP_PIPELINES.set(valueTarget, {
       sourceToken,
-      sourceLength: previousReorder?.sourceLength || previous.length,
+      sourceLength: previousSource?.sourceLength ?? previous.length,
       resultLength: value.length,
       mappedItemSources,
     });

--- a/packages/farm-react/src/compiler.ts
+++ b/packages/farm-react/src/compiler.ts
@@ -1993,10 +1993,9 @@ function keyedArrayReorderPipeline(
   let structuralSteps = 0;
   let reorderSteps = 0;
   let reachedReorder = false;
-  for (let index = 0; index < steps.length; index += 1) {
-    const step = steps[index];
+  for (const step of steps) {
     if (step.kind === "map") {
-      if (index !== 0 || reachedReorder || structuralSteps > 0) return undefined;
+      if (reachedReorder || structuralSteps > 0) return undefined;
       mapSteps += 1;
     } else if (step.kind === "filter" || step.kind === "slice") {
       if (reachedReorder) return undefined;
@@ -2006,9 +2005,9 @@ function keyedArrayReorderPipeline(
       reorderSteps += 1;
     }
   }
-  if (mapSteps > 1 || (mapSteps > 0 && structuralSteps > 0)) return undefined;
+  if (mapSteps > 0 && structuralSteps > 0) return undefined;
   if (reorderSteps < 1) return undefined;
-  if (mapSteps === 1 && reorderSteps >= 1) return steps;
+  if (mapSteps > 0 && reorderSteps >= 1) return steps;
   if (structuralSteps < 1 && reorderSteps < 2) return undefined;
   return steps;
 }


### PR DESCRIPTION
## Problem

The experimental React compiler can compose one safe same-key `map()` with a native `toSorted()` or `toReversed()` suffix, but a second equally safe map makes the complete setter fall back. Real table updates often derive separate fields in consecutive maps before restoring order, so they lose the existing keyed-row fast path and reread the complete keyed snapshot.

## Root cause

The compiler rejected reorder pipelines with more than one map step. The runtime map helper could inherit committed rows or a mapped reorder result, but it could not inherit the flattened source-row lineage from an immediately preceding map result.

## Change

- Accept one or more consecutive compiler-safe same-key maps before native sort/reverse suffixes.
- Flatten each intermediate replacement directly to its committed source row, avoiding a retained chain of map snapshots.
- Preserve one final keyed reconciliation and one LIS pass, patching each final changed row once.
- Add a 10,000-row two-map benchmark and an equivalent block-bodied complete-reconciliation control.
- Verify the exact 10,000-row amount/id permutation after every latency sample, outside the timed interval.
- Document the supported syntax, runtime validation, fallback behavior, and measured result.

## Safety and compatibility

JavaScript still executes every native map and reorder normally. Before a DOM mutation, the runtime validates native methods, ordinary dense arrays, collection token and length, one-to-one source identity, final row keys, and binding eligibility. Unsupported syntax, a custom later map, changed or duplicate keys, sparse/subclassed arrays, ambiguous ownership, and failed validation use complete React reconciliation.

Coverage includes same-row and different-row replacements across stages, queued updates, native errors, custom-method fallback, key changes, controlled-input focus and selection, delegated events, Strict Mode hydration, unmount-before-flush cleanup, and 2,000 randomized differential updates against normal React. React 18.3.1 and 19.2.8 compatibility pass.

This changes only the opt-in experimental React compiler. It adds no public API or runtime feature. Reorder-only modules still tree-shake the map-reorder helper. The optional keyed map/reorder compiler premium is 13,158 B gzip (+15 B); the core-only runtime retains an 83.4% reduction versus the complete compatibility runtime.

## Verification

Revalidated after rebasing onto `b55a3ade`:

- `pnpm --dir packages/farm-react exec vitest run src/__tests__/compiler-keyed-array-sort-hints.test.ts src/__tests__/compiler-runtime-keyed-array-map-reorder-hints.test.tsx` — 45 passed, 1 stress test skipped
- `FARM_REACT_STRESS=1 pnpm --dir packages/farm-react exec vitest run src/__tests__/compiler-runtime-keyed-array-map-reorder-hints.test.tsx` — 13 passed, including 2,000 differential updates
- Affected compiler/report/Vite suites — 18 passed
- `pnpm --filter @farm.js/react type-check`
- `pnpm --filter @farm.js/core type-check`
- `pnpm --filter @farm.js/react build`
- `pnpm --filter @farm.js/react test:compat` — React 18.3.1 and 19.2.8 passed
- `pnpm --filter @farm.js/react test:runtime-size`
- Dashboard type-check and benchmark script syntax check
- Full bracketed Chrome dashboard benchmark — result PASS; correctness, exact 10,000-row permutation, general regression, optimization persistence, scalability, all existing feature gates, and the new gate passed
  - static: 32.10 ms vs React 206.45 ms and compiled control 44.30 ms — 6.43x / 1.38x
  - hybrid: 32.40 ms vs React 206.45 ms and compiled control 44.30 ms — 6.37x / 1.37x
  - all 10,000 original row nodes preserved in the expected amount/id order; zero compiled owner executions
- `pnpm docs:check-navigation` — 74 pages
- `pnpm --dir docs exec farm generate --check`
- `pnpm docs:build`
- Focused `oxfmt`, `oxlint`, script syntax check, and `git diff --check`

Benchmark environment: Chrome 152.0.7977.82, Node.js 23.11.0, Apple M1 macOS arm64.

## Documentation and release

Updated the React renderer docs, `@farm.js/react` README, dashboard benchmark guide, executable benchmark, and recorded results. No version or release-flow change.
