### PR TITLE
fix(preview): preserve redirects in polling transport

### DIFF
--- a/packages/farm-cli/src/preview-gateway.ts
+++ b/packages/farm-cli/src/preview-gateway.ts
@@ -270,6 +270,7 @@ export async function forwardGatewayRequest(
     body: hasBody
       ? Buffer.from(request.body || "", request.encoding === "base64" ? "base64" : "utf8")
       : undefined,
+    redirect: "manual",
   });
 
   const responseHeaders: Record<string, string | string[]> = {};

--- a/packages/farm-cli/test/preview.test.mjs
+++ b/packages/farm-cli/test/preview.test.mjs
@@ -205,6 +205,38 @@ test("forwards a gateway request to the local target", async () => {
   }
 });
 
+test("forwards local redirects without following them", async () => {
+  const server = await createTestServer((req, res) => {
+    if (req.url === "/redirect") {
+      res.writeHead(302, { location: "/destination" });
+      res.end();
+      return;
+    }
+    res.end("destination");
+  });
+
+  try {
+    const response = await forwardGatewayRequest(
+      {
+        localUrl: `http://localhost:${server.port}`,
+        host: "localhost",
+        port: server.port,
+        source: "port",
+      },
+      {
+        id: "req_redirect",
+        method: "GET",
+        path: "/redirect",
+      },
+    );
+
+    assert.equal(response.status, 302);
+    assert.equal(response.headers.location, "/destination");
+  } finally {
+    await server.close();
+  }
+});
+
 test("closes the gateway session when the local target stops", async () => {
   const app = await createTestServer();
   const gateway = await createPreviewGatewayTestServer();


### PR DESCRIPTION
## Problem

The compatibility polling transport follows redirects returned by the local Farm app. Remote browsers receive the redirect destination as a `200` response instead of the original `3xx` status and `Location` header.

## Root cause

`forwardGatewayRequest` used Fetch's default `follow` redirect mode. The native preview transport already forwards redirects manually.

## Change

Use `redirect: "manual"` for compatibility forwarding and cover the status/header behavior with a local HTTP regression test.

## Safety and compatibility

Non-redirect responses are unchanged. Redirect handling now matches the native transport and ordinary reverse-proxy semantics.

## Verification

- `pnpm --filter @farm.js/cli test`
- `pnpm --filter @farm.js/cli type-check`
- The regression test fails on `main` with status `200` and no `Location` header.

## Documentation and release

None.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves redirects in the polling transport so remote browsers receive the original 3xx status and `Location` header instead of the followed redirect destination.

- Sets `redirect: "manual"` on compatibility forwarding, matching the native preview transport's behavior.
- Adds a regression test verifying 302 responses and `Location` headers are preserved.
- Non-redirect responses are unchanged.

<sup>Written for commit 2b179d4e173a047a6ceac1b91e33f82187bf5acc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/790?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

