### PR TITLE
fix(routing): reject non-path route declarations

### DIFF
--- a/docs/src/app/docs/routing/page.md
+++ b/docs/src/app/docs/routing/page.md
@@ -276,6 +276,8 @@ Use stable keys per scroll container. If two elements share a key, the latest mo
 ## Route data cache
 
 Programmatic routes can cache the value returned from `data.main`. This is useful for product pages, docs pages, dashboards, and other route data that should be reused during server rendering or prefetching.
+The first `createRoute` argument is a pathname pattern only; declare typed search parameters with
+`search` and add query strings or hashes when building a navigation URL.
 
 ```tsx
 import { createRoute, invalidate } from "@farm.js/core";

--- a/packages/farm/src/__tests__/programmatic-routes.test.ts
+++ b/packages/farm/src/__tests__/programmatic-routes.test.ts
@@ -63,6 +63,12 @@ describe("programmatic routes", () => {
     expect(() => parseProgrammaticRoutePath("/docs/[...slug]/edit")).toThrow(
       'Catch-all segment "[...slug]" must be the final segment',
     );
+    expect(() => parseProgrammaticRoutePath("/products?draft=1")).toThrow(
+      "must be a pathname without a query string or hash",
+    );
+    expect(() => parseProgrammaticRoutePath("/products#details")).toThrow(
+      "must be a pathname without a query string or hash",
+    );
   });
 
   it("owns typed named actions and resolves a default action", async () => {

--- a/packages/farm/src/routes-shared.ts
+++ b/packages/farm/src/routes-shared.ts
@@ -113,6 +113,11 @@ export function scanProgrammaticPagePaths(source: string): string[] {
 }
 
 export function normalizeProgrammaticRoutePath(routePath: string): string {
+  if (routePath.includes("?") || routePath.includes("#")) {
+    throw new TypeError(
+      `Programmatic route path "${routePath}" must be a pathname without a query string or hash.`,
+    );
+  }
   const withSlash = routePath.startsWith("/") ? routePath : `/${routePath}`;
   const withoutTrailing = withSlash.length > 1 ? withSlash.replace(/\/+$/, "") : withSlash;
   return withoutTrailing || "/";


### PR DESCRIPTION
## Problem

Programmatic route declarations silently accept query strings and hashes, producing synthetic route segments such as `products?draft=1` that no request pathname can match.

## Root cause

The route normalizer only added a leading slash and removed trailing slashes. It did not enforce that the declaration represented a pathname rather than a complete navigation URL.

## Change

Reject `?` and `#` in programmatic route declarations with an actionable error. Document that `createRoute` accepts a pathname pattern and that search/hash values belong in route search configuration or navigation URLs.

## Safety and compatibility

Valid route patterns are unchanged. Encoded literal characters remain available; only raw query/hash delimiters that created unreachable routes are rejected.

## Verification

- `pnpm --filter @farm.js/core test -- programmatic-routes.test.ts`
- `pnpm --filter @farm.js/core type-check`
- `pnpm docs:build`
- Both invalid declarations are accepted on `main` and rejected by the regression coverage here.

## Documentation and release

Updated the programmatic routing documentation. The production Vercel docs build completed successfully.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects programmatic route declarations that contain `?` or `#`, which previously produced unreachable synthetic route segments like `products?draft=1`. Valid pathname patterns and encoded literals are unchanged.

**Documentation**
- Clarified that the first `createRoute` argument is a pathname pattern only; query strings and hashes belong in route search configuration or navigation URLs.

<sup>Written for commit c6006e881067026f666998e59e7d22b3c70da954. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/798?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

