### PR TITLE
fix(routing): keep config route captures path-safe

### DIFF
--- a/docs/src/app/docs/configuration/page.md
+++ b/docs/src/app/docs/configuration/page.md
@@ -607,7 +607,9 @@ export default async function BlogPage() {
 Farm's `redirects()`, `rewrites()`, and `headers()` config functions use the same source pattern
 syntax. `:name` captures one path segment, while `:name*` and plain `*` capture the remaining
 characters. Redirect and rewrite destinations can reuse named captures or use numbered captures
-such as `$1`. All other source characters are matched literally.
+such as `$1`. Captured path segments are decoded and safely re-encoded before interpolation;
+empty segments in catch-all captures are removed consistently in development and production. All
+other source characters are matched literally.
 For redirects and rewrites, the incoming query string is preserved when the destination has no
 query. A query written in the destination replaces the incoming query string.
 Rewrites use after-files semantics in development and production: an existing Farm page, API,

--- a/packages/farm/src/__tests__/config-route-plugins.test.ts
+++ b/packages/farm/src/__tests__/config-route-plugins.test.ts
@@ -84,6 +84,41 @@ describe("config route plugins", () => {
     });
   });
 
+  it("keeps wildcard captures root-relative and aligned with production", async () => {
+    const plugin = createRedirectsPlugin([{ source: "/old/:path*", destination: "/:path*" }]);
+    const response = createResponse();
+
+    await runBeforeRequest(plugin, createRequest("/old//evil.example"), response);
+
+    expect(response.writeHead).toHaveBeenCalledWith(307, {
+      Location: "/evil.example",
+    });
+  });
+
+  it("encodes redirect and rewrite captures like the production runtime", async () => {
+    const redirect = createRedirectsPlugin([
+      { source: "/legacy/:path*", destination: "/current/:path*" },
+    ]);
+    const redirectResponse = createResponse();
+
+    await runBeforeRequest(
+      redirect,
+      createRequest("/legacy/guides/a%20b//c%2Fd"),
+      redirectResponse,
+    );
+
+    expect(redirectResponse.writeHead).toHaveBeenCalledWith(307, {
+      Location: "/current/guides/a%20b/c%2Fd",
+    });
+
+    const rewrite = createRewritesPlugin([
+      { source: "/legacy/:path*", destination: "/current/$1" },
+    ]);
+    const rewriteRequest = createRequest("/legacy/guides/a%20b//c%2Fd");
+    await runBeforeRequest(rewrite, rewriteRequest, createResponse());
+    expect(rewriteRequest.url).toBe("/current/guides/a%20b/c%2Fd");
+  });
+
   it("treats regular-expression characters as literals", async () => {
     const plugin = createRedirectsPlugin([{ source: "/promo.html", destination: "/offer" }]);
     const req = createRequest("/promoXhtml");

--- a/packages/farm/src/plugins/route-pattern.ts
+++ b/packages/farm/src/plugins/route-pattern.ts
@@ -2,7 +2,7 @@ import { localizeFarmHref, resolveFarmLocalePath } from "../i18n/routing";
 import type { ResolvedFarmI18nConfig } from "../i18n/types";
 
 type ConfigRoutePatternToken =
-  | { kind: "param"; name: string; captureIndex: number }
+  | { kind: "param"; name: string; captureIndex: number; catchAll: boolean }
   | { kind: "wildcard"; captureIndex: number };
 
 export interface CompiledConfigRoutePattern {
@@ -40,7 +40,12 @@ export function compileConfigRoutePattern(source: string): CompiledConfigRoutePa
     const rest = source.slice(index);
     const parameter = rest.match(/^:([A-Za-z0-9_]+)(\*)?/);
     if (parameter) {
-      tokens.push({ kind: "param", name: parameter[1], captureIndex });
+      tokens.push({
+        kind: "param",
+        name: parameter[1],
+        captureIndex,
+        catchAll: parameter[2] === "*",
+      });
       pattern += parameter[2] ? "(.*)" : "([^/]+)";
       captureIndex += 1;
       index += parameter[0].length;
@@ -69,9 +74,14 @@ export function interpolateConfigRouteDestination(
 ): string {
   const namedCaptures = new Map<string, string>();
   const wildcardCaptures: string[] = [];
+  const captures = new Map<number, string>();
 
   for (const token of tokens) {
-    const value = match[token.captureIndex] || "";
+    const value = normalizeConfigRouteCapture(
+      match[token.captureIndex] || "",
+      token.kind === "wildcard" || token.catchAll,
+    );
+    captures.set(token.captureIndex, value);
     if (token.kind === "param") {
       namedCaptures.set(token.name, value);
     } else {
@@ -93,7 +103,7 @@ export function interpolateConfigRouteDestination(
 
     const capture = rest.match(/^\$(\d+)/);
     if (capture) {
-      result += match[Number(capture[1])] || "";
+      result += captures.get(Number(capture[1])) ?? "";
       index += capture[0].length;
       continue;
     }
@@ -110,4 +120,26 @@ export function interpolateConfigRouteDestination(
   }
 
   return result;
+}
+
+function normalizeConfigRouteCapture(value: string, catchAll: boolean): string {
+  const segments = catchAll ? value.split("/").filter(Boolean) : [value];
+  return segments
+    .map((segment) => encodeConfigRouteSegment(decodeConfigRouteSegment(segment)))
+    .join("/");
+}
+
+function decodeConfigRouteSegment(segment: string): string {
+  try {
+    return decodeURIComponent(segment);
+  } catch {
+    return segment;
+  }
+}
+
+function encodeConfigRouteSegment(segment: string): string {
+  return encodeURIComponent(segment).replace(
+    /[!'()*]/g,
+    (character) => `%${character.charCodeAt(0).toString(16).toUpperCase()}`,
+  );
 }


### PR DESCRIPTION
## Problem

A catch-all config redirect such as `/old/:path*` could capture empty path segments from `/old//evil.example` and interpolate `//evil.example`. Browsers interpret that Location as a protocol-relative external redirect. Development also preserved and reused raw captures while the production matcher normalized and encoded them.

## Root cause

The development regular-expression matcher interpolated raw capture strings. It did not distinguish segment captures from catch-all captures or apply the guarded decode and path-segment encoding used by the generated production runtime.

## Change

Track whether named captures are catch-alls, normalize catch-all segments, and safely decode and re-encode every interpolated path segment. Named, wildcard, and numbered captures now share the same normalized value.

## Safety and compatibility

Configured captures remain usable in named and numbered destinations. Encoded path separators remain encoded, malformed percent sequences do not throw, and repeated empty catch-all segments can no longer create a protocol-relative destination. This aligns development with existing production behavior.

## Verification

- `pnpm --filter @farm.js/core test -- config-route-plugins.test.ts`
- `pnpm --filter @farm.js/core type-check`
- `pnpm exec oxlint packages/farm/src/plugins/route-pattern.ts packages/farm/src/__tests__/config-route-plugins.test.ts`

The root-relative regression test returns `//evil.example` without this fix and `/evil.example` with it.

## Documentation and release

Documented safe capture interpolation and catch-all normalization in the configuration guide.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes config route captures so catch-all segments are normalized and safely encoded, preventing empty segments from creating protocol-relative redirects in development.

- Track whether named captures are catch-alls and remove empty segments consistently.
- Decode and re-encode every interpolated path segment to match production behavior.
- Wildcard, named, and numbered captures now use the same normalized value.
- Malformed percent sequences are handled gracefully without throwing.

Updated the configuration guide to document safe capture interpolation and catch-all normalization.

<sup>Written for commit 34af2628113e7ad19496cff53d477bca4bdb4754. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/776?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

