### PR TITLE
fix(preview): reject invalid explicit targets

### DIFF
--- a/packages/farm-cli/src/preview.ts
+++ b/packages/farm-cli/src/preview.ts
@@ -114,13 +114,30 @@ export async function resolvePreviewTarget(
   options: PreviewFarmOptions = {},
 ): Promise<PreviewTarget> {
   if (options.url) {
-    const parsed = new URL(options.url);
+    let parsed: URL;
+    try {
+      parsed = new URL(options.url);
+    } catch {
+      throw new Error(`Preview URL ${JSON.stringify(options.url)} is not a valid URL.`);
+    }
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      throw new Error("Preview URL must use http or https.");
+    }
+    if (!parsed.hostname) {
+      throw new Error("Preview URL must include a hostname.");
+    }
+    if (parsed.username || parsed.password) {
+      throw new Error("Preview URL cannot include credentials.");
+    }
+    if (parsed.search || parsed.hash) {
+      throw new Error("Preview URL cannot include a query string or fragment.");
+    }
     const port = Number(parsed.port || (parsed.protocol === "https:" ? 443 : 80));
-    if (!Number.isFinite(port)) {
+    if (!Number.isInteger(port) || port <= 0 || port > 65535) {
       throw new Error(`Could not resolve a port from ${options.url}.`);
     }
     return {
-      localUrl: normalizeLocalUrl(options.url),
+      localUrl: normalizeLocalUrl(parsed.toString()),
       host: parsed.hostname,
       port,
       source: "url",
@@ -129,7 +146,11 @@ export async function resolvePreviewTarget(
 
   const root = options.root || process.cwd();
   const host = options.host || process.env.FARM_PREVIEW_HOST || "localhost";
-  const explicitPort = normalizePort(options.port || process.env.FARM_PREVIEW_PORT);
+  const configuredPort = options.port ?? process.env.FARM_PREVIEW_PORT;
+  const explicitPort = normalizePort(configuredPort);
+  if (configuredPort !== undefined && configuredPort !== "" && explicitPort === undefined) {
+    throw new Error("Preview port must be an integer between 1 and 65535.");
+  }
   const configPort = explicitPort ? undefined : await readConfigPort(root, options.configPath);
   const candidates = uniqueNumbers([
     explicitPort,

--- a/packages/farm-cli/test/preview.test.mjs
+++ b/packages/farm-cli/test/preview.test.mjs
@@ -65,6 +65,29 @@ test("formats a bare IPv6 preview host as a valid local URL", async () => {
   assert.equal(new URL(target.localUrl).hostname, "[::1]");
 });
 
+test("rejects invalid explicit preview targets", async () => {
+  await assert.rejects(resolvePreviewTarget({ url: "ftp://127.0.0.1:21" }), /http or https/);
+  await assert.rejects(resolvePreviewTarget({ url: "file:///tmp/farm" }), /http or https/);
+  await assert.rejects(
+    resolvePreviewTarget({ url: "http://user:secret@127.0.0.1:3000" }),
+    /cannot include credentials/,
+  );
+  await assert.rejects(
+    resolvePreviewTarget({ url: "http://127.0.0.1:3000/app?token=secret" }),
+    /query string or fragment/,
+  );
+  await assert.rejects(resolvePreviewTarget({ port: "3000oops" }), /integer between 1 and 65535/);
+  await assert.rejects(resolvePreviewTarget({ port: 0 }), /integer between 1 and 65535/);
+});
+
+test("normalizes a valid explicit preview URL", async () => {
+  const target = await resolvePreviewTarget({ url: "  http://127.0.0.1:3000/app/  " });
+
+  assert.equal(target.localUrl, "http://127.0.0.1:3000/app");
+  assert.equal(target.host, "127.0.0.1");
+  assert.equal(target.port, 3000);
+});
+
 test("creates a tunnel plan from the preview command template", () => {
   const previousCommand = process.env.FARM_PREVIEW_TUNNEL_COMMAND;
   const previousDomain = process.env.FARM_PREVIEW_DOMAIN;


### PR DESCRIPTION
## Problem

Explicit preview URLs can use unsupported schemes, credentials, query data, or invalid ports, and an invalid explicit preview port can be silently discarded in favor of an auto-discovered port.

## Root cause

URL parsing checked only for a numeric derived port, while explicit port normalization shared the fallback path used for absent configuration.

## Change

Require HTTP(S) URLs with a hostname and no credentials, query, or fragment; enforce ports from 1 through 65535; normalize accepted URLs; and report invalid explicit ports instead of scanning defaults.

## Safety and compatibility

Valid HTTP and HTTPS targets, configured project ports, environment fallbacks, and automatic port discovery remain unchanged. Invalid targets fail before opening a tunnel.

## Verification

- `pnpm --filter @farm.js/cli build`
- `node --test packages/farm-cli/test/preview.test.mjs` (18 tests)
- `pnpm --filter @farm.js/cli type-check`
- Focused `oxlint`

## Documentation and release

None; this tightens validation of the existing preview contract.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects invalid explicit preview targets in `@farm.js/cli` so bad URLs fail fast instead of being silently accepted or falling back to auto-discovery. Previously, non-HTTP schemes, credentials, query strings, and invalid ports could pass validation or be discarded in favor of a discovered port; now they throw clear errors. Valid HTTP(S) targets, configured ports, environment fallbacks, and port discovery are unchanged.

- Explicit URLs must be http or https, include a hostname, and contain no credentials, query string, or fragment.
- Explicit ports must be integers from 1 to 65535; invalid configured ports now error instead of being ignored.
- Accepted URLs are normalized to canonical form before use.

<sup>Written for commit f13e7181c5bfe9230affbc1bd977c6b0188bb9a3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/816?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

