### PR TITLE
perf(react): skip cancelled reverse reconciliation

### DIFF
--- a/docs/src/app/docs/renderers/react/page.md
+++ b/docs/src/app/docs/renderers/react/page.md
@@ -1255,8 +1255,8 @@ final permutation. Farm validates each mirrored source item and every changed re
 the first DOM write, then uses the minimum-move reverse operation directly. It does not allocate a
 second source-item lookup map or run LIS for that case. Further exact reversals toggle the proof:
 two reversals patch changed rows in committed order with zero DOM moves, while three use the exact
-reverse path. The same parity survives safe maps and queued exact reversals. A sort or any other
-order ambiguity keeps the general permutation path.
+reverse path. The same parity applies to safe mapped pipelines and to queued reverse-only setters.
+A sort or any other order ambiguity keeps the general permutation path.
 
 The proof requires every map callback to be inline, synchronous, compiler-safe, and to return the
 original item on one conditional branch and an object-spread replacement on the other. It requires

--- a/docs/src/app/docs/renderers/react/page.md
+++ b/docs/src/app/docs/renderers/react/page.md
@@ -1170,10 +1170,12 @@ setItems((current) => current.toReversed());
 
 Each setter still executes in order with normal JavaScript semantics. Farm carries the original
 committed token through consecutive native `toSorted()` and `toReversed()` results, validates the
-final array as the exact same set of unique item identities, and reconciles that final permutation
-once. Intermediate orders never reach the DOM. The final generic path uses LIS, so two queued
-reversals that cancel preserve every row without a DOM move. A single direct reverse keeps the
-smaller specialized `n - 1` move path described above.
+final array as the exact same set of unique item identities, and reconciles that final order once.
+Intermediate orders never reach the DOM. For a chain made only of reversals, Farm tracks whether
+the final order is exactly the committed order or its reverse. An even count validates identity and
+does not build the generic item map, run LIS, or move a DOM node. An odd count validates reverse and
+uses the specialized minimum `n - 1` move path. Any sort makes the final order a general
+permutation, so that path still uses LIS.
 
 The same proof also works when two or more native reorder operations are chained inside one concise
 functional setter:
@@ -1184,9 +1186,9 @@ setItems((current) => current.toSorted((left, right) => left.rank - right.rank).
 
 Farm prepares this pipeline at build time and evaluates each property lookup, inline comparator,
 and native call in its original JavaScript order. The intermediate arrays do not reach the DOM.
-The runtime validates only the final identity permutation against the committed collection and
-then applies one LIS-based reconciliation. A cancelling
-`current.toReversed().toReversed()` pipeline therefore performs no DOM moves.
+The runtime validates only the final order against the committed collection. A cancelling
+`current.toReversed().toReversed()` pipeline uses the exact-identity path described above; mixed
+sort/reverse pipelines apply one LIS-based reconciliation.
 
 A compiler-safe `filter()` or bounded `slice()` prefix may run before one or more native reorder
 steps in the same concise setter:
@@ -1251,8 +1253,10 @@ collection and expose only the final state.
 When the maps are followed directly by `toReversed()`, their same-order lineage proves the exact
 final permutation. Farm validates each mirrored source item and every changed replacement before
 the first DOM write, then uses the minimum-move reverse operation directly. It does not allocate a
-second source-item lookup map or run LIS for that case. A sort before the reverse, a map after a
-queued reorder, or any other order ambiguity keeps the general permutation path.
+second source-item lookup map or run LIS for that case. Further exact reversals toggle the proof:
+two reversals patch changed rows in committed order with zero DOM moves, while three use the exact
+reverse path. The same parity survives safe maps and queued exact reversals. A sort or any other
+order ambiguity keeps the general permutation path.
 
 The proof requires every map callback to be inline, synchronous, compiler-safe, and to return the
 original item on one conditional branch and an object-spread replacement on the other. It requires

--- a/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
+++ b/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
@@ -18,12 +18,12 @@ and connections after every sample.
 
 | Mode   | Exact identity | Compiled control | vs React | vs control |
 | ------ | -------------: | ---------------: | -------: | ---------: |
-| Static | 3.40 ms | 11.30 ms | 20.50x | 3.32x |
-| Hybrid | 3.60 ms | 11.20 ms | 19.36x | 3.11x |
+| Static | 3.40 ms | 11.60 ms | 16.12x | 3.41x |
+| Hybrid | 3.70 ms | 11.10 ms | 14.81x | 3.00x |
 
 Existing double-reverse workloads improved too. Queued reversal medians changed from 6.50 to
-3.70 ms in static mode and 6.30 to 4.30 ms in hybrid mode. Reversals chained inside one setter
-changed from 6.40 to 3.70 ms static and 6.20 to 4.20 ms hybrid. All existing benchmark gates passed;
+3.80 ms in static mode and 6.30 to 4.10 ms in hybrid mode. Reversals chained inside one setter
+changed from 6.40 to 3.70 ms static and 6.20 to 4.00 ms hybrid. All existing benchmark gates passed;
 compiled owner executions remained zero in both compiler modes.
 
 Deterministic tests require zero generic source-item map inserts and zero DOM moves for even parity,
@@ -31,9 +31,10 @@ and exactly `n - 1` moves for odd parity. Coverage includes parity across queued
 and subclass fallback, Strict Mode hydration, unmount-before-flush cleanup, React 18.3.1 and 19.2.8,
 and 2,000 mapped updates with one to four reversals compared with normal React.
 
-The isolated keyed map/reorder premium is 13,349 B gzip, down from 13,378 B in the preceding run;
-the runtime-size gate passed. The complete dashboard chunks are 27,095 B gzip in both compiler
-modes and 6,540 B with the compiler disabled, including the additional benchmark controls.
+On the CI-equivalent Node.js 22.13.1 runtime, the isolated keyed map/reorder premium is 13,398 B
+gzip and remains inside its fixed 13,399 B limit. The complete dashboard chunks are 27,009 B gzip
+in static mode, 27,008 B in hybrid mode, and 6,540 B with the compiler disabled, including the
+additional benchmark controls.
 
 Numbers are local medians from 10 table samples per compiler mode with 20 bracketing React samples,
 Chrome 152.0.7977.82, Node.js 23.11.0, and Apple M1 macOS arm64. Timing varies by machine; the

--- a/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
+++ b/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
@@ -2,6 +2,44 @@
 
 Latest run: 2026-09-08
 
+## Exact reverse parity — 2026-09-08
+
+Compiler-proven reverse chains now retain exact order relative to the last committed keyed rows.
+Each native call still executes in source order. An even number of reversals records exact identity,
+so the runtime validates the final array and patches mapped replacements without constructing the
+generic source-item map, running LIS, or moving a DOM node. An odd number records exact reverse and
+keeps the minimum `n - 1` move path. Sort-derived or otherwise ambiguous order remains on general
+permutation reconciliation.
+
+The new 10,000-row workload changes one row through two native maps and then calls `toReversed()`
+twice. Its block-bodied compiled control performs the same application work through complete keyed
+reconciliation. The correctness oracle checks all 10,000 values, positions, element identities,
+and connections after every sample.
+
+| Mode   | Exact identity | Compiled control | vs React | vs control |
+| ------ | -------------: | ---------------: | -------: | ---------: |
+| Static | 3.40 ms | 11.30 ms | 20.50x | 3.32x |
+| Hybrid | 3.60 ms | 11.20 ms | 19.36x | 3.11x |
+
+Existing double-reverse workloads improved too. Queued reversal medians changed from 6.50 to
+3.70 ms in static mode and 6.30 to 4.30 ms in hybrid mode. Reversals chained inside one setter
+changed from 6.40 to 3.70 ms static and 6.20 to 4.20 ms hybrid. All existing benchmark gates passed;
+compiled owner executions remained zero in both compiler modes.
+
+Deterministic tests require zero generic source-item map inserts and zero DOM moves for even parity,
+and exactly `n - 1` moves for odd parity. Coverage includes parity across queued setters, changed-key
+and subclass fallback, Strict Mode hydration, unmount-before-flush cleanup, React 18.3.1 and 19.2.8,
+and 2,000 mapped updates with one to four reversals compared with normal React.
+
+The isolated keyed map/reorder premium is 13,349 B gzip, down from 13,378 B in the preceding run;
+the runtime-size gate passed. The complete dashboard chunks are 27,095 B gzip in both compiler
+modes and 6,540 B with the compiler disabled, including the additional benchmark controls.
+
+Numbers are local medians from 10 table samples per compiler mode with 20 bracketing React samples,
+Chrome 152.0.7977.82, Node.js 23.11.0, and Apple M1 macOS arm64. Timing varies by machine; the
+deterministic correctness, move-count, fallback, compatibility, and size checks are the primary
+safety controls.
+
 ## Direct mapped reverse specialization — 2026-09-08
 
 A compiler-proven chain of safe `map()` calls followed directly by native `toReversed()` now uses

--- a/examples/react-compiler-dashboard/README.md
+++ b/examples/react-compiler-dashboard/README.md
@@ -194,17 +194,19 @@ correctness, hydration, and cleanup.
 
 Queued native reorders have another independent 10,000-row comparison. One event queues two
 concise `toReversed()` setters, so the final order equals the committed order. Farm must validate
-that final permutation once, retain every DOM node, perform no intermediate DOM moves, and remain
+that exact identity once without building the generic item map or running LIS, retain every DOM
+node, perform no intermediate DOM moves, and remain
 at least 2x faster than React and 1.25x faster than the equivalent block-bodied compiled control.
 Package tests also cover queued sorts, mixed sort/reverse chains, thousands of randomized batches,
 unsafe fallback, focus and selection, hydration, and cleanup.
 
 Native reorder pipelines have a separate 10,000-row comparison. One functional setter evaluates
 `current.toReversed().toReversed()`, so the final order again equals the committed order without
-using two queued React updates. Farm must preserve both native calls, validate the final permutation
-once, retain every DOM node, and remain at least 2x faster than React and 1.25x faster than the
-equivalent block-bodied compiled control. Package tests compile mixed sort/reverse pipelines and
-compare 2,000 deterministic two-to-four-step pipelines with normal React.
+using two queued React updates. Farm must preserve both native calls, validate exact identity
+without the generic item map or LIS, retain every DOM node, and remain at least 2x faster than React
+and 1.25x faster than the equivalent block-bodied compiled control. Package tests compile mixed
+sort/reverse pipelines and compare 2,000 deterministic two-to-four-step pipelines with normal
+React.
 
 Structural reorder pipelines add an independent 10,000-row comparison. One concise setter filters
 one row and then evaluates two native reversals, while the block-bodied version remains the compiled
@@ -240,6 +242,14 @@ least 4x faster than React and 1.2x faster than the compiled control. The assert
 reversed order, every original DOM identity and connection, and the changed row values. The hinted
 path validates mirrored row lineage and uses the minimum `n - 1` moves without a source-item map or
 LIS pass.
+
+Mapped reverse parity has an independent 10,000-row comparison. Two safe native maps update one
+row, then two native reversals restore committed order. Farm must patch the changed row without
+moving any DOM row or constructing the generic source-item map/LIS sequence. Both compiler modes
+must remain at least 8x faster than React and 1.5x faster than the equivalent block-bodied compiled
+control. The assertion checks all final values, positions, identities, and connections. Package
+tests compare one to four reversals across 2,000 deterministic updates and cover queued parity,
+changed-key and subclass fallback, Strict Mode hydration, and cleanup.
 
 Native keyed-array sorting has its own 10,000-row comparison. Concise `toSorted()` is measured
 against bracketed React and an equivalent block-bodied compiled control. Both compiler modes must
@@ -337,6 +347,10 @@ The default JSON report is `/tmp/farm-react-dashboard-benchmark.json`; change it
 - The multi-map reverse control changes the same row through two native maps and then reverses all
   rows. Its block-bodied equivalent performs the same maps and connected DOM moves, while the
   hinted path validates mirrored lineage directly and skips the temporary source map and LIS pass.
+- The multi-map reverse-parity control changes the same row through two native maps and then
+  reverses twice. Its block-bodied equivalent keeps complete reconciliation; the hinted path
+  validates exact committed order, patches the row once, and performs no generic item-map, LIS, or
+  DOM-movement work.
 - The sort control compares concise native `toSorted()` with an equivalent block-bodied compiled
   update. Both paths run the same native sort and move the same keyed DOM rows; the hint isolates
   the saved key, descriptor, and binding work while retaining only the required LIS moves.

--- a/examples/react-compiler-dashboard/scripts/benchmark.mjs
+++ b/examples/react-compiler-dashboard/scripts/benchmark.mjs
@@ -1304,7 +1304,7 @@ async function measureTrial(browser, trial, compilerMode, port) {
           " reviewed",
         );
 
-        const prepareMultiMapReversePipeline = async () => {
+        const prepareMultiMapReversePipeline = async (reverseRows = true) => {
           await create10000();
           const rows = [...table.querySelectorAll("tbody tr")];
           const target = rows.find(
@@ -1315,7 +1315,12 @@ async function measureTrial(browser, trial, compilerMode, port) {
           if (!target || !Number.isFinite(amount)) {
             throw new Error("Mapped-reverse target row is invalid.");
           }
-          return { expectedRows: [...rows].reverse(), rows, target, amount: amount + 1 };
+          return {
+            expectedRows: reverseRows ? [...rows].reverse() : rows,
+            rows,
+            target,
+            amount: amount + 1,
+          };
         };
 
         const measureMultiMapReversePipeline = async (action, prepared) => {
@@ -1339,17 +1344,17 @@ async function measureTrial(browser, trial, compilerMode, port) {
           };
         };
 
-        const measureMultiMapReverseTable = async (action) => {
+        const measureMultiMapReverseTable = async (action, reverseRows = true) => {
           for (let sample = 0; sample < warmupSamples; sample += 1) {
             const verify = await measureMultiMapReversePipeline(
               action,
-              await prepareMultiMapReversePipeline(),
+              await prepareMultiMapReversePipeline(reverseRows),
             );
             verify();
           }
           const timings = [];
           for (let sample = 0; sample < tableSamples; sample += 1) {
-            const prepared = await prepareMultiMapReversePipeline();
+            const prepared = await prepareMultiMapReversePipeline(reverseRows);
             const startedAt = performance.now();
             const verify = await measureMultiMapReversePipeline(action, prepared);
             timings.push(performance.now() - startedAt);
@@ -1363,6 +1368,14 @@ async function measureTrial(browser, trial, compilerMode, port) {
         );
         const tableMultiMapReversePipelineSnapshot = await measureMultiMapReverseTable(() =>
           tableButton("table-multi-map-reverse-pipeline-snapshot").click(),
+        );
+        const tableMultiMapReverseParity = await measureMultiMapReverseTable(
+          () => tableButton("table-multi-map-reverse-parity").click(),
+          false,
+        );
+        const tableMultiMapReverseParitySnapshot = await measureMultiMapReverseTable(
+          () => tableButton("table-multi-map-reverse-parity-snapshot").click(),
+          false,
         );
 
         const tableSort = await measureTable(
@@ -1841,6 +1854,8 @@ async function measureTrial(browser, trial, compilerMode, port) {
             multiMapReorderPipelineSnapshot: tableMultiMapReorderPipelineSnapshot,
             multiMapReversePipeline: tableMultiMapReversePipeline,
             multiMapReversePipelineSnapshot: tableMultiMapReversePipelineSnapshot,
+            multiMapReverseParity: tableMultiMapReverseParity,
+            multiMapReverseParitySnapshot: tableMultiMapReverseParitySnapshot,
             mapLookup: tableMapLookup,
             membership: tableMembership,
             prepend: tablePrepend,
@@ -1975,6 +1990,8 @@ async function measureTrial(browser, trial, compilerMode, port) {
         multiMapReversePipelineSnapshot: timingSummary(
           result.table.multiMapReversePipelineSnapshot,
         ),
+        multiMapReverseParity: timingSummary(result.table.multiMapReverseParity),
+        multiMapReverseParitySnapshot: timingSummary(result.table.multiMapReverseParitySnapshot),
         mapLookup: timingSummary(result.table.mapLookup),
         membership: timingSummary(result.table.membership),
         prepend: timingSummary(result.table.prepend),
@@ -2155,6 +2172,8 @@ const tableMetrics = [
   "multiMapReorderPipelineSnapshot",
   "multiMapReversePipeline",
   "multiMapReversePipelineSnapshot",
+  "multiMapReverseParity",
+  "multiMapReverseParitySnapshot",
   "snapshotMembership",
   "snapshotMapLookup",
   "slicePrefix",
@@ -2859,6 +2878,29 @@ const keyedMultiMapReverseRegressions = keyedMultiMapReverseResults.filter(
     !Number.isFinite(snapshotSpeedup) ||
     snapshotSpeedup < keyedMultiMapReverseMinimumSnapshotSpeedup,
 );
+// Two reversals after a compiler-proven map chain return every row to committed order. The exact
+// parity path should patch changed bindings without allocating the generic source map, running LIS,
+// or moving DOM rows. Compare it with React and the equivalent complete-reconciliation control.
+const keyedMappedReverseParityMinimumSpeedup = 8;
+const keyedMappedReverseParityMinimumSnapshotSpeedup = 1.5;
+const keyedMappedReverseParityResults = ["static", "hybrid"].map((mode) => {
+  const pipelineMedianMs = comparisons.table.multiMapReverseParity[mode].medianMs;
+  const snapshotMedianMs = comparisons.table.multiMapReverseParitySnapshot[mode].medianMs;
+  return {
+    mode,
+    pipelineMedianMs,
+    snapshotMedianMs,
+    snapshotSpeedup: snapshotMedianMs / pipelineMedianMs,
+    speedup: comparisons.table.multiMapReverseParity[`${mode}VsBaseline`].speedup,
+  };
+});
+const keyedMappedReverseParityRegressions = keyedMappedReverseParityResults.filter(
+  ({ snapshotSpeedup, speedup }) =>
+    !Number.isFinite(speedup) ||
+    speedup < keyedMappedReverseParityMinimumSpeedup ||
+    !Number.isFinite(snapshotSpeedup) ||
+    snapshotSpeedup < keyedMappedReverseParityMinimumSnapshotSpeedup,
+);
 // A direct native toSorted() exposes a permutation while preserving every keyed row object. The
 // hinted path validates that permutation by item identity, uses LIS to move only the required DOM
 // nodes, and avoids key, descriptor, and binding reads. Compare it with React and the equivalent
@@ -3050,6 +3092,7 @@ const passed =
   keyedMapReorderRegressions.length === 0 &&
   keyedMultiMapReorderRegressions.length === 0 &&
   keyedMultiMapReverseRegressions.length === 0 &&
+  keyedMappedReverseParityRegressions.length === 0 &&
   keyedSortRegressions.length === 0 &&
   keyedFilterRegressions.length === 0 &&
   keyedIdentityRegressions.length === 0 &&
@@ -3236,6 +3279,13 @@ const report = {
     regressions: keyedMultiMapReverseRegressions,
     results: keyedMultiMapReverseResults,
     status: keyedMultiMapReverseRegressions.length === 0 ? "PASS" : "FAIL",
+  },
+  keyedMappedReverseParityHintGate: {
+    minimumSnapshotSpeedup: keyedMappedReverseParityMinimumSnapshotSpeedup,
+    minimumSpeedup: keyedMappedReverseParityMinimumSpeedup,
+    regressions: keyedMappedReverseParityRegressions,
+    results: keyedMappedReverseParityResults,
+    status: keyedMappedReverseParityRegressions.length === 0 ? "PASS" : "FAIL",
   },
   keyedSortHintGate: {
     minimumSnapshotSpeedup: keyedSortMinimumSnapshotSpeedup,

--- a/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
+++ b/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
@@ -985,6 +985,48 @@ export function StandardTableBenchmark() {
           Review + reprice + reverse rows (snapshot control)
         </button>
         <button
+          data-action="table-multi-map-reverse-parity"
+          type="button"
+          onClick={() => {
+            setRows((current) =>
+              current
+                .map((row) =>
+                  row.id % 10_000 === 5_001 ? { ...row, label: `${row.label} reviewed` } : row,
+                )
+                .map((row) =>
+                  row.id % 10_000 === 5_001 ? { ...row, amount: row.amount + 1 } : row,
+                )
+                .toReversed()
+                .toReversed(),
+            );
+            setOperation("review, reprice, and preserve row order through reverse parity");
+            setRevision((value) => value + 1);
+          }}
+        >
+          Review + reprice + reverse twice
+        </button>
+        <button
+          data-action="table-multi-map-reverse-parity-snapshot"
+          type="button"
+          onClick={() => {
+            setRows((current) => {
+              return current
+                .map((row) =>
+                  row.id % 10_000 === 5_001 ? { ...row, label: `${row.label} reviewed` } : row,
+                )
+                .map((row) =>
+                  row.id % 10_000 === 5_001 ? { ...row, amount: row.amount + 1 } : row,
+                )
+                .toReversed()
+                .toReversed();
+            });
+            setOperation("review, reprice, and reverse twice (snapshot control)");
+            setRevision((value) => value + 1);
+          }}
+        >
+          Review + reprice + reverse twice (snapshot control)
+        </button>
+        <button
           data-action="table-sort"
           type="button"
           onClick={() => {

--- a/packages/farm-react/README.md
+++ b/packages/farm-react/README.md
@@ -392,8 +392,11 @@ verifies equal lengths and every reversed item identity before moving the existi
 with the minimum `n - 1` connected DOM moves. It does not reread row keys, descriptors, or bindings
 and does not run the generic LIS calculation. Consecutive concise native `toReversed()` and
 `toSorted()` setters queued before one flush compose into one final validated permutation. The
-runtime skips intermediate DOM states and uses LIS once for that final order; two reversals that
-cancel perform no DOM moves. A single concise updater may also chain two or more native reorder
+runtime skips intermediate DOM states. When the proven chain contains only reversals, Farm tracks
+their parity relative to the committed rows: an even count validates exact identity and performs
+no DOM moves, source-item map construction, or LIS; an odd count validates exact reverse and uses
+the same minimum `n - 1` moves as one reverse. A chain containing a sort keeps the general final
+permutation and uses LIS once. A single concise updater may also chain two or more native reorder
 operations:
 
 ```tsx
@@ -452,8 +455,11 @@ optional runtime.
 A direct `toReversed()` suffix is more specific than an arbitrary permutation. When all preceding
 maps retain committed row order, Farm validates the mirrored source-to-result relation and every
 changed binding before touching the DOM, then performs the minimum-move reverse without building a
-second item lookup map or running LIS. A preceding sort or a map whose source is an uncommitted
-reorder keeps the general permutation path.
+second item lookup map or running LIS. Additional exact reversals toggle that proof between reverse
+and identity. Therefore two reversals after safe maps patch changed rows in committed order without
+moving DOM nodes or creating the generic source map; three use the exact reverse path. Exact reverse
+metadata also composes across queued setters. A preceding sort or any ambiguous order keeps the
+general permutation path.
 
 A direct native immutable sort can use the same optional reorder runtime:
 

--- a/packages/farm-react/scripts/test-react-version.mjs
+++ b/packages/farm-react/scripts/test-react-version.mjs
@@ -45,6 +45,8 @@ const testSource = String.raw`
     createCompilerKeyedArrayAppend,
     createCompilerKeyedArrayBatchInsert,
     createCompilerKeyedArrayFilter,
+    createCompilerKeyedArrayMapPipeline,
+    createCompilerKeyedArrayMapReorder,
     createCompilerKeyedArrayPositionUpdate,
     createCompilerKeyedArrayPrepend,
     createCompilerKeyedArrayReorder,
@@ -91,6 +93,7 @@ const testSource = String.raw`
   flushSync(() => root.unmount());
 
   let reverseCompatibilityRows = () => undefined;
+  let mapReverseParityCompatibilityRows = () => undefined;
   let insertCompatibilityRows = () => undefined;
   let removeCompatibilityRow = () => undefined;
   let replaceCompatibilityRows = () => undefined;
@@ -112,6 +115,16 @@ const testSource = String.raw`
         state[0].set((previous) =>
           createCompilerKeyedArrayReorder(previous, previous.toReversed),
         );
+      mapReverseParityCompatibilityRows = () =>
+        state[0].set((previous) => {
+          const mapped = createCompilerKeyedArrayMapPipeline(
+            previous,
+            previous.map,
+            (item) => item.id === "b" ? { ...item, label: "Beta parity" } : item,
+          );
+          const reversed = createCompilerKeyedArrayMapReorder(mapped, mapped.toReversed);
+          return createCompilerKeyedArrayMapReorder(reversed, reversed.toReversed);
+        });
       removeCompatibilityRow = () =>
         state[0].set((previous) =>
           createCompilerKeyedArrayPositionUpdate(
@@ -234,6 +247,13 @@ const testSource = String.raw`
   await Promise.resolve();
   await Promise.resolve();
   assert.equal(reorderContainer.querySelector("li:first-child"), reorderGamma);
+  assert.equal(reorderContainer.querySelector("li:last-child"), reorderAlpha);
+  assert.equal(reorderExecutions, 1);
+  mapReverseParityCompatibilityRows();
+  await Promise.resolve();
+  await Promise.resolve();
+  assert.equal(reorderContainer.querySelector("li:first-child"), reorderGamma);
+  assert.equal(reorderContainer.querySelector("[data-key='b']").textContent, "Beta parity");
   assert.equal(reorderContainer.querySelector("li:last-child"), reorderAlpha);
   assert.equal(reorderExecutions, 1);
   const reorderBeta = reorderContainer.querySelector("[data-key='b']");

--- a/packages/farm-react/src/__tests__/compiler-keyed-array-sort-hints.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-keyed-array-sort-hints.test.ts
@@ -291,6 +291,35 @@ describe("React AOT keyed-array sort hints", () => {
     expect(result.code).toContain("keyedRowsMapReorderHintedRuntimeFeature");
   });
 
+  it("preserves every step in an exact mapped reverse-parity pipeline", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Table({ editedId, nextLabel }) {
+        const [rows, setRows] = useState([
+          { id: "a", label: "Alpha" },
+          { id: "b", label: "Beta" },
+        ]);
+        return <section>
+          <button onClick={() => setRows((current) => current
+            .map((row) => row.id === editedId ? { ...row, label: nextLabel } : row)
+            .toReversed()
+            .toReversed()
+            .toReversed()
+          )}>Edit and reverse</button>
+          <ul>{rows.map((row) => <li key={row.id}>{row.label}</li>)}</ul>
+        </section>;
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Table"]);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.optimizations.keyedMapUpdateHints).toBe(1);
+    expect(result.optimizations.keyedArrayReorderHints).toBe(3);
+    expect(result.code.match(/createCompilerKeyedArrayMapPipeline\(/g)).toHaveLength(1);
+    expect(result.code.match(/createCompilerKeyedArrayMapReorder\(/g)).toHaveLength(3);
+    expect(result.code).toContain("keyedRowsMapReorderHintedRuntimeFeature");
+  });
+
   it("does not lower map and reorder pipelines for host-backed keyed rows", async () => {
     const result = await compile(`
       import { useState } from "react";

--- a/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-map-reorder-hints.test.tsx
+++ b/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-map-reorder-hints.test.tsx
@@ -7,6 +7,7 @@ import {
   createCompiledComponent,
   createCompilerKeyedArrayMapPipeline,
   createCompilerKeyedArrayMapReorder,
+  createCompilerKeyedArrayReorder,
   type CompilerKeyedRowElement,
 } from "../compiler-runtime";
 
@@ -79,6 +80,10 @@ function hintedReverse(items: Item[]): Item[] {
   return createCompilerKeyedArrayMapReorder(items, items.toReversed) as Item[];
 }
 
+function hintedPlainReverse(items: Item[]): Item[] {
+  return createCompilerKeyedArrayReorder(items, items.toReversed) as Item[];
+}
+
 function mappedSort(items: Item[], id: string, rank: number, label?: string): Item[] {
   return hintedSort(
     hintedMap(items, (item) =>
@@ -107,6 +112,22 @@ function multiMappedReverse(items: Item[], id: string, rank: number, label: stri
   );
 }
 
+function multiMappedReversals(
+  items: Item[],
+  id: string,
+  rank: number,
+  label: string,
+  repetitions: number,
+): Item[] {
+  let value = hintedMaps(
+    items,
+    (item) => (item.id === id ? { ...item, label } : item),
+    (item) => (item.id === id ? { ...item, rank } : item),
+  );
+  for (let count = 0; count < repetitions; count += 1) value = hintedReverse(value);
+  return value;
+}
+
 function rowDescriptor(item: Item): CompilerKeyedRowElement {
   return {
     kind: "element",
@@ -133,10 +154,17 @@ function createHarness(initialItems: Item[]) {
   let editTwoAndSort: (labelId: string, rankId: string) => void = () => undefined;
   let editTwiceAndSort: (id: string, rank: number, label: string) => void = () => undefined;
   let editTwiceAndReverse: (id: string, rank: number, label: string) => void = () => undefined;
+  let editTwiceAndReverseMany: (
+    id: string,
+    rank: number,
+    label: string,
+    repetitions: number,
+  ) => void = () => undefined;
   let editSortReverse: (id: string, rank: number) => void = () => undefined;
   let queueEdits: (edits: readonly { id: string; rank: number; label: string }[]) => void = () =>
     undefined;
   let queueSortThenMapReverse: () => void = () => undefined;
+  let queueReverseThenMapReverse: () => void = () => undefined;
   let invalidateKey: () => void = () => undefined;
   let customMap: () => void = () => undefined;
   let customSecondMap: () => void = () => undefined;
@@ -162,6 +190,10 @@ function createHarness(initialItems: Item[]) {
         state[0].set((previous) => multiMappedSort(previous as Item[], id, rank, label));
       editTwiceAndReverse = (id, rank, label) =>
         state[0].set((previous) => multiMappedReverse(previous as Item[], id, rank, label));
+      editTwiceAndReverseMany = (id, rank, label, repetitions) =>
+        state[0].set((previous) =>
+          multiMappedReversals(previous as Item[], id, rank, label, repetitions),
+        );
       editSortReverse = (id, rank) =>
         state[0].set((previous) => hintedReverse(mappedSort(previous as Item[], id, rank)));
       queueEdits = (edits) => {
@@ -187,11 +219,23 @@ function createHarness(initialItems: Item[]) {
           ),
         );
       };
-      invalidateKey = () =>
+      queueReverseThenMapReverse = () => {
+        state[0].set((previous) => hintedPlainReverse(previous as Item[]));
         state[0].set((previous) =>
           hintedReverse(
             hintedMap(previous as Item[], (item) =>
-              item.id === "b" ? { ...item, id: "replacement", label: "Replacement" } : item,
+              item.id === "b" ? { ...item, label: "Beta parity" } : item,
+            ),
+          ),
+        );
+      };
+      invalidateKey = () =>
+        state[0].set((previous) =>
+          hintedReverse(
+            hintedReverse(
+              hintedMap(previous as Item[], (item) =>
+                item.id === "b" ? { ...item, id: "replacement", label: "Replacement" } : item,
+              ),
             ),
           ),
         );
@@ -300,10 +344,13 @@ function createHarness(initialItems: Item[]) {
       editTwiceAndSort(id, rank, label),
     editTwiceAndReverse: (id: string, rank: number, label: string) =>
       editTwiceAndReverse(id, rank, label),
+    editTwiceAndReverseMany: (id: string, rank: number, label: string, repetitions: number) =>
+      editTwiceAndReverseMany(id, rank, label, repetitions),
     editSortReverse: (id: string, rank: number) => editSortReverse(id, rank),
     invalidateKey: () => invalidateKey(),
     queueEdits: (edits: readonly { id: string; rank: number; label: string }[]) =>
       queueEdits(edits),
+    queueReverseThenMapReverse: () => queueReverseThenMapReverse(),
     queueSortThenMapReverse: () => queueSortThenMapReverse(),
   };
 }
@@ -432,6 +479,53 @@ describe("compiled keyed-array map and reorder hints", () => {
     expect(harness.counters.descriptors).toBe(0);
     expect(harness.counters.bindings).toBe(1);
     expect(insertBefore).toHaveBeenCalledTimes(2);
+  });
+
+  it("tracks mapped reverse parity without generic item lookup or unnecessary moves", async () => {
+    const initialItems: Item[] = [
+      { id: "a", label: "Alpha", rank: 1 },
+      { id: "b", label: "Beta", rank: 2 },
+      { id: "c", label: "Gamma", rank: 3 },
+    ];
+    const harness = createHarness(initialItems);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Table />));
+    const rows = [...container.querySelectorAll("li")];
+    const list = container.querySelector("ul")!;
+    const insertBefore = vi.spyOn(list, "insertBefore");
+    const mapSet = vi.spyOn(Map.prototype, "set");
+    harness.counters.bindings = 0;
+    harness.counters.descriptors = 0;
+    harness.counters.keys = 0;
+
+    await act(async () => {
+      harness.editTwiceAndReverseMany("a", 4, "Alpha even", 2);
+      await flushCompilerUpdates();
+    });
+
+    expect(labels(container)).toEqual(["Alpha even:4", "Beta:2", "Gamma:3"]);
+    expect([...container.querySelectorAll("li")]).toEqual(rows);
+    expect(insertBefore).not.toHaveBeenCalled();
+    expect(harness.counters.keys).toBe(1);
+    expect(harness.counters.descriptors).toBe(0);
+    expect(harness.counters.bindings).toBe(1);
+    expect(mapSet.mock.calls.filter(([key]) => initialItems.includes(key as Item))).toHaveLength(0);
+
+    insertBefore.mockClear();
+    mapSet.mockClear();
+    await act(async () => {
+      harness.editTwiceAndReverseMany("b", 5, "Beta odd", 3);
+      await flushCompilerUpdates();
+    });
+
+    expect(labels(container)).toEqual(["Gamma:3", "Beta odd:5", "Alpha even:4"]);
+    expect(insertBefore).toHaveBeenCalledTimes(2);
+    expect(mapSet.mock.calls.filter(([key]) => initialItems.includes(key as Item))).toHaveLength(0);
+    expect(harness.counters.executions).toBe(1);
+    expect(harness.counters.renders).toBe(1);
   });
 
   it("records consecutive map lineage with one source-to-result scan", async () => {
@@ -565,6 +659,41 @@ describe("compiled keyed-array map and reorder hints", () => {
     expect(harness.counters.bindings).toBe(2);
   });
 
+  it("preserves exact parity through a queued reverse and safe mapped reverse", async () => {
+    const initialItems: Item[] = [
+      { id: "a", label: "Alpha", rank: 1 },
+      { id: "b", label: "Beta", rank: 2 },
+      { id: "c", label: "Gamma", rank: 3 },
+    ];
+    const harness = createHarness(initialItems);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Table />));
+    const rows = [...container.querySelectorAll("li")];
+    const list = container.querySelector("ul")!;
+    const insertBefore = vi.spyOn(list, "insertBefore");
+    const mapSet = vi.spyOn(Map.prototype, "set");
+    harness.counters.bindings = 0;
+    harness.counters.descriptors = 0;
+    harness.counters.keys = 0;
+
+    await act(async () => {
+      harness.queueReverseThenMapReverse();
+      await flushCompilerUpdates();
+    });
+
+    expect(labels(container)).toEqual(["Alpha:1", "Beta parity:2", "Gamma:3"]);
+    expect([...container.querySelectorAll("li")]).toEqual(rows);
+    expect(insertBefore).not.toHaveBeenCalled();
+    expect(mapSet.mock.calls.filter(([key]) => initialItems.includes(key as Item))).toHaveLength(0);
+    expect(harness.counters.keys).toBe(1);
+    expect(harness.counters.descriptors).toBe(0);
+    expect(harness.counters.bindings).toBe(1);
+    expect(harness.counters.executions).toBe(1);
+  });
+
   it("falls back before DOM writes for custom map methods and changed keys", async () => {
     const harness = createHarness([
       { id: "a", label: "Alpha", rank: 2 },
@@ -587,7 +716,7 @@ describe("compiled keyed-array map and reorder hints", () => {
       harness.invalidateKey();
       await flushCompilerUpdates();
     });
-    expect(labels(container)).toEqual(["Custom:2", "Replacement:1"]);
+    expect(labels(container)).toEqual(["Replacement:1", "Custom:2"]);
   });
 
   it("discards earlier map lineage when a later map method is custom", async () => {
@@ -627,11 +756,11 @@ describe("compiled keyed-array map and reorder hints", () => {
     harness.counters.bindings = 0;
 
     await act(async () => {
-      harness.editTwiceAndReverse("a", 3, "Alpha subclass");
+      harness.editTwiceAndReverseMany("a", 3, "Alpha subclass", 2);
       await flushCompilerUpdates();
     });
 
-    expect(labels(container)).toEqual(["Beta:1", "Alpha subclass:3"]);
+    expect(labels(container)).toEqual(["Alpha subclass:3", "Beta:1"]);
     expect(container.querySelector('[data-key="a"]')).toBe(rows.get("a"));
     expect(container.querySelector('[data-key="b"]')).toBe(rows.get("b"));
     expect(harness.counters.bindings).toBe(2);
@@ -929,23 +1058,29 @@ describe("compiled keyed-array map and reorder hints", () => {
   );
 
   stressIt(
-    "matches React through 2,000 deterministic mapped reversals",
+    "matches React through 2,000 deterministic mapped reversal parity updates",
     async () => {
       const initialItems = Array.from(
         { length: 31 },
         (_, index): Item => ({ id: `row-${index}`, label: `Row ${index}`, rank: index }),
       );
       const harness = createHarness(initialItems);
-      let updateReact: (id: string, rank: number, label: string) => void = () => undefined;
+      let updateReact: (
+        id: string,
+        rank: number,
+        label: string,
+        repetitions: number,
+      ) => void = () => undefined;
       function Normal() {
         const [items, setItems] = useState(initialItems);
-        updateReact = (id, rank, label) =>
-          setItems((previous) =>
-            previous
+        updateReact = (id, rank, label, repetitions) =>
+          setItems((previous) => {
+            let next = previous
               .map((item) => (item.id === id ? { ...item, label } : item))
-              .map((item) => (item.id === id ? { ...item, rank } : item))
-              .toReversed(),
-          );
+              .map((item) => (item.id === id ? { ...item, rank } : item));
+            for (let count = 0; count < repetitions; count += 1) next = next.toReversed();
+            return next;
+          });
         return (
           <ol>
             {items.map((item) => (
@@ -973,9 +1108,10 @@ describe("compiled keyed-array map and reorder hints", () => {
         const id = `row-${seed % initialItems.length}`;
         const rank = (seed ^ (seed >>> 16)) % 4_003;
         const label = `Reversed ${update}`;
+        const repetitions = 1 + (seed % 4);
         await act(async () => {
-          harness.editTwiceAndReverse(id, rank, label);
-          updateReact(id, rank, label);
+          harness.editTwiceAndReverseMany(id, rank, label, repetitions);
+          updateReact(id, rank, label, repetitions);
           await flushCompilerUpdates();
         });
         expect(labels(compiledContainer)).toEqual(labels(reactContainer));
@@ -1008,10 +1144,10 @@ describe("compiled keyed-array map and reorder hints", () => {
     });
     roots.push(root);
     await act(async () => {
-      hydration.editTwiceAndReverse("a", 5, "Alpha hydrated");
+      hydration.editTwiceAndReverseMany("a", 5, "Alpha hydrated", 2);
       await flushCompilerUpdates();
     });
-    expect(labels(container)).toEqual(["Gamma:3", "Beta:2", "Alpha hydrated:5"]);
+    expect(labels(container)).toEqual(["Alpha hydrated:5", "Beta:2", "Gamma:3"]);
     expect(recoverable).toEqual([]);
 
     const unmounted = createHarness(initialItems);
@@ -1020,7 +1156,7 @@ describe("compiled keyed-array map and reorder hints", () => {
     const unmountRoot = createRoot(unmountContainer);
     await act(async () => unmountRoot.render(<unmounted.Table />));
     act(() => {
-      unmounted.editTwiceAndReverse("b", 8, "Never committed");
+      unmounted.editTwiceAndReverseMany("b", 8, "Never committed", 3);
       unmountRoot.unmount();
     });
     await flushCompilerUpdates();

--- a/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-map-reorder-hints.test.tsx
+++ b/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-map-reorder-hints.test.tsx
@@ -7,7 +7,6 @@ import {
   createCompiledComponent,
   createCompilerKeyedArrayMapPipeline,
   createCompilerKeyedArrayMapReorder,
-  createCompilerKeyedArrayReorder,
   type CompilerKeyedRowElement,
 } from "../compiler-runtime";
 
@@ -78,10 +77,6 @@ function hintedSort(items: Item[]): Item[] {
 
 function hintedReverse(items: Item[]): Item[] {
   return createCompilerKeyedArrayMapReorder(items, items.toReversed) as Item[];
-}
-
-function hintedPlainReverse(items: Item[]): Item[] {
-  return createCompilerKeyedArrayReorder(items, items.toReversed) as Item[];
 }
 
 function mappedSort(items: Item[], id: string, rank: number, label?: string): Item[] {
@@ -164,7 +159,6 @@ function createHarness(initialItems: Item[]) {
   let queueEdits: (edits: readonly { id: string; rank: number; label: string }[]) => void = () =>
     undefined;
   let queueSortThenMapReverse: () => void = () => undefined;
-  let queueReverseThenMapReverse: () => void = () => undefined;
   let invalidateKey: () => void = () => undefined;
   let customMap: () => void = () => undefined;
   let customSecondMap: () => void = () => undefined;
@@ -215,16 +209,6 @@ function createHarness(initialItems: Item[]) {
           hintedReverse(
             hintedMap(previous as Item[], (item) =>
               item.id === "c" ? { ...item, label: "Gamma reversed" } : item,
-            ),
-          ),
-        );
-      };
-      queueReverseThenMapReverse = () => {
-        state[0].set((previous) => hintedPlainReverse(previous as Item[]));
-        state[0].set((previous) =>
-          hintedReverse(
-            hintedMap(previous as Item[], (item) =>
-              item.id === "b" ? { ...item, label: "Beta parity" } : item,
             ),
           ),
         );
@@ -350,7 +334,6 @@ function createHarness(initialItems: Item[]) {
     invalidateKey: () => invalidateKey(),
     queueEdits: (edits: readonly { id: string; rank: number; label: string }[]) =>
       queueEdits(edits),
-    queueReverseThenMapReverse: () => queueReverseThenMapReverse(),
     queueSortThenMapReverse: () => queueSortThenMapReverse(),
   };
 }
@@ -657,41 +640,6 @@ describe("compiled keyed-array map and reorder hints", () => {
     expect(harness.counters.keys).toBe(2);
     expect(harness.counters.descriptors).toBe(0);
     expect(harness.counters.bindings).toBe(2);
-  });
-
-  it("preserves exact parity through a queued reverse and safe mapped reverse", async () => {
-    const initialItems: Item[] = [
-      { id: "a", label: "Alpha", rank: 1 },
-      { id: "b", label: "Beta", rank: 2 },
-      { id: "c", label: "Gamma", rank: 3 },
-    ];
-    const harness = createHarness(initialItems);
-    const container = document.createElement("div");
-    document.body.append(container);
-    const root = createRoot(container);
-    roots.push(root);
-    await act(async () => root.render(<harness.Table />));
-    const rows = [...container.querySelectorAll("li")];
-    const list = container.querySelector("ul")!;
-    const insertBefore = vi.spyOn(list, "insertBefore");
-    const mapSet = vi.spyOn(Map.prototype, "set");
-    harness.counters.bindings = 0;
-    harness.counters.descriptors = 0;
-    harness.counters.keys = 0;
-
-    await act(async () => {
-      harness.queueReverseThenMapReverse();
-      await flushCompilerUpdates();
-    });
-
-    expect(labels(container)).toEqual(["Alpha:1", "Beta parity:2", "Gamma:3"]);
-    expect([...container.querySelectorAll("li")]).toEqual(rows);
-    expect(insertBefore).not.toHaveBeenCalled();
-    expect(mapSet.mock.calls.filter(([key]) => initialItems.includes(key as Item))).toHaveLength(0);
-    expect(harness.counters.keys).toBe(1);
-    expect(harness.counters.descriptors).toBe(0);
-    expect(harness.counters.bindings).toBe(1);
-    expect(harness.counters.executions).toBe(1);
   });
 
   it("falls back before DOM writes for custom map methods and changed keys", async () => {

--- a/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-reorder-hints.test.tsx
+++ b/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-reorder-hints.test.tsx
@@ -65,6 +65,7 @@ function createReorderHarness(initialItems: Item[], readsCollection = false) {
   };
   let reverse: () => void = () => undefined;
   let queueTwo: () => void = () => undefined;
+  let queueThree: () => void = () => undefined;
   let plainThenReverse: () => void = () => undefined;
   let customReverse: () => void = () => undefined;
   const Table = createCompiledComponent({
@@ -75,6 +76,11 @@ function createReorderHarness(initialItems: Item[], readsCollection = false) {
       const items = () => state[0].get() as Item[];
       reverse = () => state[0].set((previous) => hintedReverse(previous as Item[]));
       queueTwo = () => {
+        state[0].set((previous) => hintedReverse(previous as Item[]));
+        state[0].set((previous) => hintedReverse(previous as Item[]));
+      };
+      queueThree = () => {
+        state[0].set((previous) => hintedReverse(previous as Item[]));
         state[0].set((previous) => hintedReverse(previous as Item[]));
         state[0].set((previous) => hintedReverse(previous as Item[]));
       };
@@ -143,6 +149,7 @@ function createReorderHarness(initialItems: Item[], readsCollection = false) {
     counters,
     customReverse: () => customReverse(),
     plainThenReverse: () => plainThenReverse(),
+    queueThree: () => queueThree(),
     queueTwo: () => queueTwo(),
     reverse: () => reverse(),
   };
@@ -190,7 +197,7 @@ describe("compiled keyed-array reorder hints", () => {
     },
   );
 
-  it("composes queued reverses as one validated final permutation", async () => {
+  it("tracks queued reverse parity as exact identity and reverse orders", async () => {
     const initialItems: Item[] = [
       { id: "a", label: "Alpha" },
       { id: "b", label: "Beta" },
@@ -205,6 +212,7 @@ describe("compiled keyed-array reorder hints", () => {
     const rows = [...container.querySelectorAll("li")];
     const list = container.querySelector("ul")!;
     const insertBefore = vi.spyOn(list, "insertBefore");
+    const mapSet = vi.spyOn(Map.prototype, "set");
     harness.counters.keys = 0;
     harness.counters.descriptors = 0;
     harness.counters.bindings = 0;
@@ -222,6 +230,18 @@ describe("compiled keyed-array reorder hints", () => {
     expect(harness.counters.keys).toBe(0);
     expect(harness.counters.descriptors).toBe(0);
     expect(harness.counters.bindings).toBe(0);
+    expect(mapSet.mock.calls.filter(([key]) => initialItems.includes(key as Item))).toHaveLength(0);
+
+    insertBefore.mockClear();
+    mapSet.mockClear();
+    await act(async () => {
+      harness.queueThree();
+      await flushCompilerUpdates();
+    });
+
+    expect(itemLabels(container)).toEqual(["Gamma", "Beta", "Alpha"]);
+    expect(insertBefore).toHaveBeenCalledTimes(2);
+    expect(mapSet.mock.calls.filter(([key]) => initialItems.includes(key as Item))).toHaveLength(0);
   });
 
   it("falls back safely for custom methods, unhinted chains, and collection-reading bindings", async () => {

--- a/packages/farm-react/src/compiler-runtime.tsx
+++ b/packages/farm-react/src/compiler-runtime.tsx
@@ -71,11 +71,14 @@ interface CompilerKeyedArrayWindowReplaceHint {
   readonly previous?: CompilerKeyedArrayWindowReplaceHint;
 }
 
-type CompilerKeyedArrayExactOrder = "identity" | "reverse";
-type CompilerKeyedArrayReorderKind = CompilerKeyedArrayExactOrder | "permutation";
+const enum CompilerKeyedArrayReorderKind {
+  Reverse,
+  Permutation,
+}
 
 interface CompilerKeyedArrayReorderHint {
-  readonly kind: CompilerKeyedArrayReorderKind;
+  /** An omitted kind is an exact identity order. */
+  readonly kind?: CompilerKeyedArrayReorderKind;
   readonly sourceToken: object;
   readonly sourceLength: number;
   readonly resultLength: number;
@@ -85,8 +88,8 @@ interface CompilerKeyedArrayReorderHint {
 }
 
 interface CompilerKeyedArrayMapPipelineHint {
-  /** Exact order relative to the committed rows, when the complete lineage proves it. */
-  readonly order?: CompilerKeyedArrayExactOrder;
+  /** True while every map preserves the committed row order. */
+  readonly ordered: boolean;
   readonly sourceToken: object;
   readonly sourceLength: number;
   readonly resultLength: number;
@@ -95,12 +98,10 @@ interface CompilerKeyedArrayMapPipelineHint {
 
 function reversedCompilerKeyedArrayOrder(
   order: CompilerKeyedArrayReorderKind | undefined,
-): CompilerKeyedArrayReorderKind {
-  return order === undefined || order === "identity"
-    ? "reverse"
-    : order === "reverse"
-      ? "identity"
-      : "permutation";
+): CompilerKeyedArrayReorderKind | undefined {
+  return order === CompilerKeyedArrayReorderKind.Reverse
+    ? undefined
+    : (order ?? CompilerKeyedArrayReorderKind.Reverse);
 }
 
 type CompilerKeyedCollectionKind = "set" | "map";
@@ -674,12 +675,7 @@ function recordCompilerKeyedArrayMapPipeline(previous: unknown, value: unknown):
         ? undefined
         : COMPILER_KEYED_ARRAY_REORDERS.get(previousTarget);
     const previousSource =
-      previousMapPipeline ||
-      (previousReorder?.mapped ||
-      previousReorder?.kind === "identity" ||
-      previousReorder?.kind === "reverse"
-        ? previousReorder
-        : undefined);
+      previousMapPipeline || (previousReorder?.mapped ? previousReorder : undefined);
     if (!committedSource && (!previousSource || previousSource.resultLength !== previous.length)) {
       return value;
     }
@@ -708,13 +704,7 @@ function recordCompilerKeyedArrayMapPipeline(previous: unknown, value: unknown):
       if (!Object.is(mappedItem, sourceItem)) mappedItemSources.set(mappedItem, sourceItem);
     }
     COMPILER_KEYED_ARRAY_MAP_PIPELINES.set(valueTarget, {
-      order:
-        previousMapPipeline?.order ||
-        (committedSource
-          ? "identity"
-          : previousReorder?.kind === "identity" || previousReorder?.kind === "reverse"
-            ? previousReorder.kind
-            : undefined),
+      ordered: previousMapPipeline?.ordered ?? committedSource,
       sourceToken,
       sourceLength: previousSource?.sourceLength ?? previous.length,
       resultLength: value.length,
@@ -799,11 +789,13 @@ export function createCompilerKeyedArrayMapReorder(
     if (!source || source.resultLength !== previous.length) return value;
     COMPILER_KEYED_ARRAY_REORDERS.set(valueTarget, {
       kind:
-        method === NATIVE_ARRAY_TO_REVERSED
-          ? reversedCompilerKeyedArrayOrder(
-              mapPipeline ? (mapPipeline.order ?? "permutation") : previousReorder?.kind,
-            )
-          : "permutation",
+        method !== NATIVE_ARRAY_TO_REVERSED
+          ? CompilerKeyedArrayReorderKind.Permutation
+          : mapPipeline?.ordered
+            ? CompilerKeyedArrayReorderKind.Reverse
+            : previousReorder
+              ? reversedCompilerKeyedArrayOrder(previousReorder.kind)
+              : CompilerKeyedArrayReorderKind.Permutation,
       sourceToken: source.sourceToken,
       sourceLength: source.sourceLength,
       resultLength: value.length,
@@ -1381,7 +1373,7 @@ export function createCompilerKeyedArraySort(
     const sourceToken = previousUpdate?.sourceToken || compilerKeyedCollectionToken(previousTarget);
     if (!sourceToken) return value;
     COMPILER_KEYED_ARRAY_REORDERS.set(valueTarget, {
-      kind: "permutation",
+      kind: CompilerKeyedArrayReorderKind.Permutation,
       sourceToken,
       sourceLength: previous.length,
       resultLength: value.length,
@@ -1395,7 +1387,7 @@ export function createCompilerKeyedArraySort(
 function recordCompilerKeyedArrayStructuralReorder(
   previous: unknown,
   value: unknown,
-  kind: CompilerKeyedArrayReorderHint["kind"],
+  kind: CompilerKeyedArrayReorderKind,
 ): unknown {
   try {
     const previousTarget = compilerObject(previous);
@@ -1421,12 +1413,7 @@ function recordCompilerKeyedArrayStructuralReorder(
     const sourceToken = previousUpdate?.sourceToken || structuralSource?.sourceToken;
     if (!sourceToken) return value;
     COMPILER_KEYED_ARRAY_REORDERS.set(valueTarget, {
-      kind:
-        previousUpdate && kind === "reverse"
-          ? reversedCompilerKeyedArrayOrder(previousUpdate.kind)
-          : previousUpdate
-            ? "permutation"
-            : kind,
+      kind: previousUpdate ? CompilerKeyedArrayReorderKind.Permutation : kind,
       sourceToken,
       sourceLength: previousUpdate?.sourceLength || structuralSource.sourceLength,
       resultLength: value.length,
@@ -1462,7 +1449,11 @@ export function createCompilerKeyedArrayStructuralReorder(
   } catch {
     return value;
   }
-  return recordCompilerKeyedArrayStructuralReorder(previous, value, "reverse");
+  return recordCompilerKeyedArrayStructuralReorder(
+    previous,
+    value,
+    CompilerKeyedArrayReorderKind.Reverse,
+  );
 }
 
 /** @internal Executes a native sort after a compiler-proven filter or slice pipeline. */
@@ -1495,7 +1486,11 @@ export function createCompilerKeyedArrayStructuralSort(
   } catch {
     return value;
   }
-  return recordCompilerKeyedArrayStructuralReorder(previous, value, "permutation");
+  return recordCompilerKeyedArrayStructuralReorder(
+    previous,
+    value,
+    CompilerKeyedArrayReorderKind.Permutation,
+  );
 }
 
 /** @internal Preserves a proven native collection mutation while recording its executed key. */
@@ -2419,6 +2414,12 @@ interface CompilerKeyedRowInstance extends CompilerHostInstance {
   item: unknown;
   index: number;
   conditionalValues: ReadonlyMap<number, readonly unknown[]>;
+}
+
+function keyedRowInstancesByKey(
+  instances: readonly CompilerKeyedRowInstance[],
+): Map<string, CompilerKeyedRowInstance> {
+  return new Map(instances.map((instance) => [instance.key, instance]));
 }
 
 interface CompilerKeyedIdentityTargetSnapshot {
@@ -3538,7 +3539,7 @@ class CompilerNestedKeyedRanges implements CompilerHostTreeScope {
       }
       anchor = instance.element;
     }
-    this.instances[rangeIndex] = new Map(nextInstances.map((instance) => [instance.key, instance]));
+    this.instances[rangeIndex] = keyedRowInstancesByKey(nextInstances);
     return true;
   }
 
@@ -3934,7 +3935,7 @@ class CompilerNestedMixedRanges implements CompilerHostTreeScope {
       }
       anchor = row.element;
     }
-    instance.value = new Map(nextInstances.map((row) => [row.key, row]));
+    instance.value = keyedRowInstancesByKey(nextInstances);
     return true;
   }
 
@@ -4984,8 +4985,7 @@ function reconcileCompilerKeyedArrayMapReorder(
   }
 
   const previousInstances = [...instances.values()];
-  const exactOrder = update.kind === "permutation" ? undefined : update.kind;
-  const reverse = exactOrder === "reverse";
+  const reverse = update.kind === CompilerKeyedArrayReorderKind.Reverse;
   const prepared = (() => {
     const changed: Array<{
       bindingUpdates: CompilerPreparedKeyedRowBindingUpdate[];
@@ -4993,7 +4993,10 @@ function reconcileCompilerKeyedArrayMapReorder(
       item: unknown;
     }> = [];
     try {
-      const instancesByItem = exactOrder ? undefined : new Map<unknown, CompilerKeyedRowInstance>();
+      const instancesByItem =
+        update.kind === CompilerKeyedArrayReorderKind.Permutation
+          ? new Map<unknown, CompilerKeyedRowInstance>()
+          : undefined;
       if (instancesByItem) {
         for (let sourceIndex = 0; sourceIndex < previousInstances.length; sourceIndex += 1) {
           const instance = previousInstances[sourceIndex];
@@ -5003,12 +5006,12 @@ function reconcileCompilerKeyedArrayMapReorder(
         }
       }
 
-      const nextInstances: CompilerKeyedRowInstance[] = exactOrder ? previousInstances : [];
-      const sequence: number[] | undefined = exactOrder ? undefined : [];
+      const nextInstances: CompilerKeyedRowInstance[] = instancesByItem ? [] : previousInstances;
+      const sequence: number[] | undefined = instancesByItem ? [] : undefined;
       for (let targetIndex = 0; targetIndex < finalValue.length; targetIndex += 1) {
         const item = finalValue[targetIndex];
         let instance: CompilerKeyedRowInstance | undefined;
-        if (exactOrder) {
+        if (!instancesByItem) {
           const sourceIndex = reverse ? finalValue.length - targetIndex - 1 : targetIndex;
           instance = previousInstances[sourceIndex];
           if (!instance || instance.index !== sourceIndex) return undefined;
@@ -5055,9 +5058,7 @@ function reconcileCompilerKeyedArrayMapReorder(
   for (let index = 0; index < prepared.nextInstances.length; index += 1) {
     prepared.nextInstances[index].index = index;
   }
-  return exactOrder === "identity"
-    ? instances
-    : new Map(prepared.nextInstances.map((instance) => [instance.key, instance]));
+  return reverse || prepared.sequence ? keyedRowInstancesByKey(prepared.nextInstances) : instances;
 }
 
 function reconcileCompilerKeyedArrayAppend(
@@ -5265,7 +5266,7 @@ function reconcileCompilerKeyedArrayPosition(
     for (let index = update.position; index < previousInstances.length; index += 1) {
       previousInstances[index].index = index;
     }
-    return new Map(previousInstances.map((instance) => [instance.key, instance]));
+    return keyedRowInstancesByKey(previousInstances);
   }
 
   let item: unknown;
@@ -5298,7 +5299,7 @@ function reconcileCompilerKeyedArrayPosition(
     for (let index = update.position + 1; index < previousInstances.length; index += 1) {
       previousInstances[index].index = index;
     }
-    return new Map(previousInstances.map((instance) => [instance.key, instance]));
+    return keyedRowInstancesByKey(previousInstances);
   }
 
   if (!previous || previous.index !== update.position) return undefined;
@@ -5330,7 +5331,7 @@ function reconcileCompilerKeyedArrayPosition(
   previous.scope?.cleanup();
   previous.element.replaceWith(replacement.element);
   previousInstances[update.position] = replacement;
-  return new Map(previousInstances.map((instance) => [instance.key, instance]));
+  return keyedRowInstancesByKey(previousInstances);
 }
 
 function reconcileCompilerKeyedArrayBatchInsert(
@@ -5406,7 +5407,7 @@ function reconcileCompilerKeyedArrayBatchInsert(
   for (let index = update.position + insertCount; index < previousInstances.length; index += 1) {
     previousInstances[index].index = index;
   }
-  return new Map(previousInstances.map((instance) => [instance.key, instance]));
+  return keyedRowInstancesByKey(previousInstances);
 }
 
 type CompilerKeyedArrayDisjointWindow = [
@@ -5669,7 +5670,7 @@ function reconcileCompilerKeyedArrayWindowReplace(
       for (let index = 0; index < nextInstances.length; index += 1) {
         nextInstances[index].index = index;
       }
-      return new Map(nextInstances.map((instance) => [instance.key, instance]));
+      return keyedRowInstancesByKey(nextInstances);
     }
 
     const touchedIndices = new Set<number>();
@@ -5752,9 +5753,7 @@ function reconcileCompilerKeyedArrayWindowReplace(
         instance.item = item;
       }
     }
-    return replacesRows
-      ? new Map(previousInstances.map((instance) => [instance.key, instance]))
-      : instances;
+    return replacesRows ? keyedRowInstancesByKey(previousInstances) : instances;
   }
 
   const update = updates[0];
@@ -5831,7 +5830,7 @@ function reconcileCompilerKeyedArrayWindowReplace(
   for (let index = update.position; index < previousInstances.length; index += 1) {
     previousInstances[index].index = index;
   }
-  return new Map(previousInstances.map((instance) => [instance.key, instance]));
+  return keyedRowInstancesByKey(previousInstances);
 }
 
 function reconcileCompilerKeyedArrayPositionWithBatch(
@@ -5968,7 +5967,7 @@ function reconcileCompilerKeyedArrayStructuralReorder(
   for (let index = 0; index < prepared.nextInstances.length; index += 1) {
     prepared.nextInstances[index].index = index;
   }
-  return new Map(prepared.nextInstances.map((instance) => [instance.key, instance]));
+  return keyedRowInstancesByKey(prepared.nextInstances);
 }
 
 function reconcileCompilerKeyedArrayReorder(
@@ -6008,7 +6007,7 @@ function reconcileCompilerKeyedArrayReorder(
   }
 
   const previousInstances = [...instances.values()];
-  if (update.kind === "permutation") {
+  if (update.kind === CompilerKeyedArrayReorderKind.Permutation) {
     const instancesByItem = new Map<unknown, CompilerKeyedRowInstance>();
     try {
       for (let sourceIndex = 0; sourceIndex < previousInstances.length; sourceIndex += 1) {
@@ -6033,7 +6032,7 @@ function reconcileCompilerKeyedArrayReorder(
       for (let index = 0; index < nextInstances.length; index += 1) {
         nextInstances[index].index = index;
       }
-      return new Map(nextInstances.map((instance) => [instance.key, instance]));
+      return keyedRowInstancesByKey(nextInstances);
     } catch {
       return undefined;
     }
@@ -6042,7 +6041,9 @@ function reconcileCompilerKeyedArrayReorder(
   try {
     for (let targetIndex = 0; targetIndex < previousInstances.length; targetIndex += 1) {
       const sourceIndex =
-        update.kind === "reverse" ? previousInstances.length - targetIndex - 1 : targetIndex;
+        update.kind === CompilerKeyedArrayReorderKind.Reverse
+          ? previousInstances.length - targetIndex - 1
+          : targetIndex;
       const instance = previousInstances[sourceIndex];
       if (instance.index !== sourceIndex || !Object.is(instance.item, finalValue[targetIndex])) {
         return undefined;
@@ -6052,13 +6053,13 @@ function reconcileCompilerKeyedArrayReorder(
     return undefined;
   }
 
-  if (update.kind === "identity") return instances;
+  if (update.kind === undefined) return instances;
 
   // A reverse has a one-row LIS. Keep the first committed row in place and
   // move every following row before the previous anchor, which performs the
   // minimum n - 1 connected DOM moves without rescanning keys or descriptors.
   reverseCompilerKeyedRows(root, previousInstances);
-  return new Map(previousInstances.map((instance) => [instance.key, instance]));
+  return keyedRowInstancesByKey(previousInstances);
 }
 
 interface CompilerPreparedKeyedArrayReorder {
@@ -6096,26 +6097,15 @@ function prepareCompilerKeyedArrayReorder(
   };
 }
 
-function callPreparedCompilerKeyedArrayReorder(
-  reconcile: typeof reconcileCompilerKeyedArrayReorder,
-  args: Parameters<typeof reconcileCompilerKeyedArrayReorder>,
-  prepared: CompilerPreparedKeyedArrayReorder,
-): ReadonlyMap<string, CompilerKeyedRowInstance> | undefined {
-  return reconcile(args[0], args[1], args[2], args[3], args[4], args[5], prepared);
-}
-
 function reconcileCompilerKeyedArrayReorderWithMap(
   ...args: Parameters<typeof reconcileCompilerKeyedArrayReorder>
 ): ReadonlyMap<string, CompilerKeyedRowInstance> | undefined {
   const prepared = prepareCompilerKeyedArrayReorder(args);
   if (!prepared) return undefined;
-  return callPreparedCompilerKeyedArrayReorder(
-    prepared.update?.mapped
-      ? reconcileCompilerKeyedArrayMapReorder
-      : reconcileCompilerKeyedArrayReorder,
-    args,
-    prepared,
-  );
+  const reconcile = prepared.update?.mapped
+    ? reconcileCompilerKeyedArrayMapReorder
+    : reconcileCompilerKeyedArrayReorder;
+  return reconcile(args[0], args[1], args[2], args[3], args[4], args[5], prepared);
 }
 
 function reconcileCompilerKeyedArrayReorderWithMapAndStructural(
@@ -6123,15 +6113,12 @@ function reconcileCompilerKeyedArrayReorderWithMapAndStructural(
 ): ReadonlyMap<string, CompilerKeyedRowInstance> | undefined {
   const prepared = prepareCompilerKeyedArrayReorder(args);
   if (!prepared) return undefined;
-  return callPreparedCompilerKeyedArrayReorder(
-    prepared.update?.mapped
-      ? reconcileCompilerKeyedArrayMapReorder
-      : prepared.update?.structuralUpdate
-        ? reconcileCompilerKeyedArrayStructuralReorder
-        : reconcileCompilerKeyedArrayReorder,
-    args,
-    prepared,
-  );
+  const reconcile = prepared.update?.mapped
+    ? reconcileCompilerKeyedArrayMapReorder
+    : prepared.update?.structuralUpdate
+      ? reconcileCompilerKeyedArrayStructuralReorder
+      : reconcileCompilerKeyedArrayReorder;
+  return reconcile(args[0], args[1], args[2], args[3], args[4], args[5], prepared);
 }
 
 function reconcileCompilerKeyedArrayPrepend(
@@ -6202,7 +6189,7 @@ function reconcileCompilerKeyedArrayPrepend(
   for (let index = 0; index < previousInstances.length; index += 1) {
     previousInstances[index].index = prefixLength + index;
   }
-  return new Map([...prepended, ...previousInstances].map((instance) => [instance.key, instance]));
+  return keyedRowInstancesByKey([...prepended, ...previousInstances]);
 }
 
 function reconcileCompilerKeyedArrayFilter(
@@ -6269,7 +6256,7 @@ function reconcileCompilerKeyedArrayFilter(
   for (let index = 0; index < survivors.length; index += 1) {
     survivors[index].index = index;
   }
-  return new Map(survivors.map((instance) => [instance.key, instance]));
+  return keyedRowInstancesByKey(survivors);
 }
 
 function createKeyedRowConditionalRuntime(): KeyedRowConditionalRuntime {
@@ -7241,7 +7228,7 @@ function createKeyedRowsBlockComponent(
       } else {
         reorderCompilerKeyedRows(this.root, nextInstances, sequence, null);
       }
-      this.instances = new Map(nextInstances.map((instance) => [instance.key, instance]));
+      this.instances = keyedRowInstancesByKey(nextInstances);
       this.rebuildElementIndex(this.instances);
       this.pruneEventHandlers(rows.keys);
       this.pruneConditionalListeners(rows.keys);

--- a/packages/farm-react/src/compiler-runtime.tsx
+++ b/packages/farm-react/src/compiler-runtime.tsx
@@ -71,8 +71,11 @@ interface CompilerKeyedArrayWindowReplaceHint {
   readonly previous?: CompilerKeyedArrayWindowReplaceHint;
 }
 
+type CompilerKeyedArrayExactOrder = "identity" | "reverse";
+type CompilerKeyedArrayReorderKind = CompilerKeyedArrayExactOrder | "permutation";
+
 interface CompilerKeyedArrayReorderHint {
-  readonly kind: "permutation" | "reverse";
+  readonly kind: CompilerKeyedArrayReorderKind;
   readonly sourceToken: object;
   readonly sourceLength: number;
   readonly resultLength: number;
@@ -82,12 +85,22 @@ interface CompilerKeyedArrayReorderHint {
 }
 
 interface CompilerKeyedArrayMapPipelineHint {
-  /** True while every map preserves the committed row order. */
-  readonly ordered: boolean;
+  /** Exact order relative to the committed rows, when the complete lineage proves it. */
+  readonly order?: CompilerKeyedArrayExactOrder;
   readonly sourceToken: object;
   readonly sourceLength: number;
   readonly resultLength: number;
   readonly mappedItemSources: ReadonlyMap<unknown, unknown>;
+}
+
+function reversedCompilerKeyedArrayOrder(
+  order: CompilerKeyedArrayReorderKind | undefined,
+): CompilerKeyedArrayReorderKind {
+  return order === undefined || order === "identity"
+    ? "reverse"
+    : order === "reverse"
+      ? "identity"
+      : "permutation";
 }
 
 type CompilerKeyedCollectionKind = "set" | "map";
@@ -661,7 +674,12 @@ function recordCompilerKeyedArrayMapPipeline(previous: unknown, value: unknown):
         ? undefined
         : COMPILER_KEYED_ARRAY_REORDERS.get(previousTarget);
     const previousSource =
-      previousMapPipeline || (previousReorder?.mapped ? previousReorder : undefined);
+      previousMapPipeline ||
+      (previousReorder?.mapped ||
+      previousReorder?.kind === "identity" ||
+      previousReorder?.kind === "reverse"
+        ? previousReorder
+        : undefined);
     if (!committedSource && (!previousSource || previousSource.resultLength !== previous.length)) {
       return value;
     }
@@ -690,7 +708,13 @@ function recordCompilerKeyedArrayMapPipeline(previous: unknown, value: unknown):
       if (!Object.is(mappedItem, sourceItem)) mappedItemSources.set(mappedItem, sourceItem);
     }
     COMPILER_KEYED_ARRAY_MAP_PIPELINES.set(valueTarget, {
-      ordered: previousMapPipeline?.ordered ?? committedSource,
+      order:
+        previousMapPipeline?.order ||
+        (committedSource
+          ? "identity"
+          : previousReorder?.kind === "identity" || previousReorder?.kind === "reverse"
+            ? previousReorder.kind
+            : undefined),
       sourceToken,
       sourceLength: previousSource?.sourceLength ?? previous.length,
       resultLength: value.length,
@@ -774,7 +798,12 @@ export function createCompilerKeyedArrayMapReorder(
     const source = mapPipeline || (previousReorder?.mapped ? previousReorder : undefined);
     if (!source || source.resultLength !== previous.length) return value;
     COMPILER_KEYED_ARRAY_REORDERS.set(valueTarget, {
-      kind: method === NATIVE_ARRAY_TO_REVERSED && mapPipeline?.ordered ? "reverse" : "permutation",
+      kind:
+        method === NATIVE_ARRAY_TO_REVERSED
+          ? reversedCompilerKeyedArrayOrder(
+              mapPipeline ? (mapPipeline.order ?? "permutation") : previousReorder?.kind,
+            )
+          : "permutation",
       sourceToken: source.sourceToken,
       sourceLength: source.sourceLength,
       resultLength: value.length,
@@ -1293,7 +1322,7 @@ export function createCompilerKeyedArrayReorder(previous: unknown, method: unkno
     const sourceToken = previousUpdate?.sourceToken || compilerKeyedCollectionToken(previousTarget);
     if (!sourceToken) return value;
     COMPILER_KEYED_ARRAY_REORDERS.set(valueTarget, {
-      kind: previousUpdate ? "permutation" : "reverse",
+      kind: reversedCompilerKeyedArrayOrder(previousUpdate?.kind),
       sourceToken,
       sourceLength: previous.length,
       resultLength: value.length,
@@ -1392,7 +1421,12 @@ function recordCompilerKeyedArrayStructuralReorder(
     const sourceToken = previousUpdate?.sourceToken || structuralSource?.sourceToken;
     if (!sourceToken) return value;
     COMPILER_KEYED_ARRAY_REORDERS.set(valueTarget, {
-      kind: previousUpdate ? "permutation" : kind,
+      kind:
+        previousUpdate && kind === "reverse"
+          ? reversedCompilerKeyedArrayOrder(previousUpdate.kind)
+          : previousUpdate
+            ? "permutation"
+            : kind,
       sourceToken,
       sourceLength: previousUpdate?.sourceLength || structuralSource.sourceLength,
       resultLength: value.length,
@@ -4950,15 +4984,16 @@ function reconcileCompilerKeyedArrayMapReorder(
   }
 
   const previousInstances = [...instances.values()];
+  const exactOrder = update.kind === "permutation" ? undefined : update.kind;
+  const reverse = exactOrder === "reverse";
   const prepared = (() => {
-    const reverse = update.kind === "reverse";
     const changed: Array<{
       bindingUpdates: CompilerPreparedKeyedRowBindingUpdate[];
       instance: CompilerKeyedRowInstance;
       item: unknown;
     }> = [];
     try {
-      const instancesByItem = reverse ? undefined : new Map<unknown, CompilerKeyedRowInstance>();
+      const instancesByItem = exactOrder ? undefined : new Map<unknown, CompilerKeyedRowInstance>();
       if (instancesByItem) {
         for (let sourceIndex = 0; sourceIndex < previousInstances.length; sourceIndex += 1) {
           const instance = previousInstances[sourceIndex];
@@ -4968,13 +5003,13 @@ function reconcileCompilerKeyedArrayMapReorder(
         }
       }
 
-      const nextInstances: CompilerKeyedRowInstance[] = reverse ? previousInstances : [];
-      const sequence: number[] | undefined = reverse ? undefined : [];
+      const nextInstances: CompilerKeyedRowInstance[] = exactOrder ? previousInstances : [];
+      const sequence: number[] | undefined = exactOrder ? undefined : [];
       for (let targetIndex = 0; targetIndex < finalValue.length; targetIndex += 1) {
         const item = finalValue[targetIndex];
         let instance: CompilerKeyedRowInstance | undefined;
-        if (reverse) {
-          const sourceIndex = finalValue.length - targetIndex - 1;
+        if (exactOrder) {
+          const sourceIndex = reverse ? finalValue.length - targetIndex - 1 : targetIndex;
           instance = previousInstances[sourceIndex];
           if (!instance || instance.index !== sourceIndex) return undefined;
           if (Object.is(instance.item, item)) continue;
@@ -5010,7 +5045,7 @@ function reconcileCompilerKeyedArrayMapReorder(
 
   if (prepared.sequence) {
     reorderCompilerKeyedRows(root, prepared.nextInstances, prepared.sequence, null);
-  } else {
+  } else if (reverse) {
     reverseCompilerKeyedRows(root, prepared.nextInstances);
   }
   for (const { bindingUpdates, instance, item } of prepared.changed) {
@@ -5020,7 +5055,9 @@ function reconcileCompilerKeyedArrayMapReorder(
   for (let index = 0; index < prepared.nextInstances.length; index += 1) {
     prepared.nextInstances[index].index = index;
   }
-  return new Map(prepared.nextInstances.map((instance) => [instance.key, instance]));
+  return exactOrder === "identity"
+    ? instances
+    : new Map(prepared.nextInstances.map((instance) => [instance.key, instance]));
 }
 
 function reconcileCompilerKeyedArrayAppend(
@@ -6003,9 +6040,10 @@ function reconcileCompilerKeyedArrayReorder(
   }
 
   try {
-    for (let sourceIndex = 0; sourceIndex < previousInstances.length; sourceIndex += 1) {
+    for (let targetIndex = 0; targetIndex < previousInstances.length; targetIndex += 1) {
+      const sourceIndex =
+        update.kind === "reverse" ? previousInstances.length - targetIndex - 1 : targetIndex;
       const instance = previousInstances[sourceIndex];
-      const targetIndex = previousInstances.length - sourceIndex - 1;
       if (instance.index !== sourceIndex || !Object.is(instance.item, finalValue[targetIndex])) {
         return undefined;
       }
@@ -6013,6 +6051,8 @@ function reconcileCompilerKeyedArrayReorder(
   } catch {
     return undefined;
   }
+
+  if (update.kind === "identity") return instances;
 
   // A reverse has a one-row LIS. Keep the first committed row in place and
   // move every following row before the previous anchor, which performs the

--- a/packages/farm-react/vitest.stress.config.ts
+++ b/packages/farm-react/vitest.stress.config.ts
@@ -20,7 +20,7 @@ export default defineConfig({
     ],
     setupFiles: ["src/__tests__/stress.setup.ts"],
     testNamePattern:
-      /2,000 deterministic mapped reorder updates|2,000 deterministic mapped reversals|3,000 deterministic recursive updates|4,096 rows/,
+      /2,000 deterministic mapped reorder updates|2,000 deterministic mapped reversal parity updates|3,000 deterministic recursive updates|4,096 rows/,
     testTimeout: 30_000,
   },
 });


### PR DESCRIPTION
## Problem

Compiler-proven reverse chains lost their exact relationship to the committed keyed-row order after the first reversal. A cancelling pair such as `rows.toReversed().toReversed()` ended in the original order but still paid for generic source-item map construction and LIS reconciliation. The same unnecessary work remained after safe same-key maps.

## Root cause

Keyed reorder metadata represented only a direct reverse or a general permutation. Composing another reverse downgraded the result to a permutation, even though reverse parity proves either exact committed order or exact reverse order.

## Change

- Track exact identity/reverse parity through consecutive native reversals, queued setters, and eligible same-key map pipelines.
- Validate even parity against committed row identity, patch only changed mapped bindings, and skip generic item-map, LIS, and DOM-movement work.
- Preserve the minimum `n - 1` connected moves for odd parity.
- Add a 10,000-row mapped double-reverse workload, a dedicated performance gate, compiler/runtime tests, React compatibility coverage, and user documentation.

## Safety and compatibility

Every native map/reverse lookup, call, result, and error still executes in JavaScript order. The fast path proves ordinary dense arrays, committed ownership, lengths, row identity, replacement keys, and binding targets before the first DOM write. Sort-derived order, changed keys, sparse or subclassed arrays, stale metadata, unsupported rows, and failed validation keep the existing generic or React fallback. There is no public API or configuration change. React 18.3.1 and 19.2.8 pass, and the optional map/reorder premium decreased from 13,378 B to 13,349 B gzip.

## Verification

- `pnpm --filter @farm.js/react type-check`
- `pnpm --filter @farm.js/react test` — 70 regular files / 696 tests passed; stress suite passed all 5 selected tests
- `pnpm --filter @farm.js/react test:compat` — React 18.3.1 and 19.2.8 passed
- `pnpm --filter @farm.js/react test:runtime-size` — passed
- `pnpm --dir examples/react-compiler-dashboard type-check`
- `FARM_EXPERIMENT_BROWSER_PATH="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" FARM_DASHBOARD_REPORT=/tmp/farm-reverse-parity-final.json pnpm --dir examples/react-compiler-dashboard benchmark` — full result PASS, correctness PASS, every existing gate PASS
- Mapped double-reverse: static 3.40 ms, 20.50x vs React and 3.32x vs control; hybrid 3.60 ms, 19.36x vs React and 3.11x vs control
- `pnpm docs:check-navigation`
- `pnpm docs:build` — Vercel/Nitro production build passed

## Documentation and release

Updated the React renderer guide and package README. Extended the maintained React compiler dashboard example, benchmark methodology, regression gate, and measured results. No version or release-flow changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Compiler-proven reverse chains no longer treat cancelling reversals as general permutations. Even parity now validates committed order and patches changed bindings without building an item map, running LIS, or moving DOM rows; odd parity keeps the minimum `n - 1` moves.

- Preserves JavaScript execution and error order across queued setters and safe same-key map pipelines.
- Falls back to existing reconciliation for ambiguous order, changed keys, sparse or unsupported arrays, and failed validation.
- Adds compiler/runtime parity tests, React 18 and 19 compatibility coverage, a 10,000-row performance gate, and updated documentation.
- Keeps the optional runtime within its fixed gzip budget with no public API or configuration changes.

<sup>Written for commit aea603de38721f36b99d1b8560b4828da194907a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/802?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

