### PR TITLE
fix(react): enforce isolated hydration budget per route

### DIFF
--- a/packages/farm/src/__tests__/production-prebuilt-ssr.test.ts
+++ b/packages/farm/src/__tests__/production-prebuilt-ssr.test.ts
@@ -972,12 +972,13 @@ export default function SecondPage() {
     }
   }, 120_000);
 
-  it("keeps the measured isolated-root overflow route-wide in development and production", async () => {
+  it("enforces the measured isolated-root budget across layouts and pages", async () => {
     const root = await createProductionFixture();
     const developmentRoot = await createProductionFixture();
 
     try {
       await fs.mkdir(path.join(root, "src", "components"), { recursive: true });
+      await fs.mkdir(path.join(root, "src", "app", "safe"), { recursive: true });
       await fs.writeFile(
         path.join(root, "src", "components", "counter.tsx"),
         `
@@ -992,21 +993,37 @@ export default function Counter({ name }) {
 `.trim(),
       );
       await fs.writeFile(
+        path.join(root, "src", "app", "layout.tsx"),
+        `
+import Counter from "../components/counter";
+
+export default function Layout({ children }) {
+  return <><header><Counter name="layout-1" /><Counter name="layout-2" /></header>{children}</>;
+}
+`.trim(),
+      );
+      await fs.writeFile(
         path.join(root, "src", "app", "page.tsx"),
         `
 import Counter from "../components/counter";
 
 export default function Page() {
   return <main>${Array.from(
-    { length: 5 },
-    (_, index) => `<Counter name="counter-${index + 1}" />`,
+    { length: 3 },
+    (_, index) => `<Counter name="overflow-${index + 1}" />`,
   ).join("")}</main>;
 }
 `.trim(),
       );
       await fs.writeFile(
-        path.join(root, "src", "app", "layout.tsx"),
-        `export default function RootLayout({ children }) { return <>{children}</>; }`,
+        path.join(root, "src", "app", "safe", "page.tsx"),
+        `
+import Counter from "../../components/counter";
+
+export default function Page() {
+  return <main><Counter name="safe-1" /><Counter name="safe-2" /></main>;
+}
+`.trim(),
       );
       await fs.writeFile(
         path.join(developmentRoot, "index.mjs"),
@@ -1028,11 +1045,23 @@ await server.listen(Number(process.env.PORT));
         force: true,
       });
 
-      const verifyRouteWideRuntime = async (response: Response) => {
+      const verifyRuntime = async (
+        response: Response,
+        expected: {
+          isolatedRoots: number;
+          pageHydrates: boolean;
+          counter: string;
+          totalCounters: number;
+        },
+      ) => {
         expect(response.status).toBe(200);
         const html = await response.text();
-        expect(html).not.toContain("<farm-client-boundary");
-        expect(html).toMatch(/id="__farm_page__"[^>]*data-farm-client="true"/);
+        expect(html.match(/<farm-client-boundary/g) ?? []).toHaveLength(expected.isolatedRoots);
+        expect(html).toMatch(
+          new RegExp(
+            `id="__farm_page__"[^>]*data-farm-client="${expected.pageHydrates ? "true" : "false"}`,
+          ),
+        );
 
         const executablePath = await resolveInstalledChromiumExecutable();
         if (!executablePath) return;
@@ -1045,18 +1074,16 @@ await server.listen(Number(process.env.PORT));
           });
           page.on("pageerror", (error) => browserErrors.push(error.message));
           await page.goto(response.url);
-          const counter = page.locator('[data-cost-counter="counter-3"]');
+          const counter = page.locator(`[data-cost-counter="${expected.counter}"]`);
           try {
             await expect
-              .poll(() =>
-                counter.evaluate((element) =>
-                  Object.keys(element).some((key) => key.startsWith("__reactProps$")),
-                ),
-              )
-              .toBe(true);
+              .poll(() => page.locator('farm-client-boundary[data-farm-hydrated="true"]').count())
+              .toBe(expected.isolatedRoots);
             await counter.click();
-            await expect.poll(() => counter.textContent()).toBe("counter-3:1");
-            await expect.poll(() => page.locator("[data-cost-counter]").count()).toBe(5);
+            await expect.poll(() => counter.textContent()).toBe(`${expected.counter}:1`);
+            await expect
+              .poll(() => page.locator("[data-cost-counter]").count())
+              .toBe(expected.totalCounters);
             expect(browserErrors).toEqual([]);
           } catch (error) {
             throw new Error(
@@ -1068,7 +1095,23 @@ await server.listen(Number(process.env.PORT));
         }
       };
 
-      await runProductionRequest(developmentRoot, verifyRouteWideRuntime);
+      const verifyServer = async (response: Response) => {
+        const origin = new URL(response.url).origin;
+        await verifyRuntime(response, {
+          isolatedRoots: 2,
+          pageHydrates: true,
+          counter: "overflow-2",
+          totalCounters: 5,
+        });
+        await verifyRuntime(await fetch(`${origin}/safe`), {
+          isolatedRoots: 4,
+          pageHydrates: false,
+          counter: "safe-2",
+          totalCounters: 4,
+        });
+      };
+
+      await runProductionRequest(developmentRoot, verifyServer);
 
       const config = await resolveConfig(
         {
@@ -1084,13 +1127,10 @@ await server.listen(Number(process.env.PORT));
 
       const clientJavaScript = await readAllClientJavaScript(root);
       expect(clientJavaScript).toContain("data-cost-counter");
-      expect(clientJavaScript).not.toContain("__farm_client_boundary_originals__");
-      expect(clientJavaScript).not.toContain("Could not hydrate isolated client boundary");
+      expect(clientJavaScript).toContain("__farm_client_boundary_originals__");
+      expect(clientJavaScript).toContain("Could not hydrate isolated client boundary");
 
-      await runProductionRequest(
-        path.join(root, ".farm", ".output", "server"),
-        verifyRouteWideRuntime,
-      );
+      await runProductionRequest(path.join(root, ".farm", ".output", "server"), verifyServer);
     } finally {
       await Promise.all(
         [root, developmentRoot].map((fixtureRoot) =>

--- a/packages/farm/src/__tests__/route-manager.test.ts
+++ b/packages/farm/src/__tests__/route-manager.test.ts
@@ -349,6 +349,110 @@ describe("RouteManager", () => {
       );
     });
 
+    it("enforces the isolated-root budget across every layout in a matched route", async () => {
+      const root = await mkdtemp(path.join(os.tmpdir(), "farm-route-hydration-budget-"));
+      temporaryDirectories.push(root);
+      await mkdir(path.join(root, "src", "app", "safe"), { recursive: true });
+      await mkdir(path.join(root, "src", "app", "overflow"), { recursive: true });
+      await mkdir(path.join(root, "src", "components"), { recursive: true });
+
+      const componentNames = [
+        "root-one",
+        "root-two",
+        "safe-one",
+        "safe-two",
+        "overflow-one",
+        "overflow-two",
+        "overflow-three",
+      ];
+      await Promise.all(
+        componentNames.map((name) =>
+          writeFile(
+            path.join(root, "src", "components", `${name}.tsx`),
+            `'use client';\nexport default function Counter() { return <button>${name}</button>; }`,
+          ),
+        ),
+      );
+      await writeFile(
+        path.join(root, "src", "app", "layout.tsx"),
+        `import One from "../components/root-one";
+import Two from "../components/root-two";
+export default function Layout({ children }) { return <><One /><Two />{children}</>; }`,
+      );
+      await writeFile(
+        path.join(root, "src", "app", "safe", "layout.tsx"),
+        `import One from "../../components/safe-one";
+import Two from "../../components/safe-two";
+export default function Layout({ children }) { return <><One /><Two />{children}</>; }`,
+      );
+      await writeFile(
+        path.join(root, "src", "app", "overflow", "layout.tsx"),
+        `import One from "../../components/overflow-one";
+import Two from "../../components/overflow-two";
+import Three from "../../components/overflow-three";
+export default function Layout({ children }) { return <><One /><Two /><Three />{children}</>; }`,
+      );
+      await Promise.all(
+        ["page.tsx", "safe/page.tsx", "overflow/page.tsx"].map((file) =>
+          writeFile(
+            path.join(root, "src", "app", file),
+            `export default function Page() { return <main>${file}</main>; }`,
+          ),
+        ),
+      );
+
+      const { globFiles, logger } = await import("../utils");
+      vi.mocked(globFiles).mockImplementation(async (pattern: string) => {
+        if (pattern.includes("page")) {
+          return ["page.tsx", "safe/page.tsx", "overflow/page.tsx"];
+        }
+        if (pattern.includes("layout")) {
+          return ["layout.tsx", "safe/layout.tsx", "overflow/layout.tsx"];
+        }
+        return [];
+      });
+      vi.mocked(logger.warn).mockClear();
+      mockConfig.root = root;
+      mockConfig.experimental = {
+        serverComponents: false,
+        serverActions: false,
+        isolatedClientHydration: "enabled",
+      };
+      routeManager = new RouteManager(mockConfig);
+      await routeManager.discoverRoutes();
+
+      const manifest = routeManager.generateClientManifest(root);
+      const rootLayout = manifest.layouts.find((layout) => layout.pattern === "/");
+      const safeLayout = manifest.layouts.find((layout) => layout.pattern === "/safe");
+      const overflowLayout = manifest.layouts.find((layout) => layout.pattern === "/overflow");
+
+      expect(rootLayout).toMatchObject({
+        shouldHydrate: false,
+        hasIsolatedClientBoundaries: true,
+      });
+      expect(rootLayout?.isolatedBoundaries).toHaveLength(2);
+      expect(safeLayout).toMatchObject({
+        shouldHydrate: false,
+        hasIsolatedClientBoundaries: true,
+      });
+      expect(safeLayout?.isolatedBoundaries).toHaveLength(2);
+      expect(overflowLayout).toMatchObject({ shouldHydrate: true });
+      expect(overflowLayout?.hasIsolatedClientBoundaries).toBeUndefined();
+      expect(overflowLayout?.isolatedBoundaries).toBeUndefined();
+      expect(routeManager.getIsolatedClientBoundaryModules(root)).toEqual(
+        new Set(
+          ["root-one", "root-two", "safe-one", "safe-two"].map((name) =>
+            path.join(root, "src", "components", `${name}.tsx`),
+          ),
+        ),
+      );
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "the matched route /overflow can create 5 isolated roots, above the measured limit of 4",
+        ),
+      );
+    });
+
     it("explains when a route-wide integration provider disables isolated roots", async () => {
       const { logger } = await import("../utils");
       vi.mocked(logger.warn).mockClear();

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -25,11 +25,14 @@ import { builtinModules, createRequire } from "module";
 import { isDeepStrictEqual } from "node:util";
 import { logger, toPosixPath, toViteModuleId } from "../utils";
 import {
+  enforceFarmIsolatedHydrationRouteBudget,
   getClientModuleHydrationPlan,
   getClientModuleMetadata,
   resolveFarmIsolatedClientHydrationMode,
+  type ClientModuleHydrationPlan,
   type IsolatedClientBoundaryReference,
 } from "../utils/client-component";
+import type { FarmIsolatedClientHydrationMode } from "../types";
 import { isFarmMarkdownPageFile } from "../app-markdown";
 import type { ProgrammaticRedirectRoute } from "../routes";
 import type { NitroConfig } from "nitro/config";
@@ -821,6 +824,7 @@ export async function buildUniversal(
     logger.info(`📋 Found ${pageRoutes.length} page routes and ${layoutRoutes.length} layouts`);
 
     const isolatedClientBoundaryModules = routeManager.getIsolatedClientBoundaryModules(root);
+    const hydrationPlanCache = new Map<string, ClientModuleHydrationPlan>();
 
     const clientOutputDir = path.join(root, distDir, "client");
     const [productionViteResult] = await productionViteResultPromise;
@@ -846,6 +850,7 @@ export async function buildUniversal(
         layoutRoutes,
         routeSlots,
         isolatedClientBoundaryModules,
+        hydrationPlanCache,
       );
     const buildSSRBundle = () =>
       buildSSRInMemory(
@@ -860,6 +865,7 @@ export async function buildUniversal(
         layoutRoutes,
         routeSlots,
         isolatedClientBoundaryModules,
+        hydrationPlanCache,
       );
 
     // Route metadata and the client/SSR graphs read independent inputs. Drain
@@ -906,6 +912,7 @@ export async function buildUniversal(
         layoutRoutes,
         routeSlots,
         isolatedClientBoundaryModules,
+        hydrationPlanCache,
       );
     }
 
@@ -1075,6 +1082,21 @@ async function validateClientBuildOutput(
 /**
  * Build client bundle (to disk) with hydration for "use client" components
  */
+function getCachedClientModuleHydrationPlan(
+  modulePath: string,
+  root: string,
+  mode: FarmIsolatedClientHydrationMode,
+  cache: Map<string, ClientModuleHydrationPlan>,
+): ClientModuleHydrationPlan {
+  const key = `${path.resolve(root)}\0${mode}\0${path.resolve(modulePath)}`;
+  let plan = cache.get(key);
+  if (!plan) {
+    plan = getClientModuleHydrationPlan(modulePath, root, mode);
+    cache.set(key, plan);
+  }
+  return { ...plan, isolatedBoundaries: [...plan.isolatedBoundaries] };
+}
+
 async function buildClient(
   productionVite: FarmProductionViteRuntime,
   config: ResolvedFarmConfig,
@@ -1085,6 +1107,7 @@ async function buildClient(
   layoutRoutes: Array<{ pattern: string; modulePath: string }> = [],
   routeSlots: UniversalRouteSlot[] = [],
   isolatedClientBoundaryModules: ReadonlySet<string> = new Set(),
+  hydrationPlanCache: Map<string, ClientModuleHydrationPlan> = new Map(),
 ) {
   const viteBuild = productionVite.build;
   const { farmPlugin } = await import("../vite");
@@ -1134,13 +1157,20 @@ async function buildClient(
 
   const clientLayouts = layoutRoutes.map((layout) => {
     try {
-      const metadata = getClientModuleHydrationPlan(layout.modulePath, root, isolatedMode);
+      const metadata = getCachedClientModuleHydrationPlan(
+        layout.modulePath,
+        root,
+        isolatedMode,
+        hydrationPlanCache,
+      );
       return {
         ...layout,
         shouldHydrate: metadata.shouldHydrate,
         islandStrategy: metadata.islandStrategy,
         legacyShouldHydrate: metadata.legacyShouldHydrate,
         legacyIslandStrategy: metadata.legacyIslandStrategy,
+        mode: metadata.mode,
+        estimatedIsolatedRootCount: metadata.estimatedIsolatedRootCount,
         hasIsolatedClientBoundaries: metadata.hasIsolatedClientBoundaries,
         isolatedHydrationEligible: metadata.isolatedHydrationEligible,
         isolatedBoundaries: metadata.isolatedBoundaries,
@@ -1153,6 +1183,8 @@ async function buildClient(
         islandStrategy: null,
         legacyShouldHydrate: false,
         legacyIslandStrategy: null,
+        mode: isolatedMode,
+        estimatedIsolatedRootCount: 0,
         hasIsolatedClientBoundaries: false,
         isolatedHydrationEligible: false,
         isolatedBoundaries: [],
@@ -1192,12 +1224,33 @@ async function buildClient(
           islandStrategy: null,
           legacyShouldHydrate: false,
           legacyIslandStrategy: null,
+          mode: isolatedMode,
+          estimatedIsolatedRootCount: 0,
           hasIsolatedClientBoundaries: false,
           isolatedBoundaries: [] as IsolatedClientBoundaryReference[],
           suppressedAsyncHydration: undefined,
         }
-      : getClientModuleHydrationPlan(route.modulePath, root, isolatedMode),
+      : getCachedClientModuleHydrationPlan(
+          route.modulePath,
+          root,
+          isolatedMode,
+          hydrationPlanCache,
+        ),
   }));
+
+  enforceFarmIsolatedHydrationRouteBudget(
+    clientLayouts.map((layout) => ({
+      pattern: layout.pattern,
+      depth: layout.pattern.split("/").filter(Boolean).length,
+      metadata: layout,
+    })),
+    routePlans.map(({ route, metadata }) => ({
+      pattern: route.pattern,
+      depth: route.pattern.split("/").filter(Boolean).length,
+      metadata,
+    })),
+    layoutAppliesToRoute,
+  );
 
   if (isolatedMode === "analyze") {
     for (const { entry, metadata } of [
@@ -1210,23 +1263,6 @@ async function buildClient(
       logger.info(
         `📊 Isolated hydration analysis: ${entry.modulePath} can exclude its server owner and hydrate ${metadata.isolatedBoundaries.length} client ${metadata.isolatedBoundaries.length === 1 ? "boundary" : "boundaries"}.`,
       );
-    }
-  }
-
-  // A route-wide layout owns its descendant page tree and cannot contain an
-  // overlapping isolated root. Route-wide pages are separate roots and can
-  // coexist with isolated client leaves in their server-owned layouts.
-  for (const { route, metadata } of routePlans) {
-    if (
-      metadata.hasIsolatedClientBoundaries &&
-      clientLayouts.some(
-        (layout) => layout.shouldHydrate && layoutAppliesToRoute(layout.pattern, route.pattern),
-      )
-    ) {
-      metadata.shouldHydrate = metadata.legacyShouldHydrate;
-      metadata.islandStrategy = metadata.legacyIslandStrategy;
-      metadata.hasIsolatedClientBoundaries = false;
-      metadata.isolatedBoundaries = [];
     }
   }
 
@@ -3161,8 +3197,8 @@ ${generateUniversalRouterStateProperties()}
         if (hasHydratableLayout(pathname)) {
           pageElement = createLayoutPageBoundary(matched.route, pageElement);
         }
-        const wrappedElement = wrapWithIntegrationProviders(
-          wrapWithLayouts(pageElement, pathname, params),
+        const wrappedElement = wrapFarmRouteClientGraph(
+          wrapWithIntegrationProviders(wrapWithLayouts(pageElement, pathname, params)),
         );
 
         await farmClientRuntime.markNavigationLoaded(clientNavigation, {
@@ -3516,6 +3552,7 @@ async function buildSSRInMemory(
   collectedLayoutRoutes: ReadonlyArray<{ pattern: string; modulePath: string }>,
   collectedRouteSlots: readonly UniversalRouteSlot[],
   isolatedClientBoundaryModules: ReadonlySet<string>,
+  hydrationPlanCache: Map<string, ClientModuleHydrationPlan>,
 ): Promise<{
   bundle: OutputBundle;
   entryFile: string;
@@ -3731,6 +3768,7 @@ async function buildSSRInMemory(
     preset,
     i18nCatalogs,
     isolatedClientBoundaryModules,
+    hydrationPlanCache,
   );
 
   // Find a temporary file path for the virtual entry
@@ -4043,6 +4081,7 @@ function generateVirtualEntryCode(
   preset: string,
   i18nCatalogs: FarmI18nCatalogs,
   isolatedClientBoundaryModules: ReadonlySet<string>,
+  hydrationPlanCache: Map<string, ClientModuleHydrationPlan>,
 ): string {
   const hasPluginRuntime = hasRuntimeIntegrationConfig || hasConfiguredRuntimePlugins;
   const adapterOwnsDocsRuntime = Boolean(
@@ -4112,35 +4151,42 @@ function generateVirtualEntryCode(
     routePattern.startsWith(`${layoutPattern}/`);
   const layoutHydrationPlans = layoutRoutes.map((layout) => ({
     ...layout,
-    hydration: getClientModuleHydrationPlan(layout.modulePath, config.root, isolatedHydrationMode),
+    hydration: getCachedClientModuleHydrationPlan(
+      layout.modulePath,
+      config.root,
+      isolatedHydrationMode,
+      hydrationPlanCache,
+    ),
   }));
   const pageHydrationPlans = new Map(
     pageRoutes
       .filter((route) => !isFarmMarkdownPageFile(route.modulePath))
       .map((route) => [
         route.modulePath,
-        getClientModuleHydrationPlan(route.modulePath, config.root, isolatedHydrationMode),
+        getCachedClientModuleHydrationPlan(
+          route.modulePath,
+          config.root,
+          isolatedHydrationMode,
+          hydrationPlanCache,
+        ),
       ]),
   );
 
-  // Match the production client plan: a route-wide layout owns its full
-  // descendant tree, so an overlapping isolated page graph must fall back to
-  // the route-wide metadata used before isolated hydration was enabled.
-  for (const route of pageRoutes) {
-    const hydration = pageHydrationPlans.get(route.modulePath);
-    if (
-      hydration?.hasIsolatedClientBoundaries &&
-      layoutHydrationPlans.some(
-        (layout) =>
-          layout.hydration.shouldHydrate && layoutAppliesToRoute(layout.pattern, route.pattern),
-      )
-    ) {
-      hydration.shouldHydrate = hydration.legacyShouldHydrate;
-      hydration.islandStrategy = hydration.legacyIslandStrategy;
-      hydration.hasIsolatedClientBoundaries = false;
-      hydration.isolatedBoundaries = [];
-    }
-  }
+  enforceFarmIsolatedHydrationRouteBudget(
+    layoutHydrationPlans.map((layout) => ({
+      pattern: layout.pattern,
+      depth: layout.pattern.split("/").filter(Boolean).length,
+      metadata: layout.hydration,
+    })),
+    pageRoutes
+      .filter((route) => !isFarmMarkdownPageFile(route.modulePath))
+      .map((route) => ({
+        pattern: route.pattern,
+        depth: route.pattern.split("/").filter(Boolean).length,
+        metadata: pageHydrationPlans.get(route.modulePath)!,
+      })),
+    layoutAppliesToRoute,
+  );
   const providerServerImports = [
     providerServerModules.hasClerkProvider
       ? `import { ClerkProvider as FarmClerkProvider } from "@clerk/react";`

--- a/packages/farm/src/routing/route-manager.ts
+++ b/packages/farm/src/routing/route-manager.ts
@@ -37,6 +37,7 @@ import {
 import path from "path";
 import type { ViteDevServer } from "vite";
 import {
+  enforceFarmIsolatedHydrationRouteBudget,
   getClientModuleHydrationPlan,
   getClientModuleMetadata,
   resolveFarmIsolatedClientHydrationMode,
@@ -631,6 +632,24 @@ export class RouteManager {
       entry,
       metadata: getClientModuleHydrationPlan(entry.modulePath, normalizedProjectRoot, isolatedMode),
     }));
+
+    enforceFarmIsolatedHydrationRouteBudget(
+      layoutEntries.map(({ entry, metadata }) => ({
+        pattern: entry.pattern,
+        depth: entry.route.segments.length,
+        metadata,
+      })),
+      routeEntries.map(({ entry, metadata }) => ({
+        pattern: entry.pattern,
+        depth: entry.route.segments.length,
+        metadata,
+      })),
+      (layoutPattern, routePattern) =>
+        layoutPattern === "/" ||
+        routePattern === layoutPattern ||
+        routePattern.startsWith(`${layoutPattern.replace(/\/$/, "")}/`),
+    );
+
     for (const { entry, metadata } of [...layoutEntries, ...routeEntries]) {
       if (!metadata.costGuardExceeded) continue;
       logger.warn(
@@ -643,26 +662,6 @@ export class RouteManager {
         logger.info(
           `[Farm.js] isolated hydration analysis: ${entry.modulePath} can keep ${metadata.isolatedBoundaries.length} client ${metadata.isolatedBoundaries.length === 1 ? "boundary" : "boundaries"} while excluding its server owner from the browser graph.`,
         );
-      }
-    }
-
-    // A route-wide layout owns its complete descendant tree, so a client leaf
-    // below it cannot also create an isolated root. A route-wide page does not
-    // conflict with isolated layout leaves because its root starts at the page
-    // boundary, outside those sibling markers.
-    for (const routeEntry of routeEntries) {
-      if (!routeEntry.metadata.hasIsolatedClientBoundaries) continue;
-      const conflictsWithLayoutRoot = layoutEntries.some(
-        ({ entry, metadata }) =>
-          metadata.shouldHydrate &&
-          (entry.pattern === "/" ||
-            routeEntry.entry.pattern === entry.pattern ||
-            routeEntry.entry.pattern.startsWith(`${entry.pattern.replace(/\/$/, "")}/`)),
-      );
-      if (conflictsWithLayoutRoot) {
-        routeEntry.metadata.shouldHydrate = routeEntry.metadata.legacyShouldHydrate;
-        routeEntry.metadata.islandStrategy = routeEntry.metadata.legacyIslandStrategy;
-        routeEntry.metadata.hasIsolatedClientBoundaries = false;
       }
     }
 

--- a/packages/farm/src/utils/client-component.ts
+++ b/packages/farm/src/utils/client-component.ts
@@ -82,6 +82,7 @@ export interface ClientModuleHydrationPlan extends ClientModuleMetadata {
   mode: FarmIsolatedClientHydrationMode;
   legacyShouldHydrate: boolean;
   legacyIslandStrategy: FarmIslandStrategy | null;
+  estimatedIsolatedRootCount: number;
   isolatedHydrationEligible: boolean;
   hasIsolatedClientBoundaries: boolean;
   isolatedBoundaries: IsolatedClientBoundaryReference[];
@@ -531,11 +532,13 @@ export function getClientModuleHydrationPlan(
   const emptyPlan = (
     fallbackReason?: string,
     costGuardExceeded = false,
+    estimatedIsolatedRootCount = 0,
   ): ClientModuleHydrationPlan => ({
     ...metadata,
     mode,
     legacyShouldHydrate: metadata.shouldHydrate,
     legacyIslandStrategy: metadata.islandStrategy,
+    estimatedIsolatedRootCount,
     isolatedHydrationEligible: false,
     hasIsolatedClientBoundaries: false,
     isolatedBoundaries: [],
@@ -557,13 +560,18 @@ export function getClientModuleHydrationPlan(
     return emptyPlan(inspection.fallbackReason);
   }
   if (inspection.fallbackReason) {
-    return emptyPlan(inspection.fallbackReason, inspection.costGuardExceeded);
+    return emptyPlan(
+      inspection.fallbackReason,
+      inspection.costGuardExceeded,
+      inspection.estimatedBoundaryCount,
+    );
   }
   const boundaryLimit = isolatedHydrationBoundaryLimit();
   if (inspection.estimatedBoundaryCount > boundaryLimit) {
     return emptyPlan(
       `the client graph can create ${inspection.estimatedBoundaryCount} isolated roots, above the measured limit of ${boundaryLimit}`,
       true,
+      inspection.estimatedBoundaryCount,
     );
   }
 
@@ -575,10 +583,114 @@ export function getClientModuleHydrationPlan(
     mode,
     legacyShouldHydrate: metadata.shouldHydrate,
     legacyIslandStrategy: metadata.islandStrategy,
+    estimatedIsolatedRootCount: inspection.estimatedBoundaryCount,
     isolatedHydrationEligible: true,
     hasIsolatedClientBoundaries: enabled,
     isolatedBoundaries: inspection.boundaries,
   };
+}
+
+interface FarmIsolatedHydrationRoutePlan {
+  mode: FarmIsolatedClientHydrationMode;
+  shouldHydrate: boolean;
+  islandStrategy: FarmIslandStrategy | null;
+  legacyShouldHydrate: boolean;
+  legacyIslandStrategy: FarmIslandStrategy | null;
+  estimatedIsolatedRootCount: number;
+  hasIsolatedClientBoundaries: boolean;
+  isolatedBoundaries: IsolatedClientBoundaryReference[];
+  costGuardExceeded?: true;
+  fallbackReason?: string;
+}
+
+interface FarmIsolatedHydrationRouteOwner {
+  pattern: string;
+  depth: number;
+  metadata: FarmIsolatedHydrationRoutePlan;
+}
+
+function restoreRouteWideHydration(
+  metadata: FarmIsolatedHydrationRoutePlan,
+  fallbackReason?: string,
+): void {
+  metadata.shouldHydrate = metadata.legacyShouldHydrate;
+  metadata.islandStrategy = metadata.legacyIslandStrategy;
+  metadata.hasIsolatedClientBoundaries = false;
+  metadata.isolatedBoundaries = [];
+  if (fallbackReason) {
+    metadata.costGuardExceeded = true;
+    metadata.fallbackReason = fallbackReason;
+  }
+}
+
+/** @internal Applies the measured root budget to each complete layout and page chain. */
+export function enforceFarmIsolatedHydrationRouteBudget(
+  layouts: FarmIsolatedHydrationRouteOwner[],
+  routes: FarmIsolatedHydrationRouteOwner[],
+  layoutAppliesToRoute: (layoutPattern: string, routePattern: string) => boolean,
+): void {
+  const boundaryLimit = isolatedHydrationBoundaryLimit();
+  const sortedLayouts = [...layouts].sort((left, right) => left.depth - right.depth);
+
+  for (const route of routes) {
+    if (route.metadata.mode !== "enabled") continue;
+    const applicableLayouts = sortedLayouts.filter((layout) =>
+      layoutAppliesToRoute(layout.pattern, route.pattern),
+    );
+    if (applicableLayouts.some((layout) => layout.metadata.shouldHydrate)) continue;
+
+    const layoutRootCount = applicableLayouts.reduce(
+      (count, layout) =>
+        count +
+        (layout.metadata.hasIsolatedClientBoundaries
+          ? layout.metadata.estimatedIsolatedRootCount
+          : 0),
+      0,
+    );
+    const routeRootCount = route.metadata.hasIsolatedClientBoundaries
+      ? route.metadata.estimatedIsolatedRootCount
+      : 0;
+    const totalRootCount = layoutRootCount + routeRootCount;
+    if (totalRootCount <= boundaryLimit) continue;
+
+    let accumulatedLayoutRoots = 0;
+    const overflowingLayout = applicableLayouts.find((layout) => {
+      if (layout.metadata.hasIsolatedClientBoundaries) {
+        accumulatedLayoutRoots += layout.metadata.estimatedIsolatedRootCount;
+      }
+      return accumulatedLayoutRoots > boundaryLimit;
+    });
+    const fallbackReason = `the matched route ${route.pattern} can create ${totalRootCount} isolated roots, above the measured limit of ${boundaryLimit}`;
+
+    if (overflowingLayout) {
+      restoreRouteWideHydration(overflowingLayout.metadata, fallbackReason);
+    } else if (route.metadata.hasIsolatedClientBoundaries) {
+      restoreRouteWideHydration(route.metadata, fallbackReason);
+    }
+  }
+
+  for (const layout of sortedLayouts) {
+    const hasRouteWideAncestor = sortedLayouts.some(
+      (ancestor) =>
+        ancestor !== layout &&
+        ancestor.depth < layout.depth &&
+        ancestor.metadata.shouldHydrate &&
+        layoutAppliesToRoute(ancestor.pattern, layout.pattern),
+    );
+    if (hasRouteWideAncestor && layout.metadata.hasIsolatedClientBoundaries) {
+      restoreRouteWideHydration(layout.metadata);
+    }
+  }
+
+  for (const route of routes) {
+    const hasRouteWideLayout = sortedLayouts.some(
+      (layout) =>
+        layout.metadata.shouldHydrate && layoutAppliesToRoute(layout.pattern, route.pattern),
+    );
+    if (hasRouteWideLayout && route.metadata.hasIsolatedClientBoundaries) {
+      restoreRouteWideHydration(route.metadata);
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
## Problem

The isolated hydration safety limit was applied to each page or layout module independently. A matched route could still exceed the measured four-root limit when its page and applicable layouts were each under budget.

For example, a layout with two isolated roots and a page with three isolated roots produced five isolated roots for one route.

Follow-up to #565.

## Root cause

Development and production calculated hydration ownership per module. Neither planner reconciled those plans against the complete matched layout and page chain.

## Change

- Carry each module's estimated isolated-root count in its hydration plan.
- Apply the existing measured limit to complete route chains in development and production.
- Promote the page or deepest overflowing layout to the existing route-wide fallback.
- Remove descendant isolated plans when a route-wide layout owns their graph.
- Reuse hydration analysis across the parallel production client and SSR builds.
- Preserve the newer route-root ownership behavior from #813.
- Cover both the four-root boundary and a five-root overflow in browser-backed development and production tests.

## Safety and compatibility

- Only `experimental.isolatedClientHydration: "enabled"` uses the route-level budget.
- Disabled and analysis-only output keep their existing behavior.
- React Server Components and incompatible integration-provider fallbacks remain route-wide.
- Non-React renderers are unchanged.
- SSR, SSG, navigation, HMR, scheduling, and interaction replay continue to use the same ownership decision.
- No new production global or public API is introduced.

## Verification

- `pnpm --filter @farm.js/core type-check`
- `pnpm --filter @farm.js/core exec vitest run src/__tests__/route-manager.test.ts`
- `pnpm --filter @farm.js/core exec vitest run src/__tests__/client-component.test.ts src/__tests__/production-async-page.test.ts`
- `pnpm --filter @farm.js/core build:runtime`
- `pnpm --filter @farm.js/core exec vitest run src/__tests__/production-prebuilt-ssr.test.ts -t 'isolates client leaves|measured isolated-root budget|isolated scheduling|one isolated ownership plan'`
- `pnpm --filter @farm.js/react test:compat`
- `pnpm --filter @farm.js/react test:runtime-size`
- `pnpm exec oxfmt --check packages/farm/src/utils/client-component.ts packages/farm/src/routing/route-manager.ts packages/farm/src/nitro/universal-build.ts packages/farm/src/__tests__/route-manager.test.ts packages/farm/src/__tests__/production-prebuilt-ssr.test.ts`
- `pnpm exec oxlint packages/farm/src/utils/client-component.ts packages/farm/src/routing/route-manager.ts packages/farm/src/nitro/universal-build.ts packages/farm/src/__tests__/route-manager.test.ts packages/farm/src/__tests__/production-prebuilt-ssr.test.ts`
- `git diff --check`

The production regression fails without the fix because the matched route emits five isolated boundaries. With the fix it emits two isolated layout boundaries plus one route-wide page root, while the four-boundary control remains fully isolated.

Environment: macOS arm64, Node 23.11.0, real Chromium browser, Node server preset.

## Documentation and release

None. This corrects internal enforcement of an existing experimental safety limit without changing its public configuration.