### PR TITLE
fix(openapi): serve reference in production

### DIFF
--- a/packages/farm/src/__tests__/production-prebuilt-ssr.test.ts
+++ b/packages/farm/src/__tests__/production-prebuilt-ssr.test.ts
@@ -371,6 +371,73 @@ async function expectNitroFallback(root: string): Promise<void> {
 }
 
 describe("production prebuilt SSR output", () => {
+  it("serves the configured OpenAPI reference in production", async () => {
+    const root = await createProductionFixture();
+    const apiDir = path.join(root, "src", "app", "api", "health");
+
+    try {
+      await fs.mkdir(apiDir, { recursive: true });
+      await fs.writeFile(
+        path.join(apiDir, "route.ts"),
+        `export function GET() { return Response.json({ ok: true }); }`,
+      );
+      const config = await resolveConfig(
+        {
+          root,
+          srcDir: "src",
+          images: { provider: "none" },
+          telemetry: false,
+          openapi: {
+            enabled: true,
+            route: "/docs/reference",
+            title: "Production API",
+          },
+          generateBuildId: () => "production-openapi-test",
+        },
+        "production",
+      );
+
+      await build(config, { root, preset: "node-server" });
+
+      await runProductionRequest(
+        path.join(root, ".farm", ".output", "server"),
+        async (response) => {
+          expect(response.status).toBe(200);
+          expect(response.headers.get("content-type")).toBe("text/html; charset=utf-8");
+          expect(response.headers.get("x-content-type-options")).toBe("nosniff");
+          const html = await response.text();
+          expect(html).toContain("<title>Production API</title>");
+          expect(html).toContain('id="api-reference"');
+          const encodedSpec = html.match(/data-url="data:application\/json;base64,([^"]+)"/)?.[1];
+          expect(encodedSpec).toBeTruthy();
+          const spec = JSON.parse(Buffer.from(encodedSpec!, "base64").toString("utf8"));
+          expect(spec.paths["/health"].get.operationId).toBe("get_health");
+        },
+        "/docs/reference?source=production-test",
+      );
+      await runProductionRequest(
+        path.join(root, ".farm", ".output", "server"),
+        async (response) => {
+          expect(response.status).toBe(200);
+          await expect(response.text()).resolves.toBe("");
+        },
+        "/docs/reference",
+        { method: "HEAD" },
+      );
+      await runProductionRequest(
+        path.join(root, ".farm", ".output", "server"),
+        async (response) => {
+          expect(response.status).toBe(405);
+          expect(response.headers.get("allow")).toBe("GET, HEAD");
+        },
+        "/docs/reference",
+        { method: "POST" },
+      );
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  }, 120_000);
+
   it("bundles automatic production-site discovery on the server only", async () => {
     const root = await createProductionFixture();
 

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -3626,6 +3626,19 @@ async function buildSSRInMemory(
     : {};
 
   const appDirs = getFarmAppDirectories(config);
+  let openAPIReference: { route: string; html: string } | null = null;
+  if (config.openapi.enabled && config.openapi.route) {
+    const { OpenAPIManager, renderOpenAPIReferenceHTML } = await import("../openapi/manager");
+    const openAPIManager = new OpenAPIManager(appDirs, config.openapi);
+    const spec = await openAPIManager.generateSpec();
+    if (!spec) {
+      throw new Error("Failed to generate the OpenAPI specification for the production build.");
+    }
+    openAPIReference = {
+      route: config.openapi.route,
+      html: renderOpenAPIReferenceHTML(spec, config.openapi),
+    };
+  }
   const middlewareRoutes = await discoverMiddlewareRoutes(appDirs);
   const instrumentationPath = resolveFarmInstrumentationFile(root, config.srcDir || "src");
 
@@ -3695,6 +3708,7 @@ async function buildSSRInMemory(
     redirectRoutes,
     configuredRewrites,
     configuredHeaderRoutes,
+    openAPIReference,
     notFoundPath,
     instrumentationPath,
     config,
@@ -4005,6 +4019,7 @@ function generateVirtualEntryCode(
   redirectRoutes: ProgrammaticRedirectRoute[],
   configuredRewriteRoutes: RewriteConfig[],
   configuredHeaderRoutes: UniversalConfiguredHeaderRoute[],
+  openAPIReference: { route: string; html: string } | null,
   notFoundPath: string | null,
   instrumentationPath: string | null,
   config: ResolvedFarmConfig,
@@ -4756,6 +4771,7 @@ const farmDocsAPIHandler = ${
 const apiRoutes = [${apiRegistrations.join(",")}
 ];
 const farmLocalAPIBasePath = ${JSON.stringify(resolveFarmAPIServerBasePath(config.api))};
+const farmOpenAPIReference = ${JSON.stringify(openAPIReference)};
 
 function isFarmLocalAPIPathname(pathname) {
   return farmLocalAPIBasePath !== "/" &&
@@ -5691,6 +5707,12 @@ function matchRouteSlots(pathname, interceptFrom) {
 
 function hasLocalRequestRoute(request, routePathname) {
   const pathname = new URL(request.url).pathname;
+  if (
+    farmOpenAPIReference &&
+    normalizeRuntimePath(pathname) === normalizeRuntimePath(farmOpenAPIReference.route)
+  ) {
+    return true;
+  }
   if (matchLocalAPIRequest(request) || matchLocalIntegrationRequest(request)) {
     return true;
   }
@@ -5725,6 +5747,15 @@ function getFarmPluginRequestOptions(request) {
   const pathname = url.pathname;
   const routePathname = getFarmRoutePathname(pathname);
   const route = { pathname };
+  if (
+    farmOpenAPIReference &&
+    normalizeRuntimePath(pathname) === normalizeRuntimePath(farmOpenAPIReference.route)
+  ) {
+    return {
+      kind: "docs",
+      route: { ...route, pattern: normalizeRuntimePath(farmOpenAPIReference.route) },
+    };
+  }
   const isDocsAPIRequest = ${config.docs?.enabled ? "isFarmDocsAPIRequest(pathname)" : "false"};
   const integrationMatch = ${
     hasServerRuntimeIntegrations
@@ -6246,6 +6277,30 @@ async function handleFarmRequestInContext(
   }
   `
       : ""
+  }
+
+  if (
+    farmOpenAPIReference &&
+    normalizeRuntimePath(pathname) === normalizeRuntimePath(farmOpenAPIReference.route)
+  ) {
+    const method = request.method.toUpperCase();
+    const response = method === "GET" || method === "HEAD"
+      ? new Response(method === "HEAD" ? null : farmOpenAPIReference.html, {
+          status: 200,
+          headers: {
+            "Content-Type": "text/html; charset=utf-8",
+            "Cache-Control": "public, max-age=0, must-revalidate",
+            "X-Content-Type-Options": "nosniff",
+          },
+        })
+      : new Response("Method Not Allowed", {
+          status: 405,
+          headers: {
+            "Allow": "GET, HEAD",
+            "Content-Type": "text/plain; charset=utf-8",
+          },
+        });
+    return applyProductionMiddlewareHeaders(response, middlewareHeaders);
   }
 
   ${

--- a/packages/farm/src/openapi/manager.ts
+++ b/packages/farm/src/openapi/manager.ts
@@ -1,6 +1,36 @@
-import { OpenAPIGenerator } from "./generator";
+import { OpenAPIGenerator, type OpenAPISpec } from "./generator";
 import { APITypeGenerator } from "../type-generator";
 import type { OpenAPIConfig } from "../config";
+
+function escapeHTML(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+export function renderOpenAPIReferenceHTML(spec: OpenAPISpec, config: OpenAPIConfig): string {
+  return `
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>${escapeHTML(config.title || "API Documentation")}</title>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="icon" href="data:," />
+  </head>
+  <body>
+    <script
+      id="api-reference"
+      data-url="data:application/json;base64,${Buffer.from(JSON.stringify(spec)).toString("base64")}"
+    ></script>
+    <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
+  </body>
+</html>
+    `;
+}
 
 export class OpenAPIManager {
   private generator: OpenAPIGenerator;
@@ -78,6 +108,15 @@ export class OpenAPIManager {
   getDocsRouteHandler() {
     return async (req: any, res: any) => {
       try {
+        const method = String(req.method || "GET").toUpperCase();
+        if (method !== "GET" && method !== "HEAD") {
+          res.statusCode = 405;
+          res.setHeader("Allow", "GET, HEAD");
+          res.setHeader("Content-Type", "text/plain; charset=utf-8");
+          res.end("Method Not Allowed");
+          return;
+        }
+
         const spec = await this.getSpec();
 
         if (!spec) {
@@ -96,11 +135,12 @@ export class OpenAPIManager {
 
         // Set headers for HTML response
         res.statusCode = 200;
-        res.setHeader("Content-Type", "text/html");
+        res.setHeader("Content-Type", "text/html; charset=utf-8");
+        res.setHeader("Cache-Control", "public, max-age=0, must-revalidate");
+        res.setHeader("X-Content-Type-Options", "nosniff");
 
         // Generate HTML with Scalar
-        const html = this.generateDocsHTML(spec);
-        res.end(html);
+        res.end(method === "HEAD" ? undefined : renderOpenAPIReferenceHTML(spec, this.config));
       } catch (error) {
         console.error("Error serving docs route:", error);
         res.statusCode = 500;
@@ -115,29 +155,5 @@ export class OpenAPIManager {
         `);
       }
     };
-  }
-
-  /**
-   * Generate HTML for docs route
-   */
-  private generateDocsHTML(spec: any): string {
-    return `
-<!DOCTYPE html>
-<html>
-  <head>
-    <title>${this.config.title || "API Documentation"}</title>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link rel="icon" href="data:," />
-  </head>
-  <body>
-    <script
-      id="api-reference"
-      data-url="data:application/json;base64,${Buffer.from(JSON.stringify(spec)).toString("base64")}"
-    ></script>
-    <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
-  </body>
-</html>
-    `;
   }
 }

--- a/packages/farm/src/vite.ts
+++ b/packages/farm/src/vite.ts
@@ -1434,7 +1434,7 @@ window.__FARM_MANIFEST__ = ${inlineValue({
           }
 
           // Handle OpenAPI docs route
-          if (openAPIManager && req.url === options.openapi?.route) {
+          if (openAPIManager && requestPathname === options.openapi?.route) {
             const docsHandler = openAPIManager.getDocsRouteHandler();
             return docsHandler(req, res);
           }


### PR DESCRIPTION
## Problem

Farm documents the configured OpenAPI reference as available after `farm build`, but standalone production output did not register or serve that route. Dev matching also failed when the request contained a query string.

## Root cause

The OpenAPI manager and reference handler were only installed by the Vite development middleware. Production generation added the URL to route types but never emitted the spec or handler into the server bundle.

## Change

Generate the OpenAPI spec during production builds, embed the Scalar reference page in the server entry, and serve it through the normal production request pipeline. GET and HEAD are supported, unsupported methods return 405, and dev now matches the parsed pathname.

## Safety and compatibility

The build-time import and output are included only when OpenAPI is enabled. Middleware headers, configured rewrites, plugin request classification, query strings, and bodyless HEAD semantics are preserved. Reference titles are HTML escaped.

## Verification

- `pnpm --filter @farm.js/core exec vitest run src/__tests__/production-prebuilt-ssr.test.ts -t 'serves the configured OpenAPI reference in production'`
- `pnpm --filter @farm.js/core exec vitest run src/__tests__/openapi-generator.test.ts`
- `pnpm --filter @farm.js/core type-check`

## Documentation and release

The existing OpenAPI documentation already describes this production contract; this change makes the implementation match it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the OpenAPI reference page never being served in production builds. The spec and Scalar page are now generated at build time and served through the production request pipeline, matching the documented behavior; the route is only emitted when OpenAPI is enabled.

**Behavior changes**
- GET and HEAD return the reference HTML; other methods return 405 with an `Allow: GET, HEAD` header.
- Dev server now matches the parsed pathname, so query strings on the docs route work.
- Reference titles are HTML-escaped; middleware headers and configured rewrites are preserved.

<sup>Written for commit 6e7a80ea33a1ffdaa8af5763a9d6f629b01a458d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/807?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

