### PR TITLE
fix(integrations): isolate logging failures

### DIFF
--- a/docs/src/app/docs/integrations/custom/page.md
+++ b/docs/src/app/docs/integrations/custom/page.md
@@ -933,7 +933,7 @@ export const acme = defineIntegration({
 });
 ```
 
-Common phases are `registered`, `validate`, `setup`, `ready`, `dispose`, `request:start`, `request:end`, and `request:error`.
+Common phases are `registered`, `validate`, `setup`, `ready`, `dispose`, `request:start`, `request:end`, and `request:error`. Logging is observational: a synchronous throw or rejected promise from the callback is isolated and does not prevent integration startup, request handling, response delivery, or shutdown.
 
 ## Client and server usage
 

--- a/packages/farm/src/__tests__/integrations.test.ts
+++ b/packages/farm/src/__tests__/integrations.test.ts
@@ -486,6 +486,52 @@ describe("integrations runtime", () => {
     expect(endLog?.context.get("seed")).toBe("shared-value");
   });
 
+  it("isolates integration log failures from lifecycle and request handling", async () => {
+    const handler = vi.fn(() => Response.json({ ok: true }));
+    const log = vi.fn(() => {
+      throw new Error("log sink unavailable");
+    });
+    const manager = createManager();
+    manager.addPlugins(
+      resolveIntegrationPlugins({
+        isolatedLogs: defineIntegration({
+          category: "custom",
+          type: "isolated-logs",
+          instance: {},
+          log,
+          routes: [
+            {
+              path: "/api/isolated-logs",
+              methods: ["GET"],
+              handler,
+            },
+          ],
+        }),
+      }),
+    );
+
+    await expect(manager.runHookParallel("init")).resolves.toBe(false);
+
+    const req = createRequest("/api/isolated-logs");
+    const res = createResponse();
+    await expect(manager.runHookParallel("beforeRequest", req as any, res as any)).resolves.toBe(
+      true,
+    );
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body.toString())).toEqual({ ok: true });
+
+    const runtime = getRegisteredIntegrationRuntime("isolatedLogs");
+    expect(runtime).toBeDefined();
+    const response = await dispatchIntegrationRequest(
+      runtime!,
+      new Request("http://localhost/api/isolated-logs"),
+    );
+    expect(response?.status).toBe(200);
+    await expect(response?.json()).resolves.toEqual({ ok: true });
+    expect(handler).toHaveBeenCalledTimes(2);
+    expect(log).toHaveBeenCalled();
+  });
+
   it("runs integration middleware before routes and can short-circuit the request", async () => {
     const manager = createManager();
     manager.addPlugins(

--- a/packages/farm/src/integrations.ts
+++ b/packages/farm/src/integrations.ts
@@ -1658,6 +1658,18 @@ function createIntegrationLifecycleLogger(
   };
 }
 
+async function emitIntegrationLog(
+  integration: FarmIntegration,
+  event: FarmIntegrationLogEvent,
+): Promise<void> {
+  try {
+    await integration.log?.(event);
+  } catch {
+    // Integration logging is optional observability. A failed sink must not
+    // block lifecycle startup, request handlers, responses, or cleanup.
+  }
+}
+
 const INTEGRATION_DATA_HEADER = "x-farm-integration-data";
 const INTEGRATION_DATA_HEADER_MAX_LENGTH = 16 * 1024;
 const BLOCKED_INTEGRATION_DATA_KEYS = new Set(["__proto__", "constructor", "prototype"]);
@@ -1811,7 +1823,7 @@ function createIntegrationPlugin(integrationKey: string, integration: FarmIntegr
       }
 
       for (const route of routes) {
-        await integration.log({
+        await emitIntegrationLog(integration, {
           category: integration.category,
           slot: integration.category,
           type: integration.type,
@@ -1826,7 +1838,7 @@ function createIntegrationPlugin(integrationKey: string, integration: FarmIntegr
       }
 
       for (const entry of middleware) {
-        await integration.log({
+        await emitIntegrationLog(integration, {
           category: integration.category,
           slot: integration.category,
           type: integration.type,
@@ -1917,7 +1929,7 @@ function createIntegrationPlugin(integrationKey: string, integration: FarmIntegr
           pluginContext: context,
         });
         const startedAt = Date.now();
-        await integration.log?.({
+        await emitIntegrationLog(integration, {
           category: integration.category,
           slot: integration.category,
           type: integration.type,
@@ -1936,7 +1948,7 @@ function createIntegrationPlugin(integrationKey: string, integration: FarmIntegr
           const response = await entry.handler(request, handlerContext);
           if (response) {
             await sendWebResponse(res, response);
-            await integration.log?.({
+            await emitIntegrationLog(integration, {
               category: integration.category,
               slot: integration.category,
               type: integration.type,
@@ -1955,7 +1967,7 @@ function createIntegrationPlugin(integrationKey: string, integration: FarmIntegr
             return;
           }
 
-          await integration.log?.({
+          await emitIntegrationLog(integration, {
             category: integration.category,
             slot: integration.category,
             type: integration.type,
@@ -1971,7 +1983,7 @@ function createIntegrationPlugin(integrationKey: string, integration: FarmIntegr
             context: handlerContext.req.snapshot(),
           });
         } catch (error) {
-          await integration.log?.({
+          await emitIntegrationLog(integration, {
             category: integration.category,
             slot: integration.category,
             type: integration.type,
@@ -2016,7 +2028,7 @@ function createIntegrationPlugin(integrationKey: string, integration: FarmIntegr
           pluginContext: context,
         });
         const startedAt = Date.now();
-        await integration.log?.({
+        await emitIntegrationLog(integration, {
           category: integration.category,
           slot: integration.category,
           type: integration.type,
@@ -2035,7 +2047,7 @@ function createIntegrationPlugin(integrationKey: string, integration: FarmIntegr
           const validation = await validateIntegrationRouteInput(route, request, url);
           if (!validation.success) {
             await sendWebResponse(res, validation.response);
-            await integration.log?.({
+            await emitIntegrationLog(integration, {
               category: integration.category,
               slot: integration.category,
               type: integration.type,
@@ -2059,7 +2071,7 @@ function createIntegrationPlugin(integrationKey: string, integration: FarmIntegr
             const middlewareResponse = await middlewareEntry.handler(request, handlerContext);
             if (middlewareResponse) {
               await sendWebResponse(res, middlewareResponse);
-              await integration.log?.({
+              await emitIntegrationLog(integration, {
                 category: integration.category,
                 slot: integration.category,
                 type: integration.type,
@@ -2092,7 +2104,7 @@ function createIntegrationPlugin(integrationKey: string, integration: FarmIntegr
               beforeResponse,
             );
             await sendWebResponse(res, response);
-            await integration.log?.({
+            await emitIntegrationLog(integration, {
               category: integration.category,
               slot: integration.category,
               type: integration.type,
@@ -2119,7 +2131,7 @@ function createIntegrationPlugin(integrationKey: string, integration: FarmIntegr
             handlerResponse,
           );
           await sendWebResponse(res, response);
-          await integration.log?.({
+          await emitIntegrationLog(integration, {
             category: integration.category,
             slot: integration.category,
             type: integration.type,
@@ -2137,7 +2149,7 @@ function createIntegrationPlugin(integrationKey: string, integration: FarmIntegr
           });
           return;
         } catch (error) {
-          await integration.log?.({
+          await emitIntegrationLog(integration, {
             category: integration.category,
             slot: integration.category,
             type: integration.type,
@@ -2758,7 +2770,7 @@ export async function dispatchIntegrationRequest(
     });
     const startedAt = Date.now();
 
-    await integration.log?.({
+    await emitIntegrationLog(integration, {
       category: integration.category,
       slot: integration.category,
       type: integration.type,
@@ -2776,7 +2788,7 @@ export async function dispatchIntegrationRequest(
     try {
       const response = await entry.handler(request, handlerContext);
       if (response) {
-        await integration.log?.({
+        await emitIntegrationLog(integration, {
           category: integration.category,
           slot: integration.category,
           type: integration.type,
@@ -2795,7 +2807,7 @@ export async function dispatchIntegrationRequest(
         return response;
       }
 
-      await integration.log?.({
+      await emitIntegrationLog(integration, {
         category: integration.category,
         slot: integration.category,
         type: integration.type,
@@ -2811,7 +2823,7 @@ export async function dispatchIntegrationRequest(
         context: handlerContext.req.snapshot(),
       });
     } catch (error) {
-      await integration.log?.({
+      await emitIntegrationLog(integration, {
         category: integration.category,
         slot: integration.category,
         type: integration.type,
@@ -2856,7 +2868,7 @@ export async function dispatchIntegrationRequest(
     });
     const startedAt = Date.now();
 
-    await integration.log?.({
+    await emitIntegrationLog(integration, {
       category: integration.category,
       slot: integration.category,
       type: integration.type,
@@ -2874,7 +2886,7 @@ export async function dispatchIntegrationRequest(
     try {
       const validation = await validateIntegrationRouteInput(route, request, url);
       if (!validation.success) {
-        await integration.log?.({
+        await emitIntegrationLog(integration, {
           category: integration.category,
           slot: integration.category,
           type: integration.type,
@@ -2897,7 +2909,7 @@ export async function dispatchIntegrationRequest(
       for (const middlewareEntry of route.middleware || []) {
         const middlewareResponse = await middlewareEntry.handler(request, handlerContext);
         if (middlewareResponse) {
-          await integration.log?.({
+          await emitIntegrationLog(integration, {
             category: integration.category,
             slot: integration.category,
             type: integration.type,
@@ -2925,7 +2937,7 @@ export async function dispatchIntegrationRequest(
           handlerContext,
           beforeResponse,
         );
-        await integration.log?.({
+        await emitIntegrationLog(integration, {
           category: integration.category,
           slot: integration.category,
           type: integration.type,
@@ -2951,7 +2963,7 @@ export async function dispatchIntegrationRequest(
         handlerContext,
         handlerResponse,
       );
-      await integration.log?.({
+      await emitIntegrationLog(integration, {
         category: integration.category,
         slot: integration.category,
         type: integration.type,
@@ -2969,7 +2981,7 @@ export async function dispatchIntegrationRequest(
       });
       return response;
     } catch (error) {
-      await integration.log?.({
+      await emitIntegrationLog(integration, {
         category: integration.category,
         slot: integration.category,
         type: integration.type,


### PR DESCRIPTION
## Problem

A synchronous throw or rejected promise from an integration `log` callback could prevent lifecycle initialization, skip a route handler, or turn a successful integration response into an error.

## Root cause

Request and registration events awaited the optional logging callback directly. Lifecycle messages already isolated logger failures, but registration and both development and server dispatch paths did not.

## Change

Route every awaited integration log event through one failure-isolating helper. Registration, middleware, validation, before/after hooks, successful responses, and request errors now retain their original behavior when the log sink is unavailable.

## Safety and compatibility

Logging remains ordered and awaited when successful. Only logger failures change: they are treated as optional observability failures and cannot affect application lifecycle or response semantics. Handler and lifecycle errors still propagate normally.

## Verification

- `pnpm --filter @farm.js/core test -- integrations.test.ts`
- `pnpm --filter @farm.js/core type-check`
- focused `oxlint` (two pre-existing unused helper warnings, zero errors)

The regression covers a throwing sink during registration, Vite/plugin request handling, and direct server integration dispatch. It fails before this change and passes with both responses intact.

## Documentation and release

Documented that integration logging is observational and failure-isolated.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Isolates integration log callback failures so a throwing or rejected `log` promise no longer blocks lifecycle startup, skips route handlers, or turns a successful response into an error.

**Bug Fixes**
- Routes every awaited integration log event through one failure-isolating helper covering registration, middleware, validation, before/after hooks, successful responses, and request errors.
- Keeps logging ordered and awaited when successful; only logger failures are swallowed. Handler and lifecycle errors still propagate normally.
- Documents that integration logging is observational and failure-isolated.

<sup>Written for commit f6a91ca4ce79a539570774317853acc1c149b3b5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/779?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

