### PR TITLE
fix(preview): close rejected agent sockets

### DIFF
--- a/packages/farm-preview-tunnel/src/agent.ts
+++ b/packages/farm-preview-tunnel/src/agent.ts
@@ -50,6 +50,7 @@ export async function startTypeScriptPreviewAgent(
   try {
     ready = await waitForReady(socket, options);
   } catch (error) {
+    await terminateSocket(socket);
     socket.off("error", onSocketError);
     throw error;
   }
@@ -287,6 +288,14 @@ function closeSocket(socket: WebSocket) {
   return new Promise<void>((resolve) => {
     socket.once("close", () => resolve());
     socket.close(1000, "Preview agent stopped");
+  });
+}
+
+function terminateSocket(socket: WebSocket) {
+  if (socket.readyState === socket.CLOSED) return Promise.resolve();
+  return new Promise<void>((resolve) => {
+    socket.once("close", () => resolve());
+    socket.terminate();
   });
 }
 

--- a/packages/farm-preview-tunnel/test/tunnel.test.mjs
+++ b/packages/farm-preview-tunnel/test/tunnel.test.mjs
@@ -150,6 +150,44 @@ test("rejects malformed and unauthenticated agent messages without crashing", as
   }
 });
 
+test("closes the agent socket when the relay rejects registration", async () => {
+  const relay = new WebSocketServer({ port: 0 });
+  await once(relay, "listening");
+  const address = relay.address();
+  assert.ok(address && typeof address === "object");
+  let resolveAgentClosed;
+  const agentClosed = new Promise((resolve) => {
+    resolveAgentClosed = resolve;
+  });
+  relay.on("connection", (socket) => {
+    socket.once("message", () => {
+      socket.send(JSON.stringify({ type: "error", message: "registration rejected" }));
+    });
+    socket.once("close", resolveAgentClosed);
+  });
+
+  try {
+    await assert.rejects(
+      startTypeScriptPreviewAgent({
+        relayUrl: `ws://127.0.0.1:${address.port}`,
+        name: "rejected-agent",
+        targetUrl: "http://127.0.0.1:3000",
+      }),
+      /registration rejected/,
+    );
+    await Promise.race([
+      agentClosed,
+      new Promise((_, reject) =>
+        setTimeout(() => reject(new Error("rejected agent socket remained open")), 500),
+      ),
+    ]);
+    assert.equal(relay.clients.size, 0);
+  } finally {
+    for (const socket of relay.clients) socket.terminate();
+    await new Promise((resolve) => relay.close(resolve));
+  }
+});
+
 test("advertises explicit public HTTP and WebSocket endpoints", async () => {
   const relay = createPersistentPreviewRelay({
     publicBaseUrl: "https://preview.example.com/",


### PR DESCRIPTION
## Problem

If the native preview relay rejects registration or sends an invalid handshake, the TypeScript agent rejects startup but leaves its WebSocket connected. That live handle can keep the CLI process running.

## Root cause

Only the handshake-timeout path terminated the socket. Other rejection paths removed listeners and rethrew without closing the connection.

## Change

Terminate and await closure of the socket before propagating every handshake failure. Add a relay regression that rejects registration without closing its side of the connection.

## Safety and compatibility

Successful handshakes and graceful agent shutdown are unchanged. Failed startup now releases its only network resource deterministically.

## Verification

- `pnpm --filter @farm.js/preview-tunnel test`
- `pnpm --filter @farm.js/preview-tunnel type-check`
- The regression reports one live relay connection on `main` and passes with zero after this change.

## Documentation and release

None.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes the preview agent’s WebSocket when registration or handshake validation fails, instead of leaving the connection open and keeping the CLI process running. Successful handshakes and graceful shutdown remain unchanged.

- Adds a regression test for a relay that rejects registration without closing its connection.

<sup>Written for commit a0b33bb2b1ccf4f253d936902e83a801cce14072. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/796?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

