### PR TITLE
fix(telemetry): exclude Vercel preview deployments

### DIFF
--- a/docs/src/app/api/telemetry/v1/sites/route.test.ts
+++ b/docs/src/app/api/telemetry/v1/sites/route.test.ts
@@ -1,9 +1,26 @@
 // @vitest-environment node
 
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { farmLegacyVercelPreviewSiteWhere } from "../../../../../lib/telemetry-sites";
 import { POST } from "./route";
 
+const prismaMocks = vi.hoisted(() => ({
+  deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
+  upsert: vi.fn().mockResolvedValue({}),
+}));
+
+vi.mock("../../../../../lib/prisma", () => ({
+  getPrisma: async () => ({
+    farmProductionSite: prismaMocks,
+  }),
+}));
+
 const originalDatabaseUrl = process.env.DATABASE_URL;
+
+beforeEach(() => {
+  prismaMocks.deleteMany.mockClear();
+  prismaMocks.upsert.mockClear();
+});
 
 afterEach(() => {
   if (originalDatabaseUrl === undefined) delete process.env.DATABASE_URL;
@@ -59,5 +76,58 @@ describe("production-site telemetry ingestion", () => {
 
     expect(response.status).toBe(400);
     await expect(response.json()).resolves.toEqual({ ok: false, error: "invalid_site" });
+  });
+
+  it("accepts but does not store a known Vercel branch-preview alias", async () => {
+    delete process.env.DATABASE_URL;
+
+    const response = await POST(
+      request(
+        sitePayload({
+          siteUrl: "https://docs-git-fix-query-array-round-trip-kinfe123s-projects.vercel.app",
+        }),
+      ),
+    );
+
+    expect(response.status).toBe(202);
+    await expect(response.json()).resolves.toEqual({
+      ok: true,
+      stored: false,
+      warning: "preview_deployment",
+    });
+  });
+
+  it("keeps a production vercel.app origin eligible", async () => {
+    delete process.env.DATABASE_URL;
+
+    const response = await POST(
+      request(sitePayload({ siteUrl: "https://farm-git-tools.vercel.app" })),
+    );
+
+    expect(response.status).toBe(202);
+    await expect(response.json()).resolves.toEqual({
+      ok: true,
+      stored: false,
+      warning: "database_not_configured",
+    });
+  });
+
+  it("removes a previously stored Vercel branch-preview alias", async () => {
+    process.env.DATABASE_URL = "postgresql://telemetry.invalid/farmjs";
+    const siteUrl = "https://docs-git-fix-query-array-round-trip-kinfe123s-projects.vercel.app";
+
+    const response = await POST(request(sitePayload({ siteUrl })));
+
+    expect(response.status).toBe(202);
+    await expect(response.json()).resolves.toEqual({
+      ok: true,
+      stored: false,
+      warning: "preview_deployment",
+    });
+    expect(prismaMocks.upsert).not.toHaveBeenCalled();
+    expect(prismaMocks.deleteMany).toHaveBeenCalledWith({ where: { url: siteUrl } });
+    expect(prismaMocks.deleteMany).toHaveBeenCalledWith({
+      where: farmLegacyVercelPreviewSiteWhere,
+    });
   });
 });

--- a/docs/src/app/api/telemetry/v1/sites/route.ts
+++ b/docs/src/app/api/telemetry/v1/sites/route.ts
@@ -6,6 +6,10 @@ import {
   normalizeFarmProductionSiteOrigin,
 } from "../../../../../../../packages/farm/src/product-telemetry";
 import { getPrisma } from "../../../../../lib/prisma";
+import {
+  farmLegacyVercelPreviewSiteWhere,
+  isFarmLegacyVercelPreviewSite,
+} from "../../../../../lib/telemetry-sites";
 import { z } from "zod";
 
 const MAX_BODY_BYTES = 8 * 1024;
@@ -71,7 +75,7 @@ function retentionDays(): number {
     : DEFAULT_RETENTION_DAYS;
 }
 
-async function pruneInactiveSites(
+async function pruneProductionSites(
   prisma: Awaited<ReturnType<typeof getPrisma>>,
   now = Date.now(),
 ): Promise<void> {
@@ -79,7 +83,12 @@ async function pruneInactiveSites(
   lastPruneAt = now;
   const cutoff = new Date(now - retentionDays() * 24 * 60 * 60 * 1_000);
   try {
-    await prisma.farmProductionSite.deleteMany({ where: { lastSeenAt: { lt: cutoff } } });
+    await Promise.all([
+      prisma.farmProductionSite.deleteMany({ where: { lastSeenAt: { lt: cutoff } } }),
+      prisma.farmProductionSite.deleteMany({
+        where: farmLegacyVercelPreviewSiteWhere,
+      }),
+    ]);
   } catch (error) {
     console.error("[farmjs.telemetry.site-prune]", error);
   }
@@ -118,12 +127,26 @@ export async function POST(request: Request): Promise<Response> {
     return json({ ok: false, error: "rate_limited" }, 429);
   }
   if (!process.env.DATABASE_URL) {
-    return json({ ok: true, stored: false, warning: "database_not_configured" }, 202);
+    return json(
+      {
+        ok: true,
+        stored: false,
+        warning: isFarmLegacyVercelPreviewSite(parsed.data.siteUrl)
+          ? "preview_deployment"
+          : "database_not_configured",
+      },
+      202,
+    );
   }
 
   try {
     const prisma = await getPrisma();
     const now = new Date();
+    if (isFarmLegacyVercelPreviewSite(parsed.data.siteUrl)) {
+      await prisma.farmProductionSite.deleteMany({ where: { url: parsed.data.siteUrl } });
+      await pruneProductionSites(prisma, now.getTime());
+      return json({ ok: true, stored: false, warning: "preview_deployment" }, 202);
+    }
     await prisma.farmProductionSite.upsert({
       where: { url: parsed.data.siteUrl },
       update: {
@@ -143,7 +166,7 @@ export async function POST(request: Request): Promise<Response> {
         lastSeenAt: now,
       },
     });
-    await pruneInactiveSites(prisma, now.getTime());
+    await pruneProductionSites(prisma, now.getTime());
     return json({ ok: true, stored: true }, 202);
   } catch (error) {
     console.error("[farmjs.telemetry.site-ingest]", error);

--- a/docs/src/app/docs/telemetry/page.md
+++ b/docs/src/app/docs/telemetry/page.md
@@ -73,8 +73,14 @@ export default defineConfig({
 });
 ```
 
-Set `FARM_TELEMETRY=0` or `FARM_TELEMETRY_DISABLED=1` only in selected deployment environments
-when, for example, previews should be excluded while production remains enabled.
+Vercel preview, development, and custom-environment deployments are skipped automatically from
+`VERCEL_ENV` and `VERCEL_TARGET_ENV`. Farm does not classify deployments from the hostname suffix,
+so a production website whose public domain ends in `.vercel.app` remains eligible. On another
+provider, set `FARM_TELEMETRY=0` or `FARM_TELEMETRY_DISABLED=1` in preview environments while
+leaving production enabled.
+
+The Farm-owned endpoint removes the Vercel-confirmed legacy preview aliases that were stored before
+this runtime guard existed. It does not guess whether a deployment is a preview from its hostname.
 
 After the first non-health production request, Farm schedules a check-in through the deployment
 runtime's background-work hook. It does not wait for the network before handling or returning the
@@ -84,9 +90,8 @@ is eligible for a later best-effort retry. Multiple instances update the same si
 The check-in contains only the detected origin, `@farm.js/core` version, renderer name, and deploy
 target. It does not contain a visitor or installation identifier, the full request URL beyond the
 reported origin, headers, cookies, IP address, user-agent string, or application data. Fully static
-exports have no server runtime and therefore do not send production-site check-ins. Public preview
-deployments can report their own HTTPS origin; disable telemetry in the preview environment if those
-should not appear.
+exports have no server runtime and therefore do not send production-site check-ins. Vercel preview,
+development, and custom-environment deployments do not send production-site check-ins.
 
 Set `telemetry: false` and redeploy to stop future check-ins. An inactive site disappears from the
 maintainer dashboard after the retention window.
@@ -133,9 +138,10 @@ Because the public clients contain no ingestion secret, dashboard origins are us
 than verified domain-ownership records.
 
 Raw telemetry events and inactive production-site records are retained for 90 days by default and
-are pruned by the ingestion service. Aggregated package-download counts remain available
-independently through npm's public download statistics. A deployment operator can change the
-retention window with `FARM_TELEMETRY_RETENTION_DAYS`.
+are pruned by the ingestion service. The verified legacy Vercel preview records are also removed
+during this maintenance pass. Aggregated package-download counts remain available independently
+through npm's public download statistics. A deployment operator can change the retention window
+with `FARM_TELEMETRY_RETENTION_DAYS`.
 
 For local endpoint development only, `FARM_TELEMETRY_ENDPOINT` and
 `FARM_TELEMETRY_SITE_ENDPOINT` can point at an HTTPS URL or an HTTP localhost address. Released

--- a/docs/src/app/telemetry/page.tsx
+++ b/docs/src/app/telemetry/page.tsx
@@ -12,6 +12,7 @@ import {
   Terminal,
 } from "lucide-react";
 import { getPrisma } from "../../lib/prisma";
+import { farmProductionSiteWhere } from "../../lib/telemetry-sites";
 
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
@@ -177,8 +178,9 @@ async function loadTelemetryData(limit: number): Promise<TelemetryData> {
         select: { identityHash: true },
       }),
       prisma.farmTelemetryEvent.count({ where: { eventType: "project_created" } }),
-      prisma.farmProductionSite.count(),
+      prisma.farmProductionSite.count({ where: farmProductionSiteWhere }),
       prisma.farmProductionSite.findMany({
+        where: farmProductionSiteWhere,
         orderBy: { lastSeenAt: "desc" },
         take: 250,
         select: {

--- a/docs/src/lib/telemetry-sites.ts
+++ b/docs/src/lib/telemetry-sites.ts
@@ -1,0 +1,25 @@
+import type { Prisma } from "@prisma/client";
+
+/** Vercel-confirmed preview aliases recorded before runtime environment filtering was added. */
+export const FARM_LEGACY_VERCEL_PREVIEW_SITE_URLS = [
+  "https://docs-git-fix-ci-duplicate-runtime-import-kinfe123s-projects.vercel.app",
+  "https://docs-git-fix-explain-programmatic-manifests-kinfe123s-projects.vercel.app",
+  "https://docs-git-fix-query-array-round-trip-kinfe123s-projects.vercel.app",
+  "https://docs-git-fix-router-skip-document-prefetch-kinfe123s-projects.vercel.app",
+  "https://docs-git-fix-server-query-force-refetch-kinfe123s-projects.vercel.app",
+  "https://docs-git-perf-react-queued-rolling-windows-kinfe123s-projects.vercel.app",
+] as const;
+
+const legacyVercelPreviewSites = new Set<string>(FARM_LEGACY_VERCEL_PREVIEW_SITE_URLS);
+
+export const farmLegacyVercelPreviewSiteWhere: Prisma.FarmProductionSiteWhereInput = {
+  url: { in: [...FARM_LEGACY_VERCEL_PREVIEW_SITE_URLS] },
+};
+
+export const farmProductionSiteWhere: Prisma.FarmProductionSiteWhereInput = {
+  NOT: farmLegacyVercelPreviewSiteWhere,
+};
+
+export function isFarmLegacyVercelPreviewSite(siteUrl: string): boolean {
+  return legacyVercelPreviewSites.has(siteUrl);
+}

--- a/packages/farm/src/__tests__/product-telemetry.test.ts
+++ b/packages/farm/src/__tests__/product-telemetry.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment node
 
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createFarmProductionSiteReporter,
   detectFarmProductionSiteOrigin,
@@ -12,7 +12,13 @@ const originalEnvironment = {
   DO_NOT_TRACK: process.env.DO_NOT_TRACK,
   FARM_TELEMETRY: process.env.FARM_TELEMETRY,
   FARM_TELEMETRY_DISABLED: process.env.FARM_TELEMETRY_DISABLED,
+  VERCEL_ENV: process.env.VERCEL_ENV,
+  VERCEL_TARGET_ENV: process.env.VERCEL_TARGET_ENV,
 };
+
+beforeEach(() => {
+  for (const key of Object.keys(originalEnvironment)) delete process.env[key];
+});
 
 afterEach(() => {
   for (const [key, value] of Object.entries(originalEnvironment)) {
@@ -159,6 +165,52 @@ describe("production-site telemetry reporting", () => {
     reporter.report("https://preview.localhost/products");
 
     expect(send).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["preview", undefined],
+    ["development", undefined],
+    [undefined, "preview"],
+    ["production", "staging"],
+  ])(
+    "does not report a Vercel non-production deployment (%s, %s)",
+    (environment, targetEnvironment) => {
+      if (environment === undefined) delete process.env.VERCEL_ENV;
+      else process.env.VERCEL_ENV = environment;
+      if (targetEnvironment === undefined) delete process.env.VERCEL_TARGET_ENV;
+      else process.env.VERCEL_TARGET_ENV = targetEnvironment;
+      const send = vi.fn<typeof fetch>();
+      const reporter = createFarmProductionSiteReporter({
+        renderer: "react",
+        deployTarget: "vercel",
+        fetch: send,
+      });
+
+      reporter.report("https://docs-git-feature-owner.vercel.app/private");
+
+      expect(send).not.toHaveBeenCalled();
+    },
+  );
+
+  it("continues to report a production site on a vercel.app domain", () => {
+    process.env.VERCEL_ENV = "production";
+    process.env.VERCEL_TARGET_ENV = "production";
+    const send = vi.fn<typeof fetch>().mockResolvedValue(new Response(null, { status: 202 }));
+    const reporter = createFarmProductionSiteReporter({
+      renderer: "react",
+      deployTarget: "vercel",
+      fetch: send,
+    });
+
+    reporter.report("https://farm-git-tools.vercel.app/products");
+
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        body: expect.stringContaining('"siteUrl":"https://farm-git-tools.vercel.app"'),
+      }),
+    );
   });
 
   it("bounds automatically detected origins per running instance", async () => {

--- a/packages/farm/src/product-telemetry.ts
+++ b/packages/farm/src/product-telemetry.ts
@@ -101,6 +101,10 @@ export function createFarmProductionSiteReporter(
   return {
     report(requestUrl, waitUntil) {
       if (productionTelemetryDisabled()) return;
+      if (!isProductionDeploymentEnvironment()) {
+        debug("production-site check-in skipped outside a production deployment");
+        return;
+      }
 
       const siteUrl = detectFarmProductionSiteOrigin(requestUrl);
       if (!siteUrl) return;
@@ -206,6 +210,27 @@ function productionTelemetryDisabled(): boolean {
   if (process.env.DO_NOT_TRACK !== undefined && !isFalse(process.env.DO_NOT_TRACK)) return true;
   if (isTrue(process.env.FARM_TELEMETRY_DISABLED)) return true;
   return isFalse(process.env.FARM_TELEMETRY);
+}
+
+/**
+ * Vercel exposes the deployment environment at build and runtime. Only its
+ * production environment represents a production site; preview, development,
+ * and custom targets must not create dashboard entries. Other deployment
+ * providers remain eligible when no Vercel environment metadata is present.
+ */
+function isProductionDeploymentEnvironment(): boolean {
+  const environment = normalizeEnvironment(process.env.VERCEL_ENV);
+  const targetEnvironment = normalizeEnvironment(process.env.VERCEL_TARGET_ENV);
+
+  if (!environment && !targetEnvironment) return true;
+  if (environment && environment !== "production") return false;
+  if (targetEnvironment && targetEnvironment !== "production") return false;
+  return true;
+}
+
+function normalizeEnvironment(value: string | undefined): string | undefined {
+  const normalized = value?.trim().toLowerCase();
+  return normalized || undefined;
 }
 
 function sanitizeDetail(value: string | undefined, fallback: string): string {


### PR DESCRIPTION
## Problem

Farm's automatic production-site telemetry records public Vercel preview URLs as production
websites. Branch aliases such as
`docs-git-fix-query-array-round-trip-kinfe123s-projects.vercel.app` then appear alongside real
production sites.

## Root cause

The runtime validates and reduces each incoming URL to a public HTTPS origin, but it does not
distinguish Vercel deployment environments. The ingestion service and dashboard consequently accept
every normalized Vercel origin.

## Change

- Skip production-site reporting when `VERCEL_ENV` or `VERCEL_TARGET_ENV` identifies preview,
  development, or a custom non-production environment.
- Keep explicit Vercel production deployments eligible, including production domains ending in
  `.vercel.app`.
- Keep the six Vercel-confirmed legacy preview URLs in one server-owned cleanup definition.
- Hide those exact legacy URLs from dashboard counts immediately, refuse their re-ingestion, and
  remove their stored rows during the ingestion maintenance pass.
- Document the automatic preview behavior and explicit cleanup.

## Safety and compatibility

The general preview decision uses deployment metadata and does not infer preview status from a
hostname. Deployments without Vercel metadata keep the existing behavior, ordinary production
`.vercel.app` domains remain tracked, and a production project slug containing `-git-` remains
eligible. Reporting stays best-effort background work and never blocks application responses.

## Verification

- `pnpm --filter @farm.js/core exec vitest run src/__tests__/product-telemetry.test.ts`
- `./packages/farm/node_modules/.bin/vitest --root docs run src/app/api/telemetry/v1/sites/route.test.ts`
- `pnpm --filter @farm.js/core type-check`
- `pnpm exec oxlint packages/farm/src/product-telemetry.ts packages/farm/src/__tests__/product-telemetry.test.ts docs/src/lib/telemetry-sites.ts docs/src/app/api/telemetry/v1/sites/route.ts docs/src/app/api/telemetry/v1/sites/route.test.ts docs/src/app/telemetry/page.tsx`
- `pnpm exec oxfmt --check packages/farm/src/product-telemetry.ts packages/farm/src/__tests__/product-telemetry.test.ts docs/src/lib/telemetry-sites.ts docs/src/app/api/telemetry/v1/sites/route.ts docs/src/app/api/telemetry/v1/sites/route.test.ts docs/src/app/telemetry/page.tsx docs/src/app/docs/telemetry/page.md`
- `NODE_OPTIONS=--max-old-space-size=6144 pnpm --filter @farm.js/core build`
- `pnpm --filter @farm.js/core exec vitest run src/__tests__/production-prebuilt-ssr.test.ts -t "bundles automatic production-site discovery on the server only"`
- `pnpm --dir docs build`

The preview-environment regression cases fail without the runtime guard and pass with this change.
Vercel inspection confirmed all six cleanup URLs are preview deployments.

## Documentation and release

Updated the product telemetry documentation. No template, generated schema, package version, or
release-flow changes.
