### PR TITLE
fix(headers): preserve production configured cookies

### DIFF
--- a/docs/src/app/docs/configuration/page.md
+++ b/docs/src/app/docs/configuration/page.md
@@ -614,7 +614,8 @@ Rewrites use after-files semantics in development and production: an existing Fa
 integration, docs, image, or metadata route wins, and the rewrite is considered only as a fallback.
 Configured response headers are applied after route handlers in both modes, so they win when the
 same header is returned by a handler. `Link` is additive: handler and configured link values are
-merged instead of replacing one another.
+merged instead of replacing one another. `Set-Cookie` is also additive, and each handler or
+configured cookie remains a separate response header.
 
 ```ts
 export default defineConfig({

--- a/packages/farm/src/__tests__/universal-build-router-runtime.test.ts
+++ b/packages/farm/src/__tests__/universal-build-router-runtime.test.ts
@@ -7,10 +7,74 @@ import {
   isFarmDeploymentMismatchResponse,
 } from "../deployment";
 import {
+  generateConfiguredResponseHeadersRuntimeSource,
   generateRuntimePathMatcherSource,
   generateUniversalRouterStateRuntime,
   generateUniversalRouterStateProperties,
 } from "../nitro/universal-build";
+
+describe("generateConfiguredResponseHeadersRuntimeSource", () => {
+  it("preserves handler and configured Set-Cookie fields separately", () => {
+    const source = generateConfiguredResponseHeadersRuntimeSource();
+    const applyConfiguredResponseHeaders = new Function(
+      "configuredHeaderRoutes",
+      "matchRuntimePathPattern",
+      "appendFarmLinkHeader",
+      `${source}; return applyConfiguredResponseHeaders;`,
+    )(
+      [
+        {
+          source: "/account",
+          headers: [
+            { key: "Set-Cookie", value: "theme=dark; Path=/" },
+            { key: "set-cookie", value: "locale=en; Path=/" },
+          ],
+        },
+      ],
+      (source: string, pathname: string) => source === pathname,
+      (headers: Headers, value: string) => headers.append("Link", value),
+    ) as (response: Response, pathname: string) => Response;
+    const handlerHeaders = new Headers();
+    handlerHeaders.append("Set-Cookie", "session=abc; Path=/; HttpOnly");
+
+    const response = applyConfiguredResponseHeaders(
+      new Response("ok", { headers: handlerHeaders }),
+      "/account",
+    );
+
+    expect(response.headers.getSetCookie()).toEqual([
+      "session=abc; Path=/; HttpOnly",
+      "theme=dark; Path=/",
+      "locale=en; Path=/",
+    ]);
+  });
+
+  it("does not duplicate an existing configured cookie", () => {
+    const source = generateConfiguredResponseHeadersRuntimeSource();
+    const applyConfiguredResponseHeaders = new Function(
+      "configuredHeaderRoutes",
+      "matchRuntimePathPattern",
+      "appendFarmLinkHeader",
+      `${source}; return applyConfiguredResponseHeaders;`,
+    )(
+      [
+        {
+          source: "/account",
+          headers: [{ key: "Set-Cookie", value: "theme=dark; Path=/" }],
+        },
+      ],
+      () => true,
+      (headers: Headers, value: string) => headers.append("Link", value),
+    ) as (response: Response, pathname: string) => Response;
+
+    const response = applyConfiguredResponseHeaders(
+      new Response("ok", { headers: { "Set-Cookie": "theme=dark; Path=/" } }),
+      "/account",
+    );
+
+    expect(response.headers.getSetCookie()).toEqual(["theme=dark; Path=/"]);
+  });
+});
 
 afterEach(() => {
   vi.unstubAllGlobals();

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -3948,6 +3948,49 @@ export function toVirtualEntryImportSpecifier(modulePath: string): string {
   return JSON.stringify(modulePath.replace(/\\/g, "/"));
 }
 
+export function generateConfiguredResponseHeadersRuntimeSource(): string {
+  return `
+function getConfiguredSetCookieHeaders(headers) {
+  const getSetCookie = headers.getSetCookie;
+  if (typeof getSetCookie === "function") return getSetCookie.call(headers);
+  const value = headers.get("set-cookie");
+  return value ? [value] : [];
+}
+
+function applyConfiguredResponseHeaders(response, pathname) {
+  let headers;
+  for (const headerRoute of configuredHeaderRoutes) {
+    if (!matchRuntimePathPattern(headerRoute.source, pathname)) continue;
+    for (const header of headerRoute.headers) {
+      const currentHeaders = headers || response.headers;
+      const normalizedKey = header.key.toLowerCase();
+      if (normalizedKey === "set-cookie") {
+        if (getConfiguredSetCookieHeaders(currentHeaders).includes(header.value)) continue;
+        if (!headers) headers = new Headers(response.headers);
+        headers.append("Set-Cookie", header.value);
+      } else {
+        const currentValue = currentHeaders.get(header.key);
+        if (currentValue === header.value) continue;
+        if (!headers) headers = new Headers(response.headers);
+        if (normalizedKey === "link") {
+          appendFarmLinkHeader(headers, header.value);
+        } else {
+          headers.set(header.key, header.value);
+        }
+      }
+    }
+  }
+
+  if (!headers) return response;
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
+`.trim();
+}
+
 function generateVirtualEntryCode(
   apiRoutes: Array<{ path: string; filePath: string; methods: string[] }>,
   pageRoutes: UniversalPageRoute[],
@@ -5508,29 +5551,7 @@ function createRewrittenRequest(request, destination) {
   return new Request(destinationUrl, request);
 }
 
-function applyConfiguredResponseHeaders(response, pathname) {
-  let headers;
-  for (const headerRoute of configuredHeaderRoutes) {
-    if (!matchRuntimePathPattern(headerRoute.source, pathname)) continue;
-    for (const header of headerRoute.headers) {
-      const currentValue = (headers || response.headers).get(header.key);
-      if (currentValue === header.value) continue;
-      if (!headers) headers = new Headers(response.headers);
-      if (header.key.toLowerCase() === "link") {
-        appendFarmLinkHeader(headers, header.value);
-      } else {
-        headers.set(header.key, header.value);
-      }
-    }
-  }
-
-  if (!headers) return response;
-  return new Response(response.body, {
-    status: response.status,
-    statusText: response.statusText,
-    headers,
-  });
-}
+${generateConfiguredResponseHeadersRuntimeSource()}
 
 // App middleware files bundled at build time (sorted by depth, root first)
 const fileMiddlewareModules = [${middlewareRegistrations.join(",")}


### PR DESCRIPTION
## Problem

Production response finalization replaced repeated configured `Set-Cookie` fields with the last value. It could also replace or duplicate a cookie already returned by the route handler, while development preserves each cookie separately.

## Root cause

The generated universal runtime handled every configured header except `Link` with `Headers.set()`. That operation is correct for ordinary singleton headers but replaces earlier `Set-Cookie` fields.

## Change

Generate a dedicated configured-header runtime helper that appends unique `Set-Cookie` fields and retains the existing replacement behavior for ordinary headers. The same helper source is executable in a focused production-runtime regression test.

## Safety and compatibility

Ordinary configured headers still override handler values, and `Link` remains additive. Cookie fields now match development behavior and native multi-value response semantics.

## Verification

- `pnpm --filter @farm.js/core test -- universal-build-router-runtime.test.ts`
- `pnpm --filter @farm.js/core type-check`
- focused `oxlint` (one pre-existing `deployOutputDir` warning in `universal-build.ts`, zero errors)

The regression test loses the first configured cookie without this fix and passes with all handler/configured cookies retained.

## Documentation and release

Documented additive, separate `Set-Cookie` behavior in the configuration guide.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes production response finalization that collapsed repeated configured `Set-Cookie` fields into the last value, so production now keeps each cookie as a separate header like development does.

- Generates a dedicated runtime helper that appends unique `Set-Cookie` fields while preserving the existing replacement behavior for ordinary headers and additive `Link` handling.
- Adds a focused regression test covering handler and configured cookies.
- Updates the configuration guide to document additive `Set-Cookie` behavior.

<sup>Written for commit 56705c40f6c3754e8cc5a4f1855ce045f943f0a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/777?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

