### PR TITLE
perf(react): retain reorder hints through keyed maps

### DIFF
--- a/docs/src/app/docs/renderers/react/page.md
+++ b/docs/src/app/docs/renderers/react/page.md
@@ -1233,13 +1233,13 @@ setItems((current) =>
 ```
 
 For a concise functional setter, Farm can prepare one or more consecutive safe same-key `map()`
-calls and the following native `toSorted()` or `toReversed()` calls as one update pipeline.
+calls before or after native `toSorted()` or `toReversed()` calls as one update pipeline.
 JavaScript still performs every map and reorder normally. For two or more accepted maps, the
 compiler runtime checks each native call as it completes but records replacement lineage only once,
-by comparing the committed input with the final mapped result. The intermediate arrays need no
-separate full scan, and the final replacements still point directly to their committed source rows.
-The reorder suffix then needs one final keyed reconciliation rather than a growing chain of
-intermediate snapshots.
+by comparing the input and final result of each consecutive map segment. The intermediate arrays
+need no separate full scan, and the final replacements still point directly to their committed
+source rows. The complete pipeline then needs one final keyed reconciliation rather than a growing
+chain of intermediate snapshots.
 
 Before changing the DOM, the runtime verifies ordinary dense arrays, exact native methods, the
 committed collection token, equal lengths, a unique one-to-one source-item match, and the key of
@@ -1249,6 +1249,23 @@ Unchanged rows need no second key or binding read. Existing row elements, delega
 controlled inputs, focus, and text selection stay attached to their keys. Multiple supported
 map-and-reorder setters queued before one compiler flush compose against the same committed
 collection and expose only the final state.
+
+A safe map may also be the final pipeline step:
+
+```tsx
+setItems((current) =>
+  current
+    .toReversed()
+    .map((item) => (item.id === editedId ? { ...item, label: nextLabel } : item))
+    .map((item) => (item.id === editedId ? { ...item, rank: nextRank } : item)),
+);
+```
+
+Here the maps retain the preceding reorder lineage instead of turning the final value into an
+unhinted snapshot. An exact reverse uses the direct minimum-move reverse path and patches only
+changed rows. An earlier sort retains its general permutation proof, so Farm creates one
+source-item lookup, runs LIS once, and still skips key and binding reads for unchanged rows. Map
+segments on both sides of a reorder flatten replacements back to the same committed source rows.
 
 Exact reverse proof can also cross a setter boundary in the same batch:
 
@@ -2149,6 +2166,10 @@ The package and example test suites verify more than generated code:
   moved-row events with the newest item and index, preserve controlled-input focus and selection,
   and cover changed-key, custom-method, and Array-subclass fallback, Strict Mode hydration, and
   unmount-before-flush cleanup;
+- 2,000 deterministic native reversals or sorts followed by consecutive same-key edits match normal
+  React; targeted tests require exact reversal to use `n - 1` direct DOM moves without a generic
+  source-item map, require ambiguous sorting to use one validated keyed reconciliation, and cover
+  changed keys, custom methods, Strict Mode hydration, and unmount-before-flush cleanup;
 - 1,000 deterministic exact-position insertions, single and contiguous-range removals, single-row
   replacements, and exact-window replacements match normal React; compiler tests cover guarded
   runtime positions plus literal and compiler-safe runtime delete counts, while targeted removal

--- a/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
+++ b/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
@@ -2,6 +2,40 @@
 
 Latest run: 2026-09-08
 
+## Native reorder followed by same-key maps — 2026-09-08
+
+A concise setter may now call native `toReversed()` or `toSorted()` before one or more safe
+same-key `map()` calls. The compiler keeps that reorder proof through the final mapped array. An
+exact reverse therefore uses the direct `n - 1` DOM-move path and patches only changed bindings;
+an ambiguous sort performs one validated source-item lookup and one LIS pass. Every native method,
+callback, result, and error still occurs in JavaScript source order.
+
+The new 10,000-row production-browser workload reverses the rows and then changes one row through
+two native maps. Its block-bodied compiled control performs the identical application work through
+complete keyed reconciliation. The correctness oracle checks all values and positions plus every
+row's DOM identity and connection after each sample.
+
+| Mode   | Reorder + maps | Compiled control | vs React | vs control |
+| ------ | -------------: | ---------------: | -------: | ---------: |
+| Static | 25.10 ms | 38.20 ms | 10.77x | 1.52x |
+| Hybrid | 22.90 ms | 34.10 ms | 11.80x | 1.49x |
+
+Both modes passed the unchanged 4x React and 1.2x compiled-control floors. The full correctness
+oracle, general performance gate, every existing optimization gate, and zero compiled owner
+executions also passed. Deterministic coverage compares 2,000 reverse-or-sort-then-map updates with
+normal React and covers maps on both sides of a reorder, custom methods, changed-key fallback,
+Strict Mode hydration, unmount-before-flush cleanup, and React 18.3.1 and 19.2.8.
+
+On Node.js 22.13.1, the isolated keyed map/reorder premium is 13,341 B gzip, 58 B below the unchanged
+13,399 B limit and 46 B smaller than the preceding release. The complete dashboard chunks are
+27,123 B gzip in both compiler modes and 6,643 B with the compiler disabled, including the new
+benchmark controls.
+
+Numbers are local medians from 10 table samples per compiler mode with 20 bracketing React samples,
+Chrome 152.0.7977.82, Node.js 23.11.0, and Apple M1 macOS arm64. Timing varies by machine; the
+deterministic parity, fallback, DOM-move, compatibility, and runtime-size checks are the primary
+safety controls.
+
 ## Queued reverse and mapped parity — 2026-09-08
 
 Exact keyed-row order now survives across separate queued setters. The benchmark first queues a
@@ -92,8 +126,8 @@ compiled-control floors, the complete correctness oracle, and every existing reg
 Correctness checks verify the complete final order and values, preserve all 10,000 row nodes and
 their connectivity, and cover changed keys, custom methods, Array subclasses, delegated events,
 controlled-input focus and selection, Strict Mode hydration, unmount cleanup, and 2,000 randomized
-mapped reversals. A preceding sort, a map after a queued reorder, ambiguous ownership, or failed
-validation remains on the general path or falls back to React before any DOM mutation.
+mapped reversals. A separately queued standalone map after a reorder, ambiguous ownership, or
+failed validation remains on the general path or falls back to React before any DOM mutation.
 
 The isolated optional runtime changed from 13,390 B to 13,378 B gzip, remaining below the 13,399 B
 ceiling. The complete dashboard compiler chunk changed from 26,919 B to 26,903 B gzip, while the

--- a/examples/react-compiler-dashboard/README.md
+++ b/examples/react-compiler-dashboard/README.md
@@ -243,6 +243,15 @@ reversed order, every original DOM identity and connection, and the changed row 
 path validates mirrored row lineage and uses the minimum `n - 1` moves without a source-item map or
 LIS pass.
 
+Reorder-then-map has its own 10,000-row comparison. The concise setter calls `toReversed()` first
+and then changes one row through two safe native maps. Its block-bodied control performs the same
+native work through complete keyed reconciliation. Both compiler modes must remain at least 4x
+faster than React and 1.2x faster than the compiled control. The assertion checks the complete
+reversed order, every existing DOM identity and connection, and the changed row values. Package
+tests also cover sort-before-map permutation reconciliation, maps on both sides of a reorder,
+changed-key and custom-method fallback, React 18/19, Strict Mode hydration, cleanup, and 2,000
+differential updates.
+
 Mapped reverse parity has an independent 10,000-row comparison. Two safe native maps update one
 row, then two native reversals restore committed order. Farm must patch the changed row without
 moving any DOM row or constructing the generic source-item map/LIS sequence. Both compiler modes
@@ -350,6 +359,9 @@ The default JSON report is `/tmp/farm-react-dashboard-benchmark.json`; change it
 - The multi-map reverse control changes the same row through two native maps and then reverses all
   rows. Its block-bodied equivalent performs the same maps and connected DOM moves, while the
   hinted path validates mirrored lineage directly and skips the temporary source map and LIS pass.
+- The reorder-then-map control reverses all rows before changing one row through two native maps.
+  Its block-bodied equivalent loses the reorder proof; the hinted path retains exact reverse order,
+  patches one row, and skips the generic source map and LIS pass.
 - The multi-map reverse-parity control changes the same row through two native maps and then
   reverses twice. Its block-bodied equivalent keeps complete reconciliation; the hinted path
   validates exact committed order, patches the row once, and performs no generic item-map, LIS, or

--- a/examples/react-compiler-dashboard/scripts/benchmark.mjs
+++ b/examples/react-compiler-dashboard/scripts/benchmark.mjs
@@ -1385,6 +1385,12 @@ async function measureTrial(browser, trial, compilerMode, port) {
           () => tableButton("table-queued-map-reverse-parity-snapshot").click(),
           false,
         );
+        const tableReorderThenMapPipeline = await measureMultiMapReverseTable(() =>
+          tableButton("table-reorder-then-map-pipeline").click(),
+        );
+        const tableReorderThenMapPipelineSnapshot = await measureMultiMapReverseTable(() =>
+          tableButton("table-reorder-then-map-pipeline-snapshot").click(),
+        );
 
         const tableSort = await measureTable(
           async () => create10000(),
@@ -1866,6 +1872,8 @@ async function measureTrial(browser, trial, compilerMode, port) {
             multiMapReverseParitySnapshot: tableMultiMapReverseParitySnapshot,
             queuedMapReverseParity: tableQueuedMapReverseParity,
             queuedMapReverseParitySnapshot: tableQueuedMapReverseParitySnapshot,
+            reorderThenMapPipeline: tableReorderThenMapPipeline,
+            reorderThenMapPipelineSnapshot: tableReorderThenMapPipelineSnapshot,
             mapLookup: tableMapLookup,
             membership: tableMembership,
             prepend: tablePrepend,
@@ -2004,6 +2012,10 @@ async function measureTrial(browser, trial, compilerMode, port) {
         multiMapReverseParitySnapshot: timingSummary(result.table.multiMapReverseParitySnapshot),
         queuedMapReverseParity: timingSummary(result.table.queuedMapReverseParity),
         queuedMapReverseParitySnapshot: timingSummary(result.table.queuedMapReverseParitySnapshot),
+        reorderThenMapPipeline: timingSummary(result.table.reorderThenMapPipeline),
+        reorderThenMapPipelineSnapshot: timingSummary(
+          result.table.reorderThenMapPipelineSnapshot,
+        ),
         mapLookup: timingSummary(result.table.mapLookup),
         membership: timingSummary(result.table.membership),
         prepend: timingSummary(result.table.prepend),
@@ -2188,6 +2200,8 @@ const tableMetrics = [
   "multiMapReverseParitySnapshot",
   "queuedMapReverseParity",
   "queuedMapReverseParitySnapshot",
+  "reorderThenMapPipeline",
+  "reorderThenMapPipelineSnapshot",
   "snapshotMembership",
   "snapshotMapLookup",
   "slicePrefix",
@@ -2938,6 +2952,28 @@ const keyedQueuedMapReverseParityRegressions = keyedQueuedMapReverseParityResult
     !Number.isFinite(snapshotSpeedup) ||
     snapshotSpeedup < keyedQueuedMapReverseParityMinimumSnapshotSpeedup,
 );
+// A safe map suffix must retain the preceding native reorder. The exact reverse path should move
+// the minimum rows, patch only changed bindings, and avoid the generic source-item lookup and LIS.
+const keyedReorderThenMapMinimumSpeedup = 4;
+const keyedReorderThenMapMinimumSnapshotSpeedup = 1.2;
+const keyedReorderThenMapResults = ["static", "hybrid"].map((mode) => {
+  const pipelineMedianMs = comparisons.table.reorderThenMapPipeline[mode].medianMs;
+  const snapshotMedianMs = comparisons.table.reorderThenMapPipelineSnapshot[mode].medianMs;
+  return {
+    mode,
+    pipelineMedianMs,
+    snapshotMedianMs,
+    snapshotSpeedup: snapshotMedianMs / pipelineMedianMs,
+    speedup: comparisons.table.reorderThenMapPipeline[`${mode}VsBaseline`].speedup,
+  };
+});
+const keyedReorderThenMapRegressions = keyedReorderThenMapResults.filter(
+  ({ snapshotSpeedup, speedup }) =>
+    !Number.isFinite(speedup) ||
+    speedup < keyedReorderThenMapMinimumSpeedup ||
+    !Number.isFinite(snapshotSpeedup) ||
+    snapshotSpeedup < keyedReorderThenMapMinimumSnapshotSpeedup,
+);
 // A direct native toSorted() exposes a permutation while preserving every keyed row object. The
 // hinted path validates that permutation by item identity, uses LIS to move only the required DOM
 // nodes, and avoids key, descriptor, and binding reads. Compare it with React and the equivalent
@@ -3131,6 +3167,7 @@ const passed =
   keyedMultiMapReverseRegressions.length === 0 &&
   keyedMappedReverseParityRegressions.length === 0 &&
   keyedQueuedMapReverseParityRegressions.length === 0 &&
+  keyedReorderThenMapRegressions.length === 0 &&
   keyedSortRegressions.length === 0 &&
   keyedFilterRegressions.length === 0 &&
   keyedIdentityRegressions.length === 0 &&
@@ -3331,6 +3368,13 @@ const report = {
     regressions: keyedQueuedMapReverseParityRegressions,
     results: keyedQueuedMapReverseParityResults,
     status: keyedQueuedMapReverseParityRegressions.length === 0 ? "PASS" : "FAIL",
+  },
+  keyedReorderThenMapHintGate: {
+    minimumSnapshotSpeedup: keyedReorderThenMapMinimumSnapshotSpeedup,
+    minimumSpeedup: keyedReorderThenMapMinimumSpeedup,
+    regressions: keyedReorderThenMapRegressions,
+    results: keyedReorderThenMapResults,
+    status: keyedReorderThenMapRegressions.length === 0 ? "PASS" : "FAIL",
   },
   keyedSortHintGate: {
     minimumSnapshotSpeedup: keyedSortMinimumSnapshotSpeedup,

--- a/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
+++ b/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
@@ -1071,6 +1071,46 @@ export function StandardTableBenchmark() {
           Queue reverse + review + restore (snapshot control)
         </button>
         <button
+          data-action="table-reorder-then-map-pipeline"
+          type="button"
+          onClick={() => {
+            setRows((current) =>
+              current
+                .toReversed()
+                .map((row) =>
+                  row.id % 10_000 === 5_001 ? { ...row, label: `${row.label} reviewed` } : row,
+                )
+                .map((row) =>
+                  row.id % 10_000 === 5_001 ? { ...row, amount: row.amount + 1 } : row,
+                ),
+            );
+            setOperation("reverse rows, then review and reprice one row");
+            setRevision((value) => value + 1);
+          }}
+        >
+          Reverse + review one row
+        </button>
+        <button
+          data-action="table-reorder-then-map-pipeline-snapshot"
+          type="button"
+          onClick={() => {
+            setRows((current) => {
+              return current
+                .toReversed()
+                .map((row) =>
+                  row.id % 10_000 === 5_001 ? { ...row, label: `${row.label} reviewed` } : row,
+                )
+                .map((row) =>
+                  row.id % 10_000 === 5_001 ? { ...row, amount: row.amount + 1 } : row,
+                );
+            });
+            setOperation("reverse rows, then review and reprice one row (snapshot control)");
+            setRevision((value) => value + 1);
+          }}
+        >
+          Reverse + review one row (snapshot control)
+        </button>
+        <button
           data-action="table-sort"
           type="button"
           onClick={() => {

--- a/packages/farm-react/README.md
+++ b/packages/farm-react/README.md
@@ -427,7 +427,7 @@ reorder fall back. Reports count each compiled step in the existing filter, slic
 counter, and modules without those operations omit their optional runtimes. Farm does not polyfill
 `Array.prototype.toReversed`.
 
-A compiler-safe same-key map may also precede the native reorder suffix:
+A compiler-safe same-key map may also appear before or after native reorder steps:
 
 ```tsx
 setItems((current) =>
@@ -439,7 +439,7 @@ setItems((current) =>
 ```
 
 Farm executes every native map and reorder call normally. For consecutive accepted maps, it checks
-each native call but compares only the committed input and final mapped result, avoiding a full
+each native call but compares only the input and final result of that map segment, avoiding a full
 lineage scan for every intermediate array. It verifies the committed token, dense-array shape, a
 one-to-one source-item match, and every final replacement key before touching the DOM, then runs one
 LIS and patches each changed row once. Unchanged rows need no second key or binding read. Queued
@@ -451,6 +451,22 @@ the same chain, computed or custom methods, sparse or subclassed arrays, collect
 bindings, nested or React-owned rows, and failed checks use complete keyed reconciliation. Reports
 use the existing map, sort, and reorder hint counters, and unrelated modules do not retain this
 optional runtime.
+
+The maps may also finish the concise pipeline:
+
+```tsx
+setItems((current) =>
+  current
+    .toReversed()
+    .map((item) => (item.id === editedId ? { ...item, label: nextLabel } : item))
+    .map((item) => (item.id === editedId ? { ...item, rank: nextRank } : item)),
+);
+```
+
+Farm retains the preceding reorder instead of treating the mapped result as an unhinted snapshot.
+An exact reverse uses the minimum-move reverse path without a general source-item lookup or LIS. A
+sort remains an ambiguous permutation, so Farm performs one validated source lookup and LIS pass.
+Safe maps on both sides of a reorder flatten their replacements back to the same committed rows.
 
 A reverse before the safe map pipeline may be queued in a separate setter:
 

--- a/packages/farm-react/scripts/test-react-version.mjs
+++ b/packages/farm-react/scripts/test-react-version.mjs
@@ -95,6 +95,7 @@ const testSource = String.raw`
   let reverseCompatibilityRows = () => undefined;
   let mapReverseParityCompatibilityRows = () => undefined;
   let queuedMapReverseParityCompatibilityRows = () => undefined;
+  let reorderThenMapCompatibilityRows = () => undefined;
   let insertCompatibilityRows = () => undefined;
   let removeCompatibilityRow = () => undefined;
   let replaceCompatibilityRows = () => undefined;
@@ -139,6 +140,15 @@ const testSource = String.raw`
           return createCompilerKeyedArrayMapReorder(mapped, mapped.toReversed);
         });
       };
+      reorderThenMapCompatibilityRows = () =>
+        state[0].set((previous) => {
+          const reversed = createCompilerKeyedArrayReorder(previous, previous.toReversed);
+          return createCompilerKeyedArrayMapPipeline(
+            reversed,
+            reversed.map,
+            (item) => item.id === "c" ? { ...item, label: "Gamma after reverse" } : item,
+          );
+        });
       removeCompatibilityRow = () =>
         state[0].set((previous) =>
           createCompilerKeyedArrayPositionUpdate(
@@ -279,6 +289,13 @@ const testSource = String.raw`
     "Beta queued parity",
   );
   assert.equal(reorderContainer.querySelector("li:last-child"), reorderAlpha);
+  assert.equal(reorderExecutions, 1);
+  reorderThenMapCompatibilityRows();
+  await Promise.resolve();
+  await Promise.resolve();
+  assert.equal(reorderContainer.querySelector("li:first-child"), reorderAlpha);
+  assert.equal(reorderContainer.querySelector("[data-key='c']").textContent, "Gamma after reverse");
+  assert.equal(reorderContainer.querySelector("li:last-child"), reorderGamma);
   assert.equal(reorderExecutions, 1);
   const reorderBeta = reorderContainer.querySelector("[data-key='b']");
   sortCompatibilityRows();

--- a/packages/farm-react/src/__tests__/compiler-keyed-array-sort-hints.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-keyed-array-sort-hints.test.ts
@@ -351,6 +351,66 @@ describe("React AOT keyed-array sort hints", () => {
     expect(result.code).toContain("keyedRowsMapReorderHintedRuntimeFeature");
   });
 
+  it("preserves an exact reverse when consecutive safe maps are the final steps", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Table({ editedId, nextLabel, nextRank }) {
+        const [rows, setRows] = useState([
+          { id: "a", label: "Alpha", rank: 1 },
+          { id: "b", label: "Beta", rank: 2 },
+        ]);
+        return <section>
+          <button onClick={() => setRows((current) => current
+            .toReversed()
+            .map((row) => row.id === editedId ? { ...row, label: nextLabel } : row)
+            .map((row) => row.id === editedId ? { ...row, rank: nextRank } : row)
+          )}>Reverse and edit</button>
+          <ul>{rows.map((row) => <li key={row.id}>{row.label}: {row.rank}</li>)}</ul>
+        </section>;
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Table"]);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.optimizations.keyedMapUpdateHints).toBe(2);
+    expect(result.optimizations.keyedArrayReorderHints).toBe(1);
+    expect(result.code.match(/createCompilerKeyedArrayReorder\(/g)).toHaveLength(1);
+    expect(result.code.match(/createCompilerKeyedArrayMapPipeline\(/g)).toHaveLength(1);
+    expect(result.code.match(/_farmApplyMap\d*\(/g)).toHaveLength(2);
+    expect(result.code.match(/createCompilerKeyedArrayMapReorder\(/g) || []).toHaveLength(0);
+    expect(result.code).toContain("keyedRowsMapReorderHintedRuntimeFeature");
+  });
+
+  it("carries mapped lineage through reorder steps on both sides of a safe map", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Table({ editedId, nextLabel }) {
+        const [rows, setRows] = useState([
+          { id: "a", label: "Alpha", rank: 1 },
+          { id: "b", label: "Beta", rank: 2 },
+        ]);
+        return <section>
+          <button onClick={() => setRows((current) => current
+            .toSorted((left, right) => left.rank - right.rank)
+            .map((row) => row.id === editedId ? { ...row, label: nextLabel } : row)
+            .toReversed()
+          )}>Sort, edit, and reverse</button>
+          <ul>{rows.map((row) => <li key={row.id}>{row.label}</li>)}</ul>
+        </section>;
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Table"]);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.optimizations.keyedMapUpdateHints).toBe(1);
+    expect(result.optimizations.keyedArraySortHints).toBe(1);
+    expect(result.optimizations.keyedArrayReorderHints).toBe(1);
+    expect(result.code.match(/createCompilerKeyedArraySort\(/g)).toHaveLength(1);
+    expect(result.code.match(/createCompilerKeyedArrayMapPipeline\(/g)).toHaveLength(1);
+    expect(result.code.match(/createCompilerKeyedArrayMapReorder\(/g)).toHaveLength(1);
+    expect(result.code).toContain("keyedRowsMapReorderHintedRuntimeFeature");
+  });
+
   it("does not lower map and reorder pipelines for host-backed keyed rows", async () => {
     const result = await compile(`
       import { useState } from "react";
@@ -420,9 +480,9 @@ describe("React AOT keyed-array sort hints", () => {
         "current.map((row) => row.id === editedId ? { ...row, rank: 0 } : row).filter((row) => row.rank > 0).toSorted((a, b) => a.rank - b.rank)",
     },
     {
-      name: "a map after reorder",
+      name: "a map after a structural reorder",
       pipeline:
-        "current.toSorted((a, b) => a.rank - b.rank).map((row) => row.id === editedId ? { ...row, rank: 0 } : row)",
+        "current.filter((row) => row.rank > 0).toReversed().map((row) => row.id === editedId ? { ...row, rank: 0 } : row)",
     },
   ])("keeps $name on complete reconciliation", async ({ declaration = "", pipeline }) => {
     const result = await compile(`

--- a/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-map-reorder-hints.test.tsx
+++ b/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-map-reorder-hints.test.tsx
@@ -8,6 +8,7 @@ import {
   createCompilerKeyedArrayMapPipeline,
   createCompilerKeyedArrayMapReorder,
   createCompilerKeyedArrayReorder,
+  createCompilerKeyedArraySort,
   type CompilerKeyedRowElement,
 } from "../compiler-runtime";
 
@@ -82,6 +83,14 @@ function hintedReverse(items: Item[]): Item[] {
 
 function hintedPlainReverse(items: Item[]): Item[] {
   return createCompilerKeyedArrayReorder(items, items.toReversed) as Item[];
+}
+
+function hintedPlainSort(items: Item[]): Item[] {
+  return createCompilerKeyedArraySort(
+    items,
+    items.toSorted,
+    (left: Item, right: Item) => left.rank - right.rank,
+  ) as Item[];
 }
 
 function mappedSort(items: Item[], id: string, rank: number, label?: string): Item[] {
@@ -165,10 +174,14 @@ function createHarness(initialItems: Item[]) {
     undefined;
   let queueReverseThenMapReverse: (id: string, rank: number, label: string) => void = () =>
     undefined;
+  let reverseThenMap: (id: string, rank: number, label: string) => void = () => undefined;
+  let sortThenMap: (id: string, rank: number, label: string) => void = () => undefined;
   let queueSortThenMapReverse: () => void = () => undefined;
   let invalidateKey: () => void = () => undefined;
   let customMap: () => void = () => undefined;
+  let customMapAfterReverse: () => void = () => undefined;
   let customSecondMap: () => void = () => undefined;
+  let invalidateKeyAfterReverse: () => void = () => undefined;
   const Table = createCompiledComponent({
     displayName: "MapReorderTable",
     initialize: () => [initialItems],
@@ -214,6 +227,22 @@ function createHarness(initialItems: Item[]) {
           ),
         );
       };
+      reverseThenMap = (id, rank, label) =>
+        state[0].set((previous) =>
+          hintedMaps(
+            hintedPlainReverse(previous as Item[]),
+            (item) => (item.id === id ? { ...item, label } : item),
+            (item) => (item.id === id ? { ...item, rank } : item),
+          ),
+        );
+      sortThenMap = (id, rank, label) =>
+        state[0].set((previous) =>
+          hintedMaps(
+            hintedPlainSort(previous as Item[]),
+            (item) => (item.id === id ? { ...item, label } : item),
+            (item) => (item.id === id ? { ...item, rank } : item),
+          ),
+        );
       queueSortThenMapReverse = () => {
         state[0].set((previous) =>
           hintedSort(
@@ -258,6 +287,19 @@ function createHarness(initialItems: Item[]) {
             (left: Item, right: Item) => left.rank - right.rank,
           );
         });
+      customMapAfterReverse = () =>
+        state[0].set((previous) => {
+          const reversed = hintedPlainReverse(previous as Item[]);
+          const customMap = function (
+            this: Item[],
+            callback: (item: Item, index: number, items: Item[]) => Item,
+          ) {
+            return Array.prototype.map.call(this, callback);
+          };
+          return createCompilerKeyedArrayMapPipeline(reversed, customMap, (item: Item) =>
+            item.id === "a" ? { ...item, label: "Custom after reverse" } : item,
+          );
+        });
       customSecondMap = () =>
         state[0].set((previous) => {
           const second = createCompilerKeyedArrayMapPipeline(
@@ -288,6 +330,12 @@ function createHarness(initialItems: Item[]) {
             (left: Item, right: Item) => left.rank - right.rank,
           );
         });
+      invalidateKeyAfterReverse = () =>
+        state[0].set((previous) =>
+          hintedMap(hintedPlainReverse(previous as Item[]), (item) =>
+            item.id === "b" ? { ...item, id: "replacement", label: "Replacement" } : item,
+          ),
+        );
       return (
         <section>
           <blocks.KeyedRows
@@ -338,6 +386,7 @@ function createHarness(initialItems: Item[]) {
     Table,
     counters,
     customMap: () => customMap(),
+    customMapAfterReverse: () => customMapAfterReverse(),
     customSecondMap: () => customSecondMap(),
     editAndSort: (id: string, rank: number, label?: string) => editAndSort(id, rank, label),
     editTwoAndSort: (labelId: string, rankId: string) => editTwoAndSort(labelId, rankId),
@@ -349,11 +398,14 @@ function createHarness(initialItems: Item[]) {
       editTwiceAndReverseMany(id, rank, label, repetitions),
     editSortReverse: (id: string, rank: number) => editSortReverse(id, rank),
     invalidateKey: () => invalidateKey(),
+    invalidateKeyAfterReverse: () => invalidateKeyAfterReverse(),
     queueEdits: (edits: readonly { id: string; rank: number; label: string }[]) =>
       queueEdits(edits),
     queueReverseThenMapReverse: (id: string, rank: number, label: string) =>
       queueReverseThenMapReverse(id, rank, label),
     queueSortThenMapReverse: () => queueSortThenMapReverse(),
+    reverseThenMap: (id: string, rank: number, label: string) => reverseThenMap(id, rank, label),
+    sortThenMap: (id: string, rank: number, label: string) => sortThenMap(id, rank, label),
   };
 }
 
@@ -696,6 +748,83 @@ describe("compiled keyed-array map and reorder hints", () => {
     expect(harness.counters.executions).toBe(1);
   });
 
+  it("takes the exact reverse path when safe maps are the final pipeline steps", async () => {
+    const initialItems: Item[] = [
+      { id: "a", label: "Alpha", rank: 1 },
+      { id: "b", label: "Beta", rank: 2 },
+      { id: "c", label: "Gamma", rank: 3 },
+    ];
+    const harness = createHarness(initialItems);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Table />));
+    const rows = new Map(
+      [...container.querySelectorAll("li")].map((row) => [row.dataset.key, row]),
+    );
+    const list = container.querySelector("ul")!;
+    const insertBefore = vi.spyOn(list, "insertBefore");
+    const mapSet = vi.spyOn(Map.prototype, "set");
+    harness.counters.bindings = 0;
+    harness.counters.descriptors = 0;
+    harness.counters.keys = 0;
+
+    await act(async () => {
+      harness.reverseThenMap("b", 5, "Beta after reverse");
+      await flushCompilerUpdates();
+    });
+
+    expect(labels(container)).toEqual(["Gamma:3", "Beta after reverse:5", "Alpha:1"]);
+    expect([...container.querySelectorAll("li")]).toEqual([
+      rows.get("c"),
+      rows.get("b"),
+      rows.get("a"),
+    ]);
+    expect(insertBefore).toHaveBeenCalledTimes(2);
+    expect(mapSet.mock.calls.filter(([key]) => initialItems.includes(key as Item))).toHaveLength(0);
+    expect(harness.counters.keys).toBe(1);
+    expect(harness.counters.descriptors).toBe(0);
+    expect(harness.counters.bindings).toBe(1);
+    expect(harness.counters.executions).toBe(1);
+  });
+
+  it("runs one validated permutation reconciliation when safe maps follow a sort", async () => {
+    const initialItems: Item[] = [
+      { id: "a", label: "Alpha", rank: 3 },
+      { id: "b", label: "Beta", rank: 1 },
+      { id: "c", label: "Gamma", rank: 2 },
+    ];
+    const harness = createHarness(initialItems);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Table />));
+    const rows = new Map(
+      [...container.querySelectorAll("li")].map((row) => [row.dataset.key, row]),
+    );
+    harness.counters.bindings = 0;
+    harness.counters.descriptors = 0;
+    harness.counters.keys = 0;
+
+    await act(async () => {
+      harness.sortThenMap("c", 4, "Gamma after sort");
+      await flushCompilerUpdates();
+    });
+
+    expect(labels(container)).toEqual(["Beta:1", "Gamma after sort:4", "Alpha:3"]);
+    expect([...container.querySelectorAll("li")]).toEqual([
+      rows.get("b"),
+      rows.get("c"),
+      rows.get("a"),
+    ]);
+    expect(harness.counters.keys).toBe(1);
+    expect(harness.counters.descriptors).toBe(0);
+    expect(harness.counters.bindings).toBe(1);
+    expect(harness.counters.executions).toBe(1);
+  });
+
   it("falls back before DOM writes for custom map methods and changed keys", async () => {
     const harness = createHarness([
       { id: "a", label: "Alpha", rank: 2 },
@@ -719,6 +848,34 @@ describe("compiled keyed-array map and reorder hints", () => {
       await flushCompilerUpdates();
     });
     expect(labels(container)).toEqual(["Replacement:1", "Custom:2"]);
+  });
+
+  it("falls back safely when a reordered map uses a custom method or changes a key", async () => {
+    const harness = createHarness([
+      { id: "a", label: "Alpha", rank: 2 },
+      { id: "b", label: "Beta", rank: 1 },
+    ]);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Table />));
+    harness.counters.bindings = 0;
+
+    await act(async () => {
+      harness.customMapAfterReverse();
+      await flushCompilerUpdates();
+    });
+    expect(labels(container)).toEqual(["Beta:1", "Custom after reverse:2"]);
+    expect(harness.counters.bindings).toBe(2);
+
+    harness.counters.bindings = 0;
+    await act(async () => {
+      harness.invalidateKeyAfterReverse();
+      await flushCompilerUpdates();
+    });
+    expect(labels(container)).toEqual(["Custom after reverse:2", "Replacement:1"]);
+    expect(harness.counters.bindings).toBe(2);
   });
 
   it("discards earlier map lineage when a later map method is custom", async () => {
@@ -1179,6 +1336,73 @@ describe("compiled keyed-array map and reorder hints", () => {
     120_000,
   );
 
+  stressIt(
+    "matches React through 2,000 reverse-or-sort then map updates",
+    async () => {
+      const initialItems = Array.from(
+        { length: 31 },
+        (_, index): Item => ({ id: `row-${index}`, label: `Row ${index}`, rank: index }),
+      );
+      const harness = createHarness(initialItems);
+      let updateReact: (
+        kind: "reverse" | "sort",
+        id: string,
+        rank: number,
+        label: string,
+      ) => void = () => undefined;
+      function Normal() {
+        const [items, setItems] = useState(initialItems);
+        updateReact = (kind, id, rank, label) =>
+          setItems((previous) => {
+            const reordered =
+              kind === "reverse"
+                ? previous.toReversed()
+                : previous.toSorted((left, right) => left.rank - right.rank);
+            return reordered
+              .map((item) => (item.id === id ? { ...item, label } : item))
+              .map((item) => (item.id === id ? { ...item, rank } : item));
+          });
+        return (
+          <ol>
+            {items.map((item) => (
+              <li data-key={item.id} key={item.id}>
+                {item.label}:{item.rank}
+              </li>
+            ))}
+          </ol>
+        );
+      }
+      const compiledContainer = document.createElement("div");
+      const reactContainer = document.createElement("div");
+      document.body.append(compiledContainer, reactContainer);
+      const compiledRoot = createRoot(compiledContainer);
+      const reactRoot = createRoot(reactContainer);
+      roots.push(compiledRoot, reactRoot);
+      await act(async () => {
+        compiledRoot.render(<harness.Table />);
+        reactRoot.render(<Normal />);
+      });
+
+      let seed = 0x31a7c5ed;
+      for (let update = 0; update < 2_000; update += 1) {
+        seed = (Math.imul(seed, 1_664_525) + 1_013_904_223) >>> 0;
+        const kind = seed & 1 ? "reverse" : "sort";
+        const id = `row-${seed % initialItems.length}`;
+        const rank = (seed ^ (seed >>> 16)) % 4_003;
+        const label = `Reorder map ${update}`;
+        await act(async () => {
+          if (kind === "reverse") harness.reverseThenMap(id, rank, label);
+          else harness.sortThenMap(id, rank, label);
+          updateReact(kind, id, rank, label);
+          await flushCompilerUpdates();
+        });
+        expect(labels(compiledContainer)).toEqual(labels(reactContainer));
+      }
+      expect(harness.counters.executions).toBe(1);
+    },
+    120_000,
+  );
+
   it("hydrates in StrictMode and drops a queued update after unmount", async () => {
     const initialItems: Item[] = [
       { id: "a", label: "Alpha", rank: 1 },
@@ -1209,11 +1433,15 @@ describe("compiled keyed-array map and reorder hints", () => {
     expect(recoverable).toEqual([]);
     const hydratedRows = [...container.querySelectorAll("li")];
     await act(async () => {
-      hydration.queueReverseThenMapReverse("b", 7, "Beta queued hydration");
+      hydration.reverseThenMap("b", 7, "Beta reordered hydration");
       await flushCompilerUpdates();
     });
-    expect(labels(container)).toEqual(["Alpha hydrated:5", "Beta queued hydration:7", "Gamma:3"]);
-    expect([...container.querySelectorAll("li")]).toEqual(hydratedRows);
+    expect(labels(container)).toEqual([
+      "Gamma:3",
+      "Beta reordered hydration:7",
+      "Alpha hydrated:5",
+    ]);
+    expect([...container.querySelectorAll("li")]).toEqual(hydratedRows.toReversed());
     expect(recoverable).toEqual([]);
 
     const unmounted = createHarness(initialItems);
@@ -1222,7 +1450,7 @@ describe("compiled keyed-array map and reorder hints", () => {
     const unmountRoot = createRoot(unmountContainer);
     await act(async () => unmountRoot.render(<unmounted.Table />));
     act(() => {
-      unmounted.queueReverseThenMapReverse("b", 8, "Never committed");
+      unmounted.sortThenMap("b", 8, "Never committed");
       unmountRoot.unmount();
     });
     await flushCompilerUpdates();

--- a/packages/farm-react/src/compiler-runtime.tsx
+++ b/packages/farm-react/src/compiler-runtime.tsx
@@ -87,15 +87,6 @@ interface CompilerKeyedArrayReorderHint {
   readonly structuralUpdate?: CompilerKeyedArrayFilterHint;
 }
 
-interface CompilerKeyedArrayMapPipelineHint {
-  /** Exact order relative to the committed rows; permutation means the order is ambiguous. */
-  readonly order?: CompilerKeyedArrayReorderKind;
-  readonly sourceToken: object;
-  readonly sourceLength: number;
-  readonly resultLength: number;
-  readonly mappedItemSources: ReadonlyMap<unknown, unknown>;
-}
-
 function reversedCompilerKeyedArrayOrder(
   order: CompilerKeyedArrayReorderKind | undefined,
 ): CompilerKeyedArrayReorderKind | undefined {
@@ -155,10 +146,6 @@ const COMPILER_KEYED_ARRAY_WINDOW_REPLACEMENTS = /* @__PURE__ */ new WeakMap<
 const COMPILER_KEYED_ARRAY_REORDERS = /* @__PURE__ */ new WeakMap<
   object,
   CompilerKeyedArrayReorderHint
->();
-const COMPILER_KEYED_ARRAY_MAP_PIPELINES = /* @__PURE__ */ new WeakMap<
-  object,
-  CompilerKeyedArrayMapPipelineHint
 >();
 const COMPILER_KEYED_COLLECTION_DRAFTS = /* @__PURE__ */ new WeakMap<
   object,
@@ -667,19 +654,11 @@ function recordCompilerKeyedArrayMapPipeline(previous: unknown, value: unknown):
     }
 
     const committedSource = COMPILER_KEYED_COMMITTED_COLLECTIONS.has(previousTarget);
-    const previousMapPipeline = committedSource
+    const previousReorder = committedSource
       ? undefined
-      : COMPILER_KEYED_ARRAY_MAP_PIPELINES.get(previousTarget);
-    const previousReorder =
-      committedSource || previousMapPipeline
-        ? undefined
-        : COMPILER_KEYED_ARRAY_REORDERS.get(previousTarget);
-    const composablePreviousReorder =
-      previousReorder &&
-      (previousReorder.mapped ||
-        previousReorder.kind !== CompilerKeyedArrayReorderKind.Permutation);
+      : COMPILER_KEYED_ARRAY_REORDERS.get(previousTarget);
     const previousSource =
-      previousMapPipeline || (composablePreviousReorder ? previousReorder : undefined);
+      previousReorder && !previousReorder.structuralUpdate ? previousReorder : undefined;
     if (!committedSource && (!previousSource || previousSource.resultLength !== previous.length)) {
       return value;
     }
@@ -707,17 +686,16 @@ function recordCompilerKeyedArrayMapPipeline(previous: unknown, value: unknown):
       const mappedItem = mappedDescriptor.value;
       if (!Object.is(mappedItem, sourceItem)) mappedItemSources.set(mappedItem, sourceItem);
     }
-    COMPILER_KEYED_ARRAY_MAP_PIPELINES.set(valueTarget, {
-      order: previousMapPipeline
-        ? previousMapPipeline.order
-        : committedSource
-          ? undefined
-          : previousReorder?.kind,
+    const hint: CompilerKeyedArrayReorderHint = {
+      kind: committedSource ? undefined : previousReorder?.kind,
       sourceToken,
       sourceLength: previousSource?.sourceLength ?? previous.length,
       resultLength: value.length,
+      mapped: true,
       mappedItemSources,
-    });
+    };
+    // A safe map can precede or follow a native reorder, including as the final pipeline step.
+    COMPILER_KEYED_ARRAY_REORDERS.set(valueTarget, hint);
   } catch {
     // Metadata must never change the result of a successful native update.
   }
@@ -725,7 +703,7 @@ function recordCompilerKeyedArrayMapPipeline(previous: unknown, value: unknown):
 }
 
 /**
- * @internal Executes proven native maps before the reorder suffix of a keyed pipeline.
+ * @internal Executes proven native maps within a keyed reorder pipeline.
  * The three-argument form remains accepted for older generated output.
  */
 export function createCompilerKeyedArrayMapPipeline(
@@ -789,21 +767,14 @@ export function createCompilerKeyedArrayMapReorder(
       }
     }
 
-    const mapPipeline = COMPILER_KEYED_ARRAY_MAP_PIPELINES.get(previousTarget);
-    const previousReorder = mapPipeline
-      ? undefined
-      : COMPILER_KEYED_ARRAY_REORDERS.get(previousTarget);
-    const source = mapPipeline || (previousReorder?.mapped ? previousReorder : undefined);
+    const previousReorder = COMPILER_KEYED_ARRAY_REORDERS.get(previousTarget);
+    const source = previousReorder?.mapped ? previousReorder : undefined;
     if (!source || source.resultLength !== previous.length) return value;
     COMPILER_KEYED_ARRAY_REORDERS.set(valueTarget, {
       kind:
         method !== NATIVE_ARRAY_TO_REVERSED
           ? CompilerKeyedArrayReorderKind.Permutation
-          : mapPipeline
-            ? reversedCompilerKeyedArrayOrder(mapPipeline.order)
-            : previousReorder
-              ? reversedCompilerKeyedArrayOrder(previousReorder.kind)
-              : CompilerKeyedArrayReorderKind.Permutation,
+          : reversedCompilerKeyedArrayOrder(source.kind),
       sourceToken: source.sourceToken,
       sourceLength: source.sourceLength,
       resultLength: value.length,

--- a/packages/farm-react/src/compiler.ts
+++ b/packages/farm-react/src/compiler.ts
@@ -2009,7 +2009,7 @@ function keyedArrayReorderPipeline(
   let reachedReorder = false;
   for (const step of steps) {
     if (step.kind === "map") {
-      if (reachedReorder || structuralSteps > 0) return undefined;
+      if (structuralSteps > 0) return undefined;
       mapSteps += 1;
     } else if (step.kind === "filter" || step.kind === "slice") {
       if (reachedReorder) return undefined;
@@ -2109,61 +2109,67 @@ function rewriteKeyedArrayReorderPipelineHints(
       const previous = t.cloneNode(updater.params[0]);
       const statements: t.Statement[] = [];
       let value: t.Expression = t.cloneNode(previous);
-      const leadingMapCount = mapPipeline ? steps.findIndex((step) => step.kind !== "map") : 0;
-      let stepIndex = 0;
-      if (leadingMapCount > 1) {
-        const pipelineValue = path.scope.generateUidIdentifier("farmMapValue");
-        const applyMap = path.scope.generateUidIdentifier("farmApplyMap");
-        const pipelineStatements: t.Statement[] = [];
-        let current: t.Expression = t.cloneNode(pipelineValue);
-        for (; stepIndex < leadingMapCount; stepIndex += 1) {
-          const step = steps[stepIndex];
-          if (step.kind !== "map") break;
-          const method = path.scope.generateUidIdentifier(`farmMap${stepIndex + 1}`);
-          const result = path.scope.generateUidIdentifier(`farmMappedItems${stepIndex + 1}`);
-          pipelineStatements.push(
-            t.variableDeclaration("const", [
-              t.variableDeclarator(
-                t.cloneNode(method),
-                t.memberExpression(t.cloneNode(current), t.identifier("map")),
-              ),
-            ]),
-            t.variableDeclaration("const", [
-              t.variableDeclarator(
-                t.cloneNode(result),
-                t.callExpression(t.cloneNode(applyMap), [
-                  t.cloneNode(current),
-                  t.cloneNode(method),
-                  t.cloneNode(step.callback, true),
+      let hasMappedLineage = false;
+      for (let stepIndex = 0; stepIndex < steps.length; stepIndex += 1) {
+        const step = steps[stepIndex];
+        if (step.kind === "map") {
+          let mapEnd = stepIndex + 1;
+          while (steps[mapEnd]?.kind === "map") mapEnd += 1;
+          if (mapEnd - stepIndex > 1) {
+            const pipelineValue = path.scope.generateUidIdentifier("farmMapValue");
+            const applyMap = path.scope.generateUidIdentifier("farmApplyMap");
+            const pipelineStatements: t.Statement[] = [];
+            let current: t.Expression = t.cloneNode(pipelineValue);
+            for (let mapIndex = stepIndex; mapIndex < mapEnd; mapIndex += 1) {
+              const mapStep = steps[mapIndex];
+              if (mapStep.kind !== "map") break;
+              const method = path.scope.generateUidIdentifier(`farmMap${mapIndex + 1}`);
+              const result = path.scope.generateUidIdentifier(`farmMappedItems${mapIndex + 1}`);
+              pipelineStatements.push(
+                t.variableDeclaration("const", [
+                  t.variableDeclarator(
+                    t.cloneNode(method),
+                    t.memberExpression(t.cloneNode(current), t.identifier("map")),
+                  ),
                 ]),
-              ),
-            ]),
-          );
-          current = t.cloneNode(result);
-        }
-        const result = path.scope.generateUidIdentifier("farmPipelineValue");
-        statements.push(
-          t.variableDeclaration("const", [
-            t.variableDeclarator(
-              t.cloneNode(result),
-              t.callExpression(t.cloneNode(mapHelperIdentifier), [
-                t.cloneNode(previous),
-                t.arrowFunctionExpression(
-                  [t.cloneNode(pipelineValue), t.cloneNode(applyMap)],
-                  t.blockStatement([
-                    ...pipelineStatements,
-                    t.returnStatement(t.cloneNode(current)),
+                t.variableDeclaration("const", [
+                  t.variableDeclarator(
+                    t.cloneNode(result),
+                    t.callExpression(t.cloneNode(applyMap), [
+                      t.cloneNode(current),
+                      t.cloneNode(method),
+                      t.cloneNode(mapStep.callback, true),
+                    ]),
+                  ),
+                ]),
+              );
+              current = t.cloneNode(result);
+            }
+            const result = path.scope.generateUidIdentifier("farmPipelineValue");
+            statements.push(
+              t.variableDeclaration("const", [
+                t.variableDeclarator(
+                  t.cloneNode(result),
+                  t.callExpression(t.cloneNode(mapHelperIdentifier), [
+                    t.cloneNode(value),
+                    t.arrowFunctionExpression(
+                      [t.cloneNode(pipelineValue), t.cloneNode(applyMap)],
+                      t.blockStatement([
+                        ...pipelineStatements,
+                        t.returnStatement(t.cloneNode(current)),
+                      ]),
+                    ),
                   ]),
                 ),
               ]),
-            ),
-          ]),
-        );
-        value = t.cloneNode(result);
-        mapCount += leadingMapCount;
-      }
-      for (; stepIndex < steps.length; stepIndex += 1) {
-        const step = steps[stepIndex];
+            );
+            value = t.cloneNode(result);
+            mapCount += mapEnd - stepIndex;
+            hasMappedLineage = true;
+            stepIndex = mapEnd - 1;
+            continue;
+          }
+        }
         const methodName =
           step.kind === "map"
             ? "map"
@@ -2194,12 +2200,12 @@ function rewriteKeyedArrayReorderPipelineHints(
               : step.kind === "slice"
                 ? sliceHelperIdentifier
                 : step.kind === "reverse"
-                  ? mapPipeline
+                  ? hasMappedLineage
                     ? mapReorderHelperIdentifier
                     : structuralPipeline
                       ? structuralReorderHelperIdentifier
                       : reorderHelperIdentifier
-                  : mapPipeline
+                  : hasMappedLineage
                     ? mapReorderHelperIdentifier
                     : structuralPipeline
                       ? structuralSortHelperIdentifier
@@ -2233,16 +2239,18 @@ function rewriteKeyedArrayReorderPipelineHints(
           ]),
         );
         value = t.cloneNode(result);
-        if (step.kind === "map") mapCount += 1;
-        else if (step.kind === "filter") filterCount += 1;
+        if (step.kind === "map") {
+          mapCount += 1;
+          hasMappedLineage = true;
+        } else if (step.kind === "filter") filterCount += 1;
         else if (step.kind === "slice") sliceCount += 1;
         else if (step.kind === "reverse") {
           reorderCount += 1;
-          if (mapPipeline) mapReorderCount += 1;
+          if (hasMappedLineage) mapReorderCount += 1;
           if (structuralPipeline) structuralReorderCount += 1;
         } else {
           sortCount += 1;
-          if (mapPipeline) mapSortCount += 1;
+          if (hasMappedLineage) mapSortCount += 1;
           if (structuralPipeline) structuralSortCount += 1;
         }
       }

--- a/packages/farm-react/vitest.stress.config.ts
+++ b/packages/farm-react/vitest.stress.config.ts
@@ -20,7 +20,7 @@ export default defineConfig({
     ],
     setupFiles: ["src/__tests__/stress.setup.ts"],
     testNamePattern:
-      /2,000 deterministic mapped reorder updates|2,000 deterministic mapped reversal parity updates|2,000 queued reverse, map, and reverse updates|3,000 deterministic recursive updates|4,096 rows/,
+      /2,000 deterministic mapped reorder updates|2,000 deterministic mapped reversal parity updates|2,000 queued reverse, map, and reverse updates|2,000 reverse-or-sort then map updates|3,000 deterministic recursive updates|4,096 rows/,
     testTimeout: 30_000,
   },
 });


### PR DESCRIPTION
## Problem

A concise keyed-row setter that called native toReversed() or toSorted() before safe same-key map() calls lost the preceding reorder proof at the final mapped value. Farm therefore used complete keyed reconciliation even though the compiler had enough information to retain DOM identity and choose the specialized reorder path.

## Root cause

The compiler only grouped safe map segments at the start of a reorder pipeline. Runtime map metadata was also stored separately from reorder metadata, so a final map segment could not carry exact reverse or general permutation lineage to commit.

## Change

The compiler now groups consecutive safe map segments wherever they appear in an eligible native reorder pipeline. Runtime metadata uses the existing keyed reorder hint and flattens mapped replacements directly to committed source rows. Exact reverse keeps the direct n - 1 move path; sort keeps one validated source lookup and LIS pass.

The dashboard adds a 10,000-row reorder-then-map experiment and an equivalent compiled snapshot control. React renderer docs, package docs, example guidance, and recorded benchmark results describe the behavior and limits.

## Safety and compatibility

Every native method lookup, callback, result, and error still executes in source order. Runtime eligibility is validated before DOM mutation. Structural/map mixtures, custom methods, sparse or subclassed arrays, changed keys, ambiguous ownership, hydration failures, and other unsupported cases keep complete reconciliation or React fallback.

This remains React-only and behind the existing experimental compiler. There is no new public API, configuration, observability counter, or disabled-mode runtime cost.

## Verification

- pnpm --filter @farm.js/react test
- pnpm --filter @farm.js/react test:stress
- pnpm --filter @farm.js/react type-check
- pnpm --filter @farm.js/react test:compat
- pnpm --filter @farm.js/react test:runtime-size
- pnpm docs:check-navigation
- pnpm docs:build
- pnpm exec oxlint on changed JavaScript and TypeScript files
- Full production-browser dashboard benchmark on Chrome 152.0.7977.82, Node.js 23.11.0, Apple M1 macOS arm64

The complete benchmark passed correctness, the general performance gate, every existing optimization gate, and the new unchanged-floor gate. Static measured 25.10 ms, 10.77x faster than React and 1.52x faster than the compiled control. Hybrid measured 22.90 ms, 11.80x faster than React and 1.49x faster than the compiled control.

The CI-equivalent Node.js 22.13.1 runtime-size check measured a 13,341 B gzip keyed map/reorder premium, 58 B below the unchanged 13,399 B cap and 46 B smaller than the preceding baseline.

## Documentation and release

Updated the React renderer guide, package README, dashboard README, executable benchmark, and benchmark results. No version or release-flow change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retains keyed reorder hints through safe same-key `map()` calls that appear anywhere in an eligible native `toReversed()`/`toSorted()` pipeline, so the compiler keeps the specialized reorder path instead of falling back to full keyed reconciliation.

- Map segments no longer have to lead the pipeline; a reorder can be followed by maps, including as the final step, without dropping the reorder proof.
- Runtime metadata carries the hint through mapped results and flattens replacements to the committed source rows.
- Exact reverse uses the direct `n - 1` move path; sort performs one validated source lookup and one LIS pass.
- Unsupported cases (structural maps, custom methods, changed keys) still use complete reconciliation or React fallback; every native call, callback, and error executes in source order.
- Adds a 10,000-row reorder-then-map dashboard benchmark with a compiled snapshot control, 2,000-update differential coverage, and updated docs and READMEs. Static measured 25.10 ms (10.77x React, 1.52x control); hybrid 22.90 ms (11.80x React, 1.49x control). Runtime premium is 13,341 B gzip, 58 B below the cap.
- React-only and behind the existing experimental compiler; no new public API, config, or runtime cost when disabled.

<sup>Written for commit 1aae1c1502c77bbc4a3b0d87791f313623806a3b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/812?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

