### PR TITLE
fix(preview): preserve target URL base paths

### DIFF
--- a/docs/src/app/docs/preview/page.md
+++ b/docs/src/app/docs/preview/page.md
@@ -79,6 +79,10 @@ farm preview --dry-run
 
 When no target is passed, Farm tries to detect a running app from the current project config and common development ports. Pass `--port` or `--url` when the app is running somewhere specific.
 
+The pathname in `--url` is a mount point. For example, `--url
+http://localhost:4319/console` forwards the public preview root to `/console/` and a public
+`/settings` request to `/console/settings` without allowing the public path to escape that mount.
+
 ## Options
 
 | Option                  | Purpose                                                                             |

--- a/packages/farm-preview-tunnel/src/agent.ts
+++ b/packages/farm-preview-tunnel/src/agent.ts
@@ -259,12 +259,17 @@ function resolveTargetUrl(targetUrl: string, requestPath: string) {
     throw new UnsafePreviewPathError();
   }
 
-  const base = new URL(ensureTrailingSlash(targetUrl));
+  const base = new URL(targetUrl);
   if (base.protocol !== "http:" && base.protocol !== "https:") {
     throw new UnsafePreviewPathError();
   }
-  const resolved = new URL(requestPath, base);
-  if (resolved.origin !== base.origin) throw new UnsafePreviewPathError();
+  base.pathname = ensureTrailingSlash(base.pathname);
+  base.search = "";
+  base.hash = "";
+  const resolved = new URL(requestPath.slice(1), base);
+  if (resolved.origin !== base.origin || !resolved.pathname.startsWith(base.pathname)) {
+    throw new UnsafePreviewPathError();
+  }
   return resolved;
 }
 

--- a/packages/farm-preview-tunnel/test/tunnel.test.mjs
+++ b/packages/farm-preview-tunnel/test/tunnel.test.mjs
@@ -56,6 +56,31 @@ test("forwards requests over one persistent websocket and closes with the agent"
   }
 });
 
+test("mounts public preview paths beneath the target URL pathname", async () => {
+  const target = createServer((request, response) => response.end(request.url));
+  await listen(target);
+  const targetAddress = target.address();
+  const relay = createPersistentPreviewRelay();
+  const relayAddress = await relay.listen();
+  const agent = await startTypeScriptPreviewAgent({
+    relayUrl: relayAddress.websocketUrl,
+    name: "base-path",
+    targetUrl: `http://127.0.0.1:${targetAddress.port}/console`,
+  });
+
+  try {
+    const nested = await fetch(`${agent.publicUrl}/dashboard?view=compact`);
+    assert.equal(await nested.text(), "/console/dashboard?view=compact");
+
+    const root = await fetch(agent.publicUrl);
+    assert.equal(await root.text(), "/console/");
+  } finally {
+    await agent.close();
+    await relay.close();
+    await close(target);
+  }
+});
+
 test("preserves repeated cookies and removes encoding after decoding a response", async () => {
   const target = createServer((_request, response) => {
     response.statusCode = 200;


### PR DESCRIPTION
## Problem

`farm preview --url http://localhost:3000/console` probed the configured URL correctly but forwarded public requests to the origin root. Public `/dashboard` reached local `/dashboard` instead of `/console/dashboard`.

## Root cause

The preview agent resolved an absolute request pathname against the target URL. WHATWG URL resolution discards the base pathname whenever the new reference starts with `/`.

## Change

Treat the target pathname as a mount point, resolve public paths relative to it, and reject any resolution that escapes that pathname. Target query/hash values are removed before per-request query resolution.

## Safety and compatibility

Origin-only targets keep their existing behavior. Nested target paths now work as documented by `--url`, queries are preserved from each public request, and encoded traversal cannot escape the configured local mount.

## Verification

- `pnpm --filter @farm.js/preview-tunnel test` (build plus 12 tunnel tests)
- `pnpm --filter @farm.js/preview-tunnel type-check`
- focused `oxlint`: zero warnings and zero errors

The regression starts a real relay and target server, then verifies public root and nested requests reach `/console/` and `/console/dashboard?...`.

## Documentation and release

Documented `--url` pathname mount behavior and its containment guarantee.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `farm preview --url` so a pathname in the target URL is treated as a mount point instead of being discarded. Public `/dashboard` now forwards to `/console/dashboard` when the target is `http://localhost:3000/console`, and requests that escape the mount are rejected.

- Origin-only targets keep their existing behavior.
- Target query and hash values are stripped; per-request queries are preserved.
- Updated the preview docs to describe the mount behavior and containment guarantee.

<sup>Written for commit 7facbf48423b9b06e85f283aa7d7d76ef7b81046. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/783?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

