### PR TITLE
fix(test): isolate development hydration fixture

### DIFF
--- a/packages/farm/src/__tests__/production-prebuilt-ssr.test.ts
+++ b/packages/farm/src/__tests__/production-prebuilt-ssr.test.ts
@@ -907,6 +907,7 @@ export default function SecondPage() {
 
   it("keeps the measured isolated-root overflow route-wide in development and production", async () => {
     const root = await createProductionFixture();
+    const developmentRoot = await createProductionFixture();
 
     try {
       await fs.mkdir(path.join(root, "src", "components"), { recursive: true });
@@ -937,7 +938,7 @@ export default function Page() {
 `.trim(),
       );
       await fs.writeFile(
-        path.join(root, "index.mjs"),
+        path.join(developmentRoot, "index.mjs"),
         `
 import { createServer } from "@farm.js/core/server";
 
@@ -951,6 +952,10 @@ server.config.server.host = "127.0.0.1";
 await server.listen(Number(process.env.PORT));
 `.trim(),
       );
+      await fs.cp(path.join(root, "src"), path.join(developmentRoot, "src"), {
+        recursive: true,
+        force: true,
+      });
 
       const verifyRouteWideRuntime = async (response: Response) => {
         expect(response.status).toBe(200);
@@ -992,7 +997,7 @@ await server.listen(Number(process.env.PORT));
         }
       };
 
-      await runProductionRequest(root, verifyRouteWideRuntime);
+      await runProductionRequest(developmentRoot, verifyRouteWideRuntime);
 
       const config = await resolveConfig(
         {
@@ -1016,7 +1021,11 @@ await server.listen(Number(process.env.PORT));
         verifyRouteWideRuntime,
       );
     } finally {
-      await fs.rm(root, { recursive: true, force: true });
+      await Promise.all(
+        [root, developmentRoot].map((fixtureRoot) =>
+          fs.rm(fixtureRoot, { recursive: true, force: true }),
+        ),
+      );
     }
   }, 120_000);
 


### PR DESCRIPTION
## Problem

The isolated-hydration development/production test leaves generated `src/farm.d.ts`, `src/lib/api.generated.ts`, and `src/app/globals.css` in the core package during CI. The following core type-check then fails because the generated declaration redeclares `Link`.

## Root cause

The test writes a development launcher named `index.mjs` into the same fixture root later passed to the Nitro production build. Nitro discovers and evaluates that root entry while loading build configuration. The launcher starts a development server with `process.cwd()`, which is the core package directory in the test runner, so generated application artifacts land in framework source.

## Change

Use separate temporary roots for the development server and production build, as the neighboring isolated-hydration tests already do. Copy only the application source into the development fixture and clean up both roots.

## Safety and compatibility

Test-only change. Runtime behavior, public APIs, renderers, and deployment output are unchanged.

## Verification

- `NODE_OPTIONS=--max-old-space-size=6144 pnpm --filter @farm.js/core build`
- `pnpm --filter @farm.js/core exec vitest run src/__tests__/production-prebuilt-ssr.test.ts -t "keeps the measured isolated-root overflow route-wide in development and production" --reporter=verbose`
- Confirmed `git status --short` contains no generated core source files after the test
- `pnpm --filter @farm.js/core type-check`
- `pnpm exec oxfmt --check packages/farm/src/__tests__/production-prebuilt-ssr.test.ts`
- `pnpm exec oxlint packages/farm/src/__tests__/production-prebuilt-ssr.test.ts`
- `git diff --check`

Without this change, the focused test followed by core type-check reproduces `TS2451: Cannot redeclare block-scoped variable Link`.

## Documentation and release

None.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the isolated-hydration test from dumping generated files (`src/farm.d.ts`, `src/lib/api.generated.ts`, `src/app/globals.css`) into the core package during CI, which previously made core type-check fail with a `Link` redeclaration error. The development server now runs from a separate temporary root that receives a copy of the app source, and both roots are cleaned up afterward.

<sup>Written for commit a47efaaf4b2d241cd47a7174f66466ff19647e31. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/772?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

