### PR TITLE
fix(routing): omit programmatic route groups

### DIFF
--- a/packages/farm/src/__tests__/programmatic-routes.test.ts
+++ b/packages/farm/src/__tests__/programmatic-routes.test.ts
@@ -65,6 +65,21 @@ describe("programmatic routes", () => {
     );
   });
 
+  it("keeps programmatic route groups out of URL segments", () => {
+    expect(parseProgrammaticRoutePath("/(marketing)/pricing")).toEqual({
+      filePath: "(marketing)/pricing/page.tsx",
+      segments: [
+        {
+          segment: "pricing",
+          isDynamic: false,
+          isOptional: false,
+          isCatchAll: false,
+        },
+      ],
+      type: "page",
+    });
+  });
+
   it("owns typed named actions and resolves a default action", async () => {
     const update = createServerFn({
       input: z.object({ id: z.string(), name: z.string() }),

--- a/packages/farm/src/routes-shared.ts
+++ b/packages/farm/src/routes-shared.ts
@@ -96,7 +96,11 @@ export function parseProgrammaticRoutePath(
 
   return {
     filePath,
-    segments: normalized.split("/").filter(Boolean).map(parseRouteSegment),
+    segments: normalized
+      .split("/")
+      .filter(Boolean)
+      .filter((segment) => !(segment.startsWith("(") && segment.endsWith(")")))
+      .map(parseRouteSegment),
     type,
   };
 }


### PR DESCRIPTION
## Problem

A programmatic route such as `/(marketing)/pricing` registers `(marketing)` as a literal URL segment instead of serving `/pricing`. File routes and the public router already treat route groups as organization-only segments.

## Root cause

The programmatic parser validates route groups correctly but mapped every non-empty segment into the URL matcher.

## Change

Filter route-group segments from the parsed URL segments while preserving them in the synthetic file path, so programmatic layout organization remains available.

## Safety and compatibility

Ordinary static and dynamic routes are unchanged. This aligns programmatic routes with Farm's documented route-group semantics.

## Verification

- `pnpm --filter @farm.js/core test -- programmatic-routes.test.ts`
- `pnpm --filter @farm.js/core type-check`
- The regression test fails on `main` because `(marketing)` appears in the parsed URL segments.

## Documentation and release

Existing routing documentation already states that route groups do not appear in URLs.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Programmatic route groups no longer appear as URL segments, so `/(marketing)/pricing` now serves `/pricing` while preserving the group in the synthetic file path.

- Adds a regression test covering the route-group behavior.
- Static, dynamic, and catch-all programmatic routes remain unchanged.

<sup>Written for commit 27d9b333ec04d8e9edec380aae92b97376aca788. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/797?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

