### PR TITLE
perf(react): preserve exact order across queued map reversals

### DIFF
--- a/docs/src/app/docs/renderers/react/page.md
+++ b/docs/src/app/docs/renderers/react/page.md
@@ -1250,13 +1250,24 @@ controlled inputs, focus, and text selection stay attached to their keys. Multip
 map-and-reorder setters queued before one compiler flush compose against the same committed
 collection and expose only the final state.
 
+Exact reverse proof can also cross a setter boundary in the same batch:
+
+```tsx
+setItems((current) => current.toReversed());
+setItems((current) =>
+  current.map((item) => (item.id === editedId ? { ...item, label: nextLabel } : item)).toReversed(),
+);
+```
+
 When the maps are followed directly by `toReversed()`, their same-order lineage proves the exact
 final permutation. Farm validates each mirrored source item and every changed replacement before
 the first DOM write, then uses the minimum-move reverse operation directly. It does not allocate a
 second source-item lookup map or run LIS for that case. Further exact reversals toggle the proof:
 two reversals patch changed rows in committed order with zero DOM moves, while three use the exact
-reverse path. The same parity applies to safe mapped pipelines and to queued reverse-only setters.
-A sort or any other order ambiguity keeps the general permutation path.
+reverse path. The runtime now retains that exact identity-or-reverse proof across separate queued
+setters too. For example, a queued reverse followed by a safe map and another reverse patches the
+changed row in committed order without moving DOM rows or constructing the generic source map. A
+sort or any other order ambiguity keeps the general permutation path.
 
 The proof requires every map callback to be inline, synchronous, compiler-safe, and to return the
 original item on one conditional branch and an object-spread replacement on the other. It requires

--- a/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
+++ b/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
@@ -2,6 +2,33 @@
 
 Latest run: 2026-09-08
 
+## Queued reverse and mapped parity — 2026-09-08
+
+Exact keyed-row order now survives across separate queued setters. The benchmark first queues a
+native `toReversed()`, then queues two safe same-key maps followed by another `toReversed()`. The
+two reversals cancel, so the runtime validates the committed lineage and patches the changed row
+without constructing the generic source-item map, running LIS, or moving a DOM row. Native calls
+and updater order remain unchanged.
+
+The block-bodied control performs the same JavaScript and produces the same DOM-visible result
+through complete keyed reconciliation. Both paths run against the same 10,000 rows. The correctness
+oracle checks every value, position, element identity, and connection after each sample.
+
+| Mode   | Exact identity | Compiled control | vs React | vs control |
+| ------ | -------------: | ---------------: | -------: | ---------: |
+| Static | 3.80 ms | 12.10 ms | 15.05x | 3.18x |
+| Hybrid | 3.60 ms | 11.80 ms | 15.89x | 3.28x |
+
+The new gate passed in a smoke run and two complete bracketing runs without changing its 8x React
+or 1.5x compiled-control floors. The general React-relative performance gate, optimization
+persistence gate, correctness oracle, and zero compiled owner executions passed in both complete
+runs. Separate deterministic coverage compares 2,000 queued updates with normal React and requires
+zero generic source-item map inserts, zero DOM moves, stable row identity, one changed key and
+binding read, React 18.3.1 and 19.2.8 compatibility, and safe ambiguous-order fallback.
+
+On Node.js 22.13.1, the isolated keyed map/reorder premium is 13,387 B gzip, below the unchanged
+13,399 B limit and 11 B smaller than the preceding release.
+
 ## Exact reverse parity — 2026-09-08
 
 Compiler-proven reverse chains now retain exact order relative to the last committed keyed rows.

--- a/examples/react-compiler-dashboard/README.md
+++ b/examples/react-compiler-dashboard/README.md
@@ -247,8 +247,11 @@ Mapped reverse parity has an independent 10,000-row comparison. Two safe native 
 row, then two native reversals restore committed order. Farm must patch the changed row without
 moving any DOM row or constructing the generic source-item map/LIS sequence. Both compiler modes
 must remain at least 8x faster than React and 1.5x faster than the equivalent block-bodied compiled
-control. The assertion checks all final values, positions, identities, and connections. Package
-tests compare one to four reversals across 2,000 deterministic updates and cover queued parity,
+control. A second operation splits the same proof across queued setters: one setter reverses the
+rows, then another applies two safe maps and reverses again. It has the same independent 8x React
+and 1.5x compiled-control floors. Both assertions check all final values, positions, identities,
+and connections. Package tests compare one to four reversals across 2,000 deterministic updates,
+run another 2,000 separately queued reverse/map/reverse updates against normal React, and cover
 changed-key and subclass fallback, Strict Mode hydration, and cleanup.
 
 Native keyed-array sorting has its own 10,000-row comparison. Concise `toSorted()` is measured

--- a/examples/react-compiler-dashboard/scripts/benchmark.mjs
+++ b/examples/react-compiler-dashboard/scripts/benchmark.mjs
@@ -1377,6 +1377,14 @@ async function measureTrial(browser, trial, compilerMode, port) {
           () => tableButton("table-multi-map-reverse-parity-snapshot").click(),
           false,
         );
+        const tableQueuedMapReverseParity = await measureMultiMapReverseTable(
+          () => tableButton("table-queued-map-reverse-parity").click(),
+          false,
+        );
+        const tableQueuedMapReverseParitySnapshot = await measureMultiMapReverseTable(
+          () => tableButton("table-queued-map-reverse-parity-snapshot").click(),
+          false,
+        );
 
         const tableSort = await measureTable(
           async () => create10000(),
@@ -1856,6 +1864,8 @@ async function measureTrial(browser, trial, compilerMode, port) {
             multiMapReversePipelineSnapshot: tableMultiMapReversePipelineSnapshot,
             multiMapReverseParity: tableMultiMapReverseParity,
             multiMapReverseParitySnapshot: tableMultiMapReverseParitySnapshot,
+            queuedMapReverseParity: tableQueuedMapReverseParity,
+            queuedMapReverseParitySnapshot: tableQueuedMapReverseParitySnapshot,
             mapLookup: tableMapLookup,
             membership: tableMembership,
             prepend: tablePrepend,
@@ -1992,6 +2002,8 @@ async function measureTrial(browser, trial, compilerMode, port) {
         ),
         multiMapReverseParity: timingSummary(result.table.multiMapReverseParity),
         multiMapReverseParitySnapshot: timingSummary(result.table.multiMapReverseParitySnapshot),
+        queuedMapReverseParity: timingSummary(result.table.queuedMapReverseParity),
+        queuedMapReverseParitySnapshot: timingSummary(result.table.queuedMapReverseParitySnapshot),
         mapLookup: timingSummary(result.table.mapLookup),
         membership: timingSummary(result.table.membership),
         prepend: timingSummary(result.table.prepend),
@@ -2174,6 +2186,8 @@ const tableMetrics = [
   "multiMapReversePipelineSnapshot",
   "multiMapReverseParity",
   "multiMapReverseParitySnapshot",
+  "queuedMapReverseParity",
+  "queuedMapReverseParitySnapshot",
   "snapshotMembership",
   "snapshotMapLookup",
   "slicePrefix",
@@ -2901,6 +2915,29 @@ const keyedMappedReverseParityRegressions = keyedMappedReverseParityResults.filt
     !Number.isFinite(snapshotSpeedup) ||
     snapshotSpeedup < keyedMappedReverseParityMinimumSnapshotSpeedup,
 );
+// Separate queued setters can reverse the committed rows, update through safe maps, and reverse
+// again. The final order is still exact identity, so it should retain the same bounded row patch
+// without generic source-map, LIS, or DOM-movement work.
+const keyedQueuedMapReverseParityMinimumSpeedup = 8;
+const keyedQueuedMapReverseParityMinimumSnapshotSpeedup = 1.5;
+const keyedQueuedMapReverseParityResults = ["static", "hybrid"].map((mode) => {
+  const pipelineMedianMs = comparisons.table.queuedMapReverseParity[mode].medianMs;
+  const snapshotMedianMs = comparisons.table.queuedMapReverseParitySnapshot[mode].medianMs;
+  return {
+    mode,
+    pipelineMedianMs,
+    snapshotMedianMs,
+    snapshotSpeedup: snapshotMedianMs / pipelineMedianMs,
+    speedup: comparisons.table.queuedMapReverseParity[`${mode}VsBaseline`].speedup,
+  };
+});
+const keyedQueuedMapReverseParityRegressions = keyedQueuedMapReverseParityResults.filter(
+  ({ snapshotSpeedup, speedup }) =>
+    !Number.isFinite(speedup) ||
+    speedup < keyedQueuedMapReverseParityMinimumSpeedup ||
+    !Number.isFinite(snapshotSpeedup) ||
+    snapshotSpeedup < keyedQueuedMapReverseParityMinimumSnapshotSpeedup,
+);
 // A direct native toSorted() exposes a permutation while preserving every keyed row object. The
 // hinted path validates that permutation by item identity, uses LIS to move only the required DOM
 // nodes, and avoids key, descriptor, and binding reads. Compare it with React and the equivalent
@@ -3093,6 +3130,7 @@ const passed =
   keyedMultiMapReorderRegressions.length === 0 &&
   keyedMultiMapReverseRegressions.length === 0 &&
   keyedMappedReverseParityRegressions.length === 0 &&
+  keyedQueuedMapReverseParityRegressions.length === 0 &&
   keyedSortRegressions.length === 0 &&
   keyedFilterRegressions.length === 0 &&
   keyedIdentityRegressions.length === 0 &&
@@ -3286,6 +3324,13 @@ const report = {
     regressions: keyedMappedReverseParityRegressions,
     results: keyedMappedReverseParityResults,
     status: keyedMappedReverseParityRegressions.length === 0 ? "PASS" : "FAIL",
+  },
+  keyedQueuedMapReverseParityHintGate: {
+    minimumSnapshotSpeedup: keyedQueuedMapReverseParityMinimumSnapshotSpeedup,
+    minimumSpeedup: keyedQueuedMapReverseParityMinimumSpeedup,
+    regressions: keyedQueuedMapReverseParityRegressions,
+    results: keyedQueuedMapReverseParityResults,
+    status: keyedQueuedMapReverseParityRegressions.length === 0 ? "PASS" : "FAIL",
   },
   keyedSortHintGate: {
     minimumSnapshotSpeedup: keyedSortMinimumSnapshotSpeedup,

--- a/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
+++ b/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
@@ -1027,6 +1027,50 @@ export function StandardTableBenchmark() {
           Review + reprice + reverse twice (snapshot control)
         </button>
         <button
+          data-action="table-queued-map-reverse-parity"
+          type="button"
+          onClick={() => {
+            setRows((current) => current.toReversed());
+            setRows((current) =>
+              current
+                .map((row) =>
+                  row.id % 10_000 === 5_001 ? { ...row, label: `${row.label} reviewed` } : row,
+                )
+                .map((row) =>
+                  row.id % 10_000 === 5_001 ? { ...row, amount: row.amount + 1 } : row,
+                )
+                .toReversed(),
+            );
+            setOperation("queue reverse, review, reprice, and restore row order");
+            setRevision((value) => value + 1);
+          }}
+        >
+          Queue reverse + review + restore
+        </button>
+        <button
+          data-action="table-queued-map-reverse-parity-snapshot"
+          type="button"
+          onClick={() => {
+            setRows((current) => {
+              return current.toReversed();
+            });
+            setRows((current) => {
+              return current
+                .map((row) =>
+                  row.id % 10_000 === 5_001 ? { ...row, label: `${row.label} reviewed` } : row,
+                )
+                .map((row) =>
+                  row.id % 10_000 === 5_001 ? { ...row, amount: row.amount + 1 } : row,
+                )
+                .toReversed();
+            });
+            setOperation("queue reverse, review, reprice, and restore row order (snapshot control)");
+            setRevision((value) => value + 1);
+          }}
+        >
+          Queue reverse + review + restore (snapshot control)
+        </button>
+        <button
           data-action="table-sort"
           type="button"
           onClick={() => {

--- a/packages/farm-react/README.md
+++ b/packages/farm-react/README.md
@@ -452,14 +452,24 @@ bindings, nested or React-owned rows, and failed checks use complete keyed recon
 use the existing map, sort, and reorder hint counters, and unrelated modules do not retain this
 optional runtime.
 
+A reverse before the safe map pipeline may be queued in a separate setter:
+
+```tsx
+setItems((current) => current.toReversed());
+setItems((current) =>
+  current.map((item) => (item.id === editedId ? { ...item, label: nextLabel } : item)).toReversed(),
+);
+```
+
 A direct `toReversed()` suffix is more specific than an arbitrary permutation. When all preceding
 maps retain committed row order, Farm validates the mirrored source-to-result relation and every
 changed binding before touching the DOM, then performs the minimum-move reverse without building a
 second item lookup map or running LIS. Additional exact reversals toggle that proof between reverse
 and identity. Therefore two reversals after safe maps patch changed rows in committed order without
 moving DOM nodes or creating the generic source map; three use the exact reverse path. Exact reverse
-metadata also composes across queued setters. A preceding sort or any ambiguous order keeps the
-general permutation path.
+metadata also composes across queued setters: a queued reverse followed by safe maps and another
+reverse retains exact identity, so only changed row bindings are patched. A preceding sort or any
+ambiguous order keeps the general permutation path.
 
 A direct native immutable sort can use the same optional reorder runtime:
 

--- a/packages/farm-react/scripts/test-react-version.mjs
+++ b/packages/farm-react/scripts/test-react-version.mjs
@@ -94,6 +94,7 @@ const testSource = String.raw`
 
   let reverseCompatibilityRows = () => undefined;
   let mapReverseParityCompatibilityRows = () => undefined;
+  let queuedMapReverseParityCompatibilityRows = () => undefined;
   let insertCompatibilityRows = () => undefined;
   let removeCompatibilityRow = () => undefined;
   let replaceCompatibilityRows = () => undefined;
@@ -125,6 +126,19 @@ const testSource = String.raw`
           const reversed = createCompilerKeyedArrayMapReorder(mapped, mapped.toReversed);
           return createCompilerKeyedArrayMapReorder(reversed, reversed.toReversed);
         });
+      queuedMapReverseParityCompatibilityRows = () => {
+        state[0].set((previous) =>
+          createCompilerKeyedArrayReorder(previous, previous.toReversed),
+        );
+        state[0].set((previous) => {
+          const mapped = createCompilerKeyedArrayMapPipeline(
+            previous,
+            previous.map,
+            (item) => item.id === "b" ? { ...item, label: "Beta queued parity" } : item,
+          );
+          return createCompilerKeyedArrayMapReorder(mapped, mapped.toReversed);
+        });
+      };
       removeCompatibilityRow = () =>
         state[0].set((previous) =>
           createCompilerKeyedArrayPositionUpdate(
@@ -254,6 +268,16 @@ const testSource = String.raw`
   await Promise.resolve();
   assert.equal(reorderContainer.querySelector("li:first-child"), reorderGamma);
   assert.equal(reorderContainer.querySelector("[data-key='b']").textContent, "Beta parity");
+  assert.equal(reorderContainer.querySelector("li:last-child"), reorderAlpha);
+  assert.equal(reorderExecutions, 1);
+  queuedMapReverseParityCompatibilityRows();
+  await Promise.resolve();
+  await Promise.resolve();
+  assert.equal(reorderContainer.querySelector("li:first-child"), reorderGamma);
+  assert.equal(
+    reorderContainer.querySelector("[data-key='b']").textContent,
+    "Beta queued parity",
+  );
   assert.equal(reorderContainer.querySelector("li:last-child"), reorderAlpha);
   assert.equal(reorderExecutions, 1);
   const reorderBeta = reorderContainer.querySelector("[data-key='b']");

--- a/packages/farm-react/src/__tests__/compiler-keyed-array-sort-hints.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-keyed-array-sort-hints.test.ts
@@ -320,6 +320,37 @@ describe("React AOT keyed-array sort hints", () => {
     expect(result.code).toContain("keyedRowsMapReorderHintedRuntimeFeature");
   });
 
+  it("preserves reverse and map metadata across separately queued setters", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Table({ editedId, nextLabel }) {
+        const [rows, setRows] = useState([
+          { id: "a", label: "Alpha" },
+          { id: "b", label: "Beta" },
+        ]);
+        return <section>
+          <button onClick={() => {
+            setRows((current) => current.toReversed());
+            setRows((current) => current
+              .map((row) => row.id === editedId ? { ...row, label: nextLabel } : row)
+              .toReversed()
+            );
+          }}>Edit without changing final order</button>
+          <ul>{rows.map((row) => <li key={row.id}>{row.label}</li>)}</ul>
+        </section>;
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Table"]);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.optimizations.keyedMapUpdateHints).toBe(1);
+    expect(result.optimizations.keyedArrayReorderHints).toBe(2);
+    expect(result.code.match(/createCompilerKeyedArrayReorder\(/g)).toHaveLength(1);
+    expect(result.code.match(/createCompilerKeyedArrayMapPipeline\(/g)).toHaveLength(1);
+    expect(result.code.match(/createCompilerKeyedArrayMapReorder\(/g)).toHaveLength(1);
+    expect(result.code).toContain("keyedRowsMapReorderHintedRuntimeFeature");
+  });
+
   it("does not lower map and reorder pipelines for host-backed keyed rows", async () => {
     const result = await compile(`
       import { useState } from "react";

--- a/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-map-reorder-hints.test.tsx
+++ b/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-map-reorder-hints.test.tsx
@@ -7,6 +7,7 @@ import {
   createCompiledComponent,
   createCompilerKeyedArrayMapPipeline,
   createCompilerKeyedArrayMapReorder,
+  createCompilerKeyedArrayReorder,
   type CompilerKeyedRowElement,
 } from "../compiler-runtime";
 
@@ -77,6 +78,10 @@ function hintedSort(items: Item[]): Item[] {
 
 function hintedReverse(items: Item[]): Item[] {
   return createCompilerKeyedArrayMapReorder(items, items.toReversed) as Item[];
+}
+
+function hintedPlainReverse(items: Item[]): Item[] {
+  return createCompilerKeyedArrayReorder(items, items.toReversed) as Item[];
 }
 
 function mappedSort(items: Item[], id: string, rank: number, label?: string): Item[] {
@@ -158,6 +163,8 @@ function createHarness(initialItems: Item[]) {
   let editSortReverse: (id: string, rank: number) => void = () => undefined;
   let queueEdits: (edits: readonly { id: string; rank: number; label: string }[]) => void = () =>
     undefined;
+  let queueReverseThenMapReverse: (id: string, rank: number, label: string) => void = () =>
+    undefined;
   let queueSortThenMapReverse: () => void = () => undefined;
   let invalidateKey: () => void = () => undefined;
   let customMap: () => void = () => undefined;
@@ -196,6 +203,16 @@ function createHarness(initialItems: Item[]) {
             multiMappedSort(previous as Item[], edit.id, edit.rank, edit.label),
           );
         }
+      };
+      queueReverseThenMapReverse = (id, rank, label) => {
+        state[0].set((previous) => hintedPlainReverse(previous as Item[]));
+        state[0].set((previous) =>
+          hintedReverse(
+            hintedMap(previous as Item[], (item) =>
+              item.id === id ? { ...item, rank, label } : item,
+            ),
+          ),
+        );
       };
       queueSortThenMapReverse = () => {
         state[0].set((previous) =>
@@ -334,6 +351,8 @@ function createHarness(initialItems: Item[]) {
     invalidateKey: () => invalidateKey(),
     queueEdits: (edits: readonly { id: string; rank: number; label: string }[]) =>
       queueEdits(edits),
+    queueReverseThenMapReverse: (id: string, rank: number, label: string) =>
+      queueReverseThenMapReverse(id, rank, label),
     queueSortThenMapReverse: () => queueSortThenMapReverse(),
   };
 }
@@ -640,6 +659,41 @@ describe("compiled keyed-array map and reorder hints", () => {
     expect(harness.counters.keys).toBe(2);
     expect(harness.counters.descriptors).toBe(0);
     expect(harness.counters.bindings).toBe(2);
+  });
+
+  it("preserves exact parity through a queued reverse and safe mapped reverse", async () => {
+    const initialItems: Item[] = [
+      { id: "a", label: "Alpha", rank: 1 },
+      { id: "b", label: "Beta", rank: 2 },
+      { id: "c", label: "Gamma", rank: 3 },
+    ];
+    const harness = createHarness(initialItems);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Table />));
+    const rows = [...container.querySelectorAll("li")];
+    const list = container.querySelector("ul")!;
+    const insertBefore = vi.spyOn(list, "insertBefore");
+    const mapSet = vi.spyOn(Map.prototype, "set");
+    harness.counters.bindings = 0;
+    harness.counters.descriptors = 0;
+    harness.counters.keys = 0;
+
+    await act(async () => {
+      harness.queueReverseThenMapReverse("b", 4, "Beta parity");
+      await flushCompilerUpdates();
+    });
+
+    expect(labels(container)).toEqual(["Alpha:1", "Beta parity:4", "Gamma:3"]);
+    expect([...container.querySelectorAll("li")]).toEqual(rows);
+    expect(insertBefore).not.toHaveBeenCalled();
+    expect(mapSet.mock.calls.filter(([key]) => initialItems.includes(key as Item))).toHaveLength(0);
+    expect(harness.counters.keys).toBe(1);
+    expect(harness.counters.descriptors).toBe(0);
+    expect(harness.counters.bindings).toBe(1);
+    expect(harness.counters.executions).toBe(1);
   });
 
   it("falls back before DOM writes for custom map methods and changed keys", async () => {
@@ -1069,6 +1123,62 @@ describe("compiled keyed-array map and reorder hints", () => {
     120_000,
   );
 
+  stressIt(
+    "matches React through 2,000 queued reverse, map, and reverse updates",
+    async () => {
+      const initialItems = Array.from(
+        { length: 31 },
+        (_, index): Item => ({ id: `row-${index}`, label: `Row ${index}`, rank: index }),
+      );
+      const harness = createHarness(initialItems);
+      let updateReact: (id: string, rank: number, label: string) => void = () => undefined;
+      function Normal() {
+        const [items, setItems] = useState(initialItems);
+        updateReact = (id, rank, label) => {
+          setItems((previous) => previous.toReversed());
+          setItems((previous) =>
+            previous.map((item) => (item.id === id ? { ...item, rank, label } : item)).toReversed(),
+          );
+        };
+        return (
+          <ol>
+            {items.map((item) => (
+              <li data-key={item.id} key={item.id}>
+                {item.label}:{item.rank}
+              </li>
+            ))}
+          </ol>
+        );
+      }
+      const compiledContainer = document.createElement("div");
+      const reactContainer = document.createElement("div");
+      document.body.append(compiledContainer, reactContainer);
+      const compiledRoot = createRoot(compiledContainer);
+      const reactRoot = createRoot(reactContainer);
+      roots.push(compiledRoot, reactRoot);
+      await act(async () => {
+        compiledRoot.render(<harness.Table />);
+        reactRoot.render(<Normal />);
+      });
+
+      let seed = 0x51ed270b;
+      for (let update = 0; update < 2_000; update += 1) {
+        seed = (Math.imul(seed, 1_664_525) + 1_013_904_223) >>> 0;
+        const id = `row-${seed % initialItems.length}`;
+        const rank = (seed ^ (seed >>> 16)) % 4_003;
+        const label = `Queued ${update}`;
+        await act(async () => {
+          harness.queueReverseThenMapReverse(id, rank, label);
+          updateReact(id, rank, label);
+          await flushCompilerUpdates();
+        });
+        expect(labels(compiledContainer)).toEqual(labels(reactContainer));
+      }
+      expect(harness.counters.executions).toBe(1);
+    },
+    120_000,
+  );
+
   it("hydrates in StrictMode and drops a queued update after unmount", async () => {
     const initialItems: Item[] = [
       { id: "a", label: "Alpha", rank: 1 },
@@ -1097,6 +1207,14 @@ describe("compiled keyed-array map and reorder hints", () => {
     });
     expect(labels(container)).toEqual(["Alpha hydrated:5", "Beta:2", "Gamma:3"]);
     expect(recoverable).toEqual([]);
+    const hydratedRows = [...container.querySelectorAll("li")];
+    await act(async () => {
+      hydration.queueReverseThenMapReverse("b", 7, "Beta queued hydration");
+      await flushCompilerUpdates();
+    });
+    expect(labels(container)).toEqual(["Alpha hydrated:5", "Beta queued hydration:7", "Gamma:3"]);
+    expect([...container.querySelectorAll("li")]).toEqual(hydratedRows);
+    expect(recoverable).toEqual([]);
 
     const unmounted = createHarness(initialItems);
     const unmountContainer = document.createElement("div");
@@ -1104,7 +1222,7 @@ describe("compiled keyed-array map and reorder hints", () => {
     const unmountRoot = createRoot(unmountContainer);
     await act(async () => unmountRoot.render(<unmounted.Table />));
     act(() => {
-      unmounted.editTwiceAndReverseMany("b", 8, "Never committed", 3);
+      unmounted.queueReverseThenMapReverse("b", 8, "Never committed");
       unmountRoot.unmount();
     });
     await flushCompilerUpdates();

--- a/packages/farm-react/src/compiler-runtime.tsx
+++ b/packages/farm-react/src/compiler-runtime.tsx
@@ -88,8 +88,8 @@ interface CompilerKeyedArrayReorderHint {
 }
 
 interface CompilerKeyedArrayMapPipelineHint {
-  /** True while every map preserves the committed row order. */
-  readonly ordered: boolean;
+  /** Exact order relative to the committed rows; permutation means the order is ambiguous. */
+  readonly order?: CompilerKeyedArrayReorderKind;
   readonly sourceToken: object;
   readonly sourceLength: number;
   readonly resultLength: number;
@@ -674,8 +674,12 @@ function recordCompilerKeyedArrayMapPipeline(previous: unknown, value: unknown):
       committedSource || previousMapPipeline
         ? undefined
         : COMPILER_KEYED_ARRAY_REORDERS.get(previousTarget);
+    const composablePreviousReorder =
+      previousReorder &&
+      (previousReorder.mapped ||
+        previousReorder.kind !== CompilerKeyedArrayReorderKind.Permutation);
     const previousSource =
-      previousMapPipeline || (previousReorder?.mapped ? previousReorder : undefined);
+      previousMapPipeline || (composablePreviousReorder ? previousReorder : undefined);
     if (!committedSource && (!previousSource || previousSource.resultLength !== previous.length)) {
       return value;
     }
@@ -704,7 +708,11 @@ function recordCompilerKeyedArrayMapPipeline(previous: unknown, value: unknown):
       if (!Object.is(mappedItem, sourceItem)) mappedItemSources.set(mappedItem, sourceItem);
     }
     COMPILER_KEYED_ARRAY_MAP_PIPELINES.set(valueTarget, {
-      ordered: previousMapPipeline?.ordered ?? committedSource,
+      order: previousMapPipeline
+        ? previousMapPipeline.order
+        : committedSource
+          ? undefined
+          : previousReorder?.kind,
       sourceToken,
       sourceLength: previousSource?.sourceLength ?? previous.length,
       resultLength: value.length,
@@ -791,8 +799,8 @@ export function createCompilerKeyedArrayMapReorder(
       kind:
         method !== NATIVE_ARRAY_TO_REVERSED
           ? CompilerKeyedArrayReorderKind.Permutation
-          : mapPipeline?.ordered
-            ? CompilerKeyedArrayReorderKind.Reverse
+          : mapPipeline
+            ? reversedCompilerKeyedArrayOrder(mapPipeline.order)
             : previousReorder
               ? reversedCompilerKeyedArrayOrder(previousReorder.kind)
               : CompilerKeyedArrayReorderKind.Permutation,

--- a/packages/farm-react/vitest.stress.config.ts
+++ b/packages/farm-react/vitest.stress.config.ts
@@ -20,7 +20,7 @@ export default defineConfig({
     ],
     setupFiles: ["src/__tests__/stress.setup.ts"],
     testNamePattern:
-      /2,000 deterministic mapped reorder updates|2,000 deterministic mapped reversal parity updates|3,000 deterministic recursive updates|4,096 rows/,
+      /2,000 deterministic mapped reorder updates|2,000 deterministic mapped reversal parity updates|2,000 queued reverse, map, and reverse updates|3,000 deterministic recursive updates|4,096 rows/,
     testTimeout: 30_000,
   },
 });


### PR DESCRIPTION
## Problem

A concise keyed update can queue one reverse setter and then a safe same-key map plus reverse setter. The final row order is exactly the committed order, but the compiler runtime discarded the first setter order proof when the map began. The update therefore used generic keyed reconciliation, including source-item lookup and LIS work, even though no DOM row needed to move.

## Root cause

Map-pipeline metadata stored only an ordered boolean and accepted previous reorder metadata only when that reorder already came from a mapped pipeline. It could not represent exact identity versus exact reverse across a normal queued reorder boundary.

## Change

Carry exact identity, reverse, or ambiguous permutation order in map-pipeline metadata. A safe map may now continue an exact normal reorder proof, and each native reverse toggles identity and reverse. The runtime still executes each updater, map, and reverse in source order, validates the complete committed lineage before the first DOM write, and patches only changed bindings when the final order is identity.

The dashboard adds a 10,000-row queued reverse, two-map, reverse workload plus an equivalent block-bodied compiled control and an independent performance gate.

## Safety and compatibility

- No public API, compiler option, report field, or renderer-neutral behavior changes.
- Only exact identity and reverse metadata compose. Sort-derived or otherwise ambiguous permutations retain complete keyed reconciliation.
- Dense native arrays, exact native methods, committed tokens, lengths, source identity, and replacement keys are validated before a fast-path DOM write.
- Changed keys, custom methods, sparse or subclassed arrays, unsupported callbacks, and failed validation keep the existing fallback.
- StrictMode hydration preserves existing DOM identity without recoverable errors.
- Unmount-before-flush cleanup drops the queued update.
- React 18.3.1 and 19.2.8 compatibility tests both pass.
- The Node 22.13.1 keyed map/reorder premium is 13,387 B gzip, below the unchanged 13,399 B ceiling and 11 B below main.

## Verification

- `pnpm --filter @farm.js/react test` — 70 files; 697 passed, 6 skipped. The stress suite passed all 6 selected cases, including 2,000 queued reverse/map/reverse updates compared with normal React.
- `pnpm --filter @farm.js/react test:compat` — React 18.3.1 and 19.2.8 passed, including the queued parity path.
- `pnpm --filter @farm.js/react type-check`
- `pnpm exec oxlint` on all changed JavaScript and TypeScript files — 0 warnings, 0 errors.
- `npx --yes node@22.13.1 packages/farm-react/scripts/benchmark-runtime-size.mjs --check` — 13,387 B gzip versus the fixed 13,399 B maximum.
- `pnpm --dir examples/react-compiler-dashboard run type-check`
- `pnpm docs:check-navigation` — 75 pages covered.
- `pnpm docs:build` — Vite client/SSR, Nitro, and Vercel output passed.
- Browser benchmark correctness passed in smoke and two complete bracketing runs. The new gate passed every run: static 3.80 ms, 15.05x React, 3.18x control; hybrid 3.60 ms, 15.89x React, 3.28x control. General React-relative and optimization-persistence gates passed both complete runs. Under unrelated host-wide FileProvider/iCloud load, one different pre-existing control-ratio gate fluctuated narrowly in each run while passing in the other; no floor was changed. A 20-sample confirmation reached the closing baseline before the host closed its headless browser.

## Documentation and release

Updated the React renderer docs, package README, executable dashboard README, and reproducible benchmark results. No version, template, generated route, or release-flow change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves exact keyed row order across separate queued setters, so a queued reverse, a safe map pipeline, and another reverse now patch only changed bindings instead of doing full keyed reconciliation with source-item lookup and LIS. Previously the first setter's reverse proof was discarded once the map began; map-pipeline metadata now carries identity, reverse, or ambiguous order, and each native reverse toggles it.

**Safety**
- Only exact identity and reverse metadata compose; ambiguous permutations still use complete keyed reconciliation.
- The complete committed lineage is validated before the first DOM write, and changed keys, custom methods, sparse or subclassed arrays, and failed validation keep the existing fallback.
- No public API, compiler option, or report field changes; StrictMode hydration and unmount-before-flush cleanup are unaffected.

**Verification**
- Adds a 10,000-row queued reverse/map/reverse benchmark with a block-bodied compiled control and an independent performance gate.
- Adds a 2,000-update stress suite compared against normal React, plus React 18.3.1 and 19.2.8 compatibility coverage.
- Runtime bundle stays below the gzip ceiling (13,387 B vs 13,399 B limit), and the renderer docs and READMEs are updated.

<sup>Written for commit 5af60e755c6b1d19121f9f41b58d49aed120606a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/804?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

