### PR TITLE
fix(webmcp): clean up failed runtime setup

### DIFF
--- a/packages/farm-webmcp/src/client.test.ts
+++ b/packages/farm-webmcp/src/client.test.ts
@@ -247,6 +247,30 @@ describe("webmcp client runtime", () => {
     expect(window.__FARM_WEBMCP__).toBeUndefined();
   });
 
+  it("cleans up the runtime when initial native registration fails", async () => {
+    const errorLog = vi.spyOn(console, "error").mockImplementation(() => {});
+    const registrationSignals: AbortSignal[] = [];
+    const registerTool = vi.fn(
+      async (_tool: NativeTool, options: { signal?: AbortSignal } = {}) => {
+        if (options.signal) registrationSignals.push(options.signal);
+        throw new Error("Native registration failed");
+      },
+    );
+    vi.stubGlobal("document", { modelContext: { registerTool } });
+    register(searchTool());
+
+    await expect(startWebMCPRuntime({ debug: true })).rejects.toThrow("Native registration failed");
+
+    expect(registrationSignals).toHaveLength(1);
+    expect(registrationSignals[0]?.aborted).toBe(true);
+    expect(window.__FARM_WEBMCP__).toBeUndefined();
+    expect(errorLog).toHaveBeenCalledOnce();
+
+    register(searchTool());
+    await Promise.resolve();
+    expect(registerTool).toHaveBeenCalledOnce();
+  });
+
   it("supports ignore, warning, and error behavior in browsers without WebMCP", async () => {
     vi.stubGlobal("document", {});
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});

--- a/packages/farm-webmcp/src/client.ts
+++ b/packages/farm-webmcp/src/client.ts
@@ -237,8 +237,13 @@ export async function startWebMCPRuntime(
   });
   activeRuntime = runtime;
   exposeDebugRuntime(runtime, options.debug === true);
-  await runtime.sync();
-  return runtime;
+  try {
+    await runtime.sync();
+    return runtime;
+  } catch (error) {
+    runtime.close();
+    throw error;
+  }
 }
 
 function createUnsupportedRuntime(): FarmWebMCPRuntime {


### PR DESCRIPTION
## Problem

When the first native WebMCP tool registration rejects, runtime startup rejects but leaves its active runtime state, abort controller, subscriber, and optional debug global behind.

## Root cause

The runtime became active before the initial awaited sync, and the rejection path did not run the existing close lifecycle.

## Change

Close the partially started runtime before rethrowing the registration error.

## Safety and compatibility

Successful startup is unchanged. Failed startup still exposes the original error, while cleanup now uses the same established runtime close path.

## Verification

- `pnpm --filter @farm.js/webmcp test` (13 tests)
- `pnpm --filter @farm.js/webmcp type-check`
- `pnpm --filter @farm.js/webmcp build`
- Focused `oxlint`

The regression test verifies the registration signal is aborted, the debug global is removed, and later registrations do not retry through the failed runtime.

## Documentation and release

None.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleans up the partially started WebMCP runtime when initial native tool registration fails. The runtime previously stayed active after a rejected startup, leaving its abort controller, subscriber, and debug global behind; it now closes through the existing runtime close path before rethrowing the original error.

**Verification**
- Regression test confirms the registration signal is aborted, the debug global is removed, and later registrations do not retry through the failed runtime.

<sup>Written for commit f5a49f34da01452739a1cdf6c049eb0548002b1a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/815?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

