### PR TITLE
perf(react): scan consecutive map reorder lineage once

### DIFF
--- a/docs/src/app/docs/renderers/react/page.md
+++ b/docs/src/app/docs/renderers/react/page.md
@@ -1232,9 +1232,12 @@ setItems((current) =>
 
 For a concise functional setter, Farm can prepare one or more consecutive safe same-key `map()`
 calls and the following native `toSorted()` or `toReversed()` calls as one update pipeline.
-JavaScript still performs every map and reorder normally. After each map, the compiler runtime
-flattens replacement lineage back to the committed source row, so any number of accepted stages
-still needs one final keyed reconciliation rather than a growing chain of intermediate snapshots.
+JavaScript still performs every map and reorder normally. For two or more accepted maps, the
+compiler runtime checks each native call as it completes but records replacement lineage only once,
+by comparing the committed input with the final mapped result. The intermediate arrays need no
+separate full scan, and the final replacements still point directly to their committed source rows.
+The reorder suffix then needs one final keyed reconciliation rather than a growing chain of
+intermediate snapshots.
 
 Before changing the DOM, the runtime verifies ordinary dense arrays, exact native methods, the
 committed collection token, equal lengths, a unique one-to-one source-item match, and the key of
@@ -2120,10 +2123,11 @@ The package and example test suites verify more than generated code:
   surviving controlled-input focus and selection, exact DOM identity, custom-method and identity
   fallback, StrictMode hydration, and unmount-before-flush cleanup;
 - 2,000 deterministic same-key edits followed by native sorting match normal React; targeted tests
-  require one changed-row binding read, preserve every keyed DOM node, compose queued map/sort and
-  map/sort/reverse pipelines, dispatch moved-row events with the newest item and index, preserve
-  controlled-input focus and selection, and cover changed-key and custom-method fallback, Strict
-  Mode hydration, and unmount-before-flush cleanup;
+  require one source-to-final descriptor scan for consecutive maps and one changed-row binding read,
+  preserve every keyed DOM node, compose queued map/sort and map/sort/reverse pipelines, dispatch
+  moved-row events with the newest item and index, preserve controlled-input focus and selection,
+  and cover changed-key, custom-method, and Array-subclass fallback, Strict Mode hydration, and
+  unmount-before-flush cleanup;
 - 1,000 deterministic exact-position insertions, single and contiguous-range removals, single-row
   replacements, and exact-window replacements match normal React; compiler tests cover guarded
   runtime positions plus literal and compiler-safe runtime delete counts, while targeted removal

--- a/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
+++ b/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
@@ -2,6 +2,42 @@
 
 Latest run: 2026-09-07
 
+## One lineage scan for consecutive maps before reorder — 2026-09-07
+
+The compiler now emits two or more safe same-key `map()` calls before a native reorder as one
+runtime proof boundary. Every native method lookup, callback, result, and error still occurs in
+source order, but the runtime compares property descriptors only between the committed input and
+the final mapped array. A three-row instrumentation test observes six descriptor reads instead of
+the twelve required by two independent lineage scans.
+
+The existing 10,000-row multi-map reorder workload and its thresholds were unchanged. It updates
+one row in two native maps and restores order through native `toSorted()`; the equivalent
+block-bodied control performs the same application work through complete keyed reconciliation.
+
+| Mode   | Before | After | Median change | vs React | vs control |
+| ------ | -----: | ----: | ------------: | -------: | ---------: |
+| Static | 32.10 ms | 29.60 ms | 7.8% lower | 8.15x | 1.43x |
+| Hybrid | 31.60 ms | 31.90 ms | 0.9% higher | 7.56x | 1.33x |
+
+Both modes passed the existing 4x React and 1.2x compiled-control floors, the correctness oracle,
+and the general regression gate. The small hybrid difference is within ordinary run-to-run noise;
+the deterministic descriptor instrumentation proves that the removed intermediate scan does not
+depend on timing. All 10,000 original row nodes kept their identity, final values and order matched
+the oracle, all six expected map hints remained reported, and compiled owner executions stayed at
+zero.
+
+Focused coverage also preserves the older single-map helper form, invalidates the entire grouped
+hint when a later method is custom, falls back for Array subclasses, propagates native errors, and
+checks queued updates, changed keys, delegated events, controlled-input focus and selection,
+Strict Mode hydration, and unmount cleanup. The 2,000-update React differential is now included in
+the serial stress suite, and compatibility passed on React 18.3.1 and 19.2.8.
+
+Compiler-off and unrelated reorder-only bundles are unchanged. The optional map/reorder runtime
+premium is 13,263 B gzip, 105 B above the earlier single-scan implementation, and the complete
+dashboard build changed from 26,852 B to 26,892 B gzip in static mode and from 26,849 B to 26,890 B
+in hybrid mode. The run used 10 table samples per compiler mode, 20 bracketing React samples,
+Chrome 151.0.7922.34, Node.js 23.11.0, and Apple M1 macOS arm64.
+
 ## Consecutive same-order keyed maps — 2026-09-07
 
 The 10,000-row table now measures a concise functional setter that updates the label and amount of

--- a/examples/react-compiler-dashboard/README.md
+++ b/examples/react-compiler-dashboard/README.md
@@ -324,7 +324,8 @@ The default JSON report is `/tmp/farm-react-dashboard-benchmark.json`; change it
   committed and final arrays once and patches each final changed row once.
 - The multi-map reorder control changes one row's label and amount in two consecutive native maps,
   then sorts the same keyed rows. Its block-bodied equivalent keeps complete reconciliation, while
-  the hinted path proves one flattened source-row lineage and patches the final row once.
+  the hinted path checks each native call, scans only the committed and final arrays for lineage,
+  and patches the final row once.
 - The sort control compares concise native `toSorted()` with an equivalent block-bodied compiled
   update. Both paths run the same native sort and move the same keyed DOM rows; the hint isolates
   the saved key, descriptor, and binding work while retaining only the required LIS moves.

--- a/packages/farm-react/README.md
+++ b/packages/farm-react/README.md
@@ -435,18 +435,19 @@ setItems((current) =>
 );
 ```
 
-Farm executes every native map and reorder call normally and flattens accepted replacement lineage
-back to the committed source rows. It verifies the committed token, dense-array shape, a one-to-one
-source-item match, and every final replacement key before touching the DOM, then runs one LIS and
-patches each changed row once. Unchanged rows need no second key or binding read. Queued supported
-map-and-reorder setters compose against the same committed rows. Every accepted map requires an
-inline synchronous conditional mapper that returns either the original item or an object-spread
-replacement, plus index-independent compiler-owned host rows. Changed keys, referenced or
-block-bodied callbacks, unconditional replacements, `thisArg`, structural calls in the same chain,
-computed or custom methods, sparse or subclassed arrays, collection-reading bindings, nested or
-React-owned rows, and
-failed checks use complete keyed reconciliation. Reports use the existing map, sort, and reorder
-hint counters, and unrelated modules do not retain this optional runtime.
+Farm executes every native map and reorder call normally. For consecutive accepted maps, it checks
+each native call but compares only the committed input and final mapped result, avoiding a full
+lineage scan for every intermediate array. It verifies the committed token, dense-array shape, a
+one-to-one source-item match, and every final replacement key before touching the DOM, then runs one
+LIS and patches each changed row once. Unchanged rows need no second key or binding read. Queued
+supported map-and-reorder setters compose against the same committed rows. Every accepted map
+requires an inline synchronous conditional mapper that returns either the original item or an
+object-spread replacement, plus index-independent compiler-owned host rows. Changed keys,
+referenced or block-bodied callbacks, unconditional replacements, `thisArg`, structural calls in
+the same chain, computed or custom methods, sparse or subclassed arrays, collection-reading
+bindings, nested or React-owned rows, and failed checks use complete keyed reconciliation. Reports
+use the existing map, sort, and reorder hint counters, and unrelated modules do not retain this
+optional runtime.
 
 A direct native immutable sort can use the same optional reorder runtime:
 

--- a/packages/farm-react/src/__tests__/compiler-keyed-array-sort-hints.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-keyed-array-sort-hints.test.ts
@@ -1,4 +1,7 @@
+// @vitest-environment node
+
 import { describe, expect, it } from "vitest";
+import { transformWithEsbuild } from "vite";
 import { compileReactModule } from "../compiler";
 import { normalizeReactCompilerOptions } from "../index";
 
@@ -243,10 +246,19 @@ describe("React AOT keyed-array sort hints", () => {
     expect(result.optimizations.keyedMapUpdateHints).toBe(2);
     expect(result.optimizations.keyedArraySortHints).toBe(1);
     expect(result.optimizations.keyedArrayReorderHints).toBe(1);
-    expect(result.code.match(/createCompilerKeyedArrayMapPipeline\(/g)).toHaveLength(2);
+    expect(result.code.match(/createCompilerKeyedArrayMapPipeline\(/g)).toHaveLength(1);
+    expect(result.code.match(/_farmApplyMap\d*\(/g)).toHaveLength(2);
     expect(result.code.match(/createCompilerKeyedArrayMapReorder\(/g)).toHaveLength(2);
     expect(result.code).toContain("keyedRowsMapReorderHintedRuntimeFeature");
     expect(result.code).not.toContain("createCompilerKeyedMapUpdate");
+    await expect(
+      transformWithEsbuild(result.code, "/app/KeyedArraySortHints.tsx", {
+        loader: "tsx",
+        jsx: "automatic",
+      }),
+    ).resolves.toMatchObject({
+      code: expect.stringContaining("createCompilerKeyedArrayMapPipeline"),
+    });
   });
 
   it("does not lower map and reorder pipelines for host-backed keyed rows", async () => {

--- a/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-map-reorder-hints.test.tsx
+++ b/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-map-reorder-hints.test.tsx
@@ -47,6 +47,26 @@ function hintedMap(
   return createCompilerKeyedArrayMapPipeline(items, items.map, callback) as Item[];
 }
 
+function hintedMaps(
+  items: Item[],
+  firstCallback: (item: Item, index: number, items: Item[]) => Item,
+  secondCallback: (item: Item, index: number, items: Item[]) => Item,
+): Item[] {
+  return createCompilerKeyedArrayMapPipeline(
+    items,
+    (
+      current: unknown,
+      applyMap: (collection: unknown, method: unknown, callback: unknown) => unknown,
+    ) => {
+      const firstItems = current as Item[];
+      const firstMap = firstItems.map;
+      const first = applyMap(firstItems, firstMap, firstCallback) as Item[];
+      const secondMap = first.map;
+      return applyMap(first, secondMap, secondCallback);
+    },
+  ) as Item[];
+}
+
 function hintedSort(items: Item[]): Item[] {
   return createCompilerKeyedArrayMapReorder(
     items,
@@ -69,8 +89,9 @@ function mappedSort(items: Item[], id: string, rank: number, label?: string): It
 
 function multiMappedSort(items: Item[], id: string, rank: number, label: string): Item[] {
   return hintedSort(
-    hintedMap(
-      hintedMap(items, (item) => (item.id === id ? { ...item, label } : item)),
+    hintedMaps(
+      items,
+      (item) => (item.id === id ? { ...item, label } : item),
       (item) => (item.id === id ? { ...item, rank } : item),
     ),
   );
@@ -118,10 +139,9 @@ function createHarness(initialItems: Item[]) {
       editTwoAndSort = (labelId, rankId) =>
         state[0].set((previous) =>
           hintedSort(
-            hintedMap(
-              hintedMap(previous as Item[], (item) =>
-                item.id === labelId ? { ...item, label: `${item.label} labeled` } : item,
-              ),
+            hintedMaps(
+              previous as Item[],
+              (item) => (item.id === labelId ? { ...item, label: `${item.label} labeled` } : item),
               (item) => (item.id === rankId ? { ...item, rank: 4 } : item),
             ),
           ),
@@ -165,17 +185,27 @@ function createHarness(initialItems: Item[]) {
         });
       customSecondMap = () =>
         state[0].set((previous) => {
-          const first = hintedMap(previous as Item[], (item) =>
-            item.id === "a" ? { ...item, label: "First map" } : item,
-          );
-          const map = function (
-            this: Item[],
-            callback: (item: Item, index: number, items: Item[]) => Item,
-          ) {
-            return Array.prototype.map.call(this, callback);
-          };
-          const second = createCompilerKeyedArrayMapPipeline(first, map, (item: Item) =>
-            item.id === "b" ? { ...item, rank: 0 } : item,
+          const second = createCompilerKeyedArrayMapPipeline(
+            previous,
+            (
+              current: unknown,
+              applyMap: (collection: unknown, method: unknown, callback: unknown) => unknown,
+            ) => {
+              const source = current as Item[];
+              const firstMap = source.map;
+              const first = applyMap(source, firstMap, (item: Item) =>
+                item.id === "a" ? { ...item, label: "First map" } : item,
+              ) as Item[];
+              const customMap = function (
+                this: Item[],
+                callback: (item: Item, index: number, items: Item[]) => Item,
+              ) {
+                return Array.prototype.map.call(this, callback);
+              };
+              return applyMap(first, customMap, (item: Item) =>
+                item.id === "b" ? { ...item, rank: 0 } : item,
+              );
+            },
           ) as Item[];
           return createCompilerKeyedArrayMapReorder(
             second,
@@ -335,6 +365,47 @@ describe("compiled keyed-array map and reorder hints", () => {
     expect(harness.counters.bindings).toBe(1);
   });
 
+  it("records consecutive map lineage with one source-to-result scan", async () => {
+    const initialItems: Item[] = [
+      { id: "a", label: "Alpha", rank: 1 },
+      { id: "b", label: "Beta", rank: 2 },
+      { id: "c", label: "Gamma", rank: 3 },
+    ];
+    const harness = createHarness(initialItems);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Table />));
+
+    let finalItems: Item[] | undefined;
+    let descriptorReads = 0;
+    const readDescriptor = Object.getOwnPropertyDescriptor;
+    vi.spyOn(Object, "getOwnPropertyDescriptor").mockImplementation((target, key) => {
+      if (target === initialItems || target === finalItems) descriptorReads += 1;
+      return readDescriptor(target, key);
+    });
+    const mapped = createCompilerKeyedArrayMapPipeline(
+      initialItems,
+      (
+        current: unknown,
+        applyMap: (collection: unknown, method: unknown, callback: unknown) => unknown,
+      ) => {
+        const source = current as Item[];
+        const first = applyMap(source, source.map, (item: Item) =>
+          item.id === "a" ? { ...item, label: "Alpha newest" } : item,
+        ) as Item[];
+        finalItems = applyMap(first, first.map, (item: Item) =>
+          item.id === "a" ? { ...item, rank: 4 } : item,
+        ) as Item[];
+        return finalItems;
+      },
+    );
+
+    expect(mapped).toBe(finalItems);
+    expect(descriptorReads).toBe(initialItems.length * 2);
+  });
+
   it("keeps source lineage for different rows changed by separate map stages", async () => {
     const harness = createHarness([
       { id: "a", label: "Alpha", rank: 1 },
@@ -438,14 +509,42 @@ describe("compiled keyed-array map and reorder hints", () => {
     expect(harness.counters.bindings).toBe(2);
   });
 
+  it("falls back for Array subclasses while preserving native results and keyed identity", async () => {
+    class ItemList extends Array<Item> {}
+    const initialItems = new ItemList();
+    initialItems.push({ id: "a", label: "Alpha", rank: 2 }, { id: "b", label: "Beta", rank: 1 });
+    const harness = createHarness(initialItems);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Table />));
+    const rows = new Map(
+      [...container.querySelectorAll("li")].map((row) => [row.dataset.key, row]),
+    );
+    harness.counters.bindings = 0;
+
+    await act(async () => {
+      harness.editTwiceAndSort("a", 3, "Alpha subclass");
+      await flushCompilerUpdates();
+    });
+
+    expect(labels(container)).toEqual(["Beta:1", "Alpha subclass:3"]);
+    expect(container.querySelector('[data-key="a"]')).toBe(rows.get("a"));
+    expect(container.querySelector('[data-key="b"]')).toBe(rows.get("b"));
+    expect(harness.counters.bindings).toBe(2);
+  });
+
   it("preserves a native error thrown by a later map stage", () => {
     const items: Item[] = [{ id: "a", label: "Alpha", rank: 1 }];
-    const first = hintedMap(items, (item) => item);
-
     expect(() =>
-      hintedMap(first, () => {
-        throw new Error("second map failed");
-      }),
+      hintedMaps(
+        items,
+        (item) => item,
+        () => {
+          throw new Error("second map failed");
+        },
+      ),
     ).toThrow("second map failed");
   });
 

--- a/packages/farm-react/src/compiler-runtime.tsx
+++ b/packages/farm-react/src/compiler-runtime.tsx
@@ -551,26 +551,13 @@ function recordCompilerKeyedMapUpdate(
   return value;
 }
 
-/**
- * @internal Executes a compiler-proven Array.map pipeline and records its final same-order delta.
- * The three-argument value/index form remains accepted for older generated output.
- */
-export function createCompilerKeyedMapUpdate(
+function executeCompilerKeyedMapPipeline(
   previous: unknown,
-  valueOrPipeline: unknown,
-  changedIndices?: unknown,
+  pipeline: (...values: readonly unknown[]) => unknown,
+  record: (previous: unknown, value: unknown) => unknown,
 ): unknown {
-  if (Array.isArray(changedIndices)) {
-    return recordCompilerKeyedMapUpdate(previous, valueOrPipeline, changedIndices);
-  }
-  if (changedIndices !== undefined || typeof valueOrPipeline !== "function") {
-    return valueOrPipeline;
-  }
-
   let eligible = true;
-  let mapCalls = 0;
   const applyMap = (collection: unknown, method: unknown, callback: unknown): unknown => {
-    mapCalls += 1;
     const value = NATIVE_REFLECT_APPLY(
       method as (...values: readonly unknown[]) => unknown,
       collection,
@@ -581,13 +568,7 @@ export function createCompilerKeyedMapUpdate(
       return value;
     }
     try {
-      if (
-        !Array.isArray(collection) ||
-        !Array.isArray(value) ||
-        Object.getPrototypeOf(collection) !== NATIVE_ARRAY_PROTOTYPE ||
-        Object.getPrototypeOf(value) !== NATIVE_ARRAY_PROTOTYPE ||
-        value.length !== collection.length
-      ) {
+      if (!Array.isArray(value) || Object.getPrototypeOf(value) !== NATIVE_ARRAY_PROTOTYPE) {
         eligible = false;
       }
     } catch {
@@ -595,13 +576,11 @@ export function createCompilerKeyedMapUpdate(
     }
     return value;
   };
-  const value = NATIVE_REFLECT_APPLY(
-    valueOrPipeline as (...values: readonly unknown[]) => unknown,
-    undefined,
-    [previous, applyMap],
-  );
-  if (!eligible || mapCalls === 0) return value;
+  const value = NATIVE_REFLECT_APPLY(pipeline, undefined, [previous, applyMap]);
+  return eligible ? record(previous, value) : value;
+}
 
+function recordCompilerKeyedMapPipelineUpdate(previous: unknown, value: unknown): unknown {
   try {
     if (
       !Array.isArray(previous) ||
@@ -633,18 +612,29 @@ export function createCompilerKeyedMapUpdate(
   }
 }
 
-/** @internal Executes a proven native map before the reorder suffix of a keyed pipeline. */
-export function createCompilerKeyedArrayMapPipeline(
+/**
+ * @internal Executes a compiler-proven Array.map pipeline and records its final same-order delta.
+ * The three-argument value/index form remains accepted for older generated output.
+ */
+export function createCompilerKeyedMapUpdate(
   previous: unknown,
-  method: unknown,
-  callback: unknown,
+  valueOrPipeline: unknown,
+  changedIndices?: unknown,
 ): unknown {
-  const value = NATIVE_REFLECT_APPLY(
-    method as (...values: readonly unknown[]) => unknown,
+  if (Array.isArray(changedIndices)) {
+    return recordCompilerKeyedMapUpdate(previous, valueOrPipeline, changedIndices);
+  }
+  if (changedIndices !== undefined || typeof valueOrPipeline !== "function") {
+    return valueOrPipeline;
+  }
+  return executeCompilerKeyedMapPipeline(
     previous,
-    [callback],
+    valueOrPipeline as (...values: readonly unknown[]) => unknown,
+    recordCompilerKeyedMapPipelineUpdate,
   );
+}
 
+function recordCompilerKeyedArrayMapPipeline(previous: unknown, value: unknown): unknown {
   try {
     const previousTarget = compilerObject(previous);
     const valueTarget = compilerObject(value);
@@ -655,8 +645,6 @@ export function createCompilerKeyedArrayMapPipeline(
       !Array.isArray(value) ||
       Object.getPrototypeOf(previous) !== NATIVE_ARRAY_PROTOTYPE ||
       Object.getPrototypeOf(value) !== NATIVE_ARRAY_PROTOTYPE ||
-      method !== NATIVE_ARRAY_MAP ||
-      typeof callback !== "function" ||
       value.length !== previous.length
     ) {
       return value;
@@ -709,6 +697,31 @@ export function createCompilerKeyedArrayMapPipeline(
     // Metadata must never change the result of a successful native update.
   }
   return value;
+}
+
+/**
+ * @internal Executes proven native maps before the reorder suffix of a keyed pipeline.
+ * The three-argument form remains accepted for older generated output.
+ */
+export function createCompilerKeyedArrayMapPipeline(
+  previous: unknown,
+  methodOrPipeline: unknown,
+  callback?: unknown,
+): unknown {
+  if (callback !== undefined) {
+    const value = NATIVE_REFLECT_APPLY(
+      methodOrPipeline as (...values: readonly unknown[]) => unknown,
+      previous,
+      [callback],
+    );
+    if (methodOrPipeline !== NATIVE_ARRAY_MAP) return value;
+    return recordCompilerKeyedArrayMapPipeline(previous, value);
+  }
+  return executeCompilerKeyedMapPipeline(
+    previous,
+    methodOrPipeline as (...values: readonly unknown[]) => unknown,
+    recordCompilerKeyedArrayMapPipeline,
+  );
 }
 
 /** @internal Executes a native reorder after a proven same-key map pipeline. */

--- a/packages/farm-react/src/compiler.ts
+++ b/packages/farm-react/src/compiler.ts
@@ -2109,7 +2109,61 @@ function rewriteKeyedArrayReorderPipelineHints(
       const previous = t.cloneNode(updater.params[0]);
       const statements: t.Statement[] = [];
       let value: t.Expression = t.cloneNode(previous);
-      for (const step of steps) {
+      const leadingMapCount = mapPipeline ? steps.findIndex((step) => step.kind !== "map") : 0;
+      let stepIndex = 0;
+      if (leadingMapCount > 1) {
+        const pipelineValue = path.scope.generateUidIdentifier("farmMapValue");
+        const applyMap = path.scope.generateUidIdentifier("farmApplyMap");
+        const pipelineStatements: t.Statement[] = [];
+        let current: t.Expression = t.cloneNode(pipelineValue);
+        for (; stepIndex < leadingMapCount; stepIndex += 1) {
+          const step = steps[stepIndex];
+          if (step.kind !== "map") break;
+          const method = path.scope.generateUidIdentifier(`farmMap${stepIndex + 1}`);
+          const result = path.scope.generateUidIdentifier(`farmMappedItems${stepIndex + 1}`);
+          pipelineStatements.push(
+            t.variableDeclaration("const", [
+              t.variableDeclarator(
+                t.cloneNode(method),
+                t.memberExpression(t.cloneNode(current), t.identifier("map")),
+              ),
+            ]),
+            t.variableDeclaration("const", [
+              t.variableDeclarator(
+                t.cloneNode(result),
+                t.callExpression(t.cloneNode(applyMap), [
+                  t.cloneNode(current),
+                  t.cloneNode(method),
+                  t.cloneNode(step.callback, true),
+                ]),
+              ),
+            ]),
+          );
+          current = t.cloneNode(result);
+        }
+        const result = path.scope.generateUidIdentifier("farmPipelineValue");
+        statements.push(
+          t.variableDeclaration("const", [
+            t.variableDeclarator(
+              t.cloneNode(result),
+              t.callExpression(t.cloneNode(mapHelperIdentifier), [
+                t.cloneNode(previous),
+                t.arrowFunctionExpression(
+                  [t.cloneNode(pipelineValue), t.cloneNode(applyMap)],
+                  t.blockStatement([
+                    ...pipelineStatements,
+                    t.returnStatement(t.cloneNode(current)),
+                  ]),
+                ),
+              ]),
+            ),
+          ]),
+        );
+        value = t.cloneNode(result);
+        mapCount += leadingMapCount;
+      }
+      for (; stepIndex < steps.length; stepIndex += 1) {
+        const step = steps[stepIndex];
         const methodName =
           step.kind === "map"
             ? "map"

--- a/packages/farm-react/vitest.stress.config.ts
+++ b/packages/farm-react/vitest.stress.config.ts
@@ -16,9 +16,11 @@ export default defineConfig({
       "src/__tests__/compiler-runtime-recursive-host-blocks.test.tsx",
       "src/__tests__/compiler-runtime-keyed-array-reorder-hints.test.tsx",
       "src/__tests__/compiler-runtime-keyed-array-sort-hints.test.tsx",
+      "src/__tests__/compiler-runtime-keyed-array-map-reorder-hints.test.tsx",
     ],
     setupFiles: ["src/__tests__/stress.setup.ts"],
-    testNamePattern: /3,000 deterministic recursive updates|4,096 rows/,
+    testNamePattern:
+      /2,000 deterministic mapped reorder updates|3,000 deterministic recursive updates|4,096 rows/,
     testTimeout: 30_000,
   },
 });


### PR DESCRIPTION
## Problem

A compiler-safe keyed update such as `current.map(...).map(...).toSorted(...)` already avoids rerunning the owner component, but generated output wrapped every `map()` separately. Each wrapper scanned the complete input and result arrays to flatten row lineage, so a chain of `k` maps paid `k` full lineage scans before the final keyed reconciliation.

## Root cause

The reorder-pipeline lowering reused the single-map helper independently for every leading map stage. Runtime metadata was therefore committed for each intermediate array even though the reorder fast path only needs the relationship between the last committed rows and the final mapped rows.

## Change

- Lower two or more eligible leading maps as one compiler-generated pipeline while preserving each method lookup and callback in source order.
- Execute every map through the exact captured native method, validate every produced intermediate array, and record lineage once from the committed input to the final mapped result.
- Share the native-map pipeline executor with the existing same-order keyed-map optimization.
- Keep the existing three-argument helper form for previously generated single-map output.
- Include the 2,000-update mapped-reorder differential in the serial stress suite.

## Safety and compatibility

The DOM fast path still begins only after every map and reorder call succeeds and runtime validation proves ordinary dense source and final arrays, exact native methods, ordinary intermediate results, unchanged length, committed ownership, same keys, and a valid final permutation. A custom method at any stage, Array subclass, sparse/accessor-backed input, changed key, unsupported compiler syntax, or failed validation uses complete keyed reconciliation before any optimized DOM write. Native method results and thrown errors are preserved.

This remains React-renderer-specific and behind the existing experimental compiler option. Compiler-off and reorder-only bundles are unchanged. The optional map/reorder runtime premium is 13,263 B gzip on the benchmark environment, 105 B above the previous implementation. The Node 22 CI-equivalent result is 13,390 B against the unchanged 13,399 B persisted ceiling. React 18.3.1 and 19.2.8 compatibility both pass.

## Verification

- `pnpm --filter @farm.js/react exec vitest run src/__tests__/compiler-keyed-update-hints.test.ts src/__tests__/compiler-runtime-keyed-update-hints.test.tsx src/__tests__/compiler-keyed-array-sort-hints.test.ts src/__tests__/compiler-runtime-keyed-array-map-reorder-hints.test.tsx`
- `pnpm --filter @farm.js/react test:stress`
- `pnpm --filter @farm.js/react type-check`
- `pnpm --filter @farm.js/react test:compat`
- `pnpm --filter @farm.js/react test:runtime-size`
- `npx -y node@22.13.1 scripts/benchmark-runtime-size.mjs --check`
- `pnpm --filter farm-react-compiler-dashboard-example type-check`
- `pnpm exec oxlint <changed React TypeScript files>`
- `pnpm docs:check-navigation`
- `pnpm docs:build`

The broad React run completed 686 passing tests; four unrelated long-running tests hit their existing timeout under full parallel load, and all four passed unchanged when rerun independently. The serial stress suite passes all four workloads, including the 2,000-update mapped-reorder comparison.

The unchanged 10,000-row browser benchmark passed correctness, the general regression gate, and the multi-map reorder gate in both modes:

| Mode | Before | After | vs React | vs compiled control |
| --- | ---: | ---: | ---: | ---: |
| Static | 32.10 ms | 29.60 ms | 8.15x | 1.43x |
| Hybrid | 31.60 ms | 31.90 ms | 7.56x | 1.33x |

The static median is 7.8% lower; the 0.9% hybrid difference is within run noise. Deterministic instrumentation proves the mechanism independently: two maps over three rows now perform six lineage descriptor reads instead of twelve. All 10,000 row nodes retained DOM identity, final values/order matched the oracle, compiler reports retained all six expected map hints, and owner executions remained zero.

The full benchmark command returned nonzero only because two unrelated queued-window micro-gates were noisy in this run; the baseline command also returned nonzero on unrelated existing micro-gates. No acceptance threshold was changed.

Environment: Chrome 151.0.7922.34, Node.js 23.11.0, Apple M1 macOS arm64.

## Documentation and release

Updated the React renderer guide, package README, dashboard benchmark guide, and checked-in benchmark results. No template, generated artifact, public option, or release-version change.
