### PR TITLE
fix(images): isolate error reporter failures

### DIFF
--- a/packages/farm/src/__tests__/image-server.test.ts
+++ b/packages/farm/src/__tests__/image-server.test.ts
@@ -279,6 +279,26 @@ describe("Farm image optimizer", () => {
     expect(response?.status).toBe(499);
     await expect(response?.text()).resolves.toBe("Image request cancelled");
   });
+
+  it("returns the optimizer response when its error reporter throws", async () => {
+    const upstreamError = new Error("upstream failed");
+    const onError = vi.fn(() => {
+      throw new Error("reporter failed");
+    });
+    const handler = createFarmImageHandler(resolveFarmImageConfig(undefined), {
+      fetch: vi.fn(async () => {
+        throw upstreamError;
+      }) as typeof fetch,
+      transform: passthroughTransformer(),
+      onError,
+    });
+
+    const response = await handler(new Request(optimizerUrl("/photo.png")));
+
+    expect(onError).toHaveBeenCalledWith(upstreamError, expect.any(Request));
+    expect(response?.status).toBe(500);
+    await expect(response?.text()).resolves.toBe("Image optimization failed");
+  });
 });
 
 describe("image runtime adapters", () => {

--- a/packages/farm/src/image-server.ts
+++ b/packages/farm/src/image-server.ts
@@ -151,7 +151,11 @@ export function createFarmImageHandler(
       return createOptimizedImageResponse(request, optimized, config);
     } catch (error) {
       if (!(error instanceof FarmImageRequestError) && !isAbortError(error)) {
-        options.onError?.(error, request);
+        try {
+          options.onError?.(error, request);
+        } catch {
+          // Error reporting must not replace the optimizer's sanitized response.
+        }
       }
       return createFarmImageErrorResponse(error);
     }


### PR DESCRIPTION
## Problem

An exception from the optional image optimizer error reporter replaces Farm's sanitized error response and causes the request handler itself to reject.

## Root cause

`onError` ran inside the handler catch block without its own isolation boundary.

## Change

Contain reporter exceptions and continue returning the response for the original optimizer failure. Add regression coverage with both an upstream failure and a throwing reporter.

## Safety and compatibility

The original error is still reported once. Request errors, cancellation, and normal image responses are unchanged; only failures from the observational callback are isolated.

## Verification

- `pnpm --filter @farm.js/core test -- image-server.test.ts`
- `pnpm --filter @farm.js/core type-check`
- The regression rejects with `reporter failed` on `main`; this change returns the intended sanitized `500` response.

## Documentation and release

None.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Image error reporter failures no longer replace Farm’s sanitized optimizer error response or cause the handler to reject. The original optimization failure still returns its normal response, while reporter failures are ignored.

- Adds regression coverage for an upstream failure combined with a throwing reporter.

<sup>Written for commit e2ba0388ea8d9916f3ae7258415a92d36741a635. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/801?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

