### PR TITLE
fix(types): ignore non-runtime API exports

### DIFF
--- a/docs/src/app/docs/api-routes/page.md
+++ b/docs/src/app/docs/api-routes/page.md
@@ -35,6 +35,9 @@ export const POST = createEndpoint(
 
 You can also manually export GET, POST, PATCH, and other handlers from the route file. Farm keeps this familiar while layering typed helpers around it.
 
+Generated API client types follow runtime value exports. Comments, string examples, and type-only
+exports named after HTTP methods do not create callable endpoints.
+
 **src/app/api/status/route.ts**
 
 ```ts

--- a/packages/farm/package.json
+++ b/packages/farm/package.json
@@ -615,6 +615,7 @@
     "@vitejs/plugin-react": "^4.2.1",
     "better-call": "^1.0.19",
     "db0": "^0.3.4",
+    "es-module-lexer": "2.0.0",
     "esbuild": "^0.28.0",
     "fast-glob": "^3.3.2",
     "h3": "2.0.1-rc.5",

--- a/packages/farm/src/__tests__/type-generator.test.ts
+++ b/packages/farm/src/__tests__/type-generator.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { existsSync, mkdtempSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -170,6 +172,29 @@ describe("APITypeGenerator", () => {
 
     expect(routes).toHaveLength(1);
     expect(routes[0]?.methods).toEqual(["GET", "POST"]);
+  });
+
+  it("ignores commented, string, and type-only HTTP exports", () => {
+    const root = mkdtempSync(path.join(os.tmpdir(), "farm-api-types-comments-"));
+    const appDir = path.join(root, "src", "app");
+    const routeDir = path.join(appDir, "api", "comments");
+    mkdirSync(routeDir, { recursive: true });
+    writeFileSync(
+      path.join(routeDir, "route.ts"),
+      [
+        "// export const GET = () => new Response('commented');",
+        "/* export async function DELETE() { return new Response('commented'); } */",
+        'const example = "export const PATCH = () => null";',
+        "type OPTIONS = () => Response;",
+        "export type { OPTIONS };",
+        "export const POST = () => new Response(example);",
+      ].join("\n"),
+    );
+
+    const routes = new APITypeGenerator(appDir).scanAPIRoutes();
+
+    expect(routes).toHaveLength(1);
+    expect(routes[0]?.methods).toEqual(["POST"]);
   });
 
   it("detects the HTTP names exposed by export lists", () => {

--- a/packages/farm/src/__tests__/type-generator.test.ts
+++ b/packages/farm/src/__tests__/type-generator.test.ts
@@ -1,5 +1,3 @@
-// @vitest-environment node
-
 import { existsSync, mkdtempSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -187,6 +185,8 @@ describe("APITypeGenerator", () => {
         'const example = "export const PATCH = () => null";',
         "type OPTIONS = () => Response;",
         "export type { OPTIONS };",
+        "type HEAD = () => Response;",
+        "export { type HEAD };",
         "export const POST = () => new Response(example);",
       ].join("\n"),
     );

--- a/packages/farm/src/__tests__/type-generator.test.ts
+++ b/packages/farm/src/__tests__/type-generator.test.ts
@@ -186,7 +186,7 @@ describe("APITypeGenerator", () => {
         "type OPTIONS = () => Response;",
         "export type { OPTIONS };",
         "type HEAD = () => Response;",
-        "export { type HEAD };",
+        "export { type /* remains type-only */ HEAD };",
         "export const POST = () => new Response(example);",
       ].join("\n"),
     );

--- a/packages/farm/src/type-generator.ts
+++ b/packages/farm/src/type-generator.ts
@@ -4,7 +4,7 @@ import { initSync, parse } from "es-module-lexer";
 import { writeFileIfChanged } from "./write-file-if-changed";
 import { isFarmAPIRouteFileName } from "./api/route-files";
 
-initSync();
+let moduleLexerInitialized = false;
 
 const API_CLIENT_METHOD_SEGMENTS = new Set([
   "get",
@@ -98,6 +98,10 @@ export class APITypeGenerator {
   }
 
   private extractExportedMethods(content: string): string[] {
+    if (!moduleLexerInitialized) {
+      initSync();
+      moduleLexerInitialized = true;
+    }
     const httpMethods = ["GET", "HEAD", "QUERY", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"];
     const [, exports] = parse(content);
     const valueExports = new Set(

--- a/packages/farm/src/type-generator.ts
+++ b/packages/farm/src/type-generator.ts
@@ -106,16 +106,39 @@ export class APITypeGenerator {
     const [, exports] = parse(content);
     const valueExports = new Set(
       exports
-        .filter((specifier) => {
-          const clauseStart = Math.max(
-            content.lastIndexOf("{", specifier.s),
-            content.lastIndexOf(",", specifier.s),
-          );
-          return !/\btype\s*$/.test(content.slice(clauseStart + 1, specifier.s));
-        })
+        .filter((specifier) => !this.isTypeOnlyExportSpecifier(content, specifier.s))
         .map((specifier) => specifier.n),
     );
     return httpMethods.filter((method) => valueExports.has(method));
+  }
+
+  private isTypeOnlyExportSpecifier(content: string, exportNameStart: number): boolean {
+    let cursor = exportNameStart - 1;
+
+    while (cursor >= 0) {
+      while (cursor >= 0 && /\s/.test(content[cursor])) cursor--;
+
+      if (content.slice(cursor - 1, cursor + 1) === "*/") {
+        const commentStart = content.lastIndexOf("/*", cursor - 1);
+        if (commentStart >= 0) {
+          cursor = commentStart - 1;
+          continue;
+        }
+      }
+
+      const lineStart = content.lastIndexOf("\n", cursor) + 1;
+      const lineCommentStart = content.indexOf("//", lineStart);
+      if (lineCommentStart >= 0 && lineCommentStart <= cursor) {
+        cursor = lineCommentStart - 1;
+        continue;
+      }
+
+      break;
+    }
+
+    const tokenEnd = cursor + 1;
+    while (cursor >= 0 && /[A-Za-z0-9_$]/.test(content[cursor])) cursor--;
+    return content.slice(cursor + 1, tokenEnd) === "type";
   }
 
   /**

--- a/packages/farm/src/type-generator.ts
+++ b/packages/farm/src/type-generator.ts
@@ -1,8 +1,10 @@
 import { readFileSync, existsSync, readdirSync, mkdirSync } from "fs";
 import { join, relative, dirname } from "path";
+import { initSync, parse } from "es-module-lexer";
 import { writeFileIfChanged } from "./write-file-if-changed";
 import { isFarmAPIRouteFileName } from "./api/route-files";
-import { buildSync, type Loader } from "esbuild";
+
+initSync();
 
 const API_CLIENT_METHOD_SEGMENTS = new Set([
   "get",
@@ -74,7 +76,7 @@ export class APITypeGenerator {
   ): APIRouteInfo | null {
     try {
       const content = readFileSync(filePath, "utf-8");
-      const methods = this.extractExportedMethods(content, filePath);
+      const methods = this.extractExportedMethods(content);
 
       if (methods.length === 0) {
         return null;
@@ -95,30 +97,21 @@ export class APITypeGenerator {
     }
   }
 
-  private extractExportedMethods(content: string, filePath: string): string[] {
-    const result = buildSync({
-      bundle: false,
-      format: "esm",
-      logLevel: "silent",
-      metafile: true,
-      platform: "neutral",
-      stdin: {
-        contents: content,
-        loader: this.getEsbuildLoader(filePath),
-        sourcefile: filePath,
-      },
-      write: false,
-    });
+  private extractExportedMethods(content: string): string[] {
     const httpMethods = ["GET", "HEAD", "QUERY", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"];
+    const [, exports] = parse(content);
     const valueExports = new Set(
-      Object.values(result.metafile.outputs).flatMap((output) => output.exports),
+      exports
+        .filter((specifier) => {
+          const clauseStart = Math.max(
+            content.lastIndexOf("{", specifier.s),
+            content.lastIndexOf(",", specifier.s),
+          );
+          return !/\btype\s*$/.test(content.slice(clauseStart + 1, specifier.s));
+        })
+        .map((specifier) => specifier.n),
     );
     return httpMethods.filter((method) => valueExports.has(method));
-  }
-
-  private getEsbuildLoader(filePath: string): Loader {
-    const extension = filePath.slice(filePath.lastIndexOf(".") + 1).toLowerCase();
-    return extension === "tsx" || extension === "jsx" || extension === "js" ? extension : "ts";
   }
 
   /**

--- a/packages/farm/src/type-generator.ts
+++ b/packages/farm/src/type-generator.ts
@@ -2,6 +2,7 @@ import { readFileSync, existsSync, readdirSync, mkdirSync } from "fs";
 import { join, relative, dirname } from "path";
 import { writeFileIfChanged } from "./write-file-if-changed";
 import { isFarmAPIRouteFileName } from "./api/route-files";
+import { buildSync, type Loader } from "esbuild";
 
 const API_CLIENT_METHOD_SEGMENTS = new Set([
   "get",
@@ -73,7 +74,7 @@ export class APITypeGenerator {
   ): APIRouteInfo | null {
     try {
       const content = readFileSync(filePath, "utf-8");
-      const methods = this.extractExportedMethods(content);
+      const methods = this.extractExportedMethods(content, filePath);
 
       if (methods.length === 0) {
         return null;
@@ -94,35 +95,30 @@ export class APITypeGenerator {
     }
   }
 
-  private extractExportedMethods(content: string): string[] {
-    const methods: string[] = [];
+  private extractExportedMethods(content: string, filePath: string): string[] {
+    const result = buildSync({
+      bundle: false,
+      format: "esm",
+      logLevel: "silent",
+      metafile: true,
+      platform: "neutral",
+      stdin: {
+        contents: content,
+        loader: this.getEsbuildLoader(filePath),
+        sourcefile: filePath,
+      },
+      write: false,
+    });
     const httpMethods = ["GET", "HEAD", "QUERY", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"];
-    const namedExports = new Set<string>();
+    const valueExports = new Set(
+      Object.values(result.metafile.outputs).flatMap((output) => output.exports),
+    );
+    return httpMethods.filter((method) => valueExports.has(method));
+  }
 
-    for (const match of content.matchAll(/export\s*\{([\s\S]*?)\}/g)) {
-      for (const specifier of match[1].split(",")) {
-        const normalized = specifier.trim().replace(/^type\s+/, "");
-        if (!normalized) continue;
-
-        const alias = normalized.match(/^([A-Za-z_$][\w$]*)\s+as\s+([A-Za-z_$][\w$]*)$/);
-        const exportedName = alias?.[2] ?? normalized.match(/^([A-Za-z_$][\w$]*)$/)?.[1];
-        if (exportedName) namedExports.add(exportedName);
-      }
-    }
-
-    for (const method of httpMethods) {
-      // Look for a direct declaration or the name exposed by an export list.
-      const patterns = [
-        new RegExp(`export\\s+(?:const|let|var)\\s+${method}\\s*(?::|=)`, "g"),
-        new RegExp(`export\\s+(?:async\\s+)?function\\s+${method}\\s*\\(`, "g"),
-      ];
-
-      if (namedExports.has(method) || patterns.some((pattern) => pattern.test(content))) {
-        methods.push(method);
-      }
-    }
-
-    return methods;
+  private getEsbuildLoader(filePath: string): Loader {
+    const extension = filePath.slice(filePath.lastIndexOf(".") + 1).toLowerCase();
+    return extension === "tsx" || extension === "jsx" || extension === "js" ? extension : "ts";
   }
 
   /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1505,6 +1505,9 @@ importers:
       db0:
         specifier: ^0.3.4
         version: 0.3.4(drizzle-orm@0.45.2)
+      es-module-lexer:
+        specifier: 2.0.0
+        version: 2.0.0
       esbuild:
         specifier: ^0.28.0
         version: 0.28.1


### PR DESCRIPTION
## Problem

Generated API types treated HTTP-looking text inside comments and strings, plus type-only exports, as live route handlers. That could generate imports for values the route module does not export and break type checking.

## Root cause

Method discovery searched raw source text with regular expressions. The scan could not distinguish executable ESM exports from comments, literals, or TypeScript-only declarations.

## Change

Use `es-module-lexer` to read each route module's runtime export names. Only actual value exports matching supported HTTP methods become generated client methods, including direct declarations and named aliases.

## Safety and compatibility

Type-only declarations, type-only export specifiers, comments, and string examples are excluded. The lexer is environment-safe for modules that transitively import type generation, and the same dependency/version is already used by Farm's official plugin package. Invalid route syntax continues through the existing per-file warning path.

## Verification\n\n- `pnpm --filter @farm.js/core test` (195 files, 1,674 passed, 1 skipped)\n
- `pnpm --filter @farm.js/core test -- type-generator.test.ts type-artifacts.test.ts api-client.test.ts integrations.test.ts`
- `pnpm --filter @farm.js/core test -- api-client.test.ts client-plugin-build.test.ts compression.test.ts integration-client.test.ts integrations.test.ts navigation-request-context.test.ts plugin-lifecycle.test.ts type-artifacts.test.ts`
- `pnpm --filter @farm.js/core type-check`
- focused `oxlint`: zero warnings and zero errors

The regression combines line/block comments, a string example, both TypeScript type-export forms, and one real handler; only the real handler is generated.

## Documentation and release

Documented that generated API methods follow runtime value exports, excluding comments, examples, and type-only names.
