### PR TITLE
fix(types): preserve layered API methods

### DIFF
--- a/docs/src/app/docs/layers/page.md
+++ b/docs/src/app/docs/layers/page.md
@@ -131,7 +131,10 @@ Security-sensitive arrays such as `serverActions.allowedOrigins` are replaced ra
 
 Farm generates route, API, environment, and static image types from the final resolved application graph. Layer routes appear in typed `Link` values, layer APIs appear in the generated API client, layer environment schemas participate in `getEnv` autocomplete, and raster imports carry image dimensions.
 
-When a project overrides a layer API route, generated API types import the project implementation. Layer-owned routes that remain active keep type-only imports to their real package or directory files.
+API route methods compose across layers. If a base layer exports `GET` and the project exports only
+`POST` at the same path, both methods remain available and generated types import each method from
+its real source. When a later layer or the project exports the same method, that method's generated
+type points to the higher-priority implementation.
 
 ## Nested layers
 

--- a/packages/farm/src/__tests__/type-artifacts.test.ts
+++ b/packages/farm/src/__tests__/type-artifacts.test.ts
@@ -216,10 +216,14 @@ describe("generateFarmTypeArtifacts", () => {
     expect(routeTypes).toContain("`/products/${string}`");
     expect(routeTypes).toContain('"/reports"');
     expect(result.apiRoutes.map((route) => [route.path, route.methods])).toEqual([
+      ["/api/catalog", ["GET"]],
       ["/api/catalog", ["POST"]],
       ["/api/inventory", ["GET"]],
     ]);
     expect(apiTypes).toContain('from "../../layers/commerce/src/app/api/inventory/route"');
+    expect(apiTypes).toContain(
+      'import type { GET as GET_catalog } from "../../layers/commerce/src/app/api/catalog/route"',
+    );
     expect(apiTypes).toContain('from "../app/api/catalog/route"');
     expect(envTypes).toContain('FarmConfig0 from "../layers/commerce/farm.config"');
     expect(envTypes).toContain('FarmConfig1 from "../farm.config"');

--- a/packages/farm/src/__tests__/type-generator.test.ts
+++ b/packages/farm/src/__tests__/type-generator.test.ts
@@ -202,4 +202,52 @@ describe("APITypeGenerator", () => {
     expect(routes.find((route) => route.path === "/api/listed")?.methods).toEqual(["GET", "POST"]);
     expect(routes.some((route) => route.path === "/api/renamed")).toBe(false);
   });
+
+  it("keeps non-overridden layer methods and imports each winning source", () => {
+    const root = mkdtempSync(path.join(os.tmpdir(), "farm-api-types-layers-"));
+    const layerAppDir = path.join(root, "layer", "src", "app");
+    const projectAppDir = path.join(root, "project", "src", "app");
+    const layerRoute = path.join(layerAppDir, "api", "users", "route.ts");
+    const projectRoute = path.join(projectAppDir, "api", "users", "route.ts");
+    mkdirSync(path.dirname(layerRoute), { recursive: true });
+    mkdirSync(path.dirname(projectRoute), { recursive: true });
+    writeFileSync(
+      layerRoute,
+      "export const GET = async () => new Response('layer');\nexport const PATCH = GET;\n",
+    );
+    writeFileSync(
+      projectRoute,
+      "export const GET = async () => new Response('project');\nexport const POST = GET;\n",
+    );
+    const outputPath = path.join(projectAppDir, "..", "lib", "api.generated.ts");
+
+    const generator = new APITypeGenerator([layerAppDir, projectAppDir]);
+    const routes = generator.scanAPIRoutes();
+    const content = generator.generateAPIRouter(routes, { outFile: outputPath });
+    const layerImport = path
+      .relative(path.dirname(outputPath), layerRoute)
+      .replace(/\\/g, "/")
+      .replace(/\.ts$/, "");
+    const projectImport = path
+      .relative(path.dirname(outputPath), projectRoute)
+      .replace(/\\/g, "/")
+      .replace(/\.ts$/, "");
+
+    expect(routes).toEqual([
+      expect.objectContaining({ filePath: layerRoute, methods: ["PATCH"] }),
+      expect.objectContaining({ filePath: projectRoute, methods: ["GET", "POST"] }),
+    ]);
+    expect(content).toContain(
+      `import type { PATCH as PATCH_users } from ${JSON.stringify(layerImport)};`,
+    );
+    expect(content).toContain(
+      `import type { GET as GET_users } from ${JSON.stringify(projectImport)};`,
+    );
+    expect(content).toContain(
+      `import type { POST as POST_users } from ${JSON.stringify(projectImport)};`,
+    );
+    expect(content).toContain("get: typeof GET_users;");
+    expect(content).toContain("post: typeof POST_users;");
+    expect(content).toContain("patch: typeof PATCH_users;");
+  });
 });

--- a/packages/farm/src/type-generator.ts
+++ b/packages/farm/src/type-generator.ts
@@ -32,7 +32,7 @@ export class APITypeGenerator {
    * Scan all API route files and extract route information
    */
   scanAPIRoutes(): APIRouteInfo[] {
-    const routes = new Map<string, APIRouteInfo>();
+    const methodSources = new Map<string, Map<string, APIRouteInfo>>();
 
     for (const appDir of this.appDirs) {
       const apiDir = join(appDir, "api");
@@ -41,11 +41,36 @@ export class APITypeGenerator {
       const discovered: APIRouteInfo[] = [];
       this.scanDirectory(apiDir, appDir, discovered);
       for (const route of discovered) {
-        routes.set(route.path, route);
+        const routeMethods = methodSources.get(route.path) ?? new Map<string, APIRouteInfo>();
+        for (const method of route.methods) {
+          routeMethods.set(method, route);
+        }
+        methodSources.set(route.path, routeMethods);
       }
     }
 
-    return Array.from(routes.values()).sort((left, right) => left.path.localeCompare(right.path));
+    const routes: APIRouteInfo[] = [];
+    for (const [routePath, methods] of methodSources) {
+      const routesByFile = new Map<string, APIRouteInfo>();
+      for (const [method, route] of methods) {
+        const existing = routesByFile.get(route.filePath);
+        if (existing) {
+          existing.methods.push(method);
+        } else {
+          routesByFile.set(route.filePath, {
+            ...route,
+            path: routePath,
+            methods: [method],
+          });
+        }
+      }
+      routes.push(...routesByFile.values());
+    }
+
+    return routes.sort(
+      (left, right) =>
+        left.path.localeCompare(right.path) || left.filePath.localeCompare(right.filePath),
+    );
   }
 
   private scanDirectory(dir: string, appDir: string, routes: APIRouteInfo[], basePath = "") {
@@ -156,17 +181,20 @@ export class APITypeGenerator {
     const usedRouteNames = new Map<string, number>();
 
     for (const [path, routeList] of routeGroups) {
-      const route = routeList[0];
-      const importPath = this.getRouteImportPath(route, options.outFile);
-      const routeName = this.uniqueRouteName(route.path, usedRouteNames);
+      const routeName = this.uniqueRouteName(path, usedRouteNames);
       const cleanPath = path === "/api" ? "" : path.replace(/^\/api\//, "");
       const parts = cleanPath ? cleanPath.split("/") : [];
 
-      // Collect all methods for this route
-      const allMethods = routeList.flatMap((r) => r.methods);
+      // Keep the final source for each method, matching runtime layer precedence.
+      const methodSources = new Map<string, APIRouteInfo>();
+      for (const route of routeList) {
+        for (const method of route.methods) methodSources.set(method, route);
+      }
+      const allMethods = [...methodSources.keys()];
 
       // Generate imports
       for (const method of allMethods) {
+        const importPath = this.getRouteImportPath(methodSources.get(method)!, options.outFile);
         const importName = `${method}_${routeName}`;
         imports.push(
           `import type { ${method} as ${importName} } from ${JSON.stringify(importPath)};`,
@@ -317,7 +345,7 @@ ${typeExports}
    */
   generateAPIIndex(outputPath: string): void {
     const routes = this.scanAPIRoutes();
-    const content = this.generateAPIRouter(routes);
+    const content = this.generateAPIRouter(routes, { outFile: outputPath });
 
     mkdirSync(dirname(outputPath), { recursive: true });
     writeFileIfChanged(outputPath, content);


### PR DESCRIPTION
## Problem

When a layer and the project contributed different HTTP methods at the same API path, runtime routing kept both methods but generated API types retained only the final route file. The typed client could therefore omit a working inherited method or import its type from the wrong module.

## Root cause

`scanAPIRoutes()` keyed its result only by route path and replaced the complete route record for each later source. The router runtime instead tracks ownership per HTTP method. The generator also assumed every method in a grouped route came from the first file.

## Change

Track the winning source per path and HTTP method, regroup methods by their owning files, and generate each method import from that source. `generateAPIIndex()` now also supplies its output path so layer imports are relative to the generated file.

## Safety and compatibility

Single-source API generation is unchanged. Later layers and the project still override matching methods, while non-colliding lower-layer methods remain available. Generated output now matches runtime precedence.

## Verification

- `pnpm --filter @farm.js/core test -- type-generator.test.ts type-artifacts.test.ts`
- `pnpm --filter @farm.js/core type-check`
- focused `oxlint`: zero warnings and zero errors

The unit fixture has layer `GET`/`PATCH` and project `GET`/`POST`; the type-artifact integration fixture also verifies that layer `GET` and project `POST` at one path are both retained and imported from their real files.

## Documentation and release

Clarified method-level API composition and generated import ownership in the Layers guide.
