### PR TITLE
fix(react): keep shared client modules inside route roots

### DIFF
--- a/packages/farm/src/__tests__/isolated-boundary.test.tsx
+++ b/packages/farm/src/__tests__/isolated-boundary.test.tsx
@@ -8,6 +8,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   createFarmIsolatedClientBoundary,
   createFarmIsolatedHydrationRuntime,
+  wrapFarmIsolatedClientGraph,
 } from "../client/isolated-boundary";
 import { scheduleFarmIslandHydration } from "../client/island-runtime";
 
@@ -60,6 +61,25 @@ describe("isolated client boundary", () => {
     );
     expect(html).toContain('{"initial":2}');
     expect(html).toContain("<button>2</button>");
+  });
+
+  it("keeps a compiled leaf inside its route-owned React root", () => {
+    function Counter() {
+      return <button data-route-counter>route</button>;
+    }
+    const Boundary = createFarmIsolatedClientBoundary(
+      React,
+      Counter,
+      "/src/counter.tsx",
+      "default",
+      "load",
+    );
+
+    const html = renderToString(wrapFarmIsolatedClientGraph(React, <Boundary />));
+
+    expect(html).toContain('<button data-route-counter="true">route</button>');
+    expect(html).not.toContain("<farm-client-boundary");
+    expect(html).not.toContain("data-farm-client-props");
   });
 
   it("keeps serialized props non-executable and round-trips supported values", async () => {

--- a/packages/farm/src/__tests__/production-prebuilt-ssr.test.ts
+++ b/packages/farm/src/__tests__/production-prebuilt-ssr.test.ts
@@ -1005,6 +1005,10 @@ export default function Page() {
 `.trim(),
       );
       await fs.writeFile(
+        path.join(root, "src", "app", "layout.tsx"),
+        `export default function RootLayout({ children }) { return <>{children}</>; }`,
+      );
+      await fs.writeFile(
         path.join(developmentRoot, "index.mjs"),
         `
 import { createServer } from "@farm.js/core/server";
@@ -1418,7 +1422,12 @@ await server.listen(Number(process.env.PORT));
         },
         "production",
       );
-    const verifyIndependentInitialScheduling = async (url: string) => {
+    const verifyIndependentInitialScheduling = async (
+      url: string,
+      options: { expectedIsolatedRoots?: number; stableCounterIsInteractive?: boolean } = {},
+    ) => {
+      const expectedIsolatedRoots = options.expectedIsolatedRoots ?? 3;
+      const stableCounterIsInteractive = options.stableCounterIsInteractive ?? true;
       const executablePath = await resolveInstalledChromiumExecutable();
       if (!executablePath) return;
       const browser = await chromium.launch({ headless: true, executablePath });
@@ -1429,23 +1438,31 @@ await server.listen(Number(process.env.PORT));
           if (message.type() === "error") browserErrors.push(message.text());
         });
         page.on("pageerror", (error) => browserErrors.push(error.message));
-        await page.goto(new URL("/fallback", url).href);
+        try {
+          await page.goto(new URL("/fallback", url).href);
 
-        await expect
-          .poll(() => page.locator('farm-client-boundary[data-farm-hydrated="true"]').count())
-          .toBe(3);
-        expect(
-          await page.locator("#__farm_page__").getAttribute("data-farm-island-hydrated"),
-        ).toBeNull();
-        await page.locator("[data-stable-counter]").click();
-        await expect
-          .poll(() => page.locator("[data-stable-counter]").textContent())
-          .toBe("stable:1");
-        await page.locator("[data-fallback-counter]").click();
-        await expect
-          .poll(() => page.locator("[data-fallback-counter]").textContent())
-          .toBe("fallback:1");
-        expect(browserErrors).toEqual([]);
+          await expect
+            .poll(() => page.locator('farm-client-boundary[data-farm-hydrated="true"]').count())
+            .toBe(expectedIsolatedRoots);
+          expect(
+            await page.locator("#__farm_page__").getAttribute("data-farm-island-hydrated"),
+          ).toBeNull();
+          if (stableCounterIsInteractive) {
+            await page.locator("[data-stable-counter]").click();
+            await expect
+              .poll(() => page.locator("[data-stable-counter]").textContent())
+              .toBe("stable:1");
+          }
+          await page.locator("[data-fallback-counter]").click();
+          await expect
+            .poll(() => page.locator("[data-fallback-counter]").textContent())
+            .toBe("fallback:1");
+          expect(browserErrors).toEqual([]);
+        } catch (error) {
+          throw new Error(
+            `${String(error)}\nBrowser errors:\n${browserErrors.join("\n")}\nDOM:\n${await page.locator("body").innerHTML()}`,
+          );
+        }
       } finally {
         await browser.close();
       }
@@ -1645,7 +1662,10 @@ export default function PageOwner() { return <section data-page-owner><LiveCount
         } finally {
           await browser.close();
         }
-        await verifyIndependentInitialScheduling(response.url);
+        await verifyIndependentInitialScheduling(response.url, {
+          expectedIsolatedRoots: 2,
+          stableCounterIsInteractive: false,
+        });
       });
 
       const streamingConfig = await resolveParityConfig(

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -2475,7 +2475,7 @@ document.addEventListener("click", function(e) {
   });
   const isolatedHydrationEnabled = isolatedBoundaryModules.size > 0;
   const isolatedHydrationImport = isolatedHydrationEnabled
-    ? `import { createFarmIsolatedHydrationRuntime } from "@farm.js/core/internal/isolated-boundary";`
+    ? `import { createFarmIsolatedHydrationRuntime, wrapFarmIsolatedClientGraph } from "@farm.js/core/internal/isolated-boundary";`
     : "";
   const isolatedHydrationRuntime = isolatedHydrationEnabled
     ? `const farmIsolatedBoundaryLoaders = {
@@ -2506,6 +2506,11 @@ async function hydrateFarmIsolatedClientBoundaries(scope = document, signal) {
   await farmIsolatedHydrationRuntime.hydrate(scope, signal);
 }`
     : "";
+  const routeClientGraphRuntime = isolatedHydrationEnabled
+    ? `function wrapFarmRouteClientGraph(element) {
+  return wrapFarmIsolatedClientGraph(React, element);
+}`
+    : `function wrapFarmRouteClientGraph(element) { return element; }`;
   clientRouteSlots.forEach((slot, index) => {
     const importPath = toImportPath(slot.modulePath);
     imports.push(`import RouteSlot${index} from "${importPath}";`);
@@ -2551,6 +2556,7 @@ ${routeEntries.join(",\n")}
 ];
 
 ${isolatedHydrationRuntime}
+${routeClientGraphRuntime}
 
 const clientRouteSlots = [
 ${routeSlotEntries.join(",\n")}
@@ -2674,11 +2680,15 @@ async function createMatchedHydrationElement(matched, pathname, searchParams, se
   }
 
   if (!pageElement) return null;
-  if (!hydrateLayouts) return wrapWithIntegrationProviders(pageElement);
+  if (!hydrateLayouts) {
+    return wrapFarmRouteClientGraph(wrapWithIntegrationProviders(pageElement));
+  }
   if (matched.route.pageShouldHydrate) {
     pageElement = createLayoutPageBoundary(matched.route, pageElement);
   }
-  return wrapWithIntegrationProviders(wrapWithLayouts(pageElement, pathname, params));
+  return wrapFarmRouteClientGraph(
+    wrapWithIntegrationProviders(wrapWithLayouts(pageElement, pathname, params)),
+  );
 }
 
 function matchesRoutePrefix(pathname, pattern) {
@@ -2737,7 +2747,9 @@ function renderClientRouteSlot(slot, registration, mode) {
   const key = routeSlotKey(slot);
   const existingRoot = routeSlotRoots.get(key);
   const props = slot.props && typeof slot.props === "object" ? slot.props : {};
-  const element = wrapWithIntegrationProviders(React.createElement(registration.Component, props));
+  const element = wrapFarmRouteClientGraph(
+    wrapWithIntegrationProviders(React.createElement(registration.Component, props)),
+  );
 
   if (mode === "hydrate") {
     if (existingRoot) return true;
@@ -3718,6 +3730,7 @@ async function buildSSRInMemory(
     hasConfiguredRuntimePlugins,
     preset,
     i18nCatalogs,
+    isolatedClientBoundaryModules,
   );
 
   // Find a temporary file path for the virtual entry
@@ -4029,6 +4042,7 @@ function generateVirtualEntryCode(
   hasConfiguredRuntimePlugins: boolean,
   preset: string,
   i18nCatalogs: FarmI18nCatalogs,
+  isolatedClientBoundaryModules: ReadonlySet<string>,
 ): string {
   const hasPluginRuntime = hasRuntimeIntegrationConfig || hasConfiguredRuntimePlugins;
   const adapterOwnsDocsRuntime = Boolean(
@@ -4037,9 +4051,20 @@ function generateVirtualEntryCode(
     config.docs.adapter?.server &&
     config.docs.adapter.react,
   );
+  const hasIsolatedClientGraphRuntime =
+    isReactRenderer(config.renderer) && isolatedClientBoundaryModules.size > 0;
   const rendererServerImports = isReactRenderer(config.renderer)
-    ? `import * as React from "react";\nimport * as ReactDOMServer from "react-dom/server";`
+    ? `import * as React from "react";\nimport * as ReactDOMServer from "react-dom/server";${
+        hasIsolatedClientGraphRuntime
+          ? '\nimport { wrapFarmIsolatedClientGraph } from "@farm.js/core/internal/isolated-boundary";'
+          : ""
+      }`
     : `import React, * as ReactDOMServer from ${JSON.stringify(config.renderer.server)};`;
+  const routeClientGraphServerRuntime = hasIsolatedClientGraphRuntime
+    ? `function wrapFarmRouteClientGraph(element) {
+  return wrapFarmIsolatedClientGraph(React, element);
+}`
+    : `function wrapFarmRouteClientGraph(element) { return element; }`;
   const hasGeneratedMetadataImages = metadataImageRoutes.some(
     (image) => image.sourceType === "module",
   );
@@ -4071,6 +4096,51 @@ function generateVirtualEntryCode(
       return providers.length > 0 ? [[name, { providers }]] : [];
     }),
   );
+  const unsupportedIntegrationProvider = renderedIntegrationProviders.find(
+    (provider) => provider.supportsIsolatedHydration !== true,
+  );
+  const isolatedHydrationMode = resolveFarmIsolatedClientHydrationMode(
+    config.experimental?.isolatedClientHydration,
+    {
+      serverComponents: config.experimental?.serverComponents === true,
+      hasUnsupportedIntegrationProvider: Boolean(unsupportedIntegrationProvider),
+    },
+  );
+  const layoutAppliesToRoute = (layoutPattern: string, routePattern: string) =>
+    layoutPattern === "/" ||
+    routePattern === layoutPattern ||
+    routePattern.startsWith(`${layoutPattern}/`);
+  const layoutHydrationPlans = layoutRoutes.map((layout) => ({
+    ...layout,
+    hydration: getClientModuleHydrationPlan(layout.modulePath, config.root, isolatedHydrationMode),
+  }));
+  const pageHydrationPlans = new Map(
+    pageRoutes
+      .filter((route) => !isFarmMarkdownPageFile(route.modulePath))
+      .map((route) => [
+        route.modulePath,
+        getClientModuleHydrationPlan(route.modulePath, config.root, isolatedHydrationMode),
+      ]),
+  );
+
+  // Match the production client plan: a route-wide layout owns its full
+  // descendant tree, so an overlapping isolated page graph must fall back to
+  // the route-wide metadata used before isolated hydration was enabled.
+  for (const route of pageRoutes) {
+    const hydration = pageHydrationPlans.get(route.modulePath);
+    if (
+      hydration?.hasIsolatedClientBoundaries &&
+      layoutHydrationPlans.some(
+        (layout) =>
+          layout.hydration.shouldHydrate && layoutAppliesToRoute(layout.pattern, route.pattern),
+      )
+    ) {
+      hydration.shouldHydrate = hydration.legacyShouldHydrate;
+      hydration.islandStrategy = hydration.legacyIslandStrategy;
+      hydration.hasIsolatedClientBoundaries = false;
+      hydration.isolatedBoundaries = [];
+    }
+  }
   const providerServerImports = [
     providerServerModules.hasClerkProvider
       ? `import { ClerkProvider as FarmClerkProvider } from "@clerk/react";`
@@ -4133,7 +4203,7 @@ function generateVirtualEntryCode(
     pageImports.push(
       `import * as ${varName} from ${toVirtualEntryImportSpecifier(route.modulePath)};`,
     );
-    const clientMetadata = getClientModuleMetadata(route.modulePath, config.root);
+    const clientMetadata = pageHydrationPlans.get(route.modulePath)!;
     pageRegistrations.push(`
   {
     pattern: ${JSON.stringify(route.pattern)},
@@ -4155,9 +4225,9 @@ function generateVirtualEntryCode(
   const layoutImports: string[] = [];
   const layoutRegistrations: string[] = [];
 
-  layoutRoutes.forEach((layout, index) => {
+  layoutHydrationPlans.forEach((layout, index) => {
     const varName = `layoutRoute${index}`;
-    const clientMetadata = getClientModuleMetadata(layout.modulePath, config.root);
+    const clientMetadata = layout.hydration;
     layoutImports.push(
       `import * as ${varName} from ${toVirtualEntryImportSpecifier(layout.modulePath)};`,
     );
@@ -4535,6 +4605,8 @@ ${imageNodeRuntimeImport}
 import { farmFontPreloadHeader } from "virtual:farm-font-runtime";
 import { isFarmRouteActive } from "@farm.js/core/router";
 ${rendererServerImports}
+
+${routeClientGraphServerRuntime}
 
 const farmPreloadConfig = ${JSON.stringify(config.performance.preload)};
 const farmProductionSiteTelemetry = ${
@@ -5921,7 +5993,7 @@ ${
     React.createElement(
       "div",
       { id: "root" },
-      wrapWithFarmIntegrationProviders(wrappedElement),
+      wrapFarmRouteClientGraph(wrapWithFarmIntegrationProviders(wrappedElement)),
     ),
   );
   let rootMarkup = renderedRoot.html;
@@ -6639,6 +6711,10 @@ async function handleFarmRequestInContext(
               pageElement = React.createElement(PageComponent, pageProps);
             }
 
+            if (route.shouldHydrate && !shouldHydrateLayout) {
+              pageElement = wrapFarmRouteClientGraph(pageElement);
+            }
+
             pageElement = React.createElement(
               "div",
               {
@@ -6671,7 +6747,9 @@ async function handleFarmRequestInContext(
                       "data-farm-route-slot": slot.name,
                       "data-farm-slot-owner": slot.ownerPattern,
                     },
-                    React.createElement(slot.module.default, slot.props),
+                    wrapFarmRouteClientGraph(
+                      React.createElement(slot.module.default, slot.props),
+                    ),
                   );
                 }
                 wrappedElement = React.createElement(LayoutComponent, {
@@ -6690,6 +6768,10 @@ async function handleFarmRequestInContext(
                 );
               }
             }
+
+          if (shouldHydrateLayout) {
+            wrappedElement = wrapFarmRouteClientGraph(wrappedElement);
+          }
 
           wrappedElement = wrapWithFarmIntegrationProviders(wrappedElement);
           return renderFarmElement(ReactDOMServer, wrappedElement);

--- a/packages/farm/src/renderer.ts
+++ b/packages/farm/src/renderer.ts
@@ -109,6 +109,8 @@ export interface FarmServerRendererRuntime {
   readonly Suspense: unknown;
   createElement(type: unknown, props?: unknown, ...children: unknown[]): unknown;
   isValidElement(value: unknown): boolean;
+  /** Wraps a route-owned client tree so compiled leaf boundaries stay inside that React root. */
+  wrapClientGraph?(element: unknown): unknown;
   renderToString(element: unknown): string | Promise<string>;
   /**
    * Optional variant for renderers whose components emit document-head markup

--- a/packages/farm/src/renderer/react/server.ts
+++ b/packages/farm/src/renderer/react/server.ts
@@ -3,6 +3,7 @@ import {
   renderToPipeableStream as reactRenderToPipeableStream,
   renderToString as reactRenderToString,
 } from "react-dom/server";
+import { wrapFarmIsolatedClientGraph } from "../../client/isolated-boundary";
 
 export class ErrorBoundary extends React.Component<
   {
@@ -42,6 +43,8 @@ export const Fragment = React.Fragment;
 export const Suspense = React.Suspense;
 export const createElement = React.createElement;
 export const isValidElement = React.isValidElement;
+export const wrapClientGraph = (element: React.ReactNode) =>
+  wrapFarmIsolatedClientGraph(React, element);
 export const renderToString = reactRenderToString;
 export const renderToPipeableStream = reactRenderToPipeableStream;
 

--- a/packages/farm/src/server/renderer.ts
+++ b/packages/farm/src/server/renderer.ts
@@ -570,6 +570,18 @@ export class ServerRenderer {
     );
   }
 
+  private wrapClientGraph(element: unknown): unknown {
+    const getIsolatedClientBoundaryModules = this.routeManager.getIsolatedClientBoundaryModules;
+    if (
+      !this.rendererRuntime.wrapClientGraph ||
+      typeof getIsolatedClientBoundaryModules !== "function" ||
+      getIsolatedClientBoundaryModules.call(this.routeManager, this.config.root).size === 0
+    ) {
+      return element;
+    }
+    return this.rendererRuntime.wrapClientGraph(element);
+  }
+
   private async renderElementToCompleteHTML(element: unknown): Promise<string> {
     const capabilities = getFarmRendererCapabilities(this.config.renderer);
     const renderToPipeableStream = capabilities.streaming.node
@@ -648,6 +660,9 @@ export class ServerRenderer {
         element,
       );
     }
+    if (input.pageShouldHydrate && !input.layoutShouldHydrate) {
+      element = this.wrapClientGraph(element);
+    }
     element = this.createPageBoundary(element, {
       pageShouldHydrate: input.pageShouldHydrate,
       layoutShouldHydrate: input.layoutShouldHydrate,
@@ -665,7 +680,8 @@ export class ServerRenderer {
       const slotProps: Record<string, unknown> = {};
       for (const slot of input.slots || []) {
         if (slot.ownerPattern !== layout.pattern || !slot.module.default) continue;
-        const slotElement = this.rendererRuntime.createElement(slot.module.default, slot.props);
+        let slotElement = this.rendererRuntime.createElement(slot.module.default, slot.props);
+        slotElement = this.wrapClientGraph(slotElement);
         slotProps[slot.name] = this.rendererRuntime.createElement(
           "div",
           {
@@ -682,6 +698,10 @@ export class ServerRenderer {
         ...slotProps,
       });
       element = this.createLayoutBoundary(layout.pattern, element);
+    }
+
+    if (input.layoutShouldHydrate) {
+      element = this.wrapClientGraph(element);
     }
 
     return this.renderElementToCompleteHTML(await this.wrapWithIntegrationProviders(element));
@@ -1505,6 +1525,13 @@ export class ServerRenderer {
               );
             }
 
+            // A route-wide page owns every compiled client component beneath
+            // its React root. Keep shared leaf modules as ordinary components
+            // here even when an isolated layout also imports the same module.
+            if ((isClientComponent || shouldHydrate) && !shouldHydrateLayout) {
+              pageElement = this.wrapClientGraph(pageElement);
+            }
+
             // Every route gets a stable HTML boundary. Server-only pages keep
             // native markup with no React root; interactive pages hydrate this
             // exact boundary.
@@ -1527,6 +1554,7 @@ export class ServerRenderer {
                   slot.module.default,
                   slot.props,
                 );
+                slotElement = this.wrapClientGraph(slotElement);
                 slotElement = this.rendererRuntime.createElement(
                   "div",
                   {
@@ -1544,6 +1572,10 @@ export class ServerRenderer {
                 ...slotProps,
               });
               wrappedElement = this.createLayoutBoundary(layoutEntry.pattern, wrappedElement);
+            }
+
+            if (shouldHydrateLayout) {
+              wrappedElement = this.wrapClientGraph(wrappedElement);
             }
 
             if (ErrorFallbackComponent && this.rendererRuntime.ErrorBoundary) {

--- a/packages/farm/src/vite.ts
+++ b/packages/farm/src/vite.ts
@@ -2921,10 +2921,15 @@ if (import.meta.hot) {
       const props = window.__FARM_PROPS__ || {};
       const nextElement = React.createElement(newModule.default, props);
       const wrapProviders = window.__FARM_WRAP_PROVIDERS__;
+      const wrapClientGraph = window.__FARM_WRAP_CLIENT_GRAPH__;
       Promise.resolve(
         typeof wrapProviders === 'function' ? wrapProviders(nextElement) : nextElement
       ).then((wrappedElement) => {
-        window.__FARM_REACT_ROOT__.render(wrappedElement);
+        window.__FARM_REACT_ROOT__.render(
+          typeof wrapClientGraph === 'function'
+            ? wrapClientGraph(wrappedElement)
+            : wrappedElement
+        );
       });
     }
   });
@@ -3623,7 +3628,7 @@ function generateClientCode(
     ? `import React from 'react'\nimport { hydrateRoot, createRoot } from 'react-dom/client'`
     : `import React, { hydrateRoot, createRoot } from ${JSON.stringify(renderer.client)}`;
   const isolatedHydrationImport = isolatedHydrationEnabled
-    ? `import { createFarmIsolatedHydrationRuntime } from '@farm.js/core/internal/isolated-boundary'`
+    ? `import { createFarmIsolatedHydrationRuntime, wrapFarmIsolatedClientGraph } from '@farm.js/core/internal/isolated-boundary'`
     : "";
   const docsAdapterImportBlock = docsAdapterReact
     ? `import * as FarmDocsAdapterReact from ${JSON.stringify(docsAdapterReact)};
@@ -3711,6 +3716,7 @@ function matchesDocumentNavigation(pathname) {
 ${providerClientCode.runtime}
 
 window.__FARM_WRAP_PROVIDERS__ = wrapWithIntegrationProviders;
+${isolatedHydrationEnabled ? "window.__FARM_WRAP_CLIENT_GRAPH__ = (element) => wrapFarmIsolatedClientGraph(React, element);" : ""}
 
 // Get manifest from window (inlined by server in HTML)
 // Fallback to empty manifest if not available yet
@@ -4104,9 +4110,8 @@ async function renderRouteSlot(slot, mode = 'render') {
     normalizeServerProps(slot.props || {}),
     window.__FARM_DEFERRED_DATA__ || {},
   );
-  const element = wrapWithIntegrationProviders(
-    React.createElement(SlotComponent, props),
-  );
+  let element = wrapWithIntegrationProviders(React.createElement(SlotComponent, props));
+  ${isolatedHydrationEnabled ? "element = wrapFarmIsolatedClientGraph(React, element);" : ""}
   const key = getRouteSlotKey(slot);
   const existingRoot = routeSlotRoots.get(key);
 
@@ -4505,6 +4510,8 @@ async function tryHydrateImportedPage(
     );
   }
   if (signal?.aborted || !container?.isConnected) return false;
+
+  ${isolatedHydrationEnabled ? "wrappedElement = wrapFarmIsolatedClientGraph(React, wrappedElement);" : ""}
 
   if (useHydrate) {
     try {


### PR DESCRIPTION
## Problem

When a React client leaf is shared by an isolated layout and a route-wide page, changing route ownership during HMR can leave the leaf compiled as an independent boundary inside the route-owned root. That produces nested React roots, hydration ID mismatches, and inconsistent root counts between development, SSR, and SSG.

## Root cause

Farm already had an escape context that makes compiled isolated leaves render as ordinary components inside a route-owned root, but route-wide page, layout, and route-slot roots did not provide it. Production SSR also derived ownership from legacy client metadata instead of the isolated hydration plan used by the client build.

## Change

Wrap React route-owned page, layout, and slot trees with the existing isolated-client-graph context in development and production. Use the same hydration ownership plan for the production server and client, including the route-wide layout conflict fallback. Add focused unit and end-to-end regression coverage, and correct the overflow fixture to use Farm-owned document-shell semantics.

## Safety and compatibility

This affects only React apps that have experimental isolated client hydration boundaries. The renderer hook is optional, and the wrapper is an identity path when isolated hydration is disabled or no isolated boundaries exist. Other renderers remain unchanged. Existing complete-root fallback behavior is preserved.

## Verification

- `pnpm --filter @farm.js/core type-check`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @farm.js/core build`
- `pnpm --filter @farm.js/core exec vitest run src/__tests__/isolated-boundary.test.tsx` (22 passed)
- `pnpm --filter @farm.js/core exec vitest run src/__tests__/server-renderer-route-states.test.tsx` (19 passed)
- Full core suite excluding the production browser file (1,667 passed, 1 skipped)
- `pnpm --filter @farm.js/core exec vitest run src/__tests__/production-prebuilt-ssr.test.ts` (31 passed)
- Focused oxfmt and oxlint (0 errors; one pre-existing unrelated warning)

The regression fails without this fix with a React hydration ID mismatch and three roots after the route becomes route-wide; it passes with two route-owned roots after the ownership change.

## Documentation and release

None — this corrects the already documented experimental isolated hydration behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes hydration mismatches when a React client leaf is shared by an isolated layout and a route-wide page. Route ownership changes during HMR could leave the leaf compiled as an independent boundary inside the route-owned root, producing nested React roots and inconsistent root counts across dev, SSR, and SSG. Route-owned page, layout, and slot trees are now wrapped with the existing isolated-client-graph context in development and production.

- Production SSR now derives hydration ownership from the same isolated hydration plan as the client build, including the route-wide layout conflict fallback.
- Adds unit and end-to-end regression coverage and corrects the overflow fixture to use Farm-owned document-shell semantics.
- Only affects React apps with experimental isolated client hydration boundaries; the wrapper is an identity path when isolated hydration is disabled, and other renderers are unchanged.

<sup>Written for commit 5dbb7f9519c21a61ff3842ff261ee8d75b34bb3c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/813?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

