### PR TITLE
perf(react): compose consecutive keyed map updates

### DIFF
--- a/docs/src/app/docs/renderers/react/page.md
+++ b/docs/src/app/docs/renderers/react/page.md
@@ -363,9 +363,9 @@ local native `Map`.
 native `Set`.
 `keyedCollectionUpdateHints` counts proven native Set/Map mutation sites that can carry their
 executed keys to the runtime.
-`keyedMapUpdateHints` counts setter sites where the compiler proved that a direct keyed collection
-can report its changed row indexes while an immutable `map()` runs. The same counts appear per
-module.
+`keyedMapUpdateHints` counts map calls where the compiler proved that a direct keyed collection can
+report its changed row indexes while one or more consecutive immutable `map()` stages run. The same
+counts appear per module.
 `keyedArrayAppendHints` counts setter sites where the compiler proved a direct keyed array append
 and can hand the appended suffix to the runtime. `keyedArrayFilterHints` counts concise keyed-array
 filter sites that can report removed positions. `keyedArrayPrependHints` counts setter sites where
@@ -875,29 +875,36 @@ The compiler can remove the runtime's second full-row scan for a common immutabl
 
 ```tsx
 setItems((current) =>
-  current.map((item) => (item.id === targetId ? { ...item, selected: !item.selected } : item)),
+  current
+    .map((item) => (item.id === targetId ? { ...item, label: nextLabel } : item))
+    .map((item) => (item.id === targetId ? { ...item, selected: !item.selected } : item)),
 );
 ```
 
 This needs no option or component primitive. At build time, Farm recognizes a functional setter on
-the direct `useState` collection used by a compiled keyed map or `List`. The mapper must be a concise
-arrow expression with a conditional result: one branch returns the original item and the other
-returns a new object that spreads that item. The condition and replacement values must use the
-compiler's safe expression subset. The hint runtime is retained only in modules where at least one
-such site is emitted; direct-only and ordinary keyed builds do not import that capability.
+the direct `useState` collection used by a compiled keyed map or `List`. The setter may contain one
+or more consecutive `map()` calls. Every mapper must be a concise arrow expression with a
+conditional result: one branch returns the original item and the other returns a new object that
+spreads that item. The conditions and replacement values must use the compiler's safe expression
+subset. The hint runtime is retained only in modules where at least one such call is emitted;
+direct-only and ordinary keyed builds do not import that capability.
 
-The generated mapper records an index only when the returned item has a different identity. The
-user's `map()` still runs and is still O(n); the optimization avoids reading every key and every row
-binding again after it finishes. Farm validates that the array length and each reported row's key
-and index are unchanged, then patches only those row instances. Multiple hinted functional updates
-queued in one compiler flush are combined.
+Every native `map()` still runs and is still O(n). After the complete chain succeeds, Farm compares
+the committed and final item identities once, validates the final key and position for every
+changed row, and patches each final row once. Intermediate arrays never receive DOM work. The
+optimization removes the runtime's second full key-and-binding scan rather than removing the
+application's map work. Multiple hinted functional updates queued in one compiler flush are
+combined.
 
-If a key changes, an insert, removal, or reorder occurs, a relevant second dependency changes, or a
-runtime check fails, Farm discards the hint and runs the existing complete keyed reconciliation and
-LIS path. Derived collections, non-functional setters, block-bodied mappers, mutating replacements,
-and other unproven shapes also keep that existing path. This is an optimization hint, not a new
-correctness contract or a way to bypass React fallback behavior. The compiler report exposes the
-number of emitted sites as `keyedMapUpdateHints`.
+Farm preserves each source property lookup and call. It records metadata only after an exact native
+`Array.prototype.map` succeeds on ordinary dense arrays. A custom method, sparse or subclassed
+array, unsupported mapper anywhere in the chain, changed key, insert, removal, reorder, relevant
+second dependency, or failed runtime check uses the existing complete keyed reconciliation and LIS
+path. Native results and thrown mapper or method errors are preserved. Derived collections,
+non-functional setters, block-bodied mappers, mutating replacements, and other unproven shapes also
+keep that existing path. This is an optimization hint, not a new correctness contract or a way to
+bypass React fallback behavior. The compiler report exposes the number of prepared map calls as
+`keyedMapUpdateHints`.
 
 #### Keyed array append hints
 
@@ -2020,16 +2027,19 @@ The package and example test suites verify more than generated code:
 - compiler-owned host rows patch text, attributes, and styles in place, preserve focus and text
   selection, use the LIS minimum for measured rotations and reversals, and remount through React
   when runtime keys are duplicated;
-- mutation-aware keyed `map()` updates patch only compiler-reported same-key row indexes, compose
-  queued hints across multiple keyed boundaries, ignore unrelated state in the same flush, and
-  reject key changes or mixed unhinted collection updates into the complete reconciliation path;
+- mutation-aware keyed `map()` updates compose consecutive safe stages, compare the committed and
+  final row identities once, patch each final same-key row once, compose queued hints across
+  multiple keyed boundaries, ignore unrelated state in the same flush, and reject key changes,
+  custom methods, sparse or subclassed arrays, or mixed unhinted updates into the complete
+  reconciliation path;
 - compiler-proven immutable Set/Map updaters carry exact native mutation keys across queued
   updates, compact long persistent snapshot chains, and fall back before binding reads for unsafe
   keys, values, collections, or ownership;
 - 2,000 deterministic hinted Set mutations and 2,000 deterministic hinted Map mutations match
   normal React while evaluating only changed present-row keys;
-- a 2,048-row instrumentation test changes one item with one key read and one binding read, while
-  2,000 deterministic queued updates match normal React with one compiled owner execution;
+- a 2,048-row instrumentation test changes one item through two maps with one key read and one
+  binding read; separate stages that change two rows read exactly those two keys and bindings; and
+  2,000 deterministic queued two-map updates match normal React with one compiled owner execution;
 - keyed DOM ranges preserve static siblings around multiple lists, support adjacent empty ranges
   and exact component roots, apply LIS independently per range, and remount the complete container
   through React when keys or parent-driven static markup invalidate adoption;

--- a/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
+++ b/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
@@ -2,6 +2,37 @@
 
 Latest run: 2026-09-07
 
+## Consecutive same-order keyed maps — 2026-09-07
+
+The 10,000-row table now measures a concise functional setter that updates the label and amount of
+every tenth row in two consecutive native `map()` calls. Farm executes both calls in source order,
+then compares the committed and final item identities once, validates every final changed key and
+position, and patches each changed row once. The equivalent block-bodied setter runs the same
+application work but remains on complete compiled keyed reconciliation.
+
+| Mode   | React median | Two-map update | Compiled control | vs React | vs control |
+| ------ | -----------: | -------------: | ---------------: | -------: | ---------: |
+| Static |     57.80 ms |        4.90 ms |         12.80 ms |   11.80x |      2.61x |
+| Hybrid |     57.80 ms |        5.00 ms |         13.50 ms |   11.56x |      2.70x |
+
+The independent gate requires at least 8x versus bracketed React and 2x versus the compiled control
+in both modes. It passed without changing either threshold. After every measured update, a separate
+oracle verified the final labels and amounts, order, connection, and original DOM identity of all
+10,000 rows. Both compiler reports emitted all six expected keyed-map calls, and compiled owner
+executions stayed at zero.
+
+Compiler coverage rejects an unsupported mapper anywhere in the chain. Runtime coverage preserves
+custom methods and native errors, falls back for sparse or subclassed arrays and changed keys,
+patches different rows or one twice-updated row exactly once, hydrates in Strict Mode, drops queued
+work after unmount, and matches ordinary React through 2,000 deterministic queued two-map updates.
+The complete React suite passed 688 tests plus three stress tests, and compatibility passed on React
+18.3.1 and 19.2.8.
+
+No public API or runtime capability was added. The existing optional keyed map/reorder runtime
+remains 13,158 B gzip, and the compiler-selected core still removes 83.4% of the complete runtime
+premium. The accepted default-count run used 10 samples per compiler mode, 20 bracketing React
+samples, Chrome 152.0.7977.82, Node.js 23.11.0, and Apple M1 macOS arm64.
+
 ## Consecutive same-key maps composed with native reorder — 2026-09-07
 
 The 10,000-row table now measures a concise functional setter that changes one row's label and

--- a/examples/react-compiler-dashboard/README.md
+++ b/examples/react-compiler-dashboard/README.md
@@ -214,6 +214,15 @@ React and 1.25x faster than the compiled control. Package tests also cover filte
 composition, queued filter-then-sort updates, 2,000 randomized removals, controlled-input focus and
 selection, hydration, cleanup, and conservative fallback.
 
+Consecutive same-order maps have their own 10,000-row comparison. One concise setter updates the
+label and amount of every tenth row in two native `map()` stages. The block-bodied form performs the
+same JavaScript and DOM-visible work through complete compiled reconciliation. Both compiler modes
+must remain at least 8x faster than React and 2x faster than that compiled control. After every
+sample the assertion verifies all 10,000 final values, row positions, connections, and DOM
+identities. Package tests separately cover one committed-to-final identity comparison, one final
+patch per row, changed keys, custom methods, subclassed arrays, native errors, queued updates,
+Strict Mode hydration, and unmount-before-flush cleanup.
+
 Same-key map-and-reorder pipelines have their own 10,000-row comparison. One concise setter
 reprices a single row through `map()` and immediately restores amount order with `toSorted()`; the
 block-bodied form performs the same JavaScript and DOM-visible work through complete compiled
@@ -310,6 +319,9 @@ The default JSON report is `/tmp/farm-react-dashboard-benchmark.json`; change it
   block-bodied equivalent rereads the complete keyed snapshot; the hinted path isolates the saved
   descriptor and unchanged-binding work while both paths run the same native map, sort, and LIS
   movement.
+- The multi-map update control changes every tenth row in two same-order native maps. Its
+  block-bodied equivalent rereads all 10,000 keys and bindings; the hinted path compares the
+  committed and final arrays once and patches each final changed row once.
 - The multi-map reorder control changes one row's label and amount in two consecutive native maps,
   then sorts the same keyed rows. Its block-bodied equivalent keeps complete reconciliation, while
   the hinted path proves one flattened source-row lineage and patches the final row once.

--- a/examples/react-compiler-dashboard/scripts/benchmark.mjs
+++ b/examples/react-compiler-dashboard/scripts/benchmark.mjs
@@ -127,8 +127,8 @@ async function inspectBuild(compilerMode) {
       "The compiler build did not emit a keyed Map-lookup target.",
     );
     assert(
-      compilerReport.summary.keyedMapUpdateHints > 0,
-      "The compiler build did not emit a mutation-aware keyed-map update hint.",
+      compilerReport.summary.keyedMapUpdateHints >= 6,
+      "The compiler build did not emit every single-map, consecutive-map, and map-reorder hint.",
     );
     assert(
       compilerReport.summary.keyedArrayAppendHints > 0,
@@ -1339,6 +1339,80 @@ async function measureTrial(browser, trial, compilerMode, port) {
           },
         );
 
+        const prepareMultiMapUpdate = async () => {
+          await create10000();
+          const rows = [...table.querySelectorAll("tbody tr")];
+          const expected = rows.map((row, index) => {
+            const label = row.querySelector("td:nth-child(2)")?.textContent;
+            const amountText = row.querySelector("td:nth-child(4)")?.textContent;
+            const amount = Number(amountText?.slice(1));
+            if (label === undefined || !Number.isFinite(amount)) {
+              throw new Error("Multi-map source row is invalid.");
+            }
+            return {
+              amount: index % 10 === 0 ? amount + 1 : amount,
+              label: index % 10 === 0 ? `${label} reviewed` : label,
+              row,
+            };
+          });
+          return { expected, rows };
+        };
+
+        const runMultiMapUpdate = async (action, prepared) => {
+          if (!prepared) throw new Error("Multi-map expectation is missing.");
+          const first = prepared.expected[0];
+          await runTableAction(action, () => {
+            const row = table.querySelector("tbody tr");
+            return (
+              row === first.row &&
+              row.querySelector("td:nth-child(2)")?.textContent === first.label &&
+              row.querySelector("td:nth-child(4)")?.textContent === `$${first.amount}`
+            );
+          });
+          return () => {
+            const nextRows = [...table.querySelectorAll("tbody tr")];
+            if (nextRows.length !== prepared.expected.length) {
+              throw new Error("Multi-map row count changed.");
+            }
+            for (let index = 0; index < prepared.expected.length; index += 1) {
+              const expected = prepared.expected[index];
+              const row = nextRows[index];
+              if (
+                row !== expected.row ||
+                !row.isConnected ||
+                row.querySelector("td:nth-child(2)")?.textContent !== expected.label ||
+                row.querySelector("td:nth-child(4)")?.textContent !== `$${expected.amount}`
+              ) {
+                throw new Error(`Multi-map row ${index} did not match its expected update.`);
+              }
+            }
+          };
+        };
+
+        const measureMultiMapUpdate = async (action) => {
+          for (let sample = 0; sample < warmupSamples; sample += 1) {
+            const prepared = await prepareMultiMapUpdate();
+            const verify = await runMultiMapUpdate(action, prepared);
+            verify();
+          }
+          const timings = [];
+          for (let sample = 0; sample < tableSamples; sample += 1) {
+            const prepared = await prepareMultiMapUpdate();
+            const startedAt = performance.now();
+            const verify = await runMultiMapUpdate(action, prepared);
+            timings.push(performance.now() - startedAt);
+            verify();
+          }
+          return timings;
+        };
+
+        const tableMultiMapUpdate = await measureMultiMapUpdate(() =>
+          tableButton("table-multi-map-update").click(),
+        );
+        const tableMultiMapUpdateSnapshot = await measureMultiMapUpdate(() =>
+          tableButton("table-multi-map-update-snapshot").click(),
+        );
+
         const tableSwap = await measureTable(
           async () => ensure1000(),
           async () => {
@@ -1700,6 +1774,8 @@ async function measureTrial(browser, trial, compilerMode, port) {
             filterReorderPipelineSnapshot: tableFilterReorderPipelineSnapshot,
             mapReorderPipeline: tableMapReorderPipeline,
             mapReorderPipelineSnapshot: tableMapReorderPipelineSnapshot,
+            multiMapUpdate: tableMultiMapUpdate,
+            multiMapUpdateSnapshot: tableMultiMapUpdateSnapshot,
             multiMapReorderPipeline: tableMultiMapReorderPipeline,
             multiMapReorderPipelineSnapshot: tableMultiMapReorderPipelineSnapshot,
             mapLookup: tableMapLookup,
@@ -1826,6 +1902,8 @@ async function measureTrial(browser, trial, compilerMode, port) {
         filterReorderPipelineSnapshot: timingSummary(result.table.filterReorderPipelineSnapshot),
         mapReorderPipeline: timingSummary(result.table.mapReorderPipeline),
         mapReorderPipelineSnapshot: timingSummary(result.table.mapReorderPipelineSnapshot),
+        multiMapUpdate: timingSummary(result.table.multiMapUpdate),
+        multiMapUpdateSnapshot: timingSummary(result.table.multiMapUpdateSnapshot),
         multiMapReorderPipeline: timingSummary(result.table.multiMapReorderPipeline),
         multiMapReorderPipelineSnapshot: timingSummary(
           result.table.multiMapReorderPipelineSnapshot,
@@ -2004,6 +2082,8 @@ const tableMetrics = [
   "filterReorderPipelineSnapshot",
   "mapReorderPipeline",
   "mapReorderPipelineSnapshot",
+  "multiMapUpdate",
+  "multiMapUpdateSnapshot",
   "multiMapReorderPipeline",
   "multiMapReorderPipelineSnapshot",
   "snapshotMembership",
@@ -2136,6 +2216,29 @@ const keyedUpdateSpeedups = keyedUpdateCases.flatMap(([group, metric]) =>
 );
 const keyedUpdateRegressions = keyedUpdateSpeedups.filter(
   ({ speedup }) => !Number.isFinite(speedup) || speedup < keyedUpdateMinimumSpeedup,
+);
+// Consecutive safe map stages should compare their committed and final item identities once, then
+// patch each final changed row once. Compare the concise chain with React and a block-bodied
+// compiled control that deliberately takes complete keyed reconciliation.
+const keyedMultiMapUpdateMinimumSpeedup = 8;
+const keyedMultiMapUpdateMinimumSnapshotSpeedup = 2;
+const keyedMultiMapUpdateResults = ["static", "hybrid"].map((mode) => {
+  const updateMedianMs = comparisons.table.multiMapUpdate[mode].medianMs;
+  const snapshotMedianMs = comparisons.table.multiMapUpdateSnapshot[mode].medianMs;
+  return {
+    mode,
+    snapshotMedianMs,
+    snapshotSpeedup: snapshotMedianMs / updateMedianMs,
+    speedup: comparisons.table.multiMapUpdate[`${mode}VsBaseline`].speedup,
+    updateMedianMs,
+  };
+});
+const keyedMultiMapUpdateRegressions = keyedMultiMapUpdateResults.filter(
+  ({ snapshotSpeedup, speedup }) =>
+    !Number.isFinite(speedup) ||
+    speedup < keyedMultiMapUpdateMinimumSpeedup ||
+    !Number.isFinite(snapshotSpeedup) ||
+    snapshotSpeedup < keyedMultiMapUpdateMinimumSnapshotSpeedup,
 );
 // A compiler-proven functional append already creates the new array and DOM rows. The append hint
 // avoids rescanning every existing key and binding before mounting only the appended suffix. Compare
@@ -2833,6 +2936,7 @@ const passed =
   performanceRegressions.length === 0 &&
   scalabilityRegressions.length === 0 &&
   keyedUpdateRegressions.length === 0 &&
+  keyedMultiMapUpdateRegressions.length === 0 &&
   keyedAppendRegressions.length === 0 &&
   keyedPrependRegressions.length === 0 &&
   keyedSliceRegressions.length === 0 &&
@@ -2875,6 +2979,13 @@ const report = {
     regressions: keyedUpdateRegressions,
     speedups: keyedUpdateSpeedups,
     status: keyedUpdateRegressions.length === 0 ? "PASS" : "FAIL",
+  },
+  keyedMultiMapUpdateHintGate: {
+    minimumSnapshotSpeedup: keyedMultiMapUpdateMinimumSnapshotSpeedup,
+    minimumSpeedup: keyedMultiMapUpdateMinimumSpeedup,
+    regressions: keyedMultiMapUpdateRegressions,
+    results: keyedMultiMapUpdateResults,
+    status: keyedMultiMapUpdateRegressions.length === 0 ? "PASS" : "FAIL",
   },
   keyedAppendHintGate: {
     minimumSnapshotSpeedup: keyedAppendMinimumSnapshotSpeedup,

--- a/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
+++ b/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
@@ -1023,6 +1023,44 @@ export function StandardTableBenchmark() {
           Update every 10th
         </button>
         <button
+          data-action="table-multi-map-update"
+          type="button"
+          onClick={() => {
+            setRows((current) =>
+              current
+                .map((row, index) =>
+                  index % 10 === 0 ? { ...row, label: `${row.label} reviewed` } : row,
+                )
+                .map((row, index) =>
+                  index % 10 === 0 ? { ...row, amount: row.amount + 1 } : row,
+                ),
+            );
+            setOperation("review and reprice every 10th");
+            setRevision((value) => value + 1);
+          }}
+        >
+          Review + reprice every 10th
+        </button>
+        <button
+          data-action="table-multi-map-update-snapshot"
+          type="button"
+          onClick={() => {
+            setRows((current) => {
+              return current
+                .map((row, index) =>
+                  index % 10 === 0 ? { ...row, label: `${row.label} reviewed` } : row,
+                )
+                .map((row, index) =>
+                  index % 10 === 0 ? { ...row, amount: row.amount + 1 } : row,
+                );
+            });
+            setOperation("review and reprice every 10th (snapshot control)");
+            setRevision((value) => value + 1);
+          }}
+        >
+          Review + reprice every 10th (snapshot control)
+        </button>
+        <button
           data-action="table-mark"
           type="button"
           onClick={() => {

--- a/packages/farm-react/README.md
+++ b/packages/farm-react/README.md
@@ -220,19 +220,27 @@ updates such as:
 
 ```tsx
 setItems((current) =>
-  current.map((item) => (item.id === targetId ? { ...item, selected: !item.selected } : item)),
+  current
+    .map((item) => (item.id === targetId ? { ...item, label: nextLabel } : item))
+    .map((item) => (item.id === targetId ? { ...item, selected: !item.selected } : item)),
 );
 ```
 
-The generated native `map()` records which indexes returned new item identities. Farm then
-validates that length, keys, and positions are unchanged and patches only those row instances. The
-user's `map()` remains O(n); this removes the keyed runtime's second full key-and-binding scan.
-Queued hints compose. Key changes, structural edits, relevant mixed dependencies, and failed runtime
-checks use the existing complete reconciliation and LIS path. Non-functional setters, derived
-collections, block-bodied or mutating mappers, and other unproven forms are simply not hinted. No
-new option is required. A compiler report exposes the emitted-site count as
-`keyedMapUpdateHints`. The separate hint runtime capability is imported only when that count is
-nonzero, so direct-only and ordinary keyed builds do not retain it.
+Farm executes every generated native `map()` and then compares the committed and final item
+identities once. It validates final length, keys, and positions and patches each final changed row
+once; intermediate arrays never receive DOM work. Every user `map()` remains O(n); this removes the
+keyed runtime's second full key-and-binding scan. Queued hints compose. The source method lookup,
+native result, callback order, and thrown errors are preserved.
+
+Each stage requires an inline synchronous conditional mapper that returns the original item or an
+object-spread replacement. An unsupported mapper anywhere in the chain disables the complete
+setter hint. Custom methods still execute but record no metadata. Key changes, structural edits,
+sparse or subclassed arrays, relevant mixed dependencies, and failed runtime checks use the
+existing complete reconciliation and LIS path. Non-functional setters, derived collections,
+block-bodied or mutating mappers, and other unproven forms are simply not hinted. No new option is
+required. A compiler report counts prepared map calls as `keyedMapUpdateHints`. The separate hint
+runtime capability is imported only when that count is nonzero, so direct-only and ordinary keyed
+builds do not retain it.
 
 The same optional runtime recognizes conservative immutable appends on a direct keyed array:
 
@@ -760,7 +768,7 @@ reasons aggregated by count. Its summary and per-module `optimizations` also rep
 `keyedMapLookupTargets`, the number of native-Map keyed lookup bindings;
 `keyedMembershipTargets`, the number of native-Set membership bindings;
 `keyedCollectionUpdateHints`, the number of compiler-proven native Set/Map mutation sites; and
-`keyedMapUpdateHints`, the number of compiler-proven direct keyed `map()` update sites; and
+`keyedMapUpdateHints`, the number of compiler-proven keyed `map()` update calls; and
 `keyedArrayAppendHints`, the number of compiler-proven direct keyed-array append sites; and
 `keyedArrayFilterHints`, the number of compiler-proven keyed-array filter sites, including supported
 structural reorder pipelines; and
@@ -783,9 +791,9 @@ commit and updates its two bindings directly. This is a deterministic structural
 assertion; it is not presented as a cross-machine timing benchmark.
 
 Application and prototype calls, dynamic style objects, handlers outside JSX events, nested,
-computed, and rest props patterns, async handlers, unkeyed or index-keyed lists, chained maps,
-unsupported conditional roots, effects, and more advanced hook support intentionally stay on React
-in this release. Compiler-owned keyed rows support either one dedicated host-only map/`List` or
+computed, and rest props patterns, async handlers, unkeyed or index-keyed lists, unsupported map
+chains, unsupported conditional roots, effects, and more advanced hook support intentionally stay
+on React in this release. Compiler-owned keyed rows support either one dedicated host-only map/`List` or
 one or more non-interactive ranges in a nested or component-root host container. A dedicated
 non-interactive row may also contain multiple recursive logical or ternary host branches beside
 stateful static host siblings, plus recursively nested non-interactive keyed ranges scoped by every

--- a/packages/farm-react/src/__tests__/compiler-keyed-update-hints.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-keyed-update-hints.test.ts
@@ -12,7 +12,7 @@ async function compile(source: string) {
 }
 
 describe("React AOT keyed update hints", () => {
-  it("records changed indexes while a proven same-order map executes", async () => {
+  it("records a final same-order delta after a proven native map executes", async () => {
     const result = await compile(`
       import { useState } from "react";
       export function Inventory() {
@@ -58,8 +58,45 @@ describe("React AOT keyed update hints", () => {
     expect(result.code).toContain("keyedRowsHintedRuntimeFeature");
     expect(result.code).toContain("collectionDependency={0}");
     expect(result.code).toContain("dependencies={[0]}");
-    expect(result.code).toMatch(/const _farmChangedIndices\d* = \[\]/);
-    expect(result.code).toMatch(/_farmChangedIndices\d*\.push\(index\)/);
+    expect(result.code).toMatch(/const _farmMap\d* = _farmMapValue\d*\.map/);
+    expect(result.code.match(/createCompilerKeyedMapUpdate\(/g)).toHaveLength(1);
+    await expect(
+      transformWithEsbuild(result.code, "/app/KeyedUpdateHints.tsx", {
+        loader: "tsx",
+        jsx: "automatic",
+      }),
+    ).resolves.toMatchObject({
+      code: expect.stringContaining("createCompilerKeyedMapUpdate"),
+    });
+  });
+
+  it("composes consecutive safe same-key maps into one final keyed update", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Inventory({ editedId, nextLabel }) {
+        const [items, setItems] = useState([
+          { id: "a", label: "Alpha", selected: false },
+          { id: "b", label: "Beta", selected: false },
+        ]);
+        return (
+          <section>
+            <button onClick={() => setItems((current) => current
+              .map((row) => row.id === editedId ? { ...row, label: nextLabel } : row)
+              .map((row) => row.id === editedId ? { ...row, selected: true } : row)
+            )}>Update</button>
+            <ul>{items.map((item) => <li key={item.id}>{item.label}</li>)}</ul>
+          </section>
+        );
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Inventory"]);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.optimizations.keyedMapUpdateHints).toBe(2);
+    expect(result.code.match(/createCompilerKeyedMapUpdate\(/g)).toHaveLength(1);
+    expect(result.code.match(/_farmApplyMap\d*\(/g)).toHaveLength(2);
+    expect(result.code).toContain("keyedRowsHintedRuntimeFeature");
+    expect(result.code).not.toContain("createCompilerKeyedArrayMapPipeline");
     await expect(
       transformWithEsbuild(result.code, "/app/KeyedUpdateHints.tsx", {
         loader: "tsx",
@@ -108,6 +145,13 @@ describe("React AOT keyed update hints", () => {
       collection: "items",
       update:
         'setItems((current) => current.map((row) => { return row.id === "a" ? { ...row, label: "Updated" } : row; }))',
+    },
+    {
+      name: "an unsupported second mapper",
+      declaration: "",
+      collection: "items",
+      update:
+        'setItems((current) => current.map((row) => row.id === "a" ? { ...row, label: "First" } : row).map((row) => ({ ...row, label: "Updated" })))',
     },
     {
       name: "a potentially mutating mapper",

--- a/packages/farm-react/src/__tests__/compiler-runtime-keyed-update-hints.test.tsx
+++ b/packages/farm-react/src/__tests__/compiler-runtime-keyed-update-hints.test.tsx
@@ -1,6 +1,7 @@
-import React, { useState } from "react";
+import React, { StrictMode, useState } from "react";
 import { act } from "react";
-import { createRoot } from "react-dom/client";
+import { createRoot, hydrateRoot, type Root } from "react-dom/client";
+import { renderToString } from "react-dom/server";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   createCompiledComponent,
@@ -46,14 +47,87 @@ function descriptor(item: Item): CompilerKeyedRowElement {
   };
 }
 
-function hintedMap(previous: Item[], update: (item: Item, index: number) => Item): unknown {
-  const changedIndices: number[] = [];
-  const value = previous.map((item, index) => {
-    const next = update(item, index);
-    if (next !== item) changedIndices.push(index);
-    return next;
+type ApplyMap = (collection: unknown, method: unknown, callback: unknown) => unknown;
+
+function hintedMaps(
+  previous: Item[],
+  updates: readonly ((item: Item, index: number) => Item)[],
+): unknown {
+  return createCompilerKeyedMapUpdate(previous, (current: unknown, applyMap: ApplyMap) => {
+    let value = current as Item[];
+    for (const update of updates) {
+      const method = value.map;
+      value = applyMap(value, method, update) as Item[];
+    }
+    return value;
   });
-  return createCompilerKeyedMapUpdate(previous, value, changedIndices);
+}
+
+function hintedMap(previous: Item[], update: (item: Item, index: number) => Item): unknown {
+  return hintedMaps(previous, [update]);
+}
+
+function createMapHarness(initialItems: Item[]) {
+  let setItems: (update: (previous: Item[]) => unknown) => void = () => undefined;
+  const counters = { bindings: 0, descriptors: 0, executions: 0, keys: 0, renders: 0 };
+  const Table = createCompiledComponent({
+    displayName: "MultiMapInventory",
+    initialize: () => [initialItems],
+    render(_props: Record<string, never>, state, blocks) {
+      counters.executions += 1;
+      const items = () => state[0].get() as Item[];
+      setItems = (update) => state[0].set((previous) => update(previous as Item[]));
+      return (
+        <section>
+          <blocks.KeyedRows
+            collectionDependency={0}
+            dependencies={[0]}
+            id={0}
+            items={items}
+            structureDependencies={[0]}
+            render={() => {
+              counters.renders += 1;
+              return (
+                <ul>
+                  {items().map((item) => (
+                    <li data-key={item.id} key={item.id}>
+                      {item.label}
+                    </li>
+                  ))}
+                </ul>
+              );
+            }}
+            rowKey={(item) => {
+              counters.keys += 1;
+              return (item as Item).id;
+            }}
+            create={(item) => {
+              counters.descriptors += 1;
+              return descriptor(item as Item);
+            }}
+            bindings={[
+              {
+                kind: "text",
+                path: [],
+                read: (item) => {
+                  counters.bindings += 1;
+                  return [(item as Item).label];
+                },
+              },
+            ]}
+          />
+        </section>
+      );
+    },
+    bindings: [{ kind: "block", id: 0, dependencies: [0] }],
+  });
+  return {
+    counters,
+    setItems(update: (previous: Item[]) => unknown) {
+      setItems(update);
+    },
+    Table,
+  };
 }
 
 describe("compiled keyed update hints", () => {
@@ -82,9 +156,10 @@ describe("compiled keyed update hints", () => {
             <button
               onClick={() => {
                 state[0].set((previous) =>
-                  hintedMap(previous as Item[], (item, index) =>
-                    index === 1_337 ? { ...item, label: "Updated 1337", selected: true } : item,
-                  ),
+                  hintedMaps(previous as Item[], [
+                    (item, index) => (index === 1_337 ? { ...item, label: "Updated 1337" } : item),
+                    (item, index) => (index === 1_337 ? { ...item, selected: true } : item),
+                  ]),
                 );
                 state[1].set((value) => Number(value) + 1);
               }}
@@ -159,6 +234,142 @@ describe("compiled keyed update hints", () => {
     expect(bindingReads).toBe(1);
   });
 
+  it("patches different rows changed by separate map stages exactly once", async () => {
+    const harness = createMapHarness([
+      { id: "a", label: "Alpha", selected: false },
+      { id: "b", label: "Beta", selected: false },
+      { id: "c", label: "Gamma", selected: false },
+    ]);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Table />));
+    const originalRows = new Map(
+      [...container.querySelectorAll<HTMLElement>("li")].map((row) => [row.dataset.key, row]),
+    );
+    harness.counters.bindings = 0;
+    harness.counters.descriptors = 0;
+    harness.counters.keys = 0;
+
+    await act(async () => {
+      harness.setItems((previous) =>
+        hintedMaps(previous, [
+          (item) => (item.id === "a" ? { ...item, label: "Alpha newest" } : item),
+          (item) => (item.id === "c" ? { ...item, label: "Gamma newest" } : item),
+        ]),
+      );
+      await flushCompilerUpdates();
+    });
+
+    expect([...container.querySelectorAll("li")].map((row) => row.textContent)).toEqual([
+      "Alpha newest",
+      "Beta",
+      "Gamma newest",
+    ]);
+    for (const [key, row] of originalRows) {
+      expect(container.querySelector(`[data-key="${key}"]`)).toBe(row);
+    }
+    expect(harness.counters.executions).toBe(1);
+    expect(harness.counters.renders).toBe(1);
+    expect(harness.counters.keys).toBe(2);
+    expect(harness.counters.descriptors).toBe(0);
+    expect(harness.counters.bindings).toBe(2);
+  });
+
+  it("drops the complete chain hint when a later map method is custom", async () => {
+    const harness = createMapHarness([
+      { id: "a", label: "Alpha", selected: false },
+      { id: "b", label: "Beta", selected: false },
+      { id: "c", label: "Gamma", selected: false },
+    ]);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Table />));
+    harness.counters.bindings = 0;
+    harness.counters.keys = 0;
+    const customMap = function (
+      this: Item[],
+      callback: (item: Item, index: number) => Item,
+    ): Item[] {
+      return Array.prototype.map.call(this, callback);
+    };
+
+    await act(async () => {
+      harness.setItems((previous) =>
+        createCompilerKeyedMapUpdate(previous, (current: unknown, applyMap: ApplyMap) => {
+          const source = current as Item[];
+          const firstMethod = source.map;
+          const first = applyMap(source, firstMethod, (item: Item) =>
+            item.id === "a" ? { ...item, label: "Alpha first" } : item,
+          ) as Item[];
+          return applyMap(first, customMap, (item: Item) =>
+            item.id === "c" ? { ...item, label: "Gamma custom" } : item,
+          );
+        }),
+      );
+      await flushCompilerUpdates();
+    });
+
+    expect([...container.querySelectorAll("li")].map((row) => row.textContent)).toEqual([
+      "Alpha first",
+      "Beta",
+      "Gamma custom",
+    ]);
+    expect(harness.counters.keys).toBe(3);
+    expect(harness.counters.bindings).toBe(3);
+  });
+
+  it("falls back after native map runs on an array subclass", async () => {
+    class ItemRows extends Array<Item> {}
+    const initialItems = new ItemRows();
+    initialItems.push(
+      { id: "a", label: "Alpha", selected: false },
+      { id: "b", label: "Beta", selected: false },
+      { id: "c", label: "Gamma", selected: false },
+    );
+    const harness = createMapHarness(initialItems);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Table />));
+    harness.counters.bindings = 0;
+    harness.counters.keys = 0;
+
+    await act(async () => {
+      harness.setItems((previous) =>
+        hintedMap(previous, (item) =>
+          item.id === "b" ? { ...item, label: "Beta subclass" } : item,
+        ),
+      );
+      await flushCompilerUpdates();
+    });
+
+    expect([...container.querySelectorAll("li")].map((row) => row.textContent)).toEqual([
+      "Alpha",
+      "Beta subclass",
+      "Gamma",
+    ]);
+    expect(harness.counters.keys).toBe(3);
+    expect(harness.counters.bindings).toBe(3);
+  });
+
+  it("preserves errors thrown by a later native map stage", () => {
+    const initialItems: Item[] = [{ id: "a", label: "Alpha", selected: false }];
+
+    expect(() =>
+      hintedMaps(initialItems, [
+        (item) => ({ ...item, label: "First" }),
+        () => {
+          throw new Error("second map failed");
+        },
+      ]),
+    ).toThrow("second map failed");
+  });
+
   it("falls back to complete keyed reconciliation when a hinted row changes its key", async () => {
     let setItems: (next: unknown) => void = () => undefined;
     const Inventory = createCompiledComponent({
@@ -210,9 +421,10 @@ describe("compiled keyed update hints", () => {
 
     await act(async () => {
       setItems((previous: Item[]) =>
-        hintedMap(previous, (item) =>
-          item.id === "b" ? { ...item, id: "z", label: "Zeta" } : item,
-        ),
+        hintedMaps(previous, [
+          (item) => (item.id === "b" ? { ...item, label: "Beta first" } : item),
+          (item) => (item.id === "b" ? { ...item, id: "z", label: "Zeta" } : item),
+        ]),
       );
       await flushCompilerUpdates();
     });
@@ -229,6 +441,13 @@ describe("compiled keyed update hints", () => {
     ]);
     expect(container.querySelector('[data-key="a"]')).toBe(alpha);
     expect(container.querySelector('[data-key="c"]')).toBe(gamma);
+  });
+
+  it("keeps the older precomputed value/index helper form compatible", () => {
+    const previous: Item[] = [{ id: "a", label: "Alpha", selected: false }];
+    const next = [{ ...previous[0], label: "Updated" }];
+
+    expect(createCompilerKeyedMapUpdate(previous, next, [0])).toBe(next);
   });
 
   it("rejects a hint whose source follows an unhinted update in the same flush", async () => {
@@ -394,11 +613,10 @@ describe("compiled keyed update hints", () => {
         const items = () => state[0].get() as Item[];
         updateCompiled = (target) =>
           state[0].set((previous) =>
-            hintedMap(previous as Item[], (item, index) =>
-              index === target
-                ? { ...item, label: `${item.label}!`, selected: !item.selected }
-                : item,
-            ),
+            hintedMaps(previous as Item[], [
+              (item, index) => (index === target ? { ...item, label: `${item.label}!` } : item),
+              (item, index) => (index === target ? { ...item, selected: !item.selected } : item),
+            ]),
           );
         return (
           <section>
@@ -438,11 +656,11 @@ describe("compiled keyed update hints", () => {
       const [items, setItems] = useState(initialItems);
       updateReact = (target) =>
         setItems((previous) =>
-          previous.map((item, index) =>
-            index === target
-              ? { ...item, label: `${item.label}!`, selected: !item.selected }
-              : item,
-          ),
+          previous
+            .map((item, index) => (index === target ? { ...item, label: `${item.label}!` } : item))
+            .map((item, index) =>
+              index === target ? { ...item, selected: !item.selected } : item,
+            ),
         );
       return (
         <ol data-owner="react">
@@ -484,5 +702,63 @@ describe("compiled keyed update hints", () => {
       );
     }
     expect(compiledExecutions).toBe(1);
+  });
+
+  it("hydrates consecutive map hints in StrictMode and drops a queued update after unmount", async () => {
+    const initialItems: Item[] = [
+      { id: "a", label: "Alpha", selected: false },
+      { id: "b", label: "Beta", selected: false },
+      { id: "c", label: "Gamma", selected: false },
+    ];
+    const hydration = createMapHarness(initialItems);
+    const container = document.createElement("div");
+    container.innerHTML = renderToString(<hydration.Table />);
+    document.body.append(container);
+    const recoverable: unknown[] = [];
+    let root!: Root;
+    await act(async () => {
+      root = hydrateRoot(
+        container,
+        <StrictMode>
+          <hydration.Table />
+        </StrictMode>,
+        { onRecoverableError: (error) => recoverable.push(error) },
+      );
+    });
+    roots.push(root);
+    const alpha = container.querySelector('[data-key="a"]');
+    await act(async () => {
+      hydration.setItems((previous) =>
+        hintedMaps(previous, [
+          (item) => (item.id === "a" ? { ...item, label: "Alpha hydrated" } : item),
+          (item) => (item.id === "a" ? { ...item, selected: true } : item),
+        ]),
+      );
+      await flushCompilerUpdates();
+    });
+    expect([...container.querySelectorAll("li")].map((row) => row.textContent)).toEqual([
+      "Alpha hydrated",
+      "Beta",
+      "Gamma",
+    ]);
+    expect(container.querySelector('[data-key="a"]')).toBe(alpha);
+    expect(recoverable).toEqual([]);
+
+    const unmounted = createMapHarness(initialItems);
+    const unmountContainer = document.createElement("div");
+    document.body.append(unmountContainer);
+    const unmountRoot = createRoot(unmountContainer);
+    await act(async () => unmountRoot.render(<unmounted.Table />));
+    act(() => {
+      unmounted.setItems((previous) =>
+        hintedMaps(previous, [
+          (item) => (item.id === "b" ? { ...item, label: "Never" } : item),
+          (item) => (item.id === "b" ? { ...item, selected: true } : item),
+        ]),
+      );
+      unmountRoot.unmount();
+    });
+    await flushCompilerUpdates();
+    expect(unmountContainer.innerHTML).toBe("");
   });
 });

--- a/packages/farm-react/src/compiler-runtime.tsx
+++ b/packages/farm-react/src/compiler-runtime.tsx
@@ -529,8 +529,7 @@ function compilerKeyedCollectionChangedKeys(
   return changedKeys;
 }
 
-/** @internal Records compiler-proven same-order Array.map metadata and returns the Array. */
-export function createCompilerKeyedMapUpdate(
+function recordCompilerKeyedMapUpdate(
   previous: unknown,
   value: unknown,
   changedIndices: readonly number[],
@@ -550,6 +549,88 @@ export function createCompilerKeyedMapUpdate(
     });
   }
   return value;
+}
+
+/**
+ * @internal Executes a compiler-proven Array.map pipeline and records its final same-order delta.
+ * The three-argument value/index form remains accepted for older generated output.
+ */
+export function createCompilerKeyedMapUpdate(
+  previous: unknown,
+  valueOrPipeline: unknown,
+  changedIndices?: unknown,
+): unknown {
+  if (Array.isArray(changedIndices)) {
+    return recordCompilerKeyedMapUpdate(previous, valueOrPipeline, changedIndices);
+  }
+  if (changedIndices !== undefined || typeof valueOrPipeline !== "function") {
+    return valueOrPipeline;
+  }
+
+  let eligible = true;
+  let mapCalls = 0;
+  const applyMap = (collection: unknown, method: unknown, callback: unknown): unknown => {
+    mapCalls += 1;
+    const value = NATIVE_REFLECT_APPLY(
+      method as (...values: readonly unknown[]) => unknown,
+      collection,
+      [callback],
+    );
+    if (method !== NATIVE_ARRAY_MAP) {
+      eligible = false;
+      return value;
+    }
+    try {
+      if (
+        !Array.isArray(collection) ||
+        !Array.isArray(value) ||
+        Object.getPrototypeOf(collection) !== NATIVE_ARRAY_PROTOTYPE ||
+        Object.getPrototypeOf(value) !== NATIVE_ARRAY_PROTOTYPE ||
+        value.length !== collection.length
+      ) {
+        eligible = false;
+      }
+    } catch {
+      eligible = false;
+    }
+    return value;
+  };
+  const value = NATIVE_REFLECT_APPLY(
+    valueOrPipeline as (...values: readonly unknown[]) => unknown,
+    undefined,
+    [previous, applyMap],
+  );
+  if (!eligible || mapCalls === 0) return value;
+
+  try {
+    if (
+      !Array.isArray(previous) ||
+      !Array.isArray(value) ||
+      Object.getPrototypeOf(previous) !== NATIVE_ARRAY_PROTOTYPE ||
+      Object.getPrototypeOf(value) !== NATIVE_ARRAY_PROTOTYPE ||
+      value.length !== previous.length
+    ) {
+      return value;
+    }
+    const finalChangedIndices: number[] = [];
+    for (let index = 0; index < previous.length; index += 1) {
+      const previousDescriptor = Object.getOwnPropertyDescriptor(previous, index);
+      const mappedDescriptor = Object.getOwnPropertyDescriptor(value, index);
+      if (
+        !previousDescriptor ||
+        !("value" in previousDescriptor) ||
+        !mappedDescriptor ||
+        !("value" in mappedDescriptor)
+      ) {
+        return value;
+      }
+      if (mappedDescriptor.value !== previousDescriptor.value) finalChangedIndices.push(index);
+    }
+    return recordCompilerKeyedMapUpdate(previous, value, finalChangedIndices);
+  } catch {
+    // Metadata must never change the result of a successful native update.
+    return value;
+  }
 }
 
 /** @internal Executes a proven native map before the reorder suffix of a keyed pipeline. */

--- a/packages/farm-react/src/compiler.ts
+++ b/packages/farm-react/src/compiler.ts
@@ -1173,6 +1173,43 @@ function isSafeKeyedMapResult(
   );
 }
 
+function keyedMapUpdatePipeline(
+  expression: t.Expression,
+  parameterName: string,
+  safeGlobals: ReadonlySet<string>,
+): readonly t.ArrowFunctionExpression[] | undefined {
+  const outerCallbacks: t.ArrowFunctionExpression[] = [];
+  let current = expression;
+  while (
+    t.isCallExpression(current) &&
+    current.arguments.length === 1 &&
+    t.isMemberExpression(current.callee) &&
+    !current.callee.computed &&
+    t.isIdentifier(current.callee.property, { name: "map" }) &&
+    t.isExpression(current.callee.object)
+  ) {
+    const callback = current.arguments[0];
+    if (
+      !t.isArrowFunctionExpression(callback) ||
+      callback.async ||
+      callback.generator ||
+      callback.params.length === 0 ||
+      callback.params.length > 3 ||
+      callback.params.some((parameter) => !t.isIdentifier(parameter)) ||
+      !t.isExpression(callback.body) ||
+      !isSafeKeyedMapResult(callback.body, callback.params[0] as t.Identifier, safeGlobals)
+    ) {
+      return undefined;
+    }
+    outerCallbacks.push(callback);
+    current = current.callee.object;
+  }
+  if (!t.isIdentifier(current, { name: parameterName }) || outerCallbacks.length === 0) {
+    return undefined;
+  }
+  return outerCallbacks.reverse();
+}
+
 function rewriteKeyedMapUpdateHints(
   root: t.JSXElement,
   hintedStateIndices: ReadonlySet<number>,
@@ -1198,75 +1235,52 @@ function rewriteKeyedMapUpdateHints(
         updater.generator ||
         updater.params.length !== 1 ||
         !t.isIdentifier(updater.params[0]) ||
-        !t.isCallExpression(updater.body) ||
-        !t.isMemberExpression(updater.body.callee) ||
-        updater.body.callee.computed ||
-        !t.isIdentifier(updater.body.callee.object, {
-          name: updater.params[0].name,
-        }) ||
-        !t.isIdentifier(updater.body.callee.property, { name: "map" })
+        !t.isExpression(updater.body)
       ) {
         return;
       }
-      const callback = updater.body.arguments[0];
-      if (
-        !t.isArrowFunctionExpression(callback) ||
-        callback.async ||
-        callback.generator ||
-        callback.params.length === 0 ||
-        callback.params.length > 3 ||
-        callback.params.some((parameter) => !t.isIdentifier(parameter)) ||
-        !t.isExpression(callback.body)
-      ) {
-        return;
-      }
-      const item = callback.params[0] as t.Identifier;
-      if (!isSafeKeyedMapResult(callback.body, item, safeGlobals)) return;
+      const callbacks = keyedMapUpdatePipeline(updater.body, updater.params[0].name, safeGlobals);
+      if (!callbacks) return;
 
-      const changedIndices = path.scope.generateUidIdentifier("farmChangedIndices");
-      const mappedItem = path.scope.generateUidIdentifier("farmMappedItem");
-      const nextValue = path.scope.generateUidIdentifier("farmNextItems");
-      const index = t.isIdentifier(callback.params[1])
-        ? t.cloneNode(callback.params[1])
-        : path.scope.generateUidIdentifier("farmMapIndex");
-      const wrappedCallback = t.cloneNode(callback, true);
-      if (wrappedCallback.params.length === 1) wrappedCallback.params.push(t.cloneNode(index));
-      wrappedCallback.body = t.blockStatement([
-        t.variableDeclaration("const", [
-          t.variableDeclarator(t.cloneNode(mappedItem), t.cloneNode(callback.body, true)),
-        ]),
-        t.ifStatement(
-          t.binaryExpression("!==", t.cloneNode(mappedItem), t.cloneNode(item)),
-          t.expressionStatement(
-            t.callExpression(
-              t.memberExpression(t.cloneNode(changedIndices), t.identifier("push")),
-              [t.cloneNode(index)],
-            ),
-          ),
-        ),
-        t.returnStatement(t.cloneNode(mappedItem)),
-      ]);
-
-      const mapCall = t.cloneNode(updater.body, true);
-      mapCall.arguments[0] = wrappedCallback;
       const previous = t.cloneNode(updater.params[0]);
+      const pipelineValue = path.scope.generateUidIdentifier("farmMapValue");
+      const applyMap = path.scope.generateUidIdentifier("farmApplyMap");
+      const statements: t.Statement[] = [];
+      let current: t.Expression = t.cloneNode(pipelineValue);
+      for (let index = 0; index < callbacks.length; index += 1) {
+        const method = path.scope.generateUidIdentifier(`farmMap${index + 1}`);
+        const nextValue = path.scope.generateUidIdentifier(`farmMappedItems${index + 1}`);
+        statements.push(
+          t.variableDeclaration("const", [
+            t.variableDeclarator(
+              t.cloneNode(method),
+              t.memberExpression(t.cloneNode(current), t.identifier("map")),
+            ),
+          ]),
+          t.variableDeclaration("const", [
+            t.variableDeclarator(
+              t.cloneNode(nextValue),
+              t.callExpression(t.cloneNode(applyMap), [
+                t.cloneNode(current),
+                t.cloneNode(method),
+                t.cloneNode(callbacks[index], true),
+              ]),
+            ),
+          ]),
+        );
+        current = nextValue;
+      }
       path.node.arguments[0] = t.arrowFunctionExpression(
         [t.cloneNode(previous)],
-        t.blockStatement([
-          t.variableDeclaration("const", [
-            t.variableDeclarator(t.cloneNode(changedIndices), t.arrayExpression([])),
-          ]),
-          t.variableDeclaration("const", [t.variableDeclarator(t.cloneNode(nextValue), mapCall)]),
-          t.returnStatement(
-            t.callExpression(t.cloneNode(helperIdentifier), [
-              t.cloneNode(previous),
-              t.cloneNode(nextValue),
-              t.cloneNode(changedIndices),
-            ]),
+        t.callExpression(t.cloneNode(helperIdentifier), [
+          t.cloneNode(previous),
+          t.arrowFunctionExpression(
+            [t.cloneNode(pipelineValue), t.cloneNode(applyMap)],
+            t.blockStatement([...statements, t.returnStatement(t.cloneNode(current))]),
           ),
         ]),
       );
-      count += 1;
+      count += callbacks.length;
       path.skip();
     },
   });


### PR DESCRIPTION
## Problem

A compiler-proven setter with consecutive immutable Array.map stages still executed complete keyed reconciliation after the application map work. A 10,000-row update therefore reread every row key and binding even when only every tenth same-key row changed.

## Root cause

The keyed update transform accepted only one direct map call. Existing map-pipeline support covered chains ending in a structural reorder, but a same-order map-only chain had no whole-pipeline hint.

## Change

- Recognize one or more consecutive safe conditional object-spread map callbacks rooted at the direct keyed state updater.
- Execute every original method lookup, native map, callback, result, and thrown error in source order.
- Compare committed and final row identities once after the complete chain succeeds, then patch every final changed row once.
- Add a 10,000-row browser benchmark and an equivalent block-bodied compiled control.
- Document the behavior, limits, report count, and benchmark methodology.

## Safety and compatibility

This adds no public API, option, or new runtime capability. It applies only when the existing experimental React compiler is enabled. Every mapper must satisfy the established safe concise conditional replacement shape; otherwise the complete setter stays on normal reconciliation. Runtime validation drops the hint for custom map methods, sparse or subclassed arrays, changed keys, structural changes, mixed dependencies, or invalid ownership. React fallback and LIS reconciliation remain authoritative. The older generated three-argument helper form remains compatible. React 18 and React 19 pass.

## Verification

- pnpm --filter @farm.js/react test — 688 passed, 4 skipped
- pnpm --filter @farm.js/react test:compat — React 18.3.1 and React 19.2.8 passed
- pnpm --filter @farm.js/react test:runtime-size — passed; keyed map/reorder premium remains 13,158 B gzip and core-only reduction remains 83.4%
- pnpm --filter @farm.js/react type-check
- pnpm --filter @farm.js/react build
- pnpm --dir examples/react-compiler-dashboard type-check
- pnpm docs:check-navigation
- pnpm --dir docs exec farm generate --check
- pnpm docs:build — Vercel/Nitro production output passed
- pnpm exec oxlint on changed TypeScript and JavaScript files
- pnpm exec oxfmt on all changed files

The accepted default-count production-browser run used 10 samples per compiler mode and 20 bracketing React samples. Static measured 4.90 ms versus React at 57.80 ms and the compiled control at 12.80 ms: 11.80x versus React and 2.61x versus control. Hybrid measured 5.00 ms: 11.56x versus React and 2.70x versus control. The new unchanged gate requires 8x and 2x respectively and passed in both modes. Every sample verified values, order, connection, and DOM identity for all 10,000 rows. One unrelated older structural-control ratio varied to 1.215x against its 1.25x microbenchmark threshold even though its compiled absolute time improved from the recorded 24.0 ms to 19.5 ms and remained 3.38x faster than React; no existing threshold was reduced.

## Documentation and release

Updated the React renderer docs, package README, benchmark example README, reproducible benchmark, and recorded results. No template, version, or release-flow change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Composes consecutive safe keyed `map()` calls in the React compiler so a multi-stage update avoids a second full key-and-binding reconciliation scan.

- Previously only a single `map()` was hinted; now any chain of safe conditional mappers is recognized.
- The runtime compares committed and final identities once after the whole chain and patches each changed row once.
- Preserves native method lookup, callback order, and thrown errors; falls back to normal reconciliation for custom methods, sparse/subclassed arrays, key changes, or structural edits.
- Adds a 10,000-row benchmark and tests for multi-map chains, hydration, queued updates, and React 18/19 compatibility.
- Keeps the older three-argument helper form compatible.

<sup>Written for commit 12c851e7a5e8db52b6634559ad49153ddf36e769. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/774?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

