### PR TITLE
perf(react): retain reorder hints across queued maps

### DIFF
--- a/docs/src/app/docs/renderers/react/page.md
+++ b/docs/src/app/docs/renderers/react/page.md
@@ -1267,6 +1267,25 @@ changed rows. An earlier sort retains its general permutation proof, so Farm cre
 source-item lookup, runs LIS once, and still skips key and binding reads for unchanged rows. Map
 segments on both sides of a reorder flatten replacements back to the same committed source rows.
 
+The same proof can cross adjacent setter calls in one synchronous block:
+
+```tsx
+setItems((current) => current.toReversed());
+setItems((current) =>
+  current.map((item) => (item.id === editedId ? { ...item, label: nextLabel } : item)),
+);
+setItems((current) =>
+  current.map((item) => (item.id === editedId ? { ...item, rank: nextRank } : item)),
+);
+```
+
+Farm links only consecutive concise calls to the same setter. Each accepted standalone map keeps
+the earlier reorder token, so an exact reverse still takes the direct minimum-move path and a sort
+still performs one validated lookup and LIS. An intervening statement, a different setter, a
+structural filter/slice reorder, an unsupported map, or host-backed/nested row structure ends this
+specialized chain and preserves the existing complete fallback. Map-only components do not retain
+the optional map-and-reorder runtime.
+
 Exact reverse proof can also cross a setter boundary in the same batch:
 
 ```tsx
@@ -2170,6 +2189,10 @@ The package and example test suites verify more than generated code:
   React; targeted tests require exact reversal to use `n - 1` direct DOM moves without a generic
   source-item map, require ambiguous sorting to use one validated keyed reconciliation, and cover
   changed keys, custom methods, Strict Mode hydration, and unmount-before-flush cleanup;
+- another 2,000 deterministic reverse-or-sort operations followed by two adjacent standalone map
+  setters match normal React; compiler tests cover same-state adjacency and conservative boundaries,
+  while targeted tests preserve DOM identity, exact reverse moves, one changed-row binding read,
+  Strict Mode hydration, and unmount-before-flush cleanup;
 - 1,000 deterministic exact-position insertions, single and contiguous-range removals, single-row
   replacements, and exact-window replacements match normal React; compiler tests cover guarded
   runtime positions plus literal and compiler-safe runtime delete counts, while targeted removal

--- a/examples/react-compiler-dashboard/README.md
+++ b/examples/react-compiler-dashboard/README.md
@@ -49,7 +49,8 @@ pnpm --filter farm-react-compiler-dashboard-example benchmark
 
 The runner builds four production trials in this order: baseline React, static compiler, default
 hybrid compiler, and a second baseline React trial. Two baseline trials bracket machine drift. Each
-trial uses the same browser, viewport, DOM, data, and user actions. It warms every scenario, reports
+trial launches a clean process of the same browser version and uses the same viewport, DOM, data,
+and user actions. It warms every scenario, reports
 median and p95 event-to-DOM timings, checks the compiler report and bundle markers, verifies final
 DOM state and component execution counts, and fails on browser errors.
 
@@ -252,6 +253,15 @@ tests also cover sort-before-map permutation reconciliation, maps on both sides 
 changed-key and custom-method fallback, React 18/19, Strict Mode hydration, cleanup, and 2,000
 differential updates.
 
+Queued reorder-then-map has a separate 10,000-row comparison. One concise setter reverses the
+rows, and two immediately adjacent setters change one row's label and amount through native maps.
+The block-bodied control performs the same three queued updates through complete reconciliation.
+Both compiler modes must remain at least 4x faster than React and 1.2x faster than the compiled
+control. The assertion verifies complete reversed order, every original DOM identity and
+connection, and both changed values. Package tests also compare 2,000 deterministic queued
+reverse-or-sort/map sequences with normal React and cover Strict Mode hydration and
+unmount-before-flush cleanup.
+
 Mapped reverse parity has an independent 10,000-row comparison. Two safe native maps update one
 row, then two native reversals restore committed order. Farm must patch the changed row without
 moving any DOM row or constructing the generic source-item map/LIS sequence. Both compiler modes
@@ -362,6 +372,9 @@ The default JSON report is `/tmp/farm-react-dashboard-benchmark.json`; change it
 - The reorder-then-map control reverses all rows before changing one row through two native maps.
   Its block-bodied equivalent loses the reorder proof; the hinted path retains exact reverse order,
   patches one row, and skips the generic source map and LIS pass.
+- The queued reorder-then-map control performs the same reverse and two maps in three adjacent
+  setter calls. Its block-bodied equivalent keeps complete reconciliation; the hinted path carries
+  one committed reorder token through both queued maps and patches only the changed row.
 - The multi-map reverse-parity control changes the same row through two native maps and then
   reverses twice. Its block-bodied equivalent keeps complete reconciliation; the hinted path
   validates exact committed order, patches the row once, and performs no generic item-map, LIS, or

--- a/examples/react-compiler-dashboard/scripts/benchmark.mjs
+++ b/examples/react-compiler-dashboard/scripts/benchmark.mjs
@@ -1391,6 +1391,12 @@ async function measureTrial(browser, trial, compilerMode, port) {
         const tableReorderThenMapPipelineSnapshot = await measureMultiMapReverseTable(() =>
           tableButton("table-reorder-then-map-pipeline-snapshot").click(),
         );
+        const tableQueuedReorderThenMapPipeline = await measureMultiMapReverseTable(() =>
+          tableButton("table-queued-reorder-then-map-pipeline").click(),
+        );
+        const tableQueuedReorderThenMapPipelineSnapshot = await measureMultiMapReverseTable(() =>
+          tableButton("table-queued-reorder-then-map-pipeline-snapshot").click(),
+        );
 
         const tableSort = await measureTable(
           async () => create10000(),
@@ -1874,6 +1880,8 @@ async function measureTrial(browser, trial, compilerMode, port) {
             queuedMapReverseParitySnapshot: tableQueuedMapReverseParitySnapshot,
             reorderThenMapPipeline: tableReorderThenMapPipeline,
             reorderThenMapPipelineSnapshot: tableReorderThenMapPipelineSnapshot,
+            queuedReorderThenMapPipeline: tableQueuedReorderThenMapPipeline,
+            queuedReorderThenMapPipelineSnapshot: tableQueuedReorderThenMapPipelineSnapshot,
             mapLookup: tableMapLookup,
             membership: tableMembership,
             prepend: tablePrepend,
@@ -2016,6 +2024,10 @@ async function measureTrial(browser, trial, compilerMode, port) {
         reorderThenMapPipelineSnapshot: timingSummary(
           result.table.reorderThenMapPipelineSnapshot,
         ),
+        queuedReorderThenMapPipeline: timingSummary(result.table.queuedReorderThenMapPipeline),
+        queuedReorderThenMapPipelineSnapshot: timingSummary(
+          result.table.queuedReorderThenMapPipelineSnapshot,
+        ),
         mapLookup: timingSummary(result.table.mapLookup),
         membership: timingSummary(result.table.membership),
         prepend: timingSummary(result.table.prepend),
@@ -2115,22 +2127,31 @@ function metricComparison(baselines, staticTrial, hybridTrial, group, metric) {
   };
 }
 
-const browser = await chromium.launch({
-  headless: true,
-  ...(browserExecutablePath ? { executablePath: browserExecutablePath } : {}),
-});
-const browserVersion = browser.version();
-let trials;
-try {
-  trials = [
-    await measureTrial(browser, "baseline-a", "off", basePort),
-    await measureTrial(browser, "static", "static", basePort + 1),
-    await measureTrial(browser, "hybrid", "hybrid", basePort + 2),
-    await measureTrial(browser, "baseline-b", "off", basePort + 3),
-  ];
-} finally {
-  await browser.close();
+async function measureIsolatedTrial(trial, compilerMode, port) {
+  const browser = await chromium.launch({
+    headless: true,
+    ...(browserExecutablePath ? { executablePath: browserExecutablePath } : {}),
+  });
+  const browserVersion = browser.version();
+  try {
+    return {
+      browserVersion,
+      result: await measureTrial(browser, trial, compilerMode, port),
+    };
+  } finally {
+    await browser.close();
+  }
 }
+
+const isolatedTrials = [
+  await measureIsolatedTrial("baseline-a", "off", basePort),
+  await measureIsolatedTrial("static", "static", basePort + 1),
+  await measureIsolatedTrial("hybrid", "hybrid", basePort + 2),
+  await measureIsolatedTrial("baseline-b", "off", basePort + 3),
+];
+const browserVersion = isolatedTrials[0].browserVersion;
+assert(isolatedTrials.every((trial) => trial.browserVersion === browserVersion));
+const trials = isolatedTrials.map((trial) => trial.result);
 
 const staticTrial = trials.find((trial) => trial.compilerMode === "static");
 const hybridTrial = trials.find((trial) => trial.compilerMode === "hybrid");
@@ -2202,6 +2223,8 @@ const tableMetrics = [
   "queuedMapReverseParitySnapshot",
   "reorderThenMapPipeline",
   "reorderThenMapPipelineSnapshot",
+  "queuedReorderThenMapPipeline",
+  "queuedReorderThenMapPipelineSnapshot",
   "snapshotMembership",
   "snapshotMapLookup",
   "slicePrefix",
@@ -2974,6 +2997,28 @@ const keyedReorderThenMapRegressions = keyedReorderThenMapResults.filter(
     !Number.isFinite(snapshotSpeedup) ||
     snapshotSpeedup < keyedReorderThenMapMinimumSnapshotSpeedup,
 );
+// Separate adjacent setters should retain the reorder proof through each safe same-order map.
+// Compare the concise queued sequence with React and block-bodied complete reconciliation.
+const keyedQueuedReorderThenMapMinimumSpeedup = 4;
+const keyedQueuedReorderThenMapMinimumSnapshotSpeedup = 1.2;
+const keyedQueuedReorderThenMapResults = ["static", "hybrid"].map((mode) => {
+  const pipelineMedianMs = comparisons.table.queuedReorderThenMapPipeline[mode].medianMs;
+  const snapshotMedianMs = comparisons.table.queuedReorderThenMapPipelineSnapshot[mode].medianMs;
+  return {
+    mode,
+    pipelineMedianMs,
+    snapshotMedianMs,
+    snapshotSpeedup: snapshotMedianMs / pipelineMedianMs,
+    speedup: comparisons.table.queuedReorderThenMapPipeline[`${mode}VsBaseline`].speedup,
+  };
+});
+const keyedQueuedReorderThenMapRegressions = keyedQueuedReorderThenMapResults.filter(
+  ({ snapshotSpeedup, speedup }) =>
+    !Number.isFinite(speedup) ||
+    speedup < keyedQueuedReorderThenMapMinimumSpeedup ||
+    !Number.isFinite(snapshotSpeedup) ||
+    snapshotSpeedup < keyedQueuedReorderThenMapMinimumSnapshotSpeedup,
+);
 // A direct native toSorted() exposes a permutation while preserving every keyed row object. The
 // hinted path validates that permutation by item identity, uses LIS to move only the required DOM
 // nodes, and avoids key, descriptor, and binding reads. Compare it with React and the equivalent
@@ -3168,6 +3213,7 @@ const passed =
   keyedMappedReverseParityRegressions.length === 0 &&
   keyedQueuedMapReverseParityRegressions.length === 0 &&
   keyedReorderThenMapRegressions.length === 0 &&
+  keyedQueuedReorderThenMapRegressions.length === 0 &&
   keyedSortRegressions.length === 0 &&
   keyedFilterRegressions.length === 0 &&
   keyedIdentityRegressions.length === 0 &&
@@ -3375,6 +3421,13 @@ const report = {
     regressions: keyedReorderThenMapRegressions,
     results: keyedReorderThenMapResults,
     status: keyedReorderThenMapRegressions.length === 0 ? "PASS" : "FAIL",
+  },
+  keyedQueuedReorderThenMapHintGate: {
+    minimumSnapshotSpeedup: keyedQueuedReorderThenMapMinimumSnapshotSpeedup,
+    minimumSpeedup: keyedQueuedReorderThenMapMinimumSpeedup,
+    regressions: keyedQueuedReorderThenMapRegressions,
+    results: keyedQueuedReorderThenMapResults,
+    status: keyedQueuedReorderThenMapRegressions.length === 0 ? "PASS" : "FAIL",
   },
   keyedSortHintGate: {
     minimumSnapshotSpeedup: keyedSortMinimumSnapshotSpeedup,

--- a/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
+++ b/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
@@ -1111,13 +1111,55 @@ export function StandardTableBenchmark() {
           Reverse + review one row (snapshot control)
         </button>
         <button
+          data-action="table-queued-reorder-then-map-pipeline"
+          type="button"
+          onClick={() => {
+            setRows((current) => current.toReversed());
+            setRows((current) =>
+              current.map((row) =>
+                row.id % 10_000 === 5_001 ? { ...row, label: `${row.label} reviewed` } : row,
+              ),
+            );
+            setRows((current) =>
+              current.map((row) =>
+                row.id % 10_000 === 5_001 ? { ...row, amount: row.amount + 1 } : row,
+              ),
+            );
+            setOperation("queue reverse, then review and reprice one row");
+            setRevision((value) => value + 1);
+          }}
+        >
+          Queue reverse + review one row
+        </button>
+        <button
+          data-action="table-queued-reorder-then-map-pipeline-snapshot"
+          type="button"
+          onClick={() => {
+            setRows((current) => {
+              return current.toReversed();
+            });
+            setRows((current) => {
+              return current.map((row) =>
+                row.id % 10_000 === 5_001 ? { ...row, label: `${row.label} reviewed` } : row,
+              );
+            });
+            setRows((current) => {
+              return current.map((row) =>
+                row.id % 10_000 === 5_001 ? { ...row, amount: row.amount + 1 } : row,
+              );
+            });
+            setOperation("queue reverse, then review and reprice one row (snapshot control)");
+            setRevision((value) => value + 1);
+          }}
+        >
+          Queue reverse + review one row (snapshot control)
+        </button>
+        <button
           data-action="table-sort"
           type="button"
           onClick={() => {
             setRows((current) =>
-              current.toSorted(
-                (left, right) => left.amount - right.amount || left.id - right.id,
-              ),
+              current.toSorted((left, right) => left.amount - right.amount || left.id - right.id),
             );
             setOperation("sort rows");
             setRevision((value) => value + 1);

--- a/packages/farm-react/README.md
+++ b/packages/farm-react/README.md
@@ -468,6 +468,24 @@ An exact reverse uses the minimum-move reverse path without a general source-ite
 sort remains an ambiguous permutation, so Farm performs one validated source lookup and LIS pass.
 Safe maps on both sides of a reorder flatten their replacements back to the same committed rows.
 
+The reorder and safe maps may also be adjacent setter calls in the same synchronous block:
+
+```tsx
+setItems((current) => current.toReversed());
+setItems((current) =>
+  current.map((item) => (item.id === editedId ? { ...item, label: nextLabel } : item)),
+);
+setItems((current) =>
+  current.map((item) => (item.id === editedId ? { ...item, rank: nextRank } : item)),
+);
+```
+
+The compiler links only consecutive calls to the same setter. It keeps the reorder token through
+each accepted native map, then validates row keys before applying the same exact-reverse or
+sort-permutation path at commit. An intervening statement, another setter, a structural
+filter/slice reorder, an unsupported map, or a changed key keeps the ordinary complete fallback.
+Standalone map-only components do not retain the map-and-reorder runtime.
+
 A reverse before the safe map pipeline may be queued in a separate setter:
 
 ```tsx

--- a/packages/farm-react/src/__tests__/compiler-keyed-array-queued-reorder-map-hints.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-keyed-array-queued-reorder-map-hints.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from "vitest";
+import { compileReactModule } from "../compiler";
+import { normalizeReactCompilerOptions } from "../index";
+
+const infer = normalizeReactCompilerOptions(true, "/app");
+
+async function compile(source: string) {
+  return compileReactModule(source, "/app/QueuedReorderMapHints.tsx", infer);
+}
+
+describe("React AOT queued keyed-array reorder and map hints", () => {
+  it("retains a reverse through an adjacent standalone map pipeline", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Table({ editedId, nextLabel, nextRank }) {
+        const [rows, setRows] = useState([
+          { id: "a", label: "Alpha", rank: 1 },
+          { id: "b", label: "Beta", rank: 2 },
+        ]);
+        return <section>
+          <button onClick={() => {
+            setRows((current) => current.toReversed());
+            setRows((current) => current
+              .map((row) => row.id === editedId ? { ...row, label: nextLabel } : row)
+              .map((row) => row.id === editedId ? { ...row, rank: nextRank } : row)
+            );
+          }}>Reverse and edit</button>
+          <ul>{rows.map((row) => <li key={row.id}>{row.label}: {row.rank}</li>)}</ul>
+        </section>;
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Table"]);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.optimizations.keyedArrayReorderHints).toBe(1);
+    expect(result.optimizations.keyedMapUpdateHints).toBe(2);
+    expect(result.code.match(/createCompilerKeyedArrayReorder\(/g)).toHaveLength(1);
+    expect(result.code.match(/createCompilerKeyedArrayQueuedMapPipeline\(/g)).toHaveLength(1);
+    expect(result.code.match(/_farmApplyMap\d*\(/g)).toHaveLength(2);
+    expect(result.code).not.toContain("createCompilerKeyedMapUpdate");
+    expect(result.code).not.toContain("createCompilerKeyedArrayMapPipeline");
+    expect(result.code).toContain("keyedRowsMapReorderHintedRuntimeFeature");
+  });
+
+  it("retains a sort through multiple adjacent standalone map setters", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Table({ editedId, nextLabel, nextRank }) {
+        const [rows, setRows] = useState([
+          { id: "a", label: "Alpha", rank: 1 },
+          { id: "b", label: "Beta", rank: 2 },
+        ]);
+        return <section>
+          <button onClick={() => {
+            setRows((current) => current.toSorted((left, right) => left.rank - right.rank));
+            setRows((current) => current.map((row) =>
+              row.id === editedId ? { ...row, label: nextLabel } : row
+            ));
+            setRows((current) => current.map((row) =>
+              row.id === editedId ? { ...row, rank: nextRank } : row
+            ));
+          }}>Sort and edit twice</button>
+          <ul>{rows.map((row) => <li key={row.id}>{row.label}: {row.rank}</li>)}</ul>
+        </section>;
+      }
+    `);
+
+    expect(result.optimizations.keyedArraySortHints).toBe(1);
+    expect(result.optimizations.keyedMapUpdateHints).toBe(2);
+    expect(result.code.match(/createCompilerKeyedArraySort\(/g)).toHaveLength(1);
+    expect(result.code.match(/createCompilerKeyedArrayQueuedMapPipeline\(/g)).toHaveLength(2);
+    expect(result.code).not.toContain("createCompilerKeyedMapUpdate");
+    expect(result.code).not.toContain("createCompilerKeyedArrayMapPipeline");
+    expect(result.code).toContain("keyedRowsMapReorderHintedRuntimeFeature");
+  });
+
+  it.each([
+    {
+      name: "an intervening statement",
+      middle: "trackUpdate();",
+      secondSetter: "setRows",
+      extraState: "",
+      extraDeclaration: "const trackUpdate = () => undefined;",
+      extraRows: "",
+    },
+    {
+      name: "a different state setter",
+      middle: "",
+      secondSetter: "setOtherRows",
+      extraState: 'const [otherRows, setOtherRows] = useState([{ id: "c", label: "Gamma" }]);',
+      extraDeclaration: "",
+      extraRows: "<ol>{otherRows.map((row) => <li key={row.id}>{row.label}</li>)}</ol>",
+    },
+  ])(
+    "keeps a standalone map after $name on its ordinary same-order hint",
+    async ({ middle, secondSetter, extraState, extraDeclaration, extraRows }) => {
+      const result = await compile(`
+        import { useState } from "react";
+        export function Table({ editedId, nextLabel }) {
+          const [rows, setRows] = useState([
+            { id: "a", label: "Alpha" },
+            { id: "b", label: "Beta" },
+          ]);
+          ${extraState}
+          ${extraDeclaration}
+          return <section>
+            <button onClick={() => {
+              setRows((current) => current.toReversed());
+              ${middle}
+              ${secondSetter}((current) => current.map((item) =>
+                item.id === editedId ? { ...item, label: nextLabel } : item
+              ));
+            }}>Update</button>
+            <ul>{rows.map((row) => <li key={row.id}>{row.label}</li>)}</ul>
+            ${extraRows}
+          </section>;
+        }
+      `);
+
+      expect(result.code).toContain("createCompilerKeyedMapUpdate");
+      expect(result.code).not.toContain("keyedRowsMapReorderHintedRuntimeFeature");
+    },
+  );
+
+  it("keeps structural reorder and host-backed rows off the queued map path", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Table({ editedId, nextLabel }) {
+        const [rows, setRows] = useState([
+          { id: "a", label: "Alpha", visible: true },
+          { id: "b", label: "Beta", visible: false },
+        ]);
+        return <section>
+          <button onClick={() => {
+            setRows((current) => current.filter((row) => row.visible).toReversed());
+            setRows((current) => current.map((row) =>
+              row.id === editedId ? { ...row, label: nextLabel } : row
+            ));
+          }}>Filter, reverse, and edit</button>
+          <ul>{rows.map((row) => <li key={row.id}>
+            <span>{row.label}</span>
+            <div>{row.visible && <strong>Visible</strong>}</div>
+          </li>)}</ul>
+        </section>;
+      }
+    `);
+
+    expect(result.code).toContain("keyedRowsHostEveryHintedRuntimeFeature");
+    expect(result.code).not.toContain("createCompilerKeyedArrayQueuedMapPipeline");
+    expect(result.code).not.toContain("keyedRowsMapReorderHintedRuntimeFeature");
+  });
+});

--- a/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-map-reorder-hints.test.tsx
+++ b/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-map-reorder-hints.test.tsx
@@ -7,6 +7,7 @@ import {
   createCompiledComponent,
   createCompilerKeyedArrayMapPipeline,
   createCompilerKeyedArrayMapReorder,
+  createCompilerKeyedArrayQueuedMapPipeline,
   createCompilerKeyedArrayReorder,
   createCompilerKeyedArraySort,
   type CompilerKeyedRowElement,
@@ -66,6 +67,20 @@ function hintedMaps(
       const secondMap = first.map;
       return applyMap(first, secondMap, secondCallback);
     },
+  ) as Item[];
+}
+
+function queuedHintedMap(
+  items: Item[],
+  callback: (item: Item, index: number, items: Item[]) => Item,
+  method: unknown = items.map,
+): Item[] {
+  return createCompilerKeyedArrayQueuedMapPipeline(
+    items,
+    (
+      current: unknown,
+      applyMap: (collection: unknown, method: unknown, callback: unknown) => unknown,
+    ) => applyMap(current, method, callback),
   ) as Item[];
 }
 
@@ -174,14 +189,22 @@ function createHarness(initialItems: Item[]) {
     undefined;
   let queueReverseThenMapReverse: (id: string, rank: number, label: string) => void = () =>
     undefined;
+  let queueReorderThenMaps: (
+    kind: "reverse" | "sort",
+    id: string,
+    rank: number,
+    label: string,
+  ) => void = () => undefined;
   let reverseThenMap: (id: string, rank: number, label: string) => void = () => undefined;
   let sortThenMap: (id: string, rank: number, label: string) => void = () => undefined;
   let queueSortThenMapReverse: () => void = () => undefined;
   let invalidateKey: () => void = () => undefined;
   let customMap: () => void = () => undefined;
   let customMapAfterReverse: () => void = () => undefined;
+  let queueCustomMapAfterReverse: () => void = () => undefined;
   let customSecondMap: () => void = () => undefined;
   let invalidateKeyAfterReverse: () => void = () => undefined;
+  let queueInvalidateKeyAfterReverse: () => void = () => undefined;
   const Table = createCompiledComponent({
     displayName: "MapReorderTable",
     initialize: () => [initialItems],
@@ -224,6 +247,23 @@ function createHarness(initialItems: Item[]) {
             hintedMap(previous as Item[], (item) =>
               item.id === id ? { ...item, rank, label } : item,
             ),
+          ),
+        );
+      };
+      queueReorderThenMaps = (kind, id, rank, label) => {
+        state[0].set((previous) =>
+          kind === "reverse"
+            ? hintedPlainReverse(previous as Item[])
+            : hintedPlainSort(previous as Item[]),
+        );
+        state[0].set((previous) =>
+          queuedHintedMap(previous as Item[], (item) =>
+            item.id === id ? { ...item, label } : item,
+          ),
+        );
+        state[0].set((previous) =>
+          queuedHintedMap(previous as Item[], (item) =>
+            item.id === id ? { ...item, rank } : item,
           ),
         );
       };
@@ -300,6 +340,23 @@ function createHarness(initialItems: Item[]) {
             item.id === "a" ? { ...item, label: "Custom after reverse" } : item,
           );
         });
+      queueCustomMapAfterReverse = () => {
+        state[0].set((previous) => hintedPlainReverse(previous as Item[]));
+        state[0].set((previous) => {
+          const source = previous as Item[];
+          const customMap = function (
+            this: Item[],
+            callback: (item: Item, index: number, items: Item[]) => Item,
+          ) {
+            return Array.prototype.map.call(this, callback);
+          };
+          return queuedHintedMap(
+            source,
+            (item) => (item.id === "a" ? { ...item, label: "Queued custom after reverse" } : item),
+            customMap,
+          );
+        });
+      };
       customSecondMap = () =>
         state[0].set((previous) => {
           const second = createCompilerKeyedArrayMapPipeline(
@@ -336,6 +393,16 @@ function createHarness(initialItems: Item[]) {
             item.id === "b" ? { ...item, id: "replacement", label: "Replacement" } : item,
           ),
         );
+      queueInvalidateKeyAfterReverse = () => {
+        state[0].set((previous) => hintedPlainReverse(previous as Item[]));
+        state[0].set((previous) =>
+          queuedHintedMap(previous as Item[], (item) =>
+            item.id === "b"
+              ? { ...item, id: "queued-replacement", label: "Queued replacement" }
+              : item,
+          ),
+        );
+      };
       return (
         <section>
           <blocks.KeyedRows
@@ -387,6 +454,7 @@ function createHarness(initialItems: Item[]) {
     counters,
     customMap: () => customMap(),
     customMapAfterReverse: () => customMapAfterReverse(),
+    queueCustomMapAfterReverse: () => queueCustomMapAfterReverse(),
     customSecondMap: () => customSecondMap(),
     editAndSort: (id: string, rank: number, label?: string) => editAndSort(id, rank, label),
     editTwoAndSort: (labelId: string, rankId: string) => editTwoAndSort(labelId, rankId),
@@ -399,10 +467,13 @@ function createHarness(initialItems: Item[]) {
     editSortReverse: (id: string, rank: number) => editSortReverse(id, rank),
     invalidateKey: () => invalidateKey(),
     invalidateKeyAfterReverse: () => invalidateKeyAfterReverse(),
+    queueInvalidateKeyAfterReverse: () => queueInvalidateKeyAfterReverse(),
     queueEdits: (edits: readonly { id: string; rank: number; label: string }[]) =>
       queueEdits(edits),
     queueReverseThenMapReverse: (id: string, rank: number, label: string) =>
       queueReverseThenMapReverse(id, rank, label),
+    queueReorderThenMaps: (kind: "reverse" | "sort", id: string, rank: number, label: string) =>
+      queueReorderThenMaps(kind, id, rank, label),
     queueSortThenMapReverse: () => queueSortThenMapReverse(),
     reverseThenMap: (id: string, rank: number, label: string) => reverseThenMap(id, rank, label),
     sortThenMap: (id: string, rank: number, label: string) => sortThenMap(id, rank, label),
@@ -789,6 +860,43 @@ describe("compiled keyed-array map and reorder hints", () => {
     expect(harness.counters.executions).toBe(1);
   });
 
+  it("takes the exact reverse path through adjacent queued map setters", async () => {
+    const initialItems: Item[] = [
+      { id: "a", label: "Alpha", rank: 1 },
+      { id: "b", label: "Beta", rank: 2 },
+      { id: "c", label: "Gamma", rank: 3 },
+    ];
+    const harness = createHarness(initialItems);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Table />));
+    const rows = [...container.querySelectorAll("li")];
+    const list = container.querySelector("ul")!;
+    const insertBefore = vi.spyOn(list, "insertBefore");
+    const mapSet = vi.spyOn(Map.prototype, "set");
+    const descriptorRead = vi.spyOn(Object, "getOwnPropertyDescriptor");
+    harness.counters.bindings = 0;
+    harness.counters.descriptors = 0;
+    harness.counters.keys = 0;
+
+    await act(async () => {
+      harness.queueReorderThenMaps("reverse", "b", 5, "Beta queued");
+      await flushCompilerUpdates();
+    });
+
+    expect(labels(container)).toEqual(["Gamma:3", "Beta queued:5", "Alpha:1"]);
+    expect([...container.querySelectorAll("li")]).toEqual(rows.toReversed());
+    expect(insertBefore).toHaveBeenCalledTimes(2);
+    expect(mapSet.mock.calls.filter(([key]) => initialItems.includes(key as Item))).toHaveLength(0);
+    expect(descriptorRead).toHaveBeenCalledTimes(initialItems.length * 2);
+    expect(harness.counters.keys).toBe(1);
+    expect(harness.counters.descriptors).toBe(0);
+    expect(harness.counters.bindings).toBe(1);
+    expect(harness.counters.executions).toBe(1);
+  });
+
   it("runs one validated permutation reconciliation when safe maps follow a sort", async () => {
     const initialItems: Item[] = [
       { id: "a", label: "Alpha", rank: 3 },
@@ -814,6 +922,42 @@ describe("compiled keyed-array map and reorder hints", () => {
     });
 
     expect(labels(container)).toEqual(["Beta:1", "Gamma after sort:4", "Alpha:3"]);
+    expect([...container.querySelectorAll("li")]).toEqual([
+      rows.get("b"),
+      rows.get("c"),
+      rows.get("a"),
+    ]);
+    expect(harness.counters.keys).toBe(1);
+    expect(harness.counters.descriptors).toBe(0);
+    expect(harness.counters.bindings).toBe(1);
+    expect(harness.counters.executions).toBe(1);
+  });
+
+  it("retains a sorted permutation through adjacent queued map setters", async () => {
+    const initialItems: Item[] = [
+      { id: "a", label: "Alpha", rank: 3 },
+      { id: "b", label: "Beta", rank: 1 },
+      { id: "c", label: "Gamma", rank: 2 },
+    ];
+    const harness = createHarness(initialItems);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Table />));
+    const rows = new Map(
+      [...container.querySelectorAll("li")].map((row) => [row.dataset.key, row]),
+    );
+    harness.counters.bindings = 0;
+    harness.counters.descriptors = 0;
+    harness.counters.keys = 0;
+
+    await act(async () => {
+      harness.queueReorderThenMaps("sort", "c", 4, "Gamma queued");
+      await flushCompilerUpdates();
+    });
+
+    expect(labels(container)).toEqual(["Beta:1", "Gamma queued:4", "Alpha:3"]);
     expect([...container.querySelectorAll("li")]).toEqual([
       rows.get("b"),
       rows.get("c"),
@@ -875,6 +1019,34 @@ describe("compiled keyed-array map and reorder hints", () => {
       await flushCompilerUpdates();
     });
     expect(labels(container)).toEqual(["Custom after reverse:2", "Replacement:1"]);
+    expect(harness.counters.bindings).toBe(2);
+  });
+
+  it("falls back safely across queued reorder and standalone map setters", async () => {
+    const harness = createHarness([
+      { id: "a", label: "Alpha", rank: 2 },
+      { id: "b", label: "Beta", rank: 1 },
+    ]);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Table />));
+    harness.counters.bindings = 0;
+
+    await act(async () => {
+      harness.queueCustomMapAfterReverse();
+      await flushCompilerUpdates();
+    });
+    expect(labels(container)).toEqual(["Beta:1", "Queued custom after reverse:2"]);
+    expect(harness.counters.bindings).toBe(2);
+
+    harness.counters.bindings = 0;
+    await act(async () => {
+      harness.queueInvalidateKeyAfterReverse();
+      await flushCompilerUpdates();
+    });
+    expect(labels(container)).toEqual(["Queued custom after reverse:2", "Queued replacement:1"]);
     expect(harness.counters.bindings).toBe(2);
   });
 
@@ -1403,6 +1575,75 @@ describe("compiled keyed-array map and reorder hints", () => {
     120_000,
   );
 
+  stressIt(
+    "matches React through 2,000 queued reorder then standalone map updates",
+    async () => {
+      const initialItems = Array.from(
+        { length: 31 },
+        (_, index): Item => ({ id: `row-${index}`, label: `Row ${index}`, rank: index }),
+      );
+      const harness = createHarness(initialItems);
+      let updateReact: (
+        kind: "reverse" | "sort",
+        id: string,
+        rank: number,
+        label: string,
+      ) => void = () => undefined;
+      function Normal() {
+        const [items, setItems] = useState(initialItems);
+        updateReact = (kind, id, rank, label) => {
+          setItems((previous) =>
+            kind === "reverse"
+              ? previous.toReversed()
+              : previous.toSorted((left, right) => left.rank - right.rank),
+          );
+          setItems((previous) =>
+            previous.map((item) => (item.id === id ? { ...item, label } : item)),
+          );
+          setItems((previous) =>
+            previous.map((item) => (item.id === id ? { ...item, rank } : item)),
+          );
+        };
+        return (
+          <ol>
+            {items.map((item) => (
+              <li data-key={item.id} key={item.id}>
+                {item.label}:{item.rank}
+              </li>
+            ))}
+          </ol>
+        );
+      }
+      const compiledContainer = document.createElement("div");
+      const reactContainer = document.createElement("div");
+      document.body.append(compiledContainer, reactContainer);
+      const compiledRoot = createRoot(compiledContainer);
+      const reactRoot = createRoot(reactContainer);
+      roots.push(compiledRoot, reactRoot);
+      await act(async () => {
+        compiledRoot.render(<harness.Table />);
+        reactRoot.render(<Normal />);
+      });
+
+      let seed = 0x9e3779b9;
+      for (let update = 0; update < 2_000; update += 1) {
+        seed = (Math.imul(seed, 1_664_525) + 1_013_904_223) >>> 0;
+        const kind = seed & 1 ? "reverse" : "sort";
+        const id = `row-${seed % initialItems.length}`;
+        const rank = (seed ^ (seed >>> 16)) % 4_003;
+        const label = `Queued reorder map ${update}`;
+        await act(async () => {
+          harness.queueReorderThenMaps(kind, id, rank, label);
+          updateReact(kind, id, rank, label);
+          await flushCompilerUpdates();
+        });
+        expect(labels(compiledContainer)).toEqual(labels(reactContainer));
+      }
+      expect(harness.counters.executions).toBe(1);
+    },
+    120_000,
+  );
+
   it("hydrates in StrictMode and drops a queued update after unmount", async () => {
     const initialItems: Item[] = [
       { id: "a", label: "Alpha", rank: 1 },
@@ -1433,7 +1674,7 @@ describe("compiled keyed-array map and reorder hints", () => {
     expect(recoverable).toEqual([]);
     const hydratedRows = [...container.querySelectorAll("li")];
     await act(async () => {
-      hydration.reverseThenMap("b", 7, "Beta reordered hydration");
+      hydration.queueReorderThenMaps("reverse", "b", 7, "Beta reordered hydration");
       await flushCompilerUpdates();
     });
     expect(labels(container)).toEqual([
@@ -1450,7 +1691,7 @@ describe("compiled keyed-array map and reorder hints", () => {
     const unmountRoot = createRoot(unmountContainer);
     await act(async () => unmountRoot.render(<unmounted.Table />));
     act(() => {
-      unmounted.sortThenMap("b", 8, "Never committed");
+      unmounted.queueReorderThenMaps("sort", "b", 8, "Never committed");
       unmountRoot.unmount();
     });
     await flushCompilerUpdates();

--- a/packages/farm-react/src/compiler-runtime.tsx
+++ b/packages/farm-react/src/compiler-runtime.tsx
@@ -83,9 +83,14 @@ interface CompilerKeyedArrayReorderHint {
   readonly sourceLength: number;
   readonly resultLength: number;
   readonly mapped?: boolean;
-  readonly mappedItemSources?: ReadonlyMap<unknown, unknown>;
-  readonly mappedSourceItems?: readonly unknown[];
+  readonly mappedItemSources?: CompilerMappedItemSources;
   readonly structuralUpdate?: CompilerKeyedArrayFilterHint;
+}
+
+interface CompilerMappedItemSources {
+  readonly queuedSourceItems?: readonly unknown[];
+  get(item: unknown): unknown;
+  has(item: unknown): boolean;
 }
 
 function reversedCompilerKeyedArrayOrder(
@@ -752,6 +757,29 @@ function recordCompilerKeyedArrayQueuedMapPipeline(previous: unknown, value: unk
     ) {
       return value;
     }
+    const sourceItems = previousReorder.mappedItemSources?.queuedSourceItems || previous;
+    let mappedItemSources: Map<unknown, unknown> | undefined;
+    const readMappedItemSources = (): Map<unknown, unknown> => {
+      if (mappedItemSources) return mappedItemSources;
+      const sources = new Map<unknown, unknown>();
+      for (let index = 0; index < value.length; index += 1) {
+        const sourceDescriptor = Object.getOwnPropertyDescriptor(sourceItems, index);
+        const mappedDescriptor = Object.getOwnPropertyDescriptor(value, index);
+        if (
+          !sourceDescriptor ||
+          !("value" in sourceDescriptor) ||
+          !mappedDescriptor ||
+          !("value" in mappedDescriptor)
+        ) {
+          throw new TypeError();
+        }
+        if (!Object.is(sourceDescriptor.value, mappedDescriptor.value)) {
+          sources.set(mappedDescriptor.value, sourceDescriptor.value);
+        }
+      }
+      mappedItemSources = sources;
+      return sources;
+    };
     COMPILER_KEYED_ARRAY_REORDERS.set(valueTarget, {
       kind: previousReorder.kind,
       sourceToken: previousReorder.sourceToken,
@@ -761,7 +789,11 @@ function recordCompilerKeyedArrayQueuedMapPipeline(previous: unknown, value: unk
       // Array.map preserves positions. Retain the first post-reorder collection and validate its
       // data properties against the final collection once, immediately before the DOM commit.
       // This avoids rescanning every intermediate Array produced by separately queued setters.
-      mappedSourceItems: previousReorder.mappedSourceItems || previous,
+      mappedItemSources: {
+        queuedSourceItems: sourceItems,
+        get: (item) => readMappedItemSources().get(item),
+        has: (item) => readMappedItemSources().has(item),
+      },
     });
   } catch {
     // Metadata must never change the result of a successful native update.
@@ -5010,7 +5042,7 @@ function reconcileCompilerKeyedArrayMapReorder(
     compilerKeyedArrayReorder(finalValue, collectionToken, instances.size);
   if (
     !update?.mapped ||
-    (!update.mappedItemSources && !update.mappedSourceItems) ||
+    !update.mappedItemSources ||
     update.structuralUpdate ||
     !Array.isArray(finalValue)
   ) {
@@ -5042,44 +5074,23 @@ function reconcileCompilerKeyedArrayMapReorder(
       const nextInstances: CompilerKeyedRowInstance[] = instancesByItem ? [] : previousInstances;
       const sequence: number[] | undefined = instancesByItem ? [] : undefined;
       for (let targetIndex = 0; targetIndex < finalValue.length; targetIndex += 1) {
-        let item: unknown;
-        let queuedSourceItem: unknown;
-        if (update.mappedSourceItems) {
-          const mappedDescriptor = Object.getOwnPropertyDescriptor(finalValue, targetIndex);
-          if (!mappedDescriptor || !("value" in mappedDescriptor)) return undefined;
-          const sourceDescriptor = Object.getOwnPropertyDescriptor(
-            update.mappedSourceItems,
-            targetIndex,
-          );
-          if (!sourceDescriptor || !("value" in sourceDescriptor)) return undefined;
-          item = mappedDescriptor.value;
-          queuedSourceItem = sourceDescriptor.value;
-        } else {
-          // Preserve the existing eager map/reorder path. Its compiler-owned native map pipeline
-          // already validated the collection while recording the source-item lookup.
-          item = finalValue[targetIndex];
-        }
+        const item = finalValue[targetIndex];
         let instance: CompilerKeyedRowInstance | undefined;
         if (!instancesByItem) {
           const sourceIndex = reverse ? finalValue.length - targetIndex - 1 : targetIndex;
           instance = previousInstances[sourceIndex];
           if (!instance || instance.index !== sourceIndex) return undefined;
           if (Object.is(instance.item, item)) continue;
-          const sourceItem = update.mappedSourceItems
-            ? queuedSourceItem
-            : update.mappedItemSources!.get(item);
           if (
-            (!update.mappedSourceItems && !update.mappedItemSources!.has(item)) ||
-            !Object.is(instance.item, sourceItem)
+            !update.mappedItemSources.has(item) ||
+            !Object.is(instance.item, update.mappedItemSources.get(item))
           ) {
             return undefined;
           }
         } else {
-          const sourceItem = update.mappedSourceItems
-            ? queuedSourceItem
-            : update.mappedItemSources!.has(item)
-              ? update.mappedItemSources!.get(item)
-              : item;
+          const sourceItem = update.mappedItemSources.has(item)
+            ? update.mappedItemSources.get(item)
+            : item;
           instance = instancesByItem!.get(sourceItem);
           if (!instance) return undefined;
           instancesByItem!.delete(sourceItem);

--- a/packages/farm-react/src/compiler-runtime.tsx
+++ b/packages/farm-react/src/compiler-runtime.tsx
@@ -84,6 +84,7 @@ interface CompilerKeyedArrayReorderHint {
   readonly resultLength: number;
   readonly mapped?: boolean;
   readonly mappedItemSources?: ReadonlyMap<unknown, unknown>;
+  readonly mappedSourceItems?: readonly unknown[];
   readonly structuralUpdate?: CompilerKeyedArrayFilterHint;
 }
 
@@ -724,6 +725,59 @@ export function createCompilerKeyedArrayMapPipeline(
     previous,
     methodOrPipeline as (...values: readonly unknown[]) => unknown,
     recordCompilerKeyedArrayMapPipeline,
+  );
+}
+
+function recordCompilerKeyedArrayQueuedMapPipeline(previous: unknown, value: unknown): unknown {
+  try {
+    const previousTarget = compilerObject(previous);
+    const valueTarget = compilerObject(value);
+    if (
+      !previousTarget ||
+      !valueTarget ||
+      !Array.isArray(previous) ||
+      !Array.isArray(value) ||
+      Object.getPrototypeOf(previous) !== NATIVE_ARRAY_PROTOTYPE ||
+      Object.getPrototypeOf(value) !== NATIVE_ARRAY_PROTOTYPE ||
+      value.length !== previous.length
+    ) {
+      return value;
+    }
+
+    const previousReorder = COMPILER_KEYED_ARRAY_REORDERS.get(previousTarget);
+    if (
+      !previousReorder ||
+      previousReorder.structuralUpdate ||
+      previousReorder.resultLength !== previous.length
+    ) {
+      return value;
+    }
+    COMPILER_KEYED_ARRAY_REORDERS.set(valueTarget, {
+      kind: previousReorder.kind,
+      sourceToken: previousReorder.sourceToken,
+      sourceLength: previousReorder.sourceLength,
+      resultLength: value.length,
+      mapped: true,
+      // Array.map preserves positions. Retain the first post-reorder collection and validate its
+      // data properties against the final collection once, immediately before the DOM commit.
+      // This avoids rescanning every intermediate Array produced by separately queued setters.
+      mappedSourceItems: previousReorder.mappedSourceItems || previous,
+    });
+  } catch {
+    // Metadata must never change the result of a successful native update.
+  }
+  return value;
+}
+
+/** @internal Executes a queued native map after a compiler-proven keyed-array reorder. */
+export function createCompilerKeyedArrayQueuedMapPipeline(
+  previous: unknown,
+  pipeline: (...values: readonly unknown[]) => unknown,
+): unknown {
+  return executeCompilerKeyedMapPipeline(
+    previous,
+    pipeline,
+    recordCompilerKeyedArrayQueuedMapPipeline,
   );
 }
 
@@ -4956,7 +5010,7 @@ function reconcileCompilerKeyedArrayMapReorder(
     compilerKeyedArrayReorder(finalValue, collectionToken, instances.size);
   if (
     !update?.mapped ||
-    !update.mappedItemSources ||
+    (!update.mappedItemSources && !update.mappedSourceItems) ||
     update.structuralUpdate ||
     !Array.isArray(finalValue)
   ) {
@@ -4988,23 +5042,44 @@ function reconcileCompilerKeyedArrayMapReorder(
       const nextInstances: CompilerKeyedRowInstance[] = instancesByItem ? [] : previousInstances;
       const sequence: number[] | undefined = instancesByItem ? [] : undefined;
       for (let targetIndex = 0; targetIndex < finalValue.length; targetIndex += 1) {
-        const item = finalValue[targetIndex];
+        let item: unknown;
+        let queuedSourceItem: unknown;
+        if (update.mappedSourceItems) {
+          const mappedDescriptor = Object.getOwnPropertyDescriptor(finalValue, targetIndex);
+          if (!mappedDescriptor || !("value" in mappedDescriptor)) return undefined;
+          const sourceDescriptor = Object.getOwnPropertyDescriptor(
+            update.mappedSourceItems,
+            targetIndex,
+          );
+          if (!sourceDescriptor || !("value" in sourceDescriptor)) return undefined;
+          item = mappedDescriptor.value;
+          queuedSourceItem = sourceDescriptor.value;
+        } else {
+          // Preserve the existing eager map/reorder path. Its compiler-owned native map pipeline
+          // already validated the collection while recording the source-item lookup.
+          item = finalValue[targetIndex];
+        }
         let instance: CompilerKeyedRowInstance | undefined;
         if (!instancesByItem) {
           const sourceIndex = reverse ? finalValue.length - targetIndex - 1 : targetIndex;
           instance = previousInstances[sourceIndex];
           if (!instance || instance.index !== sourceIndex) return undefined;
           if (Object.is(instance.item, item)) continue;
+          const sourceItem = update.mappedSourceItems
+            ? queuedSourceItem
+            : update.mappedItemSources!.get(item);
           if (
-            !update.mappedItemSources.has(item) ||
-            !Object.is(instance.item, update.mappedItemSources.get(item))
+            (!update.mappedSourceItems && !update.mappedItemSources!.has(item)) ||
+            !Object.is(instance.item, sourceItem)
           ) {
             return undefined;
           }
         } else {
-          const sourceItem = update.mappedItemSources.has(item)
-            ? update.mappedItemSources.get(item)
-            : item;
+          const sourceItem = update.mappedSourceItems
+            ? queuedSourceItem
+            : update.mappedItemSources!.has(item)
+              ? update.mappedItemSources!.get(item)
+              : item;
           instance = instancesByItem!.get(sourceItem);
           if (!instance) return undefined;
           instancesByItem!.delete(sourceItem);

--- a/packages/farm-react/src/compiler.ts
+++ b/packages/farm-react/src/compiler.ts
@@ -2278,6 +2278,131 @@ function rewriteKeyedArrayReorderPipelineHints(
   };
 }
 
+function rewriteQueuedKeyedArrayReorderMapHints(
+  root: t.JSXElement,
+  statesBySetter: ReadonlyMap<string, StateBinding>,
+  mapUpdateIdentifier: t.Identifier,
+  queuedMapPipelineIdentifier: t.Identifier,
+  mapReorderIdentifier: t.Identifier,
+  reorderIdentifier: t.Identifier,
+  sortIdentifier: t.Identifier,
+  structuralReorderIdentifier: t.Identifier,
+  structuralSortIdentifier: t.Identifier,
+  allowed: boolean,
+): { root: t.JSXElement; mapCount: number } {
+  if (!allowed) return { root: t.cloneNode(root, true), mapCount: 0 };
+  const file = expressionFile(t.cloneNode(root, true));
+  let mapCount = 0;
+
+  const containsHelperCall = (
+    updater: t.ArrowFunctionExpression,
+    helperNames: ReadonlySet<string>,
+  ): boolean => {
+    let found = false;
+    t.traverseFast(updater.body, (node) => {
+      if (
+        !found &&
+        t.isCallExpression(node) &&
+        t.isIdentifier(node.callee) &&
+        helperNames.has(node.callee.name)
+      ) {
+        found = true;
+      }
+    });
+    return found;
+  };
+  const reorderHelperNames = new Set([
+    mapReorderIdentifier.name,
+    reorderIdentifier.name,
+    sortIdentifier.name,
+  ]);
+  const structuralHelperNames = new Set([
+    structuralReorderIdentifier.name,
+    structuralSortIdentifier.name,
+  ]);
+
+  traverse(file, {
+    BlockStatement(path) {
+      let queuedReorderState: number | undefined;
+      const statements = path.get("body") as NodePath<t.Statement>[];
+      for (const statementPath of statements) {
+        const statement = statementPath.node;
+        if (!t.isExpressionStatement(statement) || !t.isCallExpression(statement.expression)) {
+          queuedReorderState = undefined;
+          continue;
+        }
+        const setterCall = statement.expression;
+        if (
+          !t.isIdentifier(setterCall.callee) ||
+          statementPath.scope.hasBinding(setterCall.callee.name) ||
+          setterCall.arguments.length !== 1
+        ) {
+          queuedReorderState = undefined;
+          continue;
+        }
+        const state = statesBySetter.get(setterCall.callee.name);
+        const updater = setterCall.arguments[0];
+        if (
+          !state ||
+          !t.isArrowFunctionExpression(updater) ||
+          updater.async ||
+          updater.generator ||
+          updater.params.length !== 1 ||
+          !t.isIdentifier(updater.params[0])
+        ) {
+          queuedReorderState = undefined;
+          continue;
+        }
+
+        if (
+          containsHelperCall(updater, reorderHelperNames) &&
+          !containsHelperCall(updater, structuralHelperNames)
+        ) {
+          queuedReorderState = state.index;
+          continue;
+        }
+
+        if (
+          queuedReorderState !== state.index ||
+          !t.isCallExpression(updater.body) ||
+          !t.isIdentifier(updater.body.callee, { name: mapUpdateIdentifier.name }) ||
+          updater.body.arguments.length !== 2
+        ) {
+          queuedReorderState = undefined;
+          continue;
+        }
+        const pipeline = updater.body.arguments[1];
+        if (
+          !t.isArrowFunctionExpression(pipeline) ||
+          pipeline.params.length !== 2 ||
+          !t.isIdentifier(pipeline.params[1])
+        ) {
+          queuedReorderState = undefined;
+          continue;
+        }
+        let pipelineMapCount = 0;
+        const applyMapName = pipeline.params[1].name;
+        t.traverseFast(pipeline.body, (node) => {
+          if (t.isCallExpression(node) && t.isIdentifier(node.callee, { name: applyMapName })) {
+            pipelineMapCount += 1;
+          }
+        });
+        if (pipelineMapCount === 0) {
+          queuedReorderState = undefined;
+          continue;
+        }
+
+        updater.body.callee = t.cloneNode(queuedMapPipelineIdentifier);
+        mapCount += pipelineMapCount;
+      }
+    },
+  });
+  return {
+    root: (file.program.body[0] as t.ExpressionStatement).expression as t.JSXElement,
+    mapCount,
+  };
+}
+
 function rewriteKeyedArraySortHints(
   root: t.JSXElement,
   hintedStateIndices: ReadonlySet<number>,
@@ -7247,6 +7372,7 @@ function compileCandidate(
   keyedArrayAppendIdentifier: t.Identifier,
   keyedArrayFilterIdentifier: t.Identifier,
   keyedArrayMapPipelineIdentifier: t.Identifier,
+  keyedArrayQueuedMapPipelineIdentifier: t.Identifier,
   keyedArrayMapReorderIdentifier: t.Identifier,
   keyedArrayPrependIdentifier: t.Identifier,
   keyedArrayPositionIdentifier: t.Identifier,
@@ -7282,6 +7408,7 @@ function compileCandidate(
     keyedArrayMapReorderHints: number;
     keyedArrayMapSortHints: number;
     keyedArrayMapUpdateHints: number;
+    keyedArrayQueuedMapUpdateHints: number;
     keyedArrayStructuralReorderHints: number;
     keyedArrayStructuralSortHints: number;
     keyedArrayWindowReplaceHints: number;
@@ -7750,6 +7877,11 @@ function compileCandidate(
       compilerUsage.keyedArrayWindowReplaceHints += positionHintedRoot.windowReplaceCount;
     }
   }
+  const allowKeyedArrayMapPipelines = (blockAnalysis.plans || []).every(
+    (plan) =>
+      plan.kind !== "keyed-rows" ||
+      (plan.conditionals.length === 0 && !plan.descriptorBlocks?.size),
+  );
   const reorderPipelineHintedRoot = rewriteKeyedArrayReorderPipelineHints(
     expandedReactiveRoot,
     shiftedIndexIndependentStateIndices,
@@ -7763,11 +7895,7 @@ function compileCandidate(
     keyedArraySortIdentifier,
     keyedArrayStructuralSortIdentifier,
     safeGlobals,
-    (blockAnalysis.plans || []).every(
-      (plan) =>
-        plan.kind !== "keyed-rows" ||
-        (plan.conditionals.length === 0 && !plan.descriptorBlocks?.size),
-    ),
+    allowKeyedArrayMapPipelines,
   );
   let appliedPipelineFilterHints = 0;
   let appliedPipelineMapHints = 0;
@@ -7974,6 +8102,45 @@ function compileCandidate(
       optimizationCounts.keyedArrayFilterHints += filterHintedRoot.count;
     }
   }
+  const queuedReorderMapHintedRoot = rewriteQueuedKeyedArrayReorderMapHints(
+    expandedReactiveRoot,
+    statesBySetter,
+    keyedMapUpdateIdentifier,
+    keyedArrayQueuedMapPipelineIdentifier,
+    keyedArrayMapReorderIdentifier,
+    keyedArrayReorderIdentifier,
+    keyedArraySortIdentifier,
+    keyedArrayStructuralReorderIdentifier,
+    keyedArrayStructuralSortIdentifier,
+    allowKeyedArrayMapPipelines,
+  );
+  let appliedQueuedReorderMapHints = 0;
+  if (queuedReorderMapHintedRoot.mapCount > 0) {
+    const hintedBlockAnalysis = analyzeComposableBlocks(
+      queuedReorderMapHintedRoot.root,
+      reactiveByValue,
+      safeGlobals,
+      listNames,
+      allowedComponentNames,
+    );
+    const hintedAnalysis = analyzeHostTree(
+      queuedReorderMapHintedRoot.root,
+      reactiveByValue,
+      safeGlobals,
+      hintedBlockAnalysis.conditionalExpressions || new Set<t.Expression>(),
+      hintedBlockAnalysis.keyedExpressions || new Set<t.Expression>(),
+      hintedBlockAnalysis.ownedElements || new Set<t.JSXElement>(),
+      hintedBlockAnalysis.componentElements || new Set<t.JSXElement>(),
+    );
+    if (!hintedBlockAnalysis.reason && !hintedAnalysis.reason) {
+      expandedReactiveRoot = queuedReorderMapHintedRoot.root;
+      blockAnalysis = hintedBlockAnalysis;
+      analysis = hintedAnalysis;
+      appliedQueuedReorderMapHints = queuedReorderMapHintedRoot.mapCount;
+      compilerUsage.keyedArrayMapUpdateHints += queuedReorderMapHintedRoot.mapCount;
+      compilerUsage.keyedArrayQueuedMapUpdateHints += queuedReorderMapHintedRoot.mapCount;
+    }
+  }
   const keyedCollectionTargetKinds = new Map<number, KeyedCollectionTargetKind>();
   const conflictingKeyedCollectionTargets = new Set<number>();
   for (const plan of blockAnalysis.plans || []) {
@@ -8074,7 +8241,7 @@ function compileCandidate(
     appliedKeyedArrayBatchInsertHints > 0,
     appliedKeyedArrayWindowReplaceHints > 0,
     appliedKeyedArrayReorderHints > 0 || appliedKeyedArraySortHints > 0,
-    appliedPipelineMapHints > 0,
+    appliedPipelineMapHints > 0 || appliedQueuedReorderMapHints > 0,
     appliedKeyedArrayRollingWindowHints > 0,
   );
   markShortCircuitBindings(analysis.bindings || []);
@@ -8289,6 +8456,7 @@ export async function compileReactModule(
     keyedArrayMapReorderHints: 0,
     keyedArrayMapSortHints: 0,
     keyedArrayMapUpdateHints: 0,
+    keyedArrayQueuedMapUpdateHints: 0,
     keyedArrayStructuralReorderHints: 0,
     keyedArrayStructuralSortHints: 0,
     keyedArrayWindowReplaceHints: 0,
@@ -8341,6 +8509,9 @@ export async function compileReactModule(
         );
         const keyedArrayMapPipelineIdentifier = programPath.scope.generateUidIdentifier(
           "createCompilerKeyedArrayMapPipeline",
+        );
+        const keyedArrayQueuedMapPipelineIdentifier = programPath.scope.generateUidIdentifier(
+          "createCompilerKeyedArrayQueuedMapPipeline",
         );
         const keyedArrayMapReorderIdentifier = programPath.scope.generateUidIdentifier(
           "createCompilerKeyedArrayMapReorder",
@@ -8406,6 +8577,7 @@ export async function compileReactModule(
             keyedArrayAppendIdentifier,
             keyedArrayFilterIdentifier,
             keyedArrayMapPipelineIdentifier,
+            keyedArrayQueuedMapPipelineIdentifier,
             keyedArrayMapReorderIdentifier,
             keyedArrayPrependIdentifier,
             keyedArrayPositionIdentifier,
@@ -8440,6 +8612,8 @@ export async function compileReactModule(
           }
         }
 
+        const hasEagerKeyedArrayMapUpdateHints =
+          compilerUsage.keyedArrayMapUpdateHints > compilerUsage.keyedArrayQueuedMapUpdateHints;
         if (compiled.length > 0) {
           programPath.unshiftContainer(
             "body",
@@ -8457,7 +8631,7 @@ export async function compileReactModule(
                       ),
                     ]
                   : []),
-                ...(compilerUsage.keyedArrayMapUpdateHints > 0
+                ...(hasEagerKeyedArrayMapUpdateHints
                   ? [
                       t.importSpecifier(
                         keyedArrayMapPipelineIdentifier,
@@ -8466,6 +8640,14 @@ export async function compileReactModule(
                       t.importSpecifier(
                         keyedArrayMapReorderIdentifier,
                         t.identifier("createCompilerKeyedArrayMapReorder"),
+                      ),
+                    ]
+                  : []),
+                ...(compilerUsage.keyedArrayQueuedMapUpdateHints > 0
+                  ? [
+                      t.importSpecifier(
+                        keyedArrayQueuedMapPipelineIdentifier,
+                        t.identifier("createCompilerKeyedArrayQueuedMapPipeline"),
                       ),
                     ]
                   : []),

--- a/packages/farm-react/vitest.stress.config.ts
+++ b/packages/farm-react/vitest.stress.config.ts
@@ -20,7 +20,7 @@ export default defineConfig({
     ],
     setupFiles: ["src/__tests__/stress.setup.ts"],
     testNamePattern:
-      /2,000 deterministic mapped reorder updates|2,000 deterministic mapped reversal parity updates|2,000 queued reverse, map, and reverse updates|2,000 reverse-or-sort then map updates|3,000 deterministic recursive updates|4,096 rows/,
+      /2,000 deterministic mapped reorder updates|2,000 deterministic mapped reversal parity updates|2,000 queued reverse, map, and reverse updates|2,000 reverse-or-sort then map updates|2,000 queued reorder then standalone map updates|3,000 deterministic recursive updates|4,096 rows/,
     testTimeout: 30_000,
   },
 });


### PR DESCRIPTION
## Problem

Farm already preserves a keyed-array reorder proof when native maps are written in the same state updater. The proof was lost when an application expressed the equivalent work as consecutive queued setters, so the final commit repeated complete keyed reconciliation even though each map preserved position and only changed row values.

```tsx
setRows((current) => current.toReversed());
setRows((current) => current.map(updateLabel));
setRows((current) => current.map(updateAmount));
```

## Root cause

Each generated setter helper recorded metadata only for its own returned array. The standalone map helper did not carry an existing non-structural reorder token into the next queued state value, so the final keyed-row commit could not prove the original source-row relationship.

## Change

- Detect consecutive concise calls to the same setter after a compiler-owned reverse or sort helper.
- Use a specialized queued native-map helper that retains the first post-reorder source array by position instead of rebuilding a source lookup for every intermediate map.
- Validate source/final own data properties, row identity, keys, and changed bindings before any DOM mutation.
- Keep exact reverse on its direct minimum-move path and sort on one validated lookup/LIS pass.
- Add a production dashboard scenario and an equivalent block-bodied full-reconciliation control.
- Launch each benchmark trial in a clean process of the same Chromium version, avoiding cumulative browser exhaustion while leaving browser launch outside measured interaction time.

## Safety and compatibility

- Only adjacent expression statements using the same state setter are linked.
- Intervening statements, another setter, structural reorder operations, host-backed/nested keyed rows, custom map methods, sparse/accessor results, changed keys, or failed runtime validation use the existing complete React fallback.
- Normal React state results and native method behavior are produced before metadata is considered.
- The existing eager single-setter map/reorder hot path remains unchanged.
- The optimization stays React-specific and optional; compiler-disabled output does not include its runtime helper.

## Verification

- `pnpm --filter @farm.js/react exec vitest run src/__tests__/compiler-keyed-array-queued-reorder-map-hints.test.ts src/__tests__/compiler-runtime-keyed-array-map-reorder-hints.test.tsx`
  - 29 passed, 5 stress cases skipped by the focused config.
- Targeted 2,000-update randomized reverse/sort plus two-map differential test passed against normal React.
- `pnpm --filter @farm.js/react type-check`
- `pnpm --filter @farm.js/react test:compat`
  - React 18.3.1 and React 19.2.8 passed.
- `pnpm --filter @farm.js/react test:runtime-size`
  - Passed; core-only isolated runtime remains 83.4% smaller than the full isolated runtime.
  - Reproduced under CI's Node 22.13.1: keyed map/reorder premium is 13,341 B gzip against a 13,399 B maximum.
- `pnpm --filter @farm.js/react build`
- Dashboard type-check and production benchmark passed.
  - Static: 22.3 ms median, 12.68x over React, 1.55x over the compiled full-reconciliation control.
  - Hybrid: 23.0 ms median, 12.29x over React, 1.57x over the compiled full-reconciliation control.
  - Correctness and every existing performance gate passed; no performance regressions were reported.
- `pnpm docs:check-navigation`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm docs:build`
- Focused `oxlint`, `oxfmt`, and `git diff --check` passed.

The all-files React test invocation also exposed a pre-existing keyed-slice `NotFoundError`; the exact failing test reproduces unchanged at base commit `ff0bd289`. Two unrelated contention timeouts from that parallel run pass in isolation.

## Documentation and release

Updated the React renderer guide, package README, and compiler-dashboard README. The maintained dashboard now demonstrates and measures the queued setter form. No version or template changes.
