### PR TITLE
fix(preview): cancel health probe responses

### DIFF
--- a/packages/farm-cli/src/preview-gateway.ts
+++ b/packages/farm-cli/src/preview-gateway.ts
@@ -218,10 +218,11 @@ async function isLocalPreviewTargetReachable(url: string, timeoutMs: number) {
   const signal = AbortSignal.timeout(timeoutMs);
 
   try {
-    await fetch(url, {
+    const response = await fetch(url, {
       method: "GET",
       signal,
     });
+    await response.body?.cancel();
     return true;
   } catch {
     return false;

--- a/packages/farm-cli/test/preview.test.mjs
+++ b/packages/farm-cli/test/preview.test.mjs
@@ -379,6 +379,41 @@ test("keeps the gateway session alive after one local request fails", async () =
   }
 });
 
+test("cancels streaming local health probe responses", async () => {
+  const app = await createStreamingTestServer();
+  const gateway = await createPreviewGatewayTestServer();
+  const plan = createPreviewGatewayPlan(
+    {
+      localUrl: `http://localhost:${app.port}`,
+      host: "localhost",
+      port: app.port,
+      source: "port",
+    },
+    { gatewayUrl: gateway.url, name: "probe-cleanup" },
+  );
+
+  try {
+    const preview = runPreviewGateway(plan, {
+      pollTimeoutMs: 25,
+      localProbeIntervalMs: 20,
+      localProbeTimeoutMs: 200,
+    });
+
+    await gateway.waitForSession();
+    await Promise.race([
+      app.waitForCancellation(),
+      new Promise((_, reject) =>
+        setTimeout(() => reject(new Error("streaming health probe was not cancelled")), 500),
+      ),
+    ]);
+    await app.close();
+    await preview;
+  } finally {
+    await app.close().catch(() => undefined);
+    await gateway.close();
+  }
+});
+
 test("falls back to gateway polling while the hosted native relay is unavailable", async () => {
   const app = await createTestServer();
   const gateway = await createPreviewGatewayTestServer();
@@ -493,6 +528,34 @@ async function createTestServer(handler) {
 
   return {
     port: address.port,
+    close: () =>
+      new Promise((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      }),
+  };
+}
+
+async function createStreamingTestServer() {
+  let resolveCancellation;
+  const cancellation = new Promise((resolve) => {
+    resolveCancellation = resolve;
+  });
+  const server = createServer((_req, res) => {
+    res.writeHead(200, { "content-type": "text/plain" });
+    res.write("streaming");
+    res.once("close", resolveCancellation);
+  });
+
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, resolve);
+  });
+  const address = server.address();
+  assert.ok(address && typeof address === "object");
+
+  return {
+    port: address.port,
+    waitForCancellation: () => cancellation,
     close: () =>
       new Promise((resolve, reject) => {
         server.close((error) => (error ? reject(error) : resolve()));


### PR DESCRIPTION
## Problem

The compatibility preview health watcher probes the local app every two seconds but leaves each response body unread. Streaming pages can keep those responses and connections alive indefinitely.

## Root cause

The reachability check returned as soon as Fetch received response headers. Unlike the native preview watcher, it did not cancel the response body.

## Change

Cancel the local probe response body before reporting the target reachable. Add an integration regression using a response that never ends.

## Safety and compatibility

Reachability still depends only on receiving a response. No page content is needed by the health check, and cancellation releases the connection immediately.

## Verification

- `pnpm --dir packages/farm-cli exec tsdown`
- `node --test packages/farm-cli/test/preview.test.mjs`
- `pnpm --filter @farm.js/cli type-check`
- The streaming-response regression times out on `main` because the probe is left open.

## Documentation and release

None.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the compatibility preview health probe to cancel response bodies so streaming pages no longer hold connections open.

- Cancels the local probe response body before reporting the target reachable.
- Adds a regression test with a streaming response that never ends.

<sup>Written for commit 821d1c7176caf5f6fa6e107bd06be794b23cc60b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/794?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

