### PR TITLE
fix(server): trust forwarded authority only when configured

### DIFF
--- a/docs/src/app/docs/configuration/page.md
+++ b/docs/src/app/docs/configuration/page.md
@@ -534,7 +534,7 @@ export default defineConfig({
 
 Farm checks `Content-Length` when present and also counts the received bytes, so chunked requests cannot bypass `bodySizeLimit`. Oversized requests receive `413 Payload Too Large` before the route or integration handler runs. Server Actions keep their separate, tighter `serverActions.bodySizeLimit` setting.
 
-`trustProxy` defaults to `false`. Enable it only when the app is behind a trusted reverse proxy that removes client-supplied forwarding headers and writes its own `X-Forwarded-For` value. A directly exposed Farm server must leave it disabled so a client cannot spoof the address used by rate limits, logs, or access policy.
+`trustProxy` defaults to `false`. Enable it only when the app is behind a trusted reverse proxy that removes client-supplied forwarding headers and writes its own `X-Forwarded-For`, `X-Forwarded-Host`, and `X-Forwarded-Proto` values. Farm uses those headers for the client address and public request URL only when the proxy is trusted. A directly exposed Farm server must leave it disabled so a client cannot spoof the address or authority used by rate limits, redirects, authentication callbacks, logs, or access policy.
 
 Workflow runner secrets are accepted only through `Authorization: Bearer <secret>` or `X-Farm-Workflow-Secret`. Farm does not accept secrets in query strings because URLs are commonly retained in logs, browser history, and referrer data.
 

--- a/packages/farm/src/__tests__/server-request.test.ts
+++ b/packages/farm/src/__tests__/server-request.test.ts
@@ -18,6 +18,7 @@ describe("createWebRequestFromFarmRequest", () => {
         "x-forwarded-host": "app.example.com, internal:3000",
         "x-forwarded-proto": "https, http",
       }),
+      { trustProxy: true },
     );
 
     expect(result.url).toBe("https://app.example.com/account?tab=profile");
@@ -30,6 +31,7 @@ describe("createWebRequestFromFarmRequest", () => {
         "x-forwarded-host": ["app.example.com", "internal:3000"],
         "x-forwarded-proto": ["https", "http"],
       }),
+      { trustProxy: true },
     );
 
     expect(result.url).toBe("https://app.example.com/account?tab=profile");
@@ -42,6 +44,7 @@ describe("createWebRequestFromFarmRequest", () => {
         "x-forwarded-host": "not a valid host",
         "x-forwarded-proto": "javascript",
       }),
+      { trustProxy: true },
     );
 
     expect(result.url).toBe("http://farm.test/account?tab=profile");
@@ -54,9 +57,40 @@ describe("createWebRequestFromFarmRequest", () => {
         "x-forwarded-host": "evil.test/path",
         "x-forwarded-proto": "HTTPS",
       }),
+      { trustProxy: true },
     );
 
     expect(result.url).toBe("https://farm.test/account?tab=profile");
+  });
+
+  it("ignores forwarded authority unless trustProxy is enabled", () => {
+    const direct = createWebRequestFromFarmRequest(
+      request({
+        host: "farm.test",
+        "x-forwarded-host": "attacker.example",
+        "x-forwarded-proto": "https",
+      }),
+    );
+    const proxied = createWebRequestFromFarmRequest(
+      request({
+        host: "internal:3000",
+        "x-forwarded-host": "app.example.com",
+        "x-forwarded-proto": "https",
+      }),
+      { trustProxy: true },
+    );
+
+    expect(direct.url).toBe("http://farm.test/account?tab=profile");
+    expect(proxied.url).toBe("https://app.example.com/account?tab=profile");
+  });
+
+  it("uses the trusted context origin for middleware Request conversion", () => {
+    const result = createWebRequestFromFarmRequest(
+      request({ host: "internal:3000", "x-forwarded-host": "ignored.example" }),
+      { origin: "https://app.example.com" },
+    );
+
+    expect(result.url).toBe("https://app.example.com/account?tab=profile");
   });
 });
 

--- a/packages/farm/src/middleware/context.ts
+++ b/packages/farm/src/middleware/context.ts
@@ -5,6 +5,8 @@
 import type { IncomingMessage, ServerResponse } from "http";
 import type { ViteDevServer } from "vite";
 import type { MiddlewareContext, CookieJar, CookieOptions } from "./types";
+import type { FarmServerConfig, ResolvedFarmServerConfig } from "../server-http";
+import { resolveFarmRequestURL } from "../server/request";
 import { parseMiddlewareCookieHeader } from "./cookie-header";
 
 /**
@@ -102,8 +104,9 @@ export function createContext(
   res: ServerResponse,
   viteServer?: ViteDevServer,
   parent?: MiddlewareContext["parent"],
+  server?: FarmServerConfig | ResolvedFarmServerConfig,
 ): MiddlewareContext {
-  const url = new URL(req.url || "/", `http://${req.headers.host || "localhost"}`);
+  const url = resolveFarmRequestURL(req, { trustProxy: server?.trustProxy });
   const headers = new Map<string, string>();
   const data = parent?.data ? new Map(parent.data) : new Map<string, any>();
   const locals = parent?.locals ? new Map(parent.locals) : new Map<string, any>();

--- a/packages/farm/src/middleware/manager.ts
+++ b/packages/farm/src/middleware/manager.ts
@@ -26,6 +26,7 @@ import { stripFarmLocaleFromPathname } from "../i18n/routing";
 import type { ResolvedFarmI18nConfig } from "../i18n/types";
 import { createCliColors } from "../cli-colors";
 import { appendMiddlewareRoutePath } from "./path";
+import type { FarmServerConfig, ResolvedFarmServerConfig } from "../server-http";
 
 export interface DiscoveredMiddleware {
   path: string;
@@ -49,16 +50,19 @@ export class MiddlewareManager {
   private viteServer?: ViteDevServer;
   private appDirs: string[];
   private i18n?: ResolvedFarmI18nConfig;
+  private server?: FarmServerConfig | ResolvedFarmServerConfig;
 
   constructor(
     appDir: string | readonly string[],
     viteServer?: ViteDevServer,
     config?: FarmMiddlewareConfig,
     i18n?: ResolvedFarmI18nConfig,
+    server?: FarmServerConfig | ResolvedFarmServerConfig,
   ) {
     this.appDirs = Array.isArray(appDir) ? [...appDir] : [appDir as string];
     this.viteServer = viteServer;
     this.i18n = i18n;
+    this.server = server;
     this.configure(config);
   }
 
@@ -208,7 +212,7 @@ export class MiddlewareManager {
     const startTime = Date.now();
 
     let parentData: MiddlewareContext["parent"] | undefined;
-    let ctx = createContext(req, res, this.viteServer);
+    let ctx = createContext(req, res, this.viteServer, undefined, this.server);
 
     if (this.globalConfig) {
       const globalMatch = this.matchesConfig(routePathname, this.globalConfig, ctx);
@@ -264,7 +268,7 @@ export class MiddlewareManager {
 
       // Create new context with parent data
       if (parentData) {
-        ctx = createContext(req, res, this.viteServer, parentData);
+        ctx = createContext(req, res, this.viteServer, parentData, this.server);
         if (routeMatch.params) {
           ctx.params = { ...ctx.params, ...routeMatch.params };
         }

--- a/packages/farm/src/middleware/module.ts
+++ b/packages/farm/src/middleware/module.ts
@@ -21,7 +21,7 @@ function toWebRequest(ctx: MiddlewareContext): Request {
   if (isWebRequest(ctx.request)) {
     return ctx.request;
   }
-  return createWebRequestFromFarmRequest(ctx.request);
+  return createWebRequestFromFarmRequest(ctx.request, { origin: ctx.url.origin });
 }
 
 function createRequestMiddlewareContext(

--- a/packages/farm/src/server-http.ts
+++ b/packages/farm/src/server-http.ts
@@ -23,7 +23,7 @@ export interface ResolvedFarmServerHealthConfig {
 export interface FarmServerConfig {
   /** Maximum request body size for API routes, integrations, workflows, and uploads. */
   bodySizeLimit?: number | string;
-  /** Trust proxy-provided client IP headers. Enable only behind a trusted proxy. */
+  /** Trust proxy-provided client address and request authority headers. Enable only behind a trusted proxy. */
   trustProxy?: boolean;
   /** Maximum time for a Node client to send complete request headers. */
   headersTimeout?: FarmServerDuration;

--- a/packages/farm/src/server/renderer.ts
+++ b/packages/farm/src/server/renderer.ts
@@ -997,7 +997,9 @@ export class ServerRenderer {
     await this.initialize();
     setFarmBasePath(this.config.basePath);
     setFarmTrailingSlashPreference(this.config.trailingSlash);
-    const request = createWebRequestFromFarmRequest(req);
+    const request = createWebRequestFromFarmRequest(req, {
+      trustProxy: this.config.server?.trustProxy,
+    });
     const runtime = this.i18nRuntime;
 
     if (runtime?.config.enabled) {
@@ -1125,7 +1127,9 @@ export class ServerRenderer {
       pluginExposedContext = getRequestContextSnapshot(req as object, {
         exposedOnly: true,
       });
-      const currentRequest = createWebRequestFromFarmRequest(req);
+      const currentRequest = createWebRequestFromFarmRequest(req, {
+        trustProxy: this.config.server?.trustProxy,
+      });
       const routeContext = await this.resolveRouteContext({
         request: currentRequest,
         rawRequest: req,
@@ -1881,7 +1885,9 @@ export class ServerRenderer {
         );
       }
 
-      const request = createWebRequestFromFarmRequest(req);
+      const request = createWebRequestFromFarmRequest(req, {
+        trustProxy: this.config.server?.trustProxy,
+      });
       const url = new URL(request.url);
       const value =
         typeof routeModule.default === "function"

--- a/packages/farm/src/server/request.ts
+++ b/packages/farm/src/server/request.ts
@@ -21,17 +21,38 @@ const requestStore = getRequestStore();
 
 _setCurrentRequestResolver(() => requestStore.getStore());
 
-export function createWebRequestFromFarmRequest(req: FarmRequest): Request {
-  const forwardedHost = firstForwardedHeaderValue(req.headers["x-forwarded-host"]);
+export interface FarmRequestURLOptions {
+  origin?: string | URL;
+  trustProxy?: boolean;
+}
+
+export function resolveFarmRequestURL(req: FarmRequest, options: FarmRequestURLOptions = {}): URL {
+  if (options.origin) {
+    return new URL(req.url || "/", options.origin);
+  }
+
+  const forwardedHost = options.trustProxy
+    ? firstForwardedHeaderValue(req.headers["x-forwarded-host"])
+    : undefined;
   const fallbackHost = firstForwardedHeaderValue(req.headers.host) || "localhost";
-  const forwardedProto = firstForwardedHeaderValue(req.headers["x-forwarded-proto"]);
+  const forwardedProto = options.trustProxy
+    ? firstForwardedHeaderValue(req.headers["x-forwarded-proto"])
+    : undefined;
   const normalizedProto = forwardedProto?.toLowerCase();
   const proto =
-    normalizedProto === "https" || normalizedProto === "http" ? normalizedProto : "http";
-  const fullUrl = new URL(
-    req.url || "/",
-    resolveRequestOrigin(proto, forwardedHost, fallbackHost),
-  ).toString();
+    normalizedProto === "https" || normalizedProto === "http"
+      ? normalizedProto
+      : isEncryptedFarmRequest(req)
+        ? "https"
+        : "http";
+  return new URL(req.url || "/", resolveRequestOrigin(proto, forwardedHost, fallbackHost));
+}
+
+export function createWebRequestFromFarmRequest(
+  req: FarmRequest,
+  options: FarmRequestURLOptions = {},
+): Request {
+  const fullUrl = resolveFarmRequestURL(req, options).toString();
 
   const headers = new Headers();
   for (const [key, value] of Object.entries(req.headers)) {
@@ -61,6 +82,10 @@ export function createWebRequestFromFarmRequest(req: FarmRequest): Request {
   }
 
   return new Request(fullUrl, init);
+}
+
+function isEncryptedFarmRequest(req: FarmRequest): boolean {
+  return Boolean((req.socket as { encrypted?: boolean } | undefined)?.encrypted);
 }
 
 function firstForwardedHeaderValue(value: string | string[] | undefined): string | undefined {

--- a/packages/farm/src/vite.ts
+++ b/packages/farm/src/vite.ts
@@ -1077,6 +1077,7 @@ export function farmPlugin(
         server,
         farmConfig.middleware,
         farmConfig.i18n,
+        farmConfig.server,
       );
       await middlewareManager.discover();
       if (pm) {


### PR DESCRIPTION
## Problem

Directly exposed Farm Node servers used `X-Forwarded-Host` and `X-Forwarded-Proto` to construct the web Request URL even though `server.trustProxy` defaults to false. A client could therefore spoof origin-dependent URLs used by redirects, callbacks, logs, and access policy.

## Root cause

Request URL conversion consumed forwarded authority unconditionally. The trust setting was applied to middleware client-address resolution but was not threaded into renderer or middleware URL construction.

## Change

Centralize Farm request URL resolution, gate forwarded host/protocol on `trustProxy`, use the encrypted socket for the direct protocol fallback, and pass the resolved server policy through renderer and middleware construction. Named middleware reuses the already trusted middleware-context origin.

## Safety and compatibility

The default now uses the direct Host and socket protocol. Apps behind a trusted proxy retain their public forwarded URL by setting `server.trustProxy: true`. Malformed forwarded values still fall back safely. Production Nitro Requests already arrive as web Requests and keep their existing platform behavior.

## Verification

- `pnpm --filter @farm.js/core test -- server-request.test.ts middleware.test.ts`
- `pnpm --filter @farm.js/core type-check`
- focused `oxlint` (two pre-existing empty-catch warnings in `middleware/manager.ts`, zero errors)

The new regression test resolves the attacker-provided forwarded authority without this fix and the direct Host with it.

## Documentation and release

Expanded the `trustProxy` API comment and configuration guide to cover forwarded client address and request authority.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a security hole where Farm built request URLs from `X-Forwarded-Host` and `X-Forwarded-Proto` even when `server.trustProxy` was disabled, letting clients spoof origin-dependent redirects, callbacks, logs, and access policy. The server now honors those headers only when `trustProxy` is enabled; direct connections use the Host header and socket protocol, and middleware contexts reuse the trusted origin.

**Migration**
- Apps behind a trusted reverse proxy must set `server.trustProxy: true` to keep their public forwarded URL.

<sup>Written for commit 1b7619843f563d7941d0d7ff09a2873bab2c6ab0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/778?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

