### PR TITLE
fix(preview): remove stale content encoding

### DIFF
--- a/packages/farm-cli/src/preview-gateway.ts
+++ b/packages/farm-cli/src/preview-gateway.ts
@@ -278,7 +278,11 @@ export async function forwardGatewayRequest(
     const normalized = key.toLowerCase();
     // Set-Cookie is collected separately: Headers.forEach folds repeated
     // headers into one comma-joined value, which corrupts multiple cookies.
-    if (!HOP_BY_HOP_HEADERS.has(normalized) && normalized !== "set-cookie") {
+    if (
+      !HOP_BY_HOP_HEADERS.has(normalized) &&
+      normalized !== "content-encoding" &&
+      normalized !== "set-cookie"
+    ) {
       responseHeaders[key] = value;
     }
   });

--- a/packages/farm-cli/test/preview.test.mjs
+++ b/packages/farm-cli/test/preview.test.mjs
@@ -6,6 +6,7 @@ import path from "node:path";
 import test from "node:test";
 import { promisify } from "node:util";
 import { fileURLToPath } from "node:url";
+import { gzipSync } from "node:zlib";
 
 const require = createRequire(import.meta.url);
 const {
@@ -232,6 +233,38 @@ test("forwards local redirects without following them", async () => {
 
     assert.equal(response.status, 302);
     assert.equal(response.headers.location, "/destination");
+  } finally {
+    await server.close();
+  }
+});
+
+test("removes content encoding after fetch decodes a local response", async () => {
+  const body = gzipSync("compressed response");
+  const server = await createTestServer((_req, res) => {
+    res.writeHead(200, {
+      "content-encoding": "gzip",
+      "content-length": body.byteLength,
+    });
+    res.end(body);
+  });
+
+  try {
+    const response = await forwardGatewayRequest(
+      {
+        localUrl: `http://localhost:${server.port}`,
+        host: "localhost",
+        port: server.port,
+        source: "port",
+      },
+      {
+        id: "req_gzip",
+        method: "GET",
+        path: "/compressed",
+      },
+    );
+
+    assert.equal(response.headers["content-encoding"], undefined);
+    assert.equal(Buffer.from(response.body, "base64").toString(), "compressed response");
   } finally {
     await server.close();
   }


### PR DESCRIPTION
## Problem

Compressed responses forwarded through compatibility gateway polling can reach the browser with decoded bytes and the original `Content-Encoding` header. The browser then attempts to decode the already-decoded body.

## Root cause

Node Fetch transparently decodes the local response body, while the polling forwarder copied `Content-Encoding`. The native transport already removes this stale header.

## Change

Exclude `Content-Encoding` from polling response headers and add a gzip regression test that verifies the forwarded bytes and headers.

## Safety and compatibility

Uncompressed responses are unchanged. Polling behavior now matches the native preview transport.

## Verification

- `pnpm --filter @farm.js/cli test`
- `pnpm --filter @farm.js/cli type-check`
- The regression test fails on `main` because the decoded response retains `content-encoding: gzip`.

## Documentation and release

None.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the preview polling forwarder so the browser no longer tries to decode an already-decoded response body. Node Fetch transparently decodes local responses, but the forwarder was copying the stale `Content-Encoding` header; polling now matches the native preview transport.

- Excludes `Content-Encoding` from forwarded polling response headers.
- Adds a gzip regression test that verifies the forwarded bytes and headers.
- Uncompressed responses are unchanged.

<sup>Written for commit f33ef384031e8d15d241c55586f73de5ecdc3a96. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/791?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

