### PR TITLE
fix(preview): isolate forwarded request failures

### DIFF
--- a/packages/farm-cli/src/preview-gateway.ts
+++ b/packages/farm-cli/src/preview-gateway.ts
@@ -126,14 +126,21 @@ export async function runPreviewGateway(
 
   const handleRequest = async (request: PreviewGatewayRequest) => {
     const startedAt = Date.now();
+    let response: PreviewGatewayResponse;
 
     try {
-      const response = await forwardGatewayRequest(plan.target, request, {
+      response = await forwardGatewayRequest(plan.target, request, {
         signal: AbortSignal.any([
           controller.signal,
           AbortSignal.timeout(options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS),
         ]),
       });
+    } catch (error) {
+      if (controller.signal.aborted) return;
+      response = createGatewayErrorResponse(error);
+    }
+
+    try {
       await sendGatewayResponse(plan, session, request.id, response, controller.signal);
       handledRequests += 1;
       logger.info(
@@ -142,9 +149,8 @@ export async function runPreviewGateway(
     } catch (error) {
       if (controller.signal.aborted) return;
       logger.warn(
-        `Local preview target ${plan.target.localUrl} is no longer reachable. Closing preview session.`,
+        `Could not return preview response for ${request.method.toUpperCase()} ${formatRequestPath(request.path)}: ${error instanceof Error ? error.message : String(error)}`,
       );
-      controller.abort(error);
     }
   };
 
@@ -397,6 +403,16 @@ function formatRequestPath(path: string) {
   }
 
   return `${path.slice(0, 93)}...`;
+}
+
+function createGatewayErrorResponse(error: unknown): PreviewGatewayResponse {
+  const message = error instanceof Error ? error.message : String(error);
+  return {
+    status: 502,
+    headers: { "content-type": "text/plain; charset=utf-8" },
+    body: Buffer.from(message).toString("base64"),
+    encoding: "base64",
+  };
 }
 
 function normalizeGatewayUrl(value: string) {

--- a/packages/farm-cli/test/preview.test.mjs
+++ b/packages/farm-cli/test/preview.test.mjs
@@ -337,6 +337,48 @@ test("closes the gateway session when the local target stops", async () => {
   }
 });
 
+test("keeps the gateway session alive after one local request fails", async () => {
+  const app = await createTestServer((req, res) => {
+    if (req.url === "/fail") {
+      req.socket.destroy();
+      return;
+    }
+    res.end("ok");
+  });
+  const gateway = await createQueuedPreviewGatewayTestServer([
+    { id: "req_fail", method: "GET", path: "/fail" },
+    { id: "req_ok", method: "GET", path: "/ok" },
+  ]);
+  const plan = createPreviewGatewayPlan(
+    {
+      localUrl: `http://localhost:${app.port}`,
+      host: "localhost",
+      port: app.port,
+      source: "port",
+    },
+    { gatewayUrl: gateway.url, name: "request-isolation" },
+  );
+
+  try {
+    await runPreviewGateway(plan, {
+      maxRequests: 2,
+      pollTimeoutMs: 10,
+      localProbeIntervalMs: 1_000,
+    });
+
+    assert.deepEqual(
+      gateway.responses.map(({ requestId, response }) => [requestId, response.status]),
+      [
+        ["req_fail", 502],
+        ["req_ok", 200],
+      ],
+    );
+  } finally {
+    await app.close();
+    await gateway.close();
+  }
+});
+
 test("falls back to gateway polling while the hosted native relay is unavailable", async () => {
   const app = await createTestServer();
   const gateway = await createPreviewGatewayTestServer();
@@ -517,6 +559,57 @@ async function createPreviewGatewayTestServer() {
       new Promise((resolve, reject) => {
         server.close((error) => (error ? reject(error) : resolve()));
       }),
+  };
+}
+
+async function createQueuedPreviewGatewayTestServer(requests) {
+  const queued = [...requests];
+  const responses = [];
+  const server = await createTestServer(async (req, res) => {
+    const url = new URL(req.url || "/", "http://localhost");
+
+    if (req.method === "POST" && url.pathname === "/api/sessions") {
+      await readRequestBody(req);
+      res.setHeader("content-type", "application/json");
+      res.end(
+        JSON.stringify({
+          id: "sess_queue",
+          name: "request-isolation",
+          token: "token_queue",
+          publicUrl: "https://request-isolation.preview.farming-labs.dev",
+        }),
+      );
+      return;
+    }
+
+    if (req.method === "GET" && url.pathname === "/api/sessions/sess_queue/requests") {
+      res.setHeader("content-type", "application/json");
+      res.end(JSON.stringify({ requests: queued.length ? [queued.shift()] : [] }));
+      return;
+    }
+
+    if (req.method === "POST" && url.pathname.startsWith("/api/sessions/sess_queue/responses/")) {
+      responses.push({
+        requestId: url.pathname.split("/").pop(),
+        response: JSON.parse(await readRequestBody(req)),
+      });
+      res.end("ok");
+      return;
+    }
+
+    if (req.method === "DELETE" && url.pathname === "/api/sessions/sess_queue") {
+      res.end("ok");
+      return;
+    }
+
+    res.statusCode = 404;
+    res.end("not found");
+  });
+
+  return {
+    url: `http://localhost:${server.port}`,
+    responses,
+    close: server.close,
   };
 }
 


### PR DESCRIPTION
## Problem

One failed local route request closes the entire compatibility preview session, interrupting unrelated users and requests.

## Root cause

The per-request handler aborts the session controller for every forwarding or response-upload exception. This conflates one request failure with the separate local-target health lifecycle.

## Change

Translate local forwarding failures into a `502` response for that request and keep polling. Log response-upload failures without terminating the session; the existing health watcher remains responsible for closing a genuinely stopped local target.

## Safety and compatibility

Successful responses are unchanged. Failure handling now matches the native tunnel's per-request isolation, while session shutdown still cancels in-flight work.

## Verification

- `pnpm --dir packages/farm-cli exec tsdown`
- `node --test packages/farm-cli/test/preview.test.mjs`
- `pnpm --filter @farm.js/cli type-check`
- The regression test sends a connection-reset request followed by a successful request through the same session. It fails on `main` because the first failure aborts the session.

## Documentation and release

None.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the compatibility preview session so a single failed local request no longer closes the session for everyone. Failed forwarding now returns a `502` for that request, and response-upload failures are logged without aborting; the health watcher still closes the session when the local target is genuinely stopped.

- Bounds each forwarded request with a 30-second timeout that cancels the request.
- Strips `content-encoding` headers because `fetch` decodes the response body.
- Adds a regression test that sends a connection-reset request followed by a successful request through the same session.

<sup>Written for commit db829b3548ddd54c70ae5d0f273c8cd273e8c32f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/793?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

