### PR TITLE
perf(docs): skip scans for unrelated requests

### DIFF
--- a/packages/farm/src/__tests__/docs-handler.test.ts
+++ b/packages/farm/src/__tests__/docs-handler.test.ts
@@ -732,6 +732,18 @@ describe("createFarmDocsHandler", () => {
     await expect(handler(new Request("http://farm.test/docs"))).resolves.toBeNull();
   });
 
+  it("does not scan docs content for unrelated requests", async () => {
+    const { root, docs } = await createDocsFixture();
+    const contentFile = path.join(root, "not-a-docs-directory");
+    await fs.writeFile(contentFile, "unrelated");
+    const handler = createFarmDocsHandler(
+      { ...docs, contentDir: contentFile },
+      { root, srcDir: "src" },
+    );
+
+    await expect(handler(new Request("http://farm.test/dashboard"))).resolves.toBeNull();
+  });
+
   it("softens a trailing .js in the sidebar brand title", async () => {
     const { root, docs } = await createDocsFixture();
     const handler = createFarmDocsHandler(

--- a/packages/farm/src/docs/handler.ts
+++ b/packages/farm/src/docs/handler.ts
@@ -680,10 +680,11 @@ function createFarmDocsPublicResponse(
   request: Request,
 ): Response | null {
   const url = new URL(request.url);
-  const loadedPages = getLoadedDocsPages(contentDir, docs);
+  let loadedPages: LoadedFarmDocsPage[] | undefined;
+  const getPages = () => (loadedPages ??= getLoadedDocsPages(contentDir, docs));
   const sitemapManifest = () =>
     buildDocsSitemapManifest({
-      pages: loadedPages.map(toDocsSitemapPage),
+      pages: getPages().map(toDocsSitemapPage),
       entry: docs.entry,
       siteTitle: getDocsTitle(docs),
       baseUrl: url.origin,
@@ -696,7 +697,7 @@ function createFarmDocsPublicResponse(
   const llmsFormat = resolveDocsLlmsTxtFormat(url);
   if (llmsFormat) {
     const generated = renderDocsLlmsTxt(
-      loadedPages.map(toDocsLlmsPage),
+      getPages().map(toDocsLlmsPage),
       getDocsLlmsOptions(docs, request),
     );
     return new Response(llmsFormat === "llms-full" ? generated.llmsFullTxt : generated.llmsTxt, {


### PR DESCRIPTION
## Problem

With Farm docs enabled, every GET or HEAD request—including unrelated application routes—walked and parsed the entire docs content tree before determining whether the request belonged to docs.

## Root cause

`createFarmDocsPublicResponse` loaded all docs pages eagerly before checking the requested public artifact.

## Change

Load the docs corpus lazily and only for public endpoints that need it, such as `llms.txt` and sitemap output. Unrelated requests and metadata-only endpoints avoid the scan.

## Safety and compatibility

Public artifact contents and docs-page rendering are unchanged. The optimization only defers existing work until a matching endpoint requires it.

## Verification

- `pnpm --filter @farm.js/core exec vitest run src/__tests__/docs-handler.test.ts`
- `pnpm --filter @farm.js/core type-check`
- Regression coverage uses an invalid content-directory shape to prove unrelated requests do not touch docs content.

## Documentation and release

None.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
With Farm docs enabled, every GET or HEAD request walked and parsed the entire docs content tree before checking whether the request belonged to docs. Docs pages now load lazily, only for public endpoints that need them (`llms.txt`, sitemap), so unrelated requests skip the scan.

- Public artifact contents and docs-page rendering are unchanged; this only defers existing work until a matching endpoint requires it.
- Adds a regression test with an invalid content-directory shape to prove unrelated requests don't touch docs content.

<sup>Written for commit 2191db5f831342de94b4232120b1167047bbd589. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/808?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

