### PR TITLE
fix(cli): format IPv6 local targets

### DIFF
--- a/packages/farm-cli/src/cron.ts
+++ b/packages/farm-cli/src/cron.ts
@@ -7,6 +7,7 @@ import {
 } from "@farm.js/core";
 import { Cron } from "croner";
 import path from "node:path";
+import { createHttpLocalUrl } from "./local-url";
 
 export interface FarmCronCLIOptions {
   root?: string;
@@ -213,7 +214,8 @@ async function invokeFarmCronJob(
 }
 
 function resolveCronTarget(job: FarmCronJob, options: RunFarmCronOptions): string {
-  const baseURL = options.url || `http://${options.host || "localhost"}:${options.port || 3000}`;
+  const baseURL =
+    options.url || createHttpLocalUrl(options.host || "localhost", options.port || 3000);
   const normalizedBase = baseURL.endsWith("/") ? baseURL : `${baseURL}/`;
   return new URL(job.path.replace(/^\/+/, ""), normalizedBase).toString();
 }

--- a/packages/farm-cli/src/doctor.ts
+++ b/packages/farm-cli/src/doctor.ts
@@ -7,6 +7,7 @@ import {
 } from "@farm.js/core";
 import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
+import { createHttpLocalUrl } from "./local-url";
 import pc from "picocolors";
 
 export type FarmDoctorCheckStatus = "pass" | "warn" | "fail" | "info";
@@ -620,7 +621,7 @@ function findConfigFile(root: string, configPath?: string): string | undefined {
 }
 
 function resolveLiveTarget(options: FarmDoctorOptions): string {
-  const raw = options.url || `http://${options.host || "localhost"}:${options.port || 3000}`;
+  const raw = options.url || createHttpLocalUrl(options.host || "localhost", options.port || 3000);
   return raw.replace(/\/+$/, "");
 }
 

--- a/packages/farm-cli/src/local-url.ts
+++ b/packages/farm-cli/src/local-url.ts
@@ -1,0 +1,5 @@
+export function createHttpLocalUrl(host: string, port: number | string): string {
+  const hostname =
+    host.includes(":") && !(host.startsWith("[") && host.endsWith("]")) ? `[${host}]` : host;
+  return `http://${hostname}:${port}`;
+}

--- a/packages/farm-cli/src/preview.ts
+++ b/packages/farm-cli/src/preview.ts
@@ -10,6 +10,7 @@ import {
   type PreviewGatewaySession,
 } from "./preview-gateway";
 import { runNativePreviewTunnel } from "./preview-native";
+import { createHttpLocalUrl } from "./local-url";
 
 export interface PreviewFarmOptions {
   root?: string;
@@ -418,7 +419,7 @@ function normalizeLocalUrl(value: string) {
 }
 
 function createLocalUrl(host: string, port: number) {
-  return `http://${host}:${port}`;
+  return createHttpLocalUrl(host, port);
 }
 
 function normalizePort(value: unknown): number | undefined {

--- a/packages/farm-cli/test/cron.test.mjs
+++ b/packages/farm-cli/test/cron.test.mjs
@@ -69,6 +69,27 @@ test("runs a configured route with cron metadata and bearer auth", async () => {
   }
 });
 
+test("formats a bare IPv6 cron host as a valid request URL", async () => {
+  const root = await createTempProject();
+  let requestedUrl;
+
+  try {
+    await runFarmCronJob("dailyCleanup", {
+      root,
+      host: "::1",
+      port: 4319,
+      fetch: async (input) => {
+        requestedUrl = String(input);
+        return Response.json({ ok: true });
+      },
+    });
+
+    assert.equal(requestedUrl, "http://[::1]:4319/api/maintenance/cleanup");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test("starts UTC development schedules and stops them cleanly", async () => {
   const root = await createTempProject();
 

--- a/packages/farm-cli/test/preview.test.mjs
+++ b/packages/farm-cli/test/preview.test.mjs
@@ -58,6 +58,13 @@ test("resolves a running local preview target", async () => {
   }
 });
 
+test("formats a bare IPv6 preview host as a valid local URL", async () => {
+  const target = await resolvePreviewTarget({ host: "::1", port: 4321, noProbe: true });
+
+  assert.equal(target.localUrl, "http://[::1]:4321");
+  assert.equal(new URL(target.localUrl).hostname, "[::1]");
+});
+
 test("creates a tunnel plan from the preview command template", () => {
   const previousCommand = process.env.FARM_PREVIEW_TUNNEL_COMMAND;
   const previousDomain = process.env.FARM_PREVIEW_DOMAIN;


### PR DESCRIPTION
## Problem

Passing a bare IPv6 host such as `::1` to preview, doctor, or cron produces malformed URLs like `http://::1:4321`.

## Root cause

Each command interpolated the host and port directly instead of adding the brackets required around an IPv6 URL host.

## Change

Use one internal local-URL formatter across preview, doctor, and cron. Bare IPv6 hosts are bracketed while hostnames, IPv4 addresses, and already-bracketed addresses are preserved.

## Safety and compatibility

Existing hostname and IPv4 output is unchanged. The helper only changes hosts containing colons that are not already bracketed.

## Verification

- `pnpm --dir packages/farm-cli exec tsdown`
- `node --test packages/farm-cli/test/preview.test.mjs packages/farm-cli/test/cron.test.mjs`
- `pnpm --filter @farm.js/cli type-check`
- Regression coverage verifies valid preview and cron URLs for `::1`; the preview assertion fails on `main` with `http://::1:4321`.

## Documentation and release

None.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Formats local CLI URLs with bracketed IPv6 hosts, fixing malformed preview, doctor, and cron targets such as `http://::1:4321`. Hostnames, IPv4 addresses, and already-bracketed IPv6 addresses keep their existing formatting.

**Verification**

- Adds regression coverage for valid IPv6 preview and cron URLs.
- Uses one formatter across all three commands.

<sup>Written for commit 1df93716dbdec9ea7aec7fa425e76de0b479603b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/795?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

