### PR TITLE
fix(ppr): avoid caching completed suspense responses

### DIFF
--- a/docs/src/app/docs/cache-ppr/page.md
+++ b/docs/src/app/docs/cache-ppr/page.md
@@ -194,6 +194,10 @@ export async function POST(request: Request) {
 
 PPR works best when the stable page shell is outside Suspense and request-specific or slow data lives inside Suspense.
 
+When a production render actually suspends, Farm currently buffers that response for late status
+errors and bypasses the shared PPR shell cache. This preserves fresh request-specific content
+instead of caching a completed response as though it were a reusable partial shell.
+
 ```tsx
 import { Suspense } from "react";
 

--- a/packages/farm/src/__tests__/production-prebuilt-ssr.test.ts
+++ b/packages/farm/src/__tests__/production-prebuilt-ssr.test.ts
@@ -2367,8 +2367,10 @@ export async function QUERY(request: Request) {
       try {
         if (useReact18) await linkReact18(root);
         const suspenseDir = path.join(root, "src", "app", "suspense");
+        const pprSuspenseDir = path.join(root, "src", "app", "ppr-suspense");
         const failureDir = path.join(root, "src", "app", "failure");
         await fs.mkdir(suspenseDir, { recursive: true });
+        await fs.mkdir(pprSuspenseDir, { recursive: true });
         await fs.mkdir(failureDir, { recursive: true });
         await fs.writeFile(
           path.join(root, "src", "app", "layout.tsx"),
@@ -2405,6 +2407,38 @@ export default function SuspensePage() {
     <main data-page-render-count={renderCount}>
       <Suspense fallback={<p>suspense-fallback</p>}>
         <SuspenseContent />
+      </Suspense>
+    </main>
+  );
+}
+`.trim(),
+        );
+        await fs.writeFile(
+          path.join(pprSuspenseDir, "content.tsx"),
+          `
+export default function PPRSuspenseContent() {
+  return <p data-ppr-suspense="ready">ppr-suspense-ready</p>;
+}
+`.trim(),
+        );
+        await fs.writeFile(
+          path.join(pprSuspenseDir, "page.tsx"),
+          `
+import React, { lazy, Suspense } from "react";
+
+export const ppr = true;
+
+const PPRSuspenseContent = lazy(() =>
+  new Promise((resolve) => {
+    setTimeout(() => resolve(import("./content")), 100);
+  }),
+);
+
+export default function PPRSuspensePage() {
+  return (
+    <main>
+      <Suspense fallback={<p>ppr-suspense-fallback</p>}>
+        <PPRSuspenseContent />
       </Suspense>
     </main>
   );
@@ -2578,6 +2612,15 @@ export default defineRoutes(() => [
             expect(html).not.toContain("renderToString which does not support Suspense");
           },
           "/suspense",
+        );
+        await runProductionRequest(
+          serverDir,
+          async (response) => {
+            expect(response.status).toBe(200);
+            expect(response.headers.get("x-farm-ppr")).toBe("bypass");
+            await expect(response.text()).resolves.toContain("ppr-suspense-ready");
+          },
+          "/ppr-suspense",
         );
         await runProductionRequest(
           serverDir,

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -6318,7 +6318,7 @@ async function handleFarmRequestInContext(
       const pprBypassReason = pprConfig.enabled
         ? getPPRShellBypassReason(request, middlewareData, middlewareContext)
         : undefined;
-      const pprCanCache = pprConfig.enabled && !pprBypassReason;
+      let pprCanCache = pprConfig.enabled && !pprBypassReason;
       const pprCacheKey = pprCanCache
         ? getPPRShellCacheKey(url, farmLocaleResolution?.locale)
         : null;
@@ -6644,6 +6644,21 @@ async function handleFarmRequestInContext(
         )`
             : "await renderPageElement()"
         };
+
+        // A completed document is not a reusable PPR shell: it already contains
+        // the request's resolved Suspense content. Until the production runtime
+        // can persist and resume the partial shell itself, buffer streamed PPR
+        // responses for late status errors but do not cache their dynamic HTML.
+        const shouldCachePPRShell = Boolean(pprCacheKey && !renderedPage.stream);
+        if (!shouldCachePPRShell && pprCacheKey) {
+          pprCanCache = false;
+          emitFarmEvent({
+            type: "ppr.shell.bypass",
+            route: pathname,
+            reason: "suspense-stream",
+          });
+          emitFarmEvent({ type: "cache.bypass", route: pathname, reason: "suspense-stream" });
+        }
         
         // Collect static and generated metadata from layouts and page.
         // Later entries override earlier entries, matching the development renderer.
@@ -6860,7 +6875,12 @@ async function handleFarmRequestInContext(
           getFarmTheme(request)
         );
 
-        if (pageStatus === 200 && pprCacheKey && request.method.toUpperCase() !== "HEAD") {
+        if (
+          pageStatus === 200 &&
+          shouldCachePPRShell &&
+          pprCacheKey &&
+          request.method.toUpperCase() !== "HEAD"
+        ) {
           await pprShellCache.setAsync(
             pprCacheKey,
             { html: fullHtml },


### PR DESCRIPTION
## Problem

A production PPR route that actually suspends can store its completed, request-specific HTML as the reusable shell. Later requests can receive stale dynamic content instead of a fresh render.

## Root cause

The production cache decision was made before rendering and did not account for the renderer returning a Suspense stream. Farm buffered that stream to preserve late error status handling, then treated the completed buffer as a cacheable shell.

## Change

Bypass the shared PPR shell cache whenever the rendered page contains a Suspense stream. The response remains buffered so late render errors and route error boundaries keep their existing status behavior.

## Safety and compatibility

Non-suspending PPR shells retain their existing cache behavior. The fallback applies only after the renderer proves that the request suspended, and is covered with React 18 and React 19.

## Verification

- `pnpm --filter @farm.js/core exec vitest run src/__tests__/production-prebuilt-ssr.test.ts -t 'streams'`
- `pnpm --filter @farm.js/core type-check`

## Documentation and release

Updated `docs/src/app/docs/cache-ppr/page.md` to document Suspense buffering and cache bypass behavior.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes production PPR routes that suspend from caching the completed, request-specific HTML as the reusable shell, so later requests no longer receive stale dynamic content.

- Bypasses the shared PPR shell cache whenever the rendered page contains a Suspense stream.
- Still buffers the response so late render errors and route error boundaries keep their existing status behavior.
- Non-suspending PPR shells keep the existing cache behavior.
- Adds tests covering Suspense streaming with React 18 and React 19.
- Updates the PPR cache docs to describe Suspense buffering and cache bypass.

<sup>Written for commit 62abbae959dd9870602e8bc1f7c762e369a4a78a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/806?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

