### PR TITLE
perf(react): specialize mapped reversals

### DIFF
--- a/docs/src/app/docs/renderers/react/page.md
+++ b/docs/src/app/docs/renderers/react/page.md
@@ -1248,6 +1248,12 @@ controlled inputs, focus, and text selection stay attached to their keys. Multip
 map-and-reorder setters queued before one compiler flush compose against the same committed
 collection and expose only the final state.
 
+When the maps are followed directly by `toReversed()`, their same-order lineage proves the exact
+final permutation. Farm validates each mirrored source item and every changed replacement before
+the first DOM write, then uses the minimum-move reverse operation directly. It does not allocate a
+second source-item lookup map or run LIS for that case. A sort before the reverse, a map after a
+queued reorder, or any other order ambiguity keeps the general permutation path.
+
 The proof requires every map callback to be inline, synchronous, compiler-safe, and to return the
 original item on one conditional branch and an object-spread replacement on the other. It requires
 compiler-owned host rows whose render and key do not observe the index. Referenced or block-bodied

--- a/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
+++ b/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
@@ -1,6 +1,42 @@
 # Complex dashboard and 21,000-row peak result
 
-Latest run: 2026-09-07
+Latest run: 2026-09-08
+
+## Direct mapped reverse specialization — 2026-09-08
+
+A compiler-proven chain of safe `map()` calls followed directly by native `toReversed()` now uses
+an exact reverse path. The runtime validates every mirrored row and any changed replacement before
+touching the DOM, then performs the required minimum of 9,999 connected row moves. It does not
+allocate the general source-item lookup map or run LIS, and unchanged rows skip lineage lookups.
+
+The existing 10,000-row benchmark was extended with two native maps that update one row before a
+complete reversal. The block-bodied compiled control performs the same application work but uses
+the general keyed reconciliation path.
+
+| Mode   | General path before | Exact reverse | Compiled control | vs React | vs control |
+| ------ | ------------------: | ------------: | ---------------: | -------: | ---------: |
+| Static | 24.70 ms | 24.60 ms | 35.30 ms | 11.48x | 1.43x |
+| Hybrid | 25.80 ms | 24.60 ms | 37.00 ms | 11.48x | 1.50x |
+
+The end-to-end latency change against the former path is intentionally modest because both paths
+execute the same maps and must move the same 9,999 DOM rows. The larger comparison with the control
+isolates the avoided generic reconciliation work. Both compiler modes passed the 4x React and 1.2x
+compiled-control floors, the complete correctness oracle, and every existing regression gate.
+
+Correctness checks verify the complete final order and values, preserve all 10,000 row nodes and
+their connectivity, and cover changed keys, custom methods, Array subclasses, delegated events,
+controlled-input focus and selection, Strict Mode hydration, unmount cleanup, and 2,000 randomized
+mapped reversals. A preceding sort, a map after a queued reorder, ambiguous ownership, or failed
+validation remains on the general path or falls back to React before any DOM mutation.
+
+The isolated optional runtime changed from 13,390 B to 13,378 B gzip, remaining below the 13,399 B
+ceiling. The complete dashboard compiler chunk changed from 26,919 B to 26,903 B gzip, while the
+6,480 B compiler-off chunk was unchanged. This adds no public API or observability counter.
+
+Numbers are local medians from 10 table samples per compiler mode with 20 bracketing React samples,
+Chrome 152.0.7977.82, Node.js 23.11.0, and Apple M1 macOS arm64. Timing varies by machine; the
+deterministic correctness, move-count, descriptor-read, and runtime-size checks are the primary
+safety controls.
 
 ## One lineage scan for consecutive maps before reorder — 2026-09-07
 

--- a/examples/react-compiler-dashboard/README.md
+++ b/examples/react-compiler-dashboard/README.md
@@ -233,6 +233,14 @@ edits, map/sort/reverse composition, changed-key and custom-method fallback, del
 controlled-input focus and selection, 2,000 differential updates, Strict Mode hydration, and
 unmount-before-flush cleanup.
 
+Direct mapped reversal has a separate 10,000-row comparison. Two concise native maps change one
+row's label and amount before `toReversed()`; the block-bodied control performs the same native
+calls and DOM-visible work through complete reconciliation. Both compiler modes must remain at
+least 4x faster than React and 1.2x faster than the compiled control. The assertion checks the full
+reversed order, every original DOM identity and connection, and the changed row values. The hinted
+path validates mirrored row lineage and uses the minimum `n - 1` moves without a source-item map or
+LIS pass.
+
 Native keyed-array sorting has its own 10,000-row comparison. Concise `toSorted()` is measured
 against bracketed React and an equivalent block-bodied compiled control. Both compiler modes must
 remain at least 4x faster than React and 1.25x faster than the compiled control. The report must
@@ -326,6 +334,9 @@ The default JSON report is `/tmp/farm-react-dashboard-benchmark.json`; change it
   then sorts the same keyed rows. Its block-bodied equivalent keeps complete reconciliation, while
   the hinted path checks each native call, scans only the committed and final arrays for lineage,
   and patches the final row once.
+- The multi-map reverse control changes the same row through two native maps and then reverses all
+  rows. Its block-bodied equivalent performs the same maps and connected DOM moves, while the
+  hinted path validates mirrored lineage directly and skips the temporary source map and LIS pass.
 - The sort control compares concise native `toSorted()` with an equivalent block-bodied compiled
   update. Both paths run the same native sort and move the same keyed DOM rows; the hint isolates
   the saved key, descriptor, and binding work while retaining only the required LIS moves.

--- a/examples/react-compiler-dashboard/scripts/benchmark.mjs
+++ b/examples/react-compiler-dashboard/scripts/benchmark.mjs
@@ -1304,6 +1304,67 @@ async function measureTrial(browser, trial, compilerMode, port) {
           " reviewed",
         );
 
+        const prepareMultiMapReversePipeline = async () => {
+          await create10000();
+          const rows = [...table.querySelectorAll("tbody tr")];
+          const target = rows.find(
+            (row) => Number(row.getAttribute("data-row-id")) % 10_000 === 5_001,
+          );
+          const amountText = target?.querySelector("td:nth-child(4)")?.textContent;
+          const amount = Number(amountText?.slice(1));
+          if (!target || !Number.isFinite(amount)) {
+            throw new Error("Mapped-reverse target row is invalid.");
+          }
+          return { expectedRows: [...rows].reverse(), rows, target, amount: amount + 1 };
+        };
+
+        const measureMultiMapReversePipeline = async (action, prepared) => {
+          if (!prepared) throw new Error("Mapped-reverse expectation is missing.");
+          const { expectedRows, rows, target, amount } = prepared;
+          await runTableAction(action, () => {
+            const nextRows = table.querySelectorAll("tbody tr");
+            return (
+              nextRows.length === 10_000 &&
+              nextRows[0] === expectedRows[0] &&
+              target.querySelector("td:nth-child(2)")?.textContent?.endsWith(" reviewed") ===
+                true &&
+              target.querySelector("td:nth-child(4)")?.textContent === `$${amount}`
+            );
+          });
+          return () => {
+            const nextRows = table.querySelectorAll("tbody tr");
+            if (!rowsMatch(nextRows, expectedRows) || rows.some((row) => !row.isConnected)) {
+              throw new Error("Mapped-reverse rows do not match the complete expected reversal.");
+            }
+          };
+        };
+
+        const measureMultiMapReverseTable = async (action) => {
+          for (let sample = 0; sample < warmupSamples; sample += 1) {
+            const verify = await measureMultiMapReversePipeline(
+              action,
+              await prepareMultiMapReversePipeline(),
+            );
+            verify();
+          }
+          const timings = [];
+          for (let sample = 0; sample < tableSamples; sample += 1) {
+            const prepared = await prepareMultiMapReversePipeline();
+            const startedAt = performance.now();
+            const verify = await measureMultiMapReversePipeline(action, prepared);
+            timings.push(performance.now() - startedAt);
+            verify();
+          }
+          return timings;
+        };
+
+        const tableMultiMapReversePipeline = await measureMultiMapReverseTable(() =>
+          tableButton("table-multi-map-reverse-pipeline").click(),
+        );
+        const tableMultiMapReversePipelineSnapshot = await measureMultiMapReverseTable(() =>
+          tableButton("table-multi-map-reverse-pipeline-snapshot").click(),
+        );
+
         const tableSort = await measureTable(
           async () => create10000(),
           async () => {
@@ -1778,6 +1839,8 @@ async function measureTrial(browser, trial, compilerMode, port) {
             multiMapUpdateSnapshot: tableMultiMapUpdateSnapshot,
             multiMapReorderPipeline: tableMultiMapReorderPipeline,
             multiMapReorderPipelineSnapshot: tableMultiMapReorderPipelineSnapshot,
+            multiMapReversePipeline: tableMultiMapReversePipeline,
+            multiMapReversePipelineSnapshot: tableMultiMapReversePipelineSnapshot,
             mapLookup: tableMapLookup,
             membership: tableMembership,
             prepend: tablePrepend,
@@ -1907,6 +1970,10 @@ async function measureTrial(browser, trial, compilerMode, port) {
         multiMapReorderPipeline: timingSummary(result.table.multiMapReorderPipeline),
         multiMapReorderPipelineSnapshot: timingSummary(
           result.table.multiMapReorderPipelineSnapshot,
+        ),
+        multiMapReversePipeline: timingSummary(result.table.multiMapReversePipeline),
+        multiMapReversePipelineSnapshot: timingSummary(
+          result.table.multiMapReversePipelineSnapshot,
         ),
         mapLookup: timingSummary(result.table.mapLookup),
         membership: timingSummary(result.table.membership),
@@ -2086,6 +2153,8 @@ const tableMetrics = [
   "multiMapUpdateSnapshot",
   "multiMapReorderPipeline",
   "multiMapReorderPipelineSnapshot",
+  "multiMapReversePipeline",
+  "multiMapReversePipelineSnapshot",
   "snapshotMembership",
   "snapshotMapLookup",
   "slicePrefix",
@@ -2768,6 +2837,28 @@ const keyedMultiMapReorderRegressions = keyedMultiMapReorderResults.filter(
     !Number.isFinite(snapshotSpeedup) ||
     snapshotSpeedup < keyedMultiMapReorderMinimumSnapshotSpeedup,
 );
+// A compiler-proven map chain followed directly by toReversed() has an exact permutation. It
+// should use the minimum-move reverse path instead of allocating an item map and running LIS.
+const keyedMultiMapReverseMinimumSpeedup = 4;
+const keyedMultiMapReverseMinimumSnapshotSpeedup = 1.2;
+const keyedMultiMapReverseResults = ["static", "hybrid"].map((mode) => {
+  const pipelineMedianMs = comparisons.table.multiMapReversePipeline[mode].medianMs;
+  const snapshotMedianMs = comparisons.table.multiMapReversePipelineSnapshot[mode].medianMs;
+  return {
+    mode,
+    pipelineMedianMs,
+    snapshotMedianMs,
+    snapshotSpeedup: snapshotMedianMs / pipelineMedianMs,
+    speedup: comparisons.table.multiMapReversePipeline[`${mode}VsBaseline`].speedup,
+  };
+});
+const keyedMultiMapReverseRegressions = keyedMultiMapReverseResults.filter(
+  ({ snapshotSpeedup, speedup }) =>
+    !Number.isFinite(speedup) ||
+    speedup < keyedMultiMapReverseMinimumSpeedup ||
+    !Number.isFinite(snapshotSpeedup) ||
+    snapshotSpeedup < keyedMultiMapReverseMinimumSnapshotSpeedup,
+);
 // A direct native toSorted() exposes a permutation while preserving every keyed row object. The
 // hinted path validates that permutation by item identity, uses LIS to move only the required DOM
 // nodes, and avoids key, descriptor, and binding reads. Compare it with React and the equivalent
@@ -2958,6 +3049,7 @@ const passed =
   keyedStructuralReorderRegressions.length === 0 &&
   keyedMapReorderRegressions.length === 0 &&
   keyedMultiMapReorderRegressions.length === 0 &&
+  keyedMultiMapReverseRegressions.length === 0 &&
   keyedSortRegressions.length === 0 &&
   keyedFilterRegressions.length === 0 &&
   keyedIdentityRegressions.length === 0 &&
@@ -3137,6 +3229,13 @@ const report = {
     regressions: keyedMultiMapReorderRegressions,
     results: keyedMultiMapReorderResults,
     status: keyedMultiMapReorderRegressions.length === 0 ? "PASS" : "FAIL",
+  },
+  keyedMultiMapReverseHintGate: {
+    minimumSnapshotSpeedup: keyedMultiMapReverseMinimumSnapshotSpeedup,
+    minimumSpeedup: keyedMultiMapReverseMinimumSpeedup,
+    regressions: keyedMultiMapReverseRegressions,
+    results: keyedMultiMapReverseResults,
+    status: keyedMultiMapReverseRegressions.length === 0 ? "PASS" : "FAIL",
   },
   keyedSortHintGate: {
     minimumSnapshotSpeedup: keyedSortMinimumSnapshotSpeedup,

--- a/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
+++ b/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
@@ -945,6 +945,46 @@ export function StandardTableBenchmark() {
           Review + reprice + sort one row (snapshot control)
         </button>
         <button
+          data-action="table-multi-map-reverse-pipeline"
+          type="button"
+          onClick={() => {
+            setRows((current) =>
+              current
+                .map((row) =>
+                  row.id % 10_000 === 5_001 ? { ...row, label: `${row.label} reviewed` } : row,
+                )
+                .map((row) =>
+                  row.id % 10_000 === 5_001 ? { ...row, amount: row.amount + 1 } : row,
+                )
+                .toReversed(),
+            );
+            setOperation("review, reprice, and reverse rows");
+            setRevision((value) => value + 1);
+          }}
+        >
+          Review + reprice + reverse rows
+        </button>
+        <button
+          data-action="table-multi-map-reverse-pipeline-snapshot"
+          type="button"
+          onClick={() => {
+            setRows((current) => {
+              return current
+                .map((row) =>
+                  row.id % 10_000 === 5_001 ? { ...row, label: `${row.label} reviewed` } : row,
+                )
+                .map((row) =>
+                  row.id % 10_000 === 5_001 ? { ...row, amount: row.amount + 1 } : row,
+                )
+                .toReversed();
+            });
+            setOperation("review, reprice, and reverse rows (snapshot control)");
+            setRevision((value) => value + 1);
+          }}
+        >
+          Review + reprice + reverse rows (snapshot control)
+        </button>
+        <button
           data-action="table-sort"
           type="button"
           onClick={() => {

--- a/packages/farm-react/README.md
+++ b/packages/farm-react/README.md
@@ -449,6 +449,12 @@ bindings, nested or React-owned rows, and failed checks use complete keyed recon
 use the existing map, sort, and reorder hint counters, and unrelated modules do not retain this
 optional runtime.
 
+A direct `toReversed()` suffix is more specific than an arbitrary permutation. When all preceding
+maps retain committed row order, Farm validates the mirrored source-to-result relation and every
+changed binding before touching the DOM, then performs the minimum-move reverse without building a
+second item lookup map or running LIS. A preceding sort or a map whose source is an uncommitted
+reorder keeps the general permutation path.
+
 A direct native immutable sort can use the same optional reorder runtime:
 
 ```tsx

--- a/packages/farm-react/src/__tests__/compiler-keyed-array-sort-hints.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-keyed-array-sort-hints.test.ts
@@ -261,6 +261,36 @@ describe("React AOT keyed-array sort hints", () => {
     });
   });
 
+  it("groups multiple safe maps before a direct native reverse", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Table({ editedId, nextRank, nextLabel }) {
+        const [rows, setRows] = useState([
+          { id: "a", label: "Alpha", rank: 1 },
+          { id: "b", label: "Beta", rank: 2 },
+        ]);
+        return <section>
+          <button onClick={() => setRows((current) => current
+            .map((row) => row.id === editedId ? { ...row, label: nextLabel } : row)
+            .map((row) => row.id === editedId ? { ...row, rank: nextRank } : row)
+            .toReversed()
+          )}>Edit and reverse</button>
+          <ul>{rows.map((row) => <li key={row.id}>{row.label}: {row.rank}</li>)}</ul>
+        </section>;
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Table"]);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.optimizations.keyedMapUpdateHints).toBe(2);
+    expect(result.optimizations.keyedArraySortHints).toBe(0);
+    expect(result.optimizations.keyedArrayReorderHints).toBe(1);
+    expect(result.code.match(/createCompilerKeyedArrayMapPipeline\(/g)).toHaveLength(1);
+    expect(result.code.match(/_farmApplyMap\d*\(/g)).toHaveLength(2);
+    expect(result.code.match(/createCompilerKeyedArrayMapReorder\(/g)).toHaveLength(1);
+    expect(result.code).toContain("keyedRowsMapReorderHintedRuntimeFeature");
+  });
+
   it("does not lower map and reorder pipelines for host-backed keyed rows", async () => {
     const result = await compile(`
       import { useState } from "react";

--- a/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-map-reorder-hints.test.tsx
+++ b/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-map-reorder-hints.test.tsx
@@ -97,6 +97,16 @@ function multiMappedSort(items: Item[], id: string, rank: number, label: string)
   );
 }
 
+function multiMappedReverse(items: Item[], id: string, rank: number, label: string): Item[] {
+  return hintedReverse(
+    hintedMaps(
+      items,
+      (item) => (item.id === id ? { ...item, label } : item),
+      (item) => (item.id === id ? { ...item, rank } : item),
+    ),
+  );
+}
+
 function rowDescriptor(item: Item): CompilerKeyedRowElement {
   return {
     kind: "element",
@@ -122,9 +132,11 @@ function createHarness(initialItems: Item[]) {
   let editAndSort: (id: string, rank: number, label?: string) => void = () => undefined;
   let editTwoAndSort: (labelId: string, rankId: string) => void = () => undefined;
   let editTwiceAndSort: (id: string, rank: number, label: string) => void = () => undefined;
+  let editTwiceAndReverse: (id: string, rank: number, label: string) => void = () => undefined;
   let editSortReverse: (id: string, rank: number) => void = () => undefined;
   let queueEdits: (edits: readonly { id: string; rank: number; label: string }[]) => void = () =>
     undefined;
+  let queueSortThenMapReverse: () => void = () => undefined;
   let invalidateKey: () => void = () => undefined;
   let customMap: () => void = () => undefined;
   let customSecondMap: () => void = () => undefined;
@@ -148,6 +160,8 @@ function createHarness(initialItems: Item[]) {
         );
       editTwiceAndSort = (id, rank, label) =>
         state[0].set((previous) => multiMappedSort(previous as Item[], id, rank, label));
+      editTwiceAndReverse = (id, rank, label) =>
+        state[0].set((previous) => multiMappedReverse(previous as Item[], id, rank, label));
       editSortReverse = (id, rank) =>
         state[0].set((previous) => hintedReverse(mappedSort(previous as Item[], id, rank)));
       queueEdits = (edits) => {
@@ -157,9 +171,25 @@ function createHarness(initialItems: Item[]) {
           );
         }
       };
-      invalidateKey = () =>
+      queueSortThenMapReverse = () => {
         state[0].set((previous) =>
           hintedSort(
+            hintedMap(previous as Item[], (item) =>
+              item.id === "a" ? { ...item, label: "Alpha sorted" } : item,
+            ),
+          ),
+        );
+        state[0].set((previous) =>
+          hintedReverse(
+            hintedMap(previous as Item[], (item) =>
+              item.id === "c" ? { ...item, label: "Gamma reversed" } : item,
+            ),
+          ),
+        );
+      };
+      invalidateKey = () =>
+        state[0].set((previous) =>
+          hintedReverse(
             hintedMap(previous as Item[], (item) =>
               item.id === "b" ? { ...item, id: "replacement", label: "Replacement" } : item,
             ),
@@ -268,10 +298,13 @@ function createHarness(initialItems: Item[]) {
     editTwoAndSort: (labelId: string, rankId: string) => editTwoAndSort(labelId, rankId),
     editTwiceAndSort: (id: string, rank: number, label: string) =>
       editTwiceAndSort(id, rank, label),
+    editTwiceAndReverse: (id: string, rank: number, label: string) =>
+      editTwiceAndReverse(id, rank, label),
     editSortReverse: (id: string, rank: number) => editSortReverse(id, rank),
     invalidateKey: () => invalidateKey(),
     queueEdits: (edits: readonly { id: string; rank: number; label: string }[]) =>
       queueEdits(edits),
+    queueSortThenMapReverse: () => queueSortThenMapReverse(),
   };
 }
 
@@ -363,6 +396,42 @@ describe("compiled keyed-array map and reorder hints", () => {
     expect(harness.counters.keys).toBe(1);
     expect(harness.counters.descriptors).toBe(0);
     expect(harness.counters.bindings).toBe(1);
+  });
+
+  it("patches mapped rows and takes the exact reverse path", async () => {
+    const harness = createHarness([
+      { id: "a", label: "Alpha", rank: 1 },
+      { id: "b", label: "Beta", rank: 2 },
+      { id: "c", label: "Gamma", rank: 3 },
+    ]);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Table />));
+    const rows = new Map(
+      [...container.querySelectorAll("li")].map((row) => [row.dataset.key, row]),
+    );
+    const insertBefore = vi.spyOn(container.querySelector("ul")!, "insertBefore");
+    harness.counters.bindings = 0;
+    harness.counters.descriptors = 0;
+    harness.counters.keys = 0;
+
+    await act(async () => {
+      harness.editTwiceAndReverse("a", 4, "Alpha reversed");
+      await flushCompilerUpdates();
+    });
+
+    expect(labels(container)).toEqual(["Gamma:3", "Beta:2", "Alpha reversed:4"]);
+    for (const [key, row] of rows) {
+      expect(container.querySelector(`[data-key="${key}"]`)).toBe(row);
+    }
+    expect(harness.counters.executions).toBe(1);
+    expect(harness.counters.renders).toBe(1);
+    expect(harness.counters.keys).toBe(1);
+    expect(harness.counters.descriptors).toBe(0);
+    expect(harness.counters.bindings).toBe(1);
+    expect(insertBefore).toHaveBeenCalledTimes(2);
   });
 
   it("records consecutive map lineage with one source-to-result scan", async () => {
@@ -463,6 +532,39 @@ describe("compiled keyed-array map and reorder hints", () => {
     expect(harness.counters.executions).toBe(1);
   });
 
+  it("keeps a map after a queued reorder on the general permutation path", async () => {
+    const harness = createHarness([
+      { id: "a", label: "Alpha", rank: 3 },
+      { id: "b", label: "Beta", rank: 1 },
+      { id: "c", label: "Gamma", rank: 2 },
+    ]);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Table />));
+    const rows = new Map(
+      [...container.querySelectorAll("li")].map((row) => [row.dataset.key, row]),
+    );
+    harness.counters.bindings = 0;
+    harness.counters.descriptors = 0;
+    harness.counters.keys = 0;
+
+    await act(async () => {
+      harness.queueSortThenMapReverse();
+      await flushCompilerUpdates();
+    });
+
+    expect(labels(container)).toEqual(["Alpha sorted:3", "Gamma reversed:2", "Beta:1"]);
+    for (const [key, row] of rows) {
+      expect(container.querySelector(`[data-key="${key}"]`)).toBe(row);
+    }
+    expect(harness.counters.executions).toBe(1);
+    expect(harness.counters.keys).toBe(2);
+    expect(harness.counters.descriptors).toBe(0);
+    expect(harness.counters.bindings).toBe(2);
+  });
+
   it("falls back before DOM writes for custom map methods and changed keys", async () => {
     const harness = createHarness([
       { id: "a", label: "Alpha", rank: 2 },
@@ -485,7 +587,7 @@ describe("compiled keyed-array map and reorder hints", () => {
       harness.invalidateKey();
       await flushCompilerUpdates();
     });
-    expect(labels(container)).toEqual(["Replacement:1", "Custom:2"]);
+    expect(labels(container)).toEqual(["Custom:2", "Replacement:1"]);
   });
 
   it("discards earlier map lineage when a later map method is custom", async () => {
@@ -525,7 +627,7 @@ describe("compiled keyed-array map and reorder hints", () => {
     harness.counters.bindings = 0;
 
     await act(async () => {
-      harness.editTwiceAndSort("a", 3, "Alpha subclass");
+      harness.editTwiceAndReverse("a", 3, "Alpha subclass");
       await flushCompilerUpdates();
     });
 
@@ -592,7 +694,13 @@ describe("compiled keyed-array map and reorder hints", () => {
       render(_props: Record<string, never>, state, blocks) {
         const items = () => state[0].get() as Item[];
         update = () =>
-          state[0].set((previous) => mappedSort(previous as Item[], "b", 5, "Beta newest"));
+          state[0].set((previous) =>
+            hintedReverse(
+              hintedMap(previous as Item[], (item) =>
+                item.id === "a" ? { ...item, label: "Alpha newest" } : item,
+              ),
+            ),
+          );
         return (
           <section>
             <blocks.KeyedRows
@@ -640,7 +748,7 @@ describe("compiled keyed-array map and reorder hints", () => {
     const root = createRoot(container);
     roots.push(root);
     await act(async () => root.render(<Form />));
-    const input = container.querySelector('[data-key="b"]') as HTMLInputElement;
+    const input = container.querySelector('[data-key="a"]') as HTMLInputElement;
     input.focus();
     input.setSelectionRange(1, 3);
 
@@ -649,8 +757,8 @@ describe("compiled keyed-array map and reorder hints", () => {
       await flushCompilerUpdates();
     });
 
-    expect(container.querySelector('[data-key="b"]')).toBe(input);
-    expect(input.value).toBe("Beta newest");
+    expect(container.querySelector('[data-key="a"]')).toBe(input);
+    expect(input.value).toBe("Alpha newest");
     expect(document.activeElement).toBe(input);
     expect([input.selectionStart, input.selectionEnd]).toEqual([1, 3]);
   });
@@ -669,7 +777,13 @@ describe("compiled keyed-array map and reorder hints", () => {
       render(_props: Record<string, never>, state, blocks) {
         const items = () => state[0].get() as Item[];
         update = () =>
-          state[0].set((previous) => mappedSort(previous as Item[], "b", 0, "Beta newest"));
+          state[0].set((previous) =>
+            hintedReverse(
+              hintedMap(previous as Item[], (item) =>
+                item.id === "b" ? { ...item, rank: 0, label: "Beta newest" } : item,
+              ),
+            ),
+          );
         return (
           <section>
             <blocks.KeyedRows
@@ -814,6 +928,63 @@ describe("compiled keyed-array map and reorder hints", () => {
     120_000,
   );
 
+  stressIt(
+    "matches React through 2,000 deterministic mapped reversals",
+    async () => {
+      const initialItems = Array.from(
+        { length: 31 },
+        (_, index): Item => ({ id: `row-${index}`, label: `Row ${index}`, rank: index }),
+      );
+      const harness = createHarness(initialItems);
+      let updateReact: (id: string, rank: number, label: string) => void = () => undefined;
+      function Normal() {
+        const [items, setItems] = useState(initialItems);
+        updateReact = (id, rank, label) =>
+          setItems((previous) =>
+            previous
+              .map((item) => (item.id === id ? { ...item, label } : item))
+              .map((item) => (item.id === id ? { ...item, rank } : item))
+              .toReversed(),
+          );
+        return (
+          <ol>
+            {items.map((item) => (
+              <li data-key={item.id} key={item.id}>
+                {item.label}:{item.rank}
+              </li>
+            ))}
+          </ol>
+        );
+      }
+      const compiledContainer = document.createElement("div");
+      const reactContainer = document.createElement("div");
+      document.body.append(compiledContainer, reactContainer);
+      const compiledRoot = createRoot(compiledContainer);
+      const reactRoot = createRoot(reactContainer);
+      roots.push(compiledRoot, reactRoot);
+      await act(async () => {
+        compiledRoot.render(<harness.Table />);
+        reactRoot.render(<Normal />);
+      });
+
+      let seed = 0x1b873593;
+      for (let update = 0; update < 2_000; update += 1) {
+        seed = (Math.imul(seed, 1_664_525) + 1_013_904_223) >>> 0;
+        const id = `row-${seed % initialItems.length}`;
+        const rank = (seed ^ (seed >>> 16)) % 4_003;
+        const label = `Reversed ${update}`;
+        await act(async () => {
+          harness.editTwiceAndReverse(id, rank, label);
+          updateReact(id, rank, label);
+          await flushCompilerUpdates();
+        });
+        expect(labels(compiledContainer)).toEqual(labels(reactContainer));
+      }
+      expect(harness.counters.executions).toBe(1);
+    },
+    120_000,
+  );
+
   it("hydrates in StrictMode and drops a queued update after unmount", async () => {
     const initialItems: Item[] = [
       { id: "a", label: "Alpha", rank: 1 },
@@ -837,10 +1008,10 @@ describe("compiled keyed-array map and reorder hints", () => {
     });
     roots.push(root);
     await act(async () => {
-      hydration.editTwiceAndSort("a", 5, "Alpha hydrated");
+      hydration.editTwiceAndReverse("a", 5, "Alpha hydrated");
       await flushCompilerUpdates();
     });
-    expect(labels(container)).toEqual(["Beta:2", "Gamma:3", "Alpha hydrated:5"]);
+    expect(labels(container)).toEqual(["Gamma:3", "Beta:2", "Alpha hydrated:5"]);
     expect(recoverable).toEqual([]);
 
     const unmounted = createHarness(initialItems);
@@ -849,7 +1020,7 @@ describe("compiled keyed-array map and reorder hints", () => {
     const unmountRoot = createRoot(unmountContainer);
     await act(async () => unmountRoot.render(<unmounted.Table />));
     act(() => {
-      unmounted.editAndSort("b", 8, "Never committed");
+      unmounted.editTwiceAndReverse("b", 8, "Never committed");
       unmountRoot.unmount();
     });
     await flushCompilerUpdates();

--- a/packages/farm-react/src/compiler-runtime.tsx
+++ b/packages/farm-react/src/compiler-runtime.tsx
@@ -82,6 +82,8 @@ interface CompilerKeyedArrayReorderHint {
 }
 
 interface CompilerKeyedArrayMapPipelineHint {
+  /** True while every map preserves the committed row order. */
+  readonly ordered: boolean;
   readonly sourceToken: object;
   readonly sourceLength: number;
   readonly resultLength: number;
@@ -688,6 +690,7 @@ function recordCompilerKeyedArrayMapPipeline(previous: unknown, value: unknown):
       if (!Object.is(mappedItem, sourceItem)) mappedItemSources.set(mappedItem, sourceItem);
     }
     COMPILER_KEYED_ARRAY_MAP_PIPELINES.set(valueTarget, {
+      ordered: previousMapPipeline?.ordered ?? committedSource,
       sourceToken,
       sourceLength: previousSource?.sourceLength ?? previous.length,
       resultLength: value.length,
@@ -771,7 +774,7 @@ export function createCompilerKeyedArrayMapReorder(
     const source = mapPipeline || (previousReorder?.mapped ? previousReorder : undefined);
     if (!source || source.resultLength !== previous.length) return value;
     COMPILER_KEYED_ARRAY_REORDERS.set(valueTarget, {
-      kind: "permutation",
+      kind: method === NATIVE_ARRAY_TO_REVERSED && mapPipeline?.ordered ? "reverse" : "permutation",
       sourceToken: source.sourceToken,
       sourceLength: source.sourceLength,
       resultLength: value.length,
@@ -4599,8 +4602,7 @@ function reorderCompilerKeyedRows(
   sequence: readonly number[],
   anchor: ChildNode | null,
 ): void {
-  const activeElement = root.ownerDocument.activeElement;
-  const restoreFocus = Boolean(activeElement && root.contains(activeElement));
+  const activeElement = compilerFocusedElement(root);
   const stablePositions = longestIncreasingSubsequencePositions(sequence);
   for (let index = instances.length - 1; index >= 0; index -= 1) {
     const instance = instances[index];
@@ -4621,14 +4623,37 @@ function reorderCompilerKeyedRows(
       anchor = instance.element;
     }
   }
+  restoreCompilerFocus(activeElement);
+}
+
+function compilerFocusedElement(root: Element): Element | null {
+  const activeElement = root.ownerDocument.activeElement;
+  return activeElement && root.contains(activeElement) ? activeElement : null;
+}
+
+function restoreCompilerFocus(activeElement: Element | null): void {
   if (
-    restoreFocus &&
     activeElement?.isConnected &&
     activeElement.ownerDocument.activeElement !== activeElement &&
     "focus" in activeElement
   ) {
     (activeElement as HTMLElement).focus({ preventScroll: true });
   }
+}
+
+function reverseCompilerKeyedRows(root: Element, instances: CompilerKeyedRowInstance[]): void {
+  const activeElement = compilerFocusedElement(root);
+  let anchor = instances[0]?.element || null;
+  for (let sourceIndex = 1; sourceIndex < instances.length; sourceIndex += 1) {
+    const element = instances[sourceIndex].element;
+    root.insertBefore(element, anchor);
+    anchor = element;
+  }
+  instances.reverse();
+  for (let index = 0; index < instances.length; index += 1) {
+    instances[index].index = index;
+  }
+  restoreCompilerFocus(activeElement);
 }
 
 type RowConditionalRefresh = (item: unknown, index: number, afterCommit?: () => void) => void;
@@ -4926,40 +4951,56 @@ function reconcileCompilerKeyedArrayMapReorder(
 
   const previousInstances = [...instances.values()];
   const prepared = (() => {
+    const reverse = update.kind === "reverse";
+    const changed: Array<{
+      bindingUpdates: CompilerPreparedKeyedRowBindingUpdate[];
+      instance: CompilerKeyedRowInstance;
+      item: unknown;
+    }> = [];
     try {
-      const instancesByItem = new Map<unknown, CompilerKeyedRowInstance>();
-      for (let sourceIndex = 0; sourceIndex < previousInstances.length; sourceIndex += 1) {
-        const instance = previousInstances[sourceIndex];
-        if (instance.index !== sourceIndex || instancesByItem.has(instance.item)) return undefined;
-        instancesByItem.set(instance.item, instance);
-      }
-
-      const nextInstances: CompilerKeyedRowInstance[] = [];
-      const sequence: number[] = [];
-      const changed: Array<{
-        bindingUpdates: CompilerPreparedKeyedRowBindingUpdate[];
-        instance: CompilerKeyedRowInstance;
-        item: unknown;
-        index: number;
-      }> = [];
-      for (let targetIndex = 0; targetIndex < finalValue.length; targetIndex += 1) {
-        const item = finalValue[targetIndex];
-        const sourceItem = update.mappedItemSources.has(item)
-          ? update.mappedItemSources.get(item)
-          : item;
-        const instance = instancesByItem.get(sourceItem);
-        if (!instance) return undefined;
-        instancesByItem.delete(sourceItem);
-        nextInstances.push(instance);
-        sequence.push(instance.index);
-        if (!Object.is(instance.item, item)) {
-          if (keyedRowIdentity(props.rowKey(item, targetIndex)) !== instance.key) return undefined;
-          const bindingUpdates = prepareKeyedRowBindingUpdates(props, instance, item, targetIndex);
-          if (!bindingUpdates) return undefined;
-          changed.push({ bindingUpdates, instance, item, index: targetIndex });
+      const instancesByItem = reverse ? undefined : new Map<unknown, CompilerKeyedRowInstance>();
+      if (instancesByItem) {
+        for (let sourceIndex = 0; sourceIndex < previousInstances.length; sourceIndex += 1) {
+          const instance = previousInstances[sourceIndex];
+          if (instance.index !== sourceIndex || instancesByItem.has(instance.item))
+            return undefined;
+          instancesByItem.set(instance.item, instance);
         }
       }
-      if (instancesByItem.size > 0) return undefined;
+
+      const nextInstances: CompilerKeyedRowInstance[] = reverse ? previousInstances : [];
+      const sequence: number[] | undefined = reverse ? undefined : [];
+      for (let targetIndex = 0; targetIndex < finalValue.length; targetIndex += 1) {
+        const item = finalValue[targetIndex];
+        let instance: CompilerKeyedRowInstance | undefined;
+        if (reverse) {
+          const sourceIndex = finalValue.length - targetIndex - 1;
+          instance = previousInstances[sourceIndex];
+          if (!instance || instance.index !== sourceIndex) return undefined;
+          if (Object.is(instance.item, item)) continue;
+          if (
+            !update.mappedItemSources.has(item) ||
+            !Object.is(instance.item, update.mappedItemSources.get(item))
+          ) {
+            return undefined;
+          }
+        } else {
+          const sourceItem = update.mappedItemSources.has(item)
+            ? update.mappedItemSources.get(item)
+            : item;
+          instance = instancesByItem!.get(sourceItem);
+          if (!instance) return undefined;
+          instancesByItem!.delete(sourceItem);
+          nextInstances.push(instance);
+          sequence!.push(instance.index);
+          if (Object.is(instance.item, item)) continue;
+        }
+        if (keyedRowIdentity(props.rowKey(item, targetIndex)) !== instance.key) return undefined;
+        const bindingUpdates = prepareKeyedRowBindingUpdates(props, instance, item, targetIndex);
+        if (!bindingUpdates) return undefined;
+        changed.push({ bindingUpdates, instance, item });
+      }
+      if (instancesByItem?.size) return undefined;
       return { changed, nextInstances, sequence };
     } catch {
       return undefined;
@@ -4967,11 +5008,14 @@ function reconcileCompilerKeyedArrayMapReorder(
   })();
   if (!prepared) return undefined;
 
-  reorderCompilerKeyedRows(root, prepared.nextInstances, prepared.sequence, null);
-  for (const { bindingUpdates, instance, item, index } of prepared.changed) {
+  if (prepared.sequence) {
+    reorderCompilerKeyedRows(root, prepared.nextInstances, prepared.sequence, null);
+  } else {
+    reverseCompilerKeyedRows(root, prepared.nextInstances);
+  }
+  for (const { bindingUpdates, instance, item } of prepared.changed) {
     applyPreparedKeyedRowBindingUpdates(props, instance, bindingUpdates);
     instance.item = item;
-    instance.index = index;
   }
   for (let index = 0; index < prepared.nextInstances.length; index += 1) {
     prepared.nextInstances[index].index = index;
@@ -5948,25 +5992,9 @@ function reconcileCompilerKeyedArrayReorder(
       }
       if (instancesByItem.size > 0) return undefined;
 
-      const activeElement = root.ownerDocument.activeElement;
-      const restoreFocus = Boolean(activeElement && root.contains(activeElement));
-      const stablePositions = longestIncreasingSubsequencePositions(sequence);
-      let anchor: ChildNode | null = null;
-      for (let index = nextInstances.length - 1; index >= 0; index -= 1) {
-        const instance = nextInstances[index];
-        if (!stablePositions.has(index) && instance.element.nextSibling !== anchor) {
-          root.insertBefore(instance.element, anchor);
-        }
-        anchor = instance.element;
-        instance.index = index;
-      }
-      if (
-        restoreFocus &&
-        activeElement?.isConnected &&
-        activeElement.ownerDocument.activeElement !== activeElement &&
-        "focus" in activeElement
-      ) {
-        (activeElement as HTMLElement).focus({ preventScroll: true });
+      reorderCompilerKeyedRows(root, nextInstances, sequence, null);
+      for (let index = 0; index < nextInstances.length; index += 1) {
+        nextInstances[index].index = index;
       }
       return new Map(nextInstances.map((instance) => [instance.key, instance]));
     } catch {
@@ -5986,30 +6014,10 @@ function reconcileCompilerKeyedArrayReorder(
     return undefined;
   }
 
-  const activeElement = root.ownerDocument.activeElement;
-  const restoreFocus = Boolean(activeElement && root.contains(activeElement));
   // A reverse has a one-row LIS. Keep the first committed row in place and
   // move every following row before the previous anchor, which performs the
   // minimum n - 1 connected DOM moves without rescanning keys or descriptors.
-  let anchor = previousInstances[0]?.element || null;
-  for (let sourceIndex = 1; sourceIndex < previousInstances.length; sourceIndex += 1) {
-    const element = previousInstances[sourceIndex].element;
-    root.insertBefore(element, anchor);
-    anchor = element;
-  }
-
-  previousInstances.reverse();
-  for (let index = 0; index < previousInstances.length; index += 1) {
-    previousInstances[index].index = index;
-  }
-  if (
-    restoreFocus &&
-    activeElement?.isConnected &&
-    activeElement.ownerDocument.activeElement !== activeElement &&
-    "focus" in activeElement
-  ) {
-    (activeElement as HTMLElement).focus({ preventScroll: true });
-  }
+  reverseCompilerKeyedRows(root, previousInstances);
   return new Map(previousInstances.map((instance) => [instance.key, instance]));
 }
 

--- a/packages/farm-react/vitest.stress.config.ts
+++ b/packages/farm-react/vitest.stress.config.ts
@@ -20,7 +20,7 @@ export default defineConfig({
     ],
     setupFiles: ["src/__tests__/stress.setup.ts"],
     testNamePattern:
-      /2,000 deterministic mapped reorder updates|3,000 deterministic recursive updates|4,096 rows/,
+      /2,000 deterministic mapped reorder updates|2,000 deterministic mapped reversals|3,000 deterministic recursive updates|4,096 rows/,
     testTimeout: 30_000,
   },
 });


### PR DESCRIPTION
## Problem

A compiler-proven same-key `map()` pipeline followed by `toReversed()` was recorded as an arbitrary permutation. Runtime reconciliation therefore allocated a source-item lookup map and ran LIS even though the final order was known exactly at build time.

On a 10,000-row reversal, both the generic and specialized paths must perform the same 9,999 connected DOM moves, so the remaining opportunity is to remove unnecessary reconciliation bookkeeping without weakening React semantics.

## Root cause

Mapped reorder metadata retained item lineage but did not distinguish pipelines that still matched committed row order from pipelines composed after a sort or another uncommitted reorder. The runtime consequently could not safely select the existing exact-reverse algorithm.

## Change

- Track whether a compiler-proven map pipeline preserves committed row order.
- Mark a direct native `toReversed()` suffix as an exact reverse only for that ordered lineage.
- Validate every mirrored row and changed replacement before the first DOM write.
- Reuse the minimum-move reverse helper, skip the temporary source-item map and LIS pass, and avoid lineage lookups for unchanged rows.
- Keep general mapped permutations on the existing source-map and LIS path.
- Add a 10,000-row dashboard benchmark, regression gate, executable control, documentation, and recorded results.

## Safety and compatibility

- A preceding sort, a map after a queued reorder, or ambiguous lineage remains on general reconciliation.
- Changed keys, custom methods, Array subclasses, sparse or accessor-backed arrays, unsupported ownership, and failed validation fall back before compiler DOM mutation.
- DOM identity, focus, controlled-input selection, delegated event indexes, hydration, Strict Mode, unmount cleanup, native evaluation order, and native errors remain covered.
- React 18.3.1 and React 19.2.8 compatibility passed.
- There is no public API or observability-counter change. The optimization remains inside the optional React compiler runtime.

## Verification

- `pnpm --filter @farm.js/react test` — passed before the final conflict-free rebase: 693 ordinary tests passed, then 5 serial stress tests passed.
- `pnpm --filter @farm.js/react exec vitest run src/__tests__/compiler-keyed-array-sort-hints.test.ts src/__tests__/compiler-runtime-keyed-array-map-reorder-hints.test.tsx` — 50 passed after rebase.
- `pnpm --filter @farm.js/react test:stress` — 5 passed after rebase, including 2,000 mapped reorder updates, 2,000 mapped reversals, and 4,096-row minimum-move controls.
- `pnpm --filter @farm.js/react type-check`
- `pnpm --filter @farm.js/react test:compat`
- `pnpm --filter @farm.js/react build`
- Node 22.13.1 runtime-size check — keyed map/reorder premium is 13,378 B gzip, 12 B below current main and 21 B below the persisted ceiling.
- `pnpm --dir examples/react-compiler-dashboard type-check`
- Full dashboard benchmark — correctness, performance, optimization-persistence, and all existing gates passed.
- `pnpm docs:check-navigation`
- `pnpm --dir docs exec farm generate --check`
- `pnpm docs:build` — Vercel/Nitro production output passed.

The post-rebase full parallel package rerun also surfaced two unrelated existing failures: one timeout that passed immediately in isolation, and the deterministic keyed-filter `NotFoundError`, which reproduces unchanged on current `origin/main`. No timeout or unrelated test was changed in this PR.

Local 10,000-row benchmark medians:

| Mode | General path before | Exact reverse | Compiled control | vs React | vs control |
| --- | ---: | ---: | ---: | ---: | ---: |
| Static | 24.70 ms | 24.60 ms | 35.30 ms | 11.48x | 1.43x |
| Hybrid | 25.80 ms | 24.60 ms | 37.00 ms | 11.48x | 1.50x |

The complete compiler chunk decreased from 26,919 B to 26,903 B gzip. Compiler-off remained 6,480 B gzip.

## Documentation and release

- Expanded the React experimental compiler documentation and package README.
- Extended the maintained React compiler dashboard example and benchmark gate.
- Recorded methodology, safety controls, environment, and before/after results.
- No version bump or release-flow change.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Specializes compiler-proven `map()` pipelines followed by `toReversed()` to the exact minimum-move reverse path instead of treating them as generic permutations, so reconciliation no longer allocates a source-item lookup map or runs LIS. Pipelines with ambiguous or unsafe lineage keep the existing general behavior.

**What changed**
- Tracks whether a map pipeline preserves committed row order and marks a direct `toReversed()` suffix as a reverse only for that ordered lineage.
- Validates every mirrored row and changed replacement before the first DOM write.
- Reuses the minimum-move reverse helper and skips lineage lookups for unchanged rows.

**Safety and verification**
- Preceding sorts, maps after queued reorders, changed keys, custom methods, Array subclasses, sparse or accessor-backed arrays, and failed validation fall back before DOM mutation.
- Added a 10,000-row dashboard benchmark and regression gate plus a 2,000-iteration deterministic mapped-reversal stress test.
- DOM identity, focus, controlled-input selection, delegated events, hydration, Strict Mode, and unmount cleanup remain covered.

<sup>Written for commit 55464af16dbc865d0a14e443662bae0018e06b93. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/788?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

