### PR TITLE
fix(storage): dispose partial initialization

### DIFF
--- a/packages/farm/src/__tests__/storage.test.ts
+++ b/packages/farm/src/__tests__/storage.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { IncomingMessage, ServerResponse } from "node:http";
 import { Socket } from "node:net";
+import memoryDriver from "unstorage/drivers/memory";
 import { middleware } from "../middleware/chain";
 import { createContext } from "../middleware/context";
 import {
@@ -104,6 +105,32 @@ describe("Storage", () => {
     expect(await storage.getItem("greeting")).toEqual({ hello: "world" });
 
     await storage.dispose();
+  });
+
+  it("disposes initialized drivers when a later mount fails", async () => {
+    const rootDriver = memoryDriver();
+    const mountedDriver = memoryDriver();
+    const disposeRoot = vi.fn();
+    const disposeMount = vi.fn();
+    rootDriver.dispose = disposeRoot;
+    mountedDriver.dispose = disposeMount;
+
+    await expect(
+      createFarmStorage({
+        driver: rootDriver,
+        mounts: {
+          ready: { driver: mountedDriver },
+          failed: {
+            driver: async () => {
+              throw new Error("mount failed");
+            },
+          },
+        },
+      }),
+    ).rejects.toThrow("mount failed");
+
+    expect(disposeRoot).toHaveBeenCalledOnce();
+    expect(disposeMount).toHaveBeenCalledOnce();
   });
 
   it("re-creates the driver after dispose instead of reviving the disposed one", async () => {

--- a/packages/farm/src/storage/index.ts
+++ b/packages/farm/src/storage/index.ts
@@ -523,7 +523,12 @@ export async function createFarmStorage(config: FarmStorageUserConfig = {}): Pro
     driver: await resolveDriver(rootConfig),
   });
 
-  await mountNamespaces(storage, config.mounts);
+  try {
+    await mountNamespaces(storage, config.mounts);
+  } catch (error) {
+    await storage.dispose().catch(() => {});
+    throw error;
+  }
   return storage;
 }
 


### PR DESCRIPTION
## Problem

When a later storage mount fails during startup, the root driver and earlier mounted drivers remain open. Provider-backed drivers can leak database, Redis, or filesystem resources even though storage initialization failed.

## Root cause

`createFarmStorage` returned ownership only after all mounts succeeded and had no cleanup path around partial mounting.

## Change

Dispose the partially created unstorage instance before rethrowing the original mount error. Add regression drivers with observable disposal hooks.

## Safety and compatibility

Successful initialization is unchanged. Cleanup errors are intentionally contained so the actionable mount failure remains the reported startup error.

## Verification

- `pnpm --filter @farm.js/core test -- storage.test.ts`
- `pnpm --filter @farm.js/core type-check`
- The regression observes zero disposal calls on `main` and one for both initialized drivers with this change.

## Documentation and release

None.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes storage cleanup when a later mount fails during startup, so provider-backed drivers no longer leak resources.

**Bug Fixes**
- Disposes the partially created unstorage instance before rethrowing the original mount error.
- Swallows cleanup errors so the mount failure remains the reported startup error; successful initialization is unchanged.

<sup>Written for commit 9c92a55de516a595d9850e491b4bd3bf76fff520. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/799?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

