### PR TITLE
fix(renderer): settle concurrent renderer actions

### DIFF
--- a/packages/farm/src/__tests__/renderer-client.test.ts
+++ b/packages/farm/src/__tests__/renderer-client.test.ts
@@ -91,6 +91,35 @@ describe("renderer-neutral client primitives", () => {
     expect(ping).toHaveBeenCalledWith(undefined);
   });
 
+  it("settles after an older concurrent action finishes last", async () => {
+    const resolvers = new Map<number, (value: string) => void>();
+    const save = vi.fn(
+      (input: number) =>
+        new Promise<string>((resolve) => {
+          resolvers.set(input, resolve);
+        }),
+    ) as unknown as ServerFn<number, string>;
+    const action = createRendererAction(save);
+
+    const first = action.submit(1);
+    const second = action.submit(2);
+    resolvers.get(2)?.("second");
+    await expect(second).resolves.toBe("second");
+    expect(action.getSnapshot()).toMatchObject({
+      pending: true,
+      status: "pending",
+      data: "second",
+    });
+
+    resolvers.get(1)?.("first");
+    await expect(first).resolves.toBe("first");
+    expect(action.getSnapshot()).toMatchObject({
+      pending: false,
+      status: "success",
+      data: "second",
+    });
+  });
+
   it("shares query cache state and supports forced refetches", async () => {
     let version = 0;
     const query = (async ({ id }: { id: string }) => ({ id, version: ++version })) as ServerQuery<

--- a/packages/farm/src/renderer-client.ts
+++ b/packages/farm/src/renderer-client.ts
@@ -179,6 +179,7 @@ export function createRendererAction<TInput, TResult, TError extends Error = Err
   const initialResult = options.initialResult ?? null;
   let requestId = 0;
   let pendingCount = 0;
+  let latestSettledStatus: FarmActionSnapshot<TResult, TError>["status"] = "idle";
   let snapshot: FarmActionSnapshot<TResult, TError> = {
     pending: false,
     status: "idle",
@@ -215,6 +216,7 @@ export function createRendererAction<TInput, TResult, TError extends Error = Err
         const result = await serverFn(input as TInput | FormData);
         pendingCount = Math.max(0, pendingCount - 1);
         if (currentRequest === requestId) {
+          latestSettledStatus = "success";
           update({
             pending: pendingCount > 0,
             status: pendingCount > 0 ? "pending" : "success",
@@ -223,12 +225,15 @@ export function createRendererAction<TInput, TResult, TError extends Error = Err
           });
           options.onSuccess?.(result);
           options.onSettled?.(result, null);
+        } else if (pendingCount === 0) {
+          update({ ...snapshot, pending: false, status: latestSettledStatus });
         }
         return result;
       } catch (cause) {
         pendingCount = Math.max(0, pendingCount - 1);
         const error = normalizeRendererClientError(cause) as TError;
         if (currentRequest === requestId) {
+          latestSettledStatus = "error";
           update({
             pending: pendingCount > 0,
             status: pendingCount > 0 ? "pending" : "error",
@@ -242,6 +247,8 @@ export function createRendererAction<TInput, TResult, TError extends Error = Err
           });
           options.onError?.(error);
           options.onSettled?.(null, error);
+        } else if (pendingCount === 0) {
+          update({ ...snapshot, pending: false, status: latestSettledStatus });
         }
         throw error;
       }
@@ -249,6 +256,7 @@ export function createRendererAction<TInput, TResult, TError extends Error = Err
     reset() {
       requestId += 1;
       pendingCount = 0;
+      latestSettledStatus = "idle";
       update({ pending: false, status: "idle", data: initialResult, error: null });
     },
   } as FarmAction<TInput, TResult, TError>;


### PR DESCRIPTION
## Problem

Renderer-neutral actions can remain permanently `pending` when an older request settles after the newer request. Vue, Solid, and Svelte bindings all consume this shared primitive.

## Root cause

Every completion decrements `pendingCount`, but stale completions publish no snapshot. If the latest request finishes while an older request remains, its snapshot stays `pending`; the final stale completion reaches zero without notifying subscribers.

## Change

Remember the latest request's terminal status and publish a final non-pending snapshot when the last stale request settles. Latest-result data and callback behavior remain unchanged.

## Safety and compatibility

The latest request still owns data, errors, and callbacks. Older requests only clear aggregate pending state. Reset continues to invalidate in-flight requests and now also resets the remembered terminal status.

## Verification

- `pnpm --filter @farm.js/core test -- renderer-client.test.ts`
- `pnpm --filter @farm.js/core type-check`
- Regression coverage completes two requests out of order and fails on current `main` because the action remains pending.

## Documentation and release

None.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes concurrent renderer actions so they settle even when an older request finishes after a newer one. Previously, stale completions didn't publish a snapshot, leaving pending status stuck. Now the latest request's terminal status is remembered and published when the last stale request settles. Latest-result data and callbacks remain unchanged; reset also clears the remembered status.

<sup>Written for commit 01e2eeb00b62ebb684b3450a8b8792e186899b8e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/789?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

