### PR TITLE
fix(workflows): remove stale generated tasks

### DIFF
--- a/docs/src/app/docs/cron/page.md
+++ b/docs/src/app/docs/cron/page.md
@@ -236,4 +236,6 @@ parses `application/json` and `application/*+json` bodies as JSON, wraps other n
 should use `cron` config plus an ordinary API route so local, deployment, security, and testing
 behavior share one model. Existing workflow-module applications may configure `workflows.dir` or
 `workflows.dirs` with project-relative or absolute directories; absolute directories remain rooted
-outside the project instead of being remounted below it.
+outside the project instead of being remounted below it. Production preparation replaces the
+generated workflow wrappers on each run, so removed modules or disabling `workflows` cannot leave
+an executable stale task behind.

--- a/packages/farm/src/__tests__/workflows.test.ts
+++ b/packages/farm/src/__tests__/workflows.test.ts
@@ -385,6 +385,34 @@ describe("Farm workflows", () => {
     expect((malformedResponse as Response).status).toBe(400);
   });
 
+  it("removes generated wrappers when workflows are removed or disabled", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "farm-workflow-cleanup-"));
+    const jobsDir = path.join(root, "src", "jobs");
+    const firstWorkflow = path.join(jobsDir, "first.mjs");
+    const remainingWorkflow = path.join(jobsDir, "remaining.mjs");
+    const generatedDir = path.join(root, ".farm", ".nitro", "farm-workflows");
+    await fs.mkdir(jobsDir, { recursive: true });
+    const workflowSource = "export default { async run() { return { ok: true }; } };";
+    await Promise.all([
+      fs.writeFile(firstWorkflow, workflowSource),
+      fs.writeFile(remainingWorkflow, workflowSource),
+    ]);
+
+    await prepareFarmWorkflowsForNitro({ root, workflows: {} });
+    await expect(fs.stat(path.join(generatedDir, "first.mjs"))).resolves.toBeDefined();
+    await expect(fs.stat(path.join(generatedDir, "remaining.mjs"))).resolves.toBeDefined();
+
+    await fs.unlink(firstWorkflow);
+    await prepareFarmWorkflowsForNitro({ root, workflows: {} });
+    await expect(fs.stat(path.join(generatedDir, "first.mjs"))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+    await expect(fs.stat(path.join(generatedDir, "remaining.mjs"))).resolves.toBeDefined();
+
+    await prepareFarmWorkflowsForNitro({ root, workflows: false });
+    await expect(fs.stat(generatedDir)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
   it("emits only internal imports the production runtime actually exports", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "farm-workflow-imports-"));
     await fs.mkdir(path.join(root, "src", "jobs"), { recursive: true });

--- a/packages/farm/src/workflows.ts
+++ b/packages/farm/src/workflows.ts
@@ -302,12 +302,18 @@ export async function prepareFarmWorkflowsForNitro(config: {
   const workflowConfig = isResolvedWorkflowConfig(config.workflows)
     ? config.workflows
     : resolveWorkflowsConfig(config.workflows);
+  const root = config.root || process.cwd();
+  const distDir = config.distDir || ".farm";
+  const fs = await import("fs/promises");
+  const path = await import("path");
+  const generatedDir = path.join(root, distDir, ".nitro", "farm-workflows");
   const workflows = await discoverFarmWorkflows({
-    root: config.root,
+    root,
     workflows: workflowConfig,
   });
 
   if (workflows.length === 0) {
+    await fs.rm(generatedDir, { recursive: true, force: true });
     return {
       workflows,
       tasks: {},
@@ -315,11 +321,7 @@ export async function prepareFarmWorkflowsForNitro(config: {
     };
   }
 
-  const root = config.root || process.cwd();
-  const distDir = config.distDir || ".farm";
-  const fs = await import("fs/promises");
-  const path = await import("path");
-  const generatedDir = path.join(root, distDir, ".nitro", "farm-workflows");
+  await fs.rm(generatedDir, { recursive: true, force: true });
   await fs.mkdir(generatedDir, { recursive: true });
 
   const tasks: PreparedFarmWorkflows["tasks"] = {};


### PR DESCRIPTION
## Problem

Removing a workflow module or disabling compatibility workflows could leave its generated Nitro wrapper and manifest in `.farm/.nitro/farm-workflows`. Incremental or direct production preparation could therefore retain an executable stale task.

## Root cause

Workflow preparation returned immediately when discovery found no modules and otherwise wrote into the existing generated directory without clearing it. Framework cron preparation already owns and replaces its generated directory, but the workflow path did not.

## Change

Resolve the generated directory before discovery, remove it when workflows are disabled/empty, and replace it before writing a non-empty workflow set.

## Safety and compatibility

Only Farm-owned generated files under the exact workflow output directory are removed. Source modules and unrelated build output are untouched. Current workflows are regenerated with the existing handler, manifest, and task shapes.

## Verification

- `pnpm --filter @farm.js/core test -- workflows.test.ts`
- `pnpm --filter @farm.js/core type-check`
- focused `oxlint`: zero warnings and zero errors

The regression prepares two workflows, removes one and verifies its wrapper disappears, then disables workflows and verifies the generated directory is removed.

## Documentation and release

Documented generated workflow replacement and stale-task cleanup.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale generated workflow tasks so production preparation no longer retains an executable task when workflow modules are removed or workflows are disabled.

- Resolves the generated output directory before discovery and deletes it when no workflows are found or workflows are disabled.
- Replaces the generated directory before writing a non-empty workflow set, ensuring only current workflows remain.

<sup>Written for commit 1776a25b2b41ee1e18d82333d07641fa37409dae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/785?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

