### PR TITLE
fix(ci): avoid rebuilding packages during type checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
           TMP: ${{ runner.temp }}
 
       - name: Type check
-        run: pnpm type-check
+        run: pnpm type-check:ci
         env:
           NODE_OPTIONS: --max-old-space-size=8192
 

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "lint:fix": "oxlint --fix . && oxfmt .",
     "format:check": "oxfmt --check .",
     "type-check": "turbo type-check",
+    "type-check:ci": "turbo type-check --only",
     "clean": "turbo clean",
     "bump": "bumpp",
     "version-packages": "pnpm run bump",

--- a/scripts/pnpm-script-shell.test.js
+++ b/scripts/pnpm-script-shell.test.js
@@ -27,6 +27,14 @@ test("workspace scripts use the pnpm binary installed by the caller", () => {
   }
 });
 
+test("CI type-check does not rerun package builds", () => {
+  const manifest = JSON.parse(fs.readFileSync(path.join(repoRoot, "package.json"), "utf8"));
+  const workflow = fs.readFileSync(path.join(repoRoot, ".github", "workflows", "ci.yml"), "utf8");
+
+  assert.equal(manifest.scripts["type-check:ci"], "turbo type-check --only");
+  assert.match(workflow, /^\s*run: pnpm type-check:ci$/m);
+});
+
 /**
  * Runs a package script through pnpm inside a throwaway package that carries
  * the repository's .npmrc, so the test exercises the same script shell the


### PR DESCRIPTION
## Problem

The PR #768 CI run failed in all three full test matrices during the final workspace type-check. The first run reported `src/client.ts(109,10): error TS2451: Cannot redeclare block-scoped variable Link` even though the checked merge ref contains one Link export and focused core/workspace type-checks pass outside the CI graph.

## Root cause

CI already runs `pnpm build` before tests and type-checking. The later `pnpm type-check` command lets Turbo execute parent build tasks again. That causes `@farm.js/core#build` to clean and regenerate declarations while type-check tasks resolve the same package output. Serializing the core tasks only moved the failure into the redundant second build (`TS5055: Cannot write file ... because it would overwrite input file`).

## Change

Add a CI-specific `type-check:ci` script using Turbo `--only`, and use it after the existing successful build step. Normal developer `pnpm type-check` behavior is unchanged. Add a regression assertion that keeps the workflow and script contract together.

## Safety and compatibility

This changes CI orchestration only. CI still builds all packages before running tests and type-checks. Runtime behavior, public APIs, renderers, deployment targets, and package output are unchanged.

## Verification

- `node --test --test-name-pattern="CI type-check does not rerun" scripts/pnpm-script-shell.test.js`
- Turbo dry-run for core and React contains only their type-check tasks and no build tasks
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm exec turbo type-check --only --force --filter=@farm.js/core --filter=@farm.js/react` (2/2 tasks passed in a clean worktree)
- `pnpm exec oxlint scripts/pnpm-script-shell.test.js`
- `pnpm exec oxfmt --check package.json .github/workflows/ci.yml scripts/pnpm-script-shell.test.js`

## Documentation and release

None.