### PR TITLE
docs(readme): require Node 22.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,7 +327,7 @@ Visit [farmjs.dev](https://farmjs.dev) for comprehensive documentation, guides, 
 
 ### Prerequisites
 
-- Node.js 22.12 or newer
+- Node.js 22.13 or newer
 - pnpm 8+
 
 ### Setup


### PR DESCRIPTION
## Problem

The root README says Node.js 22.12 is supported, but the workspace engine, starter engines, CLI doctor check, and getting-started guide require Node.js 22.13.

## Root cause

The top-level prerequisite was not updated when the runtime baseline moved to 22.13.

## Change

Correct the README prerequisite to Node.js 22.13 or newer.

## Safety and compatibility

Documentation only; runtime behavior is unchanged.

## Verification

Confirmed the README now matches the root and starter package engine declarations.

## Documentation and release

README only. No release metadata changed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the README prerequisite to Node.js 22.13 or newer so it matches the workspace engine, starter engines, CLI doctor check, and getting-started guide. This is a documentation-only change; runtime behavior is unchanged.

<sup>Written for commit 6b98742e14cfb9f5be882616c2877c3ace1b7b11. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/817?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

