### PR TITLE
fix(docs): omit bodies from HEAD responses

### DIFF
--- a/packages/farm/src/__tests__/docs-handler.test.ts
+++ b/packages/farm/src/__tests__/docs-handler.test.ts
@@ -744,6 +744,27 @@ describe("createFarmDocsHandler", () => {
     await expect(handler(new Request("http://farm.test/dashboard"))).resolves.toBeNull();
   });
 
+  it("returns bodyless HEAD responses for docs pages and public artifacts", async () => {
+    const { root, docs } = await createDocsFixture();
+    const handler = createFarmDocsHandler(docs, { root, srcDir: "src" });
+
+    for (const pathname of ["/docs/guide", "/docs/guide.md", "/llms.txt"]) {
+      const getResponse = await handler(new Request(`http://farm.test${pathname}`));
+      const headResponse = await handler(
+        new Request(`http://farm.test${pathname}`, { method: "HEAD" }),
+      );
+
+      expect(headResponse?.status).toBe(getResponse?.status);
+      expect(headResponse?.headers.get("content-type")).toBe(
+        getResponse?.headers.get("content-type"),
+      );
+      expect(headResponse?.headers.get("cache-control")).toBe(
+        getResponse?.headers.get("cache-control"),
+      );
+      await expect(headResponse?.text()).resolves.toBe("");
+    }
+  });
+
   it("softens a trailing .js in the sidebar brand title", async () => {
     const { root, docs } = await createDocsFixture();
     const handler = createFarmDocsHandler(
@@ -814,6 +835,13 @@ describe("createDocsAPI", () => {
         entry: "docs",
       },
     });
+
+    const headResponse = await handler(
+      new Request("http://farm.test/api/docs?format=config", { method: "HEAD" }),
+    );
+    expect(headResponse?.status).toBe(200);
+    expect(headResponse?.headers.get("content-type")).toBe("application/json");
+    await expect(headResponse?.text()).resolves.toBe("");
   });
 
   it("creates Next-style GET and POST route handlers for Farm API routes", async () => {

--- a/packages/farm/src/docs/api.ts
+++ b/packages/farm/src/docs/api.ts
@@ -118,6 +118,14 @@ function text(content: string, contentType: string, init: ResponseInit = {}): Re
   return new Response(content, { ...init, headers });
 }
 
+function omitHeadBody(response: Response): Response {
+  return new Response(null, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: response.headers,
+  });
+}
+
 function normalizeAction(value: string | null | undefined): string | undefined {
   return value?.trim().toLowerCase().replace(/_/g, "-") || undefined;
 }
@@ -657,7 +665,8 @@ export function createFarmDocsAPIHandler(
 
     const method = request.method.toUpperCase();
     if (method === "GET" || method === "HEAD") {
-      return handlers.GET(request);
+      const response = await handlers.GET(request);
+      return method === "HEAD" ? omitHeadBody(response) : response;
     }
     if (method === "POST") {
       return handlers.POST(request);

--- a/packages/farm/src/docs/handler.ts
+++ b/packages/farm/src/docs/handler.ts
@@ -791,6 +791,15 @@ function createFarmDocsPublicResponse(
   return null;
 }
 
+function omitFarmDocsHeadBody(request: Request, response: Response): Response {
+  if (request.method !== "HEAD") return response;
+  return new Response(null, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: response.headers,
+  });
+}
+
 function escapeHtml(value: string): string {
   return value
     .replace(/&/g, "&amp;")
@@ -1782,7 +1791,7 @@ export function createFarmDocsHandler(
     }
 
     const publicResponse = createFarmDocsPublicResponse(contentDir, docs, request);
-    if (publicResponse) return publicResponse;
+    if (publicResponse) return omitFarmDocsHeadBody(request, publicResponse);
 
     if (!isFarmDocsRequest(docs, request)) return null;
 
@@ -1791,19 +1800,22 @@ export function createFarmDocsHandler(
 
     if (shouldReturnMarkdown(request)) {
       const origin = new URL(request.url).origin;
-      return new Response(
-        renderDocsMarkdownDocument(toFarmDocsMarkdownPage(page), {
-          origin,
-          llms: docs.config.llmsTxt ?? true,
-          sitemap: docs.config.sitemap,
-        }),
-        {
-          status: 200,
-          headers: {
-            "Content-Type": "text/markdown; charset=utf-8",
-            "Cache-Control": "public, max-age=60",
+      return omitFarmDocsHeadBody(
+        request,
+        new Response(
+          renderDocsMarkdownDocument(toFarmDocsMarkdownPage(page), {
+            origin,
+            llms: docs.config.llmsTxt ?? true,
+            sitemap: docs.config.sitemap,
+          }),
+          {
+            status: 200,
+            headers: {
+              "Content-Type": "text/markdown; charset=utf-8",
+              "Cache-Control": "public, max-age=60",
+            },
           },
-        },
+        ),
       );
     }
 
@@ -1815,26 +1827,29 @@ export function createFarmDocsHandler(
       ? renderFarmLayoutFontPreloadHeader(layoutFonts)
       : fallbackFontPreloadHeader;
 
-    return new Response(
-      renderPixelDocsHtml(
-        page,
-        discoverFarmDocsPages(contentDir, docs),
-        docs,
-        options.clientEntry || "/farm-client.js",
-        faviconHref,
-        requestUrl,
-        activeFontAssets,
-        usesLayoutFonts ? options.fontStylesheetHref : undefined,
-        options.globalStylesheetHref,
-      ),
-      {
-        status: 200,
-        headers: {
-          "Content-Type": "text/html; charset=utf-8",
-          "Cache-Control": "public, s-maxage=60, stale-while-revalidate=300",
-          ...(fontPreloadHeader ? { Link: fontPreloadHeader } : {}),
+    return omitFarmDocsHeadBody(
+      request,
+      new Response(
+        renderPixelDocsHtml(
+          page,
+          discoverFarmDocsPages(contentDir, docs),
+          docs,
+          options.clientEntry || "/farm-client.js",
+          faviconHref,
+          requestUrl,
+          activeFontAssets,
+          usesLayoutFonts ? options.fontStylesheetHref : undefined,
+          options.globalStylesheetHref,
+        ),
+        {
+          status: 200,
+          headers: {
+            "Content-Type": "text/html; charset=utf-8",
+            "Cache-Control": "public, s-maxage=60, stale-while-revalidate=300",
+            ...(fontPreloadHeader ? { Link: fontPreloadHeader } : {}),
+          },
         },
-      },
+      ),
     );
   };
 }


### PR DESCRIPTION
## Problem

Several docs surfaces accepted HEAD but returned the same response body as GET, including HTML pages, markdown mirrors, public docs artifacts, and `/api/docs`.

## Root cause

HEAD was routed through the GET handlers without converting the resulting response to bodyless HTTP semantics. Only generated social images handled HEAD explicitly.

## Change

Preserve the GET status and headers while omitting the response body for all remaining docs HEAD paths.

## Safety and compatibility

GET output is unchanged. Existing status codes, content types, cache headers, font preload headers, and API headers are retained on HEAD responses.

## Verification

- `pnpm --filter @farm.js/core exec vitest run src/__tests__/docs-handler.test.ts`
- `pnpm --filter @farm.js/core type-check`
- `pnpm exec oxlint packages/farm/src/docs/handler.ts packages/farm/src/docs/api.ts packages/farm/src/__tests__/docs-handler.test.ts`

## Documentation and release

None.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes docs HEAD responses so they return an empty body while keeping GET status and headers.

- Applies to HTML pages, markdown mirrors, public docs artifacts, and `/api/docs`.
- GET responses are unchanged.

<sup>Written for commit d8c3243b6bff431121fd06b534dd3596d1ea7393. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/810?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

