### PR TITLE
fix(workflows): preserve absolute discovery directories

### DIFF
--- a/docs/src/app/docs/cron/page.md
+++ b/docs/src/app/docs/cron/page.md
@@ -234,4 +234,6 @@ The older `defineCron()` workflow-module API remains available for compatibility
 parses `application/json` and `application/*+json` bodies as JSON, wraps other non-empty bodies as
 `{ text }`, and rejects malformed JSON consistently in development and production. New applications
 should use `cron` config plus an ordinary API route so local, deployment, security, and testing
-behavior share one model.
+behavior share one model. Existing workflow-module applications may configure `workflows.dir` or
+`workflows.dirs` with project-relative or absolute directories; absolute directories remain rooted
+outside the project instead of being remounted below it.

--- a/packages/farm/src/__tests__/workflows.test.ts
+++ b/packages/farm/src/__tests__/workflows.test.ts
@@ -69,6 +69,24 @@ describe("Farm workflows", () => {
     ]);
   });
 
+  it("discovers workflows from an absolute directory outside the project", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "farm-workflow-project-"));
+    const workflowDir = await fs.mkdtemp(path.join(os.tmpdir(), "farm-workflow-shared-"));
+    const workflowPath = path.join(workflowDir, "shared-sync.mjs");
+    await fs.writeFile(workflowPath, "export default { async run() { return { ok: true }; } };");
+
+    const config = resolveWorkflowsConfig({ dir: workflowDir });
+    const workflows = await discoverFarmWorkflows({ root, workflows: config });
+
+    expect(config.dirs).toEqual([path.normalize(workflowDir)]);
+    expect(workflows).toEqual([
+      expect.objectContaining({
+        id: "shared-sync",
+        filePath: workflowPath,
+      }),
+    ]);
+  });
+
   it("runs workflow modules through the HTTP handler", async () => {
     const workflow = {
       id: "sync-users",

--- a/packages/farm/src/workflows.ts
+++ b/packages/farm/src/workflows.ts
@@ -8,6 +8,13 @@ import {
 import { searchParamsToObject } from "./search-params";
 import { decodeRouteSegment } from "./utils/decode";
 import { toPosixPath } from "./utils";
+import {
+  isAbsolute as isAbsolutePath,
+  normalize as normalizePath,
+  relative as relativeFilePath,
+  resolve as resolvePath,
+  sep as pathSeparator,
+} from "node:path";
 
 export type FarmWorkflowSchedule = string | string[];
 
@@ -173,7 +180,9 @@ export async function discoverFarmWorkflows(
     const definition = resolveWorkflowDefinition(module);
     if (!definition) continue;
 
-    const id = normalizeWorkflowId(definition.id || workflowIdFromFile(root, filePath));
+    const id = normalizeWorkflowId(
+      definition.id || workflowIdFromFile(root, workflowConfig.dirs, filePath),
+    );
     const previousPath = seenIds.get(id);
     if (previousPath) {
       throw new Error(
@@ -412,7 +421,13 @@ function normalizeWorkflowDirs(options: FarmWorkflowsUserConfig): string[] {
     options.dirs ||
     (Array.isArray(options.dir) ? options.dir : options.dir ? [options.dir] : undefined);
   const dirs = rawDirs && rawDirs.length > 0 ? rawDirs : DEFAULT_FARM_WORKFLOW_DIRS;
-  return [...new Set(dirs.map((dir) => trimSlashes(dir)).filter(Boolean))];
+  return [...new Set(dirs.map(normalizeWorkflowDir).filter(Boolean))];
+}
+
+function normalizeWorkflowDir(value: string): string {
+  const dir = value.trim();
+  if (!dir) return "";
+  return isAbsolutePath(dir) ? normalizePath(dir) : trimSlashes(dir);
 }
 
 function normalizeWorkflowRoute(route: string): string {
@@ -452,7 +467,6 @@ function resolveWorkflowDefinition(
 }
 
 async function findWorkflowFiles(root: string, dirs: string[]): Promise<string[]> {
-  const fs = await import("fs/promises");
   const path = await import("path");
   const files: string[] = [];
 
@@ -528,15 +542,16 @@ async function loadWorkflowModule(filePath: string, root: string): Promise<Recor
   }
 }
 
-function workflowIdFromFile(root: string, filePath: string): string {
-  const normalizedRoot = root.replace(/\\/g, "/");
-  const normalizedFile = filePath.replace(/\\/g, "/");
-  const relative = normalizedFile.startsWith(`${normalizedRoot}/`)
-    ? normalizedFile.slice(normalizedRoot.length + 1)
-    : normalizedFile;
-  return normalizeWorkflowId(
-    relative.replace(/^src\/(?:jobs|workflows|cron)\//, "").replace(/\.(tsx?|jsx?|mjs|cjs)$/, ""),
-  );
+function workflowIdFromFile(root: string, dirs: string[], filePath: string): string {
+  for (const dir of dirs) {
+    const scanRoot = isAbsolutePath(dir) ? dir : resolvePath(root, dir);
+    const candidate = relativeFilePath(scanRoot, filePath);
+    if (candidate && candidate !== ".." && !candidate.startsWith(`..${pathSeparator}`)) {
+      return normalizeWorkflowId(candidate);
+    }
+  }
+
+  return normalizeWorkflowId(relativeFilePath(root, filePath));
 }
 
 function createScheduledTasks(


### PR DESCRIPTION
## Problem

Legacy workflow discovery accepted `workflows.dir`/`dirs` strings but removed the leading slash from absolute directories. `/tmp/shared-workflows` was searched as `<project>/tmp/shared-workflows`, and any externally discovered file would receive an absolute-path-derived workflow ID.

## Root cause

Directory normalization used the route-oriented `trimSlashes()` helper before discovery checked `path.isAbsolute()`. Workflow IDs were also calculated only relative to the project/default directory prefixes.

## Change

Preserve and platform-normalize absolute directory values, normalize only relative directory slashes, and derive implicit workflow IDs relative to the configured scan root.

## Safety and compatibility

Default workflow directories retain their existing IDs. Relative custom directories continue to resolve below the project, while explicitly configured absolute directories remain outside it. Explicit workflow IDs still win.

## Verification

- `pnpm --filter @farm.js/core test -- workflows.test.ts`
- `pnpm --filter @farm.js/core type-check`
- focused `oxlint`: zero warnings and zero errors

The regression creates a workflow directory outside the project, verifies it remains absolute, discovers the module, and assigns the stable `shared-sync` ID.

## Documentation and release

Documented relative and absolute directory behavior for compatibility workflow modules.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes workflow discovery so absolute directories like `/tmp/shared-workflows` stay absolute instead of being searched below the project root as `<project>/tmp/shared-workflows`. Implicit workflow IDs for files found outside the project are now derived relative to the configured scan root rather than the project root.

**Bug Fixes**
- Absolute directory values are normalized with `node:path`; only relative values get leading and trailing slashes stripped.
- ID derivation checks each configured directory and uses it as the scan root when the file lives under it, then falls back to the project root.
- Default workflow directories keep their existing IDs, and explicit workflow IDs still take precedence.
- Adds a regression test that writes a workflow outside the project and verifies discovery and the stable `shared-sync` ID.

<sup>Written for commit 22cf3369a7b449c60119d121a304a4e8e67a25e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/784?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

