### PR TITLE
fix(cli): explain malformed request paths

### DIFF
--- a/docs/src/app/docs/cli/page.md
+++ b/docs/src/app/docs/cli/page.md
@@ -224,6 +224,9 @@ farm explain /products/42 --json
 - static or generated metadata and the nearest Open Graph and Twitter images;
 - the deployment target, preset, runtime compatibility, and actionable warnings.
 
+Request paths are not required to contain valid percent escapes. `farm explain` keeps a malformed
+segment raw, matching the runtime router, instead of aborting the diagnostic with a URI error.
+
 Use the text output while debugging and `--json` for tooling. The command is read-only and fails when no page route matches the supplied URL.
 
 ## Build

--- a/packages/farm-cli/src/explain.ts
+++ b/packages/farm-cli/src/explain.ts
@@ -619,7 +619,15 @@ function normalizePathname(value: string, basePath: string): string {
 }
 
 function splitPath(value: string) {
-  return value.split("/").filter(Boolean).map(decodeURIComponent);
+  return value.split("/").filter(Boolean).map(decodeExplainPathSegment);
+}
+
+function decodeExplainPathSegment(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
 }
 
 function toProjectPath(root: string, filePath: string) {

--- a/packages/farm-cli/test/explain.test.mjs
+++ b/packages/farm-cli/test/explain.test.mjs
@@ -49,6 +49,19 @@ test("explains a dynamic page and its inherited route behavior", async () => {
   }
 });
 
+test("keeps malformed percent-encoded route parameters raw", async () => {
+  const root = await createExplainProject();
+
+  try {
+    const explanation = await explainFarmRoute("/products/%ZZ", { root });
+
+    assert.equal(explanation.pattern, "/products/[id]");
+    assert.deepEqual(explanation.params, { id: "%ZZ" });
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test("prints route explanations as JSON through the CLI", async () => {
   const root = await createExplainProject();
 


### PR DESCRIPTION
## Problem

`farm explain` threw `URIError: URI malformed` for request paths containing an invalid percent escape such as `/products/%ZZ`. The deployed and development routers intentionally keep malformed segments raw instead of crashing.

## Root cause

The CLI route matcher mapped path segments through bare `decodeURIComponent`, while runtime route matching uses guarded decoding.

## Change

Guard route-segment decoding in `farm explain` and retain the raw segment when decoding fails.

## Safety and compatibility

Valid encoded segments decode exactly as before. Only malformed input changes, from an uncaught CLI exception to normal route matching with the raw parameter value. This matches runtime behavior and does not relax filesystem handling.

## Verification

- `pnpm --filter @farm.js/cli test` (90 tests)
- `pnpm --filter @farm.js/cli type-check`
- focused `oxlint`: zero warnings and zero errors

The regression explains `/products/%ZZ` and verifies the dynamic parameter remains `%ZZ`; it throws before this fix.

## Documentation and release

Documented malformed path handling in the CLI guide.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `farm explain` crashing with `URIError: URI malformed` on request paths containing invalid percent escapes like `/products/%ZZ`. The CLI now guards route-segment decoding and keeps the raw segment when decoding fails, matching the runtime router's behavior. Valid encoded segments decode exactly as before, and the CLI guide now documents malformed path handling.

<sup>Written for commit 196d0258977e1481db872f341129bb4ba4565baf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/786?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

