### PR TITLE
fix(images): cancel discarded source responses

### DIFF
--- a/packages/farm/src/__tests__/image-server.test.ts
+++ b/packages/farm/src/__tests__/image-server.test.ts
@@ -239,6 +239,53 @@ describe("Farm image optimizer", () => {
     );
   });
 
+  it("cancels a redirect response before following its location", async () => {
+    const cancel = vi.fn();
+    const redirectBody = new ReadableStream({ cancel });
+    const fetcher = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(redirectBody, {
+          status: 302,
+          headers: { location: "https://cdn.example.test/final.png" },
+        }),
+      )
+      .mockResolvedValueOnce(new Response(PNG, { headers: { "content-type": "image/png" } }));
+    const handler = createFarmImageHandler(
+      resolveFarmImageConfig({
+        remotePatterns: [{ protocol: "https", hostname: "**.example.test", pathname: "/**" }],
+      }),
+      {
+        fetch: fetcher as typeof fetch,
+        transform: passthroughTransformer(),
+        validateRemoteUrl: vi.fn(),
+      },
+    );
+
+    const response = await handler(
+      new Request(optimizerUrl("https://images.example.test/photo.png")),
+    );
+
+    expect(response?.status).toBe(200);
+    expect(cancel).toHaveBeenCalledOnce();
+  });
+
+  it("cancels a source rejected from its content length", async () => {
+    const cancel = vi.fn();
+    const sourceBody = new ReadableStream({ cancel });
+    const handler = createFarmImageHandler(resolveFarmImageConfig({ maximumResponseBody: 16 }), {
+      fetch: vi.fn(
+        async () => new Response(sourceBody, { headers: { "content-length": "17" } }),
+      ) as typeof fetch,
+      transform: passthroughTransformer(),
+    });
+
+    const response = await handler(new Request(optimizerUrl("/large.png")));
+
+    expect(response?.status).toBe(413);
+    expect(cancel).toHaveBeenCalledOnce();
+  });
+
   it("caps streamed bodies and rejects SVG content by signature", async () => {
     const oversizedHandler = createFarmImageHandler(
       resolveFarmImageConfig({ maximumResponseBody: 16 }),

--- a/packages/farm/src/image-server.ts
+++ b/packages/farm/src/image-server.ts
@@ -358,6 +358,7 @@ async function fetchImageSource(
 
     if (![301, 302, 303, 307, 308].includes(response.status)) {
       if (!response.ok) {
+        await cancelResponseBody(response);
         throw new FarmImageRequestError(
           "UNSUPPORTED_IMAGE",
           response.status === 404 ? 404 : 502,
@@ -368,6 +369,7 @@ async function fetchImageSource(
     }
 
     if (redirectCount >= config.maximumRedirects) {
+      await cancelResponseBody(response);
       throw new FarmImageRequestError(
         "TOO_MANY_REDIRECTS",
         400,
@@ -376,8 +378,10 @@ async function fetchImageSource(
     }
     const location = response.headers.get("location");
     if (!location) {
+      await cancelResponseBody(response);
       throw new FarmImageRequestError("UNSUPPORTED_IMAGE", 502, "Invalid image redirect");
     }
+    await cancelResponseBody(response);
     currentUrl = new URL(location, currentUrl);
     await validateImageSourceUrl(currentUrl, requestOrigin, config, validateRemoteUrl);
   }
@@ -386,6 +390,7 @@ async function fetchImageSource(
 async function readResponseWithLimit(response: Response, limit: number): Promise<Uint8Array> {
   const contentLength = response.headers.get("content-length");
   if (contentLength && Number(contentLength) > limit) {
+    await cancelResponseBody(response);
     throw new FarmImageRequestError("BODY_TOO_LARGE", 413, "Source image is too large");
   }
 
@@ -412,6 +417,14 @@ async function readResponseWithLimit(response: Response, limit: number): Promise
     offset += chunk.byteLength;
   }
   return result;
+}
+
+async function cancelResponseBody(response: Response): Promise<void> {
+  try {
+    await response.body?.cancel();
+  } catch {
+    // Cleanup must not replace the request error or redirect result.
+  }
 }
 
 function detectImageContentType(bytes: Uint8Array): string {


### PR DESCRIPTION
## Problem

The image optimizer can discard a source response without cancelling its body when following redirects, rejecting upstream errors, or rejecting an oversized `Content-Length`. The upstream download and connection may continue after Farm has already produced its response.

## Root cause

Only the streamed-size overflow path cancelled its reader. Earlier rejection and redirect branches left the Fetch body untouched.

## Change

Cancel every response body that the optimizer will not consume, while preventing cleanup failures from replacing the intended request error. Add explicit cancellation coverage for redirects and early size rejection.

## Safety and compatibility

Consumed image responses and transformed output are unchanged. Redirect validation still happens before the next fetch, and cleanup remains best-effort.

## Verification

- `pnpm --filter @farm.js/core test -- image-server.test.ts`
- `pnpm --filter @farm.js/core type-check`
- Both cancellation spies remain untouched on `main` and are called once with this change.

## Documentation and release

None.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cancels image source response bodies whenever the optimizer discards them, including redirects, upstream errors, invalid redirects, and oversized `Content-Length` responses. Previously, these bodies could continue downloading after Farm returned an error or followed a redirect; cleanup failures remain best-effort and cannot replace the intended result.

<sup>Written for commit 6d7de1b587ef54462c0f9fb8eb53edb6b4e8ad14. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/800?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

