### PR TITLE
fix(dev): report stale generated route types

### DIFF
--- a/packages/farm/src/__tests__/vite-config.test.ts
+++ b/packages/farm/src/__tests__/vite-config.test.ts
@@ -1,8 +1,12 @@
 // @vitest-environment node
 
-import { describe, expect, it } from "vitest";
+import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
+import { createServer } from "vite";
+import { describe, expect, it, vi } from "vitest";
 import { FARM_CLIENT_OPTIMIZE_DEPS_INCLUDE } from "../server/vite-config";
+import { logger } from "../utils";
 import { defineConfig, farmPlugin } from "../vite";
 
 describe("Farm Vite dependency optimization", () => {
@@ -47,5 +51,37 @@ describe("Farm Vite publicDir", () => {
       { command: "serve", mode: "development", isSsrBuild: false },
     );
     expect("publicDir" in config).toBe(false);
+  });
+});
+
+describe("Farm Vite type artifacts", () => {
+  it("warns when startup generation leaves farm.d.ts stale", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "farm-vite-type-warning-"));
+    await fs.mkdir(path.join(root, "src", "app"), { recursive: true });
+    await fs.mkdir(path.join(root, "src", "farm.d.ts"));
+    const warning = vi.spyOn(logger, "warn").mockImplementation(() => {});
+    const server = await createServer({
+      root,
+      configFile: false,
+      logLevel: "silent",
+      plugins: [
+        farmPlugin({
+          root,
+          images: { provider: "none" },
+          telemetry: false,
+        }),
+      ],
+      server: { middlewareMode: true },
+    });
+
+    try {
+      expect(warning).toHaveBeenCalledWith(
+        expect.stringMatching(/^Route type generation failed \(farm\.d\.ts may be stale\): /),
+      );
+    } finally {
+      await server.close();
+      warning.mockRestore();
+      await fs.rm(root, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/farm/src/vite.ts
+++ b/packages/farm/src/vite.ts
@@ -858,9 +858,8 @@ export function farmPlugin(
             await openAPIManager.invalidateCache();
           }
         } catch (e) {
-          if (process.env.FARM_VERBOSE) {
-            logger.warn("Type artifact generation failed: " + (e as Error).message);
-          }
+          const message = e instanceof Error ? e.message : String(e);
+          logger.warn(`Route type generation failed (farm.d.ts may be stale): ${message}`);
           if (pm) {
             await emitPluginError("type-artifact-generation", e, { reason });
           }


### PR DESCRIPTION
## Problem

When startup type generation failed in development, Farm could leave `farm.d.ts` stale without showing a warning unless `FARM_VERBOSE` was enabled.

## Root cause

The dev error path gated its warning behind the verbose environment flag even though production builds already report the non-fatal stale-type condition unconditionally.

## Change

Always emit the same actionable stale-`farm.d.ts` warning used by the build path, while preserving plugin error reporting and non-fatal startup behavior.

## Safety and compatibility

Successful generation remains silent. Failures still do not stop the dev server; they now make the degraded type state visible.

## Verification

- `pnpm --filter @farm.js/core exec vitest run src/__tests__/vite-config.test.ts`
- `pnpm --filter @farm.js/core type-check`
- `pnpm exec oxlint packages/farm/src/vite.ts packages/farm/src/__tests__/vite-config.test.ts`

## Documentation and release

None.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes dev startup so stale generated route types always produce a warning, matching the build path. Previously the warning only appeared when `FARM_VERBOSE` was set.

<sup>Written for commit b47959573068925f2277cb946f520c39dc568c59. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/811?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

