### PR TITLE
fix(preview): bound local request forwarding

### DIFF
--- a/packages/farm-cli/src/preview-gateway.ts
+++ b/packages/farm-cli/src/preview-gateway.ts
@@ -43,6 +43,11 @@ export interface RunPreviewGatewayOptions {
   localProbeTimeoutMs?: number;
   maxRequests?: number;
   maxConcurrentRequests?: number;
+  requestTimeoutMs?: number;
+}
+
+export interface ForwardGatewayRequestOptions {
+  signal?: AbortSignal;
 }
 
 const DEFAULT_GATEWAY_URL = "https://preview.farming-labs.dev";
@@ -51,6 +56,7 @@ const DEFAULT_POLL_TIMEOUT_MS = 15000;
 const DEFAULT_LOCAL_PROBE_INTERVAL_MS = 2000;
 const DEFAULT_LOCAL_PROBE_TIMEOUT_MS = 1000;
 const DEFAULT_MAX_CONCURRENT_REQUESTS = 25;
+const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
 const HOP_BY_HOP_HEADERS = new Set([
   "connection",
   "content-length",
@@ -122,7 +128,12 @@ export async function runPreviewGateway(
     const startedAt = Date.now();
 
     try {
-      const response = await forwardGatewayRequest(plan.target, request);
+      const response = await forwardGatewayRequest(plan.target, request, {
+        signal: AbortSignal.any([
+          controller.signal,
+          AbortSignal.timeout(options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS),
+        ]),
+      });
       await sendGatewayResponse(plan, session, request.id, response, controller.signal);
       handledRequests += 1;
       logger.info(
@@ -250,6 +261,7 @@ function getSetCookies(headers: Headers): string[] {
 export async function forwardGatewayRequest(
   target: PreviewTarget,
   request: PreviewGatewayRequest,
+  options: ForwardGatewayRequestOptions = {},
 ): Promise<PreviewGatewayResponse> {
   const headers = new Headers();
   for (const [key, value] of Object.entries(request.headers || {})) {
@@ -271,6 +283,7 @@ export async function forwardGatewayRequest(
       ? Buffer.from(request.body || "", request.encoding === "base64" ? "base64" : "utf8")
       : undefined,
     redirect: "manual",
+    signal: options.signal,
   });
 
   const responseHeaders: Record<string, string | string[]> = {};

--- a/packages/farm-cli/test/preview.test.mjs
+++ b/packages/farm-cli/test/preview.test.mjs
@@ -270,6 +270,32 @@ test("removes content encoding after fetch decodes a local response", async () =
   }
 });
 
+test("cancels a forwarded local request at its deadline", async () => {
+  const server = await createTestServer(() => undefined);
+
+  try {
+    await assert.rejects(
+      forwardGatewayRequest(
+        {
+          localUrl: `http://localhost:${server.port}`,
+          host: "localhost",
+          port: server.port,
+          source: "port",
+        },
+        {
+          id: "req_timeout",
+          method: "GET",
+          path: "/slow",
+        },
+        { signal: AbortSignal.timeout(20) },
+      ),
+      (error) => error?.name === "TimeoutError",
+    );
+  } finally {
+    await server.close();
+  }
+});
+
 test("closes the gateway session when the local target stops", async () => {
   const app = await createTestServer();
   const gateway = await createPreviewGatewayTestServer();


### PR DESCRIPTION
## Problem

Compatibility preview requests to a local handler can wait forever. Enough hanging handlers exhaust the 25-request concurrency limit and stop the public preview from forwarding any more traffic.

## Root cause

Polling and response uploads use the session abort signal, but the local Fetch call had neither that signal nor a per-request deadline.

## Change

Pass a combined session/deadline signal into every local request. The default request deadline is 30 seconds and can be adjusted through the existing internal gateway options.

## Safety and compatibility

Completed requests are unchanged. Session shutdown now cancels active local fetches, and a stalled handler releases its concurrency slot at the deadline.

## Verification

- `pnpm --dir packages/farm-cli exec tsdown`
- `node --test packages/farm-cli/test/preview.test.mjs`
- `pnpm --filter @farm.js/cli type-check`
- The regression test fails on `main` because `forwardGatewayRequest` cannot be cancelled.

## Documentation and release

None.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds local request forwarding in the preview gateway so stalled handlers release concurrency slots at a deadline, and removes stale `content-encoding` headers from decoded local responses.

- Adds a 30-second default deadline to every local Fetch call, adjustable via `requestTimeoutMs` in gateway options.
- Cancels active local fetches when the session shuts down.
- Drops the `content-encoding` header when `fetch` has already decoded the body.
- Adds regression tests for both the cancellation and the header removal.

<sup>Written for commit 94c2d62519bd787fb2c8c20e5e6ab39ec2ff779f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/792?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

