### PR TITLE
fix(create-app): keep Better Auth migrations out of builds

### DIFF
--- a/packages/create-farm-app/src/index.ts
+++ b/packages/create-farm-app/src/index.ts
@@ -68,7 +68,7 @@ const templateDetails: Record<string, TemplateDetails> = {
     description: "Better Auth with Postgres, secure sessions, and protected routes",
     instructions: [
       "Before starting, copy .env.example to .env.local and set DATABASE_URL and BETTER_AUTH_SECRET.",
-      "Better Auth migrations run automatically when the auth instance starts.",
+      "Run pnpm auth:migrate before starting the app or serving production traffic.",
     ],
   },
   ai: integrationTemplate({

--- a/packages/create-farm-app/templates/_integrations/better-auth/preact/farm.config.ts
+++ b/packages/create-farm-app/templates/_integrations/better-auth/preact/farm.config.ts
@@ -11,6 +11,9 @@ export default defineConfig({
   integrations: {
     auth: betterAuth({ instance: auth }),
   },
+  migrations: {
+    commands: [{ name: "Better Auth schema", command: "pnpm auth:migrate" }],
+  },
   deploy: {
     target: "vercel",
   },

--- a/packages/create-farm-app/templates/_integrations/better-auth/solid/farm.config.ts
+++ b/packages/create-farm-app/templates/_integrations/better-auth/solid/farm.config.ts
@@ -11,6 +11,9 @@ export default defineConfig({
   integrations: {
     auth: betterAuth({ instance: auth }),
   },
+  migrations: {
+    commands: [{ name: "Better Auth schema", command: "pnpm auth:migrate" }],
+  },
   deploy: {
     target: "vercel",
   },

--- a/packages/create-farm-app/templates/_integrations/better-auth/svelte/farm.config.ts
+++ b/packages/create-farm-app/templates/_integrations/better-auth/svelte/farm.config.ts
@@ -11,6 +11,9 @@ export default defineConfig({
   integrations: {
     auth: betterAuth({ instance: auth }),
   },
+  migrations: {
+    commands: [{ name: "Better Auth schema", command: "pnpm auth:migrate" }],
+  },
   deploy: {
     target: "vercel",
   },

--- a/packages/create-farm-app/templates/_integrations/better-auth/vue/farm.config.ts
+++ b/packages/create-farm-app/templates/_integrations/better-auth/vue/farm.config.ts
@@ -11,6 +11,9 @@ export default defineConfig({
   integrations: {
     auth: betterAuth({ instance: auth }),
   },
+  migrations: {
+    commands: [{ name: "Better Auth schema", command: "pnpm auth:migrate" }],
+  },
   deploy: {
     target: "vercel",
   },

--- a/packages/create-farm-app/templates/better-auth/README.md
+++ b/packages/create-farm-app/templates/better-auth/README.md
@@ -10,7 +10,7 @@ This project was generated from the Better Auth template included with `@farm.js
 - email and password sign-up and sign-in
 - Better Auth session cookies
 - a server-middleware-protected `/dashboard`
-- pooled Postgres persistence and automatic Better Auth migrations
+- pooled Postgres persistence and explicit Better Auth migrations
 - a dark-first, one-page welcome screen set in Geist Sans and Geist Mono
 - pending, error, unauthorized, loading, and not-found states
 - responsive starter UI
@@ -34,6 +34,7 @@ Then install and start the app:
 
 ```bash
 pnpm install
+pnpm auth:migrate
 pnpm dev
 ```
 
@@ -41,8 +42,9 @@ Open [http://localhost:3000](http://localhost:3000), create an account, and cont
 
 ## How it is wired
 
-- [`src/lib/auth.ts`](./src/lib/auth.ts) creates the Better Auth instance, configures the pooled
-  Postgres connection, and runs programmatic migrations.
+- [`src/lib/auth.ts`](./src/lib/auth.ts) creates the Better Auth instance and configures the pooled
+  Postgres connection without touching the database during a build.
+- [`src/lib/migrate-auth.ts`](./src/lib/migrate-auth.ts) runs schema migrations only when requested.
 - [`farm.config.ts`](./farm.config.ts) mounts that instance through `@farm.js/better-auth`.
 - [`src/lib/auth-client.ts`](./src/lib/auth-client.ts) exposes the browser client.
 - [`src/lib/session.ts`](./src/lib/session.ts) resolves the current request session on the server.
@@ -72,12 +74,16 @@ The starter uses `pg` with a small connection pool suitable for a pooled Neon en
 `DATABASE_URL`, `BETTER_AUTH_SECRET`, and the production `BETTER_AUTH_URL` to your deployment
 environment before building.
 
+Run `pnpm auth:migrate` (or `farm migrate`) as an explicit deployment step before serving traffic.
+The production build itself never runs database migrations.
+
 The FARMJS deployment target is configured in [`farm.config.ts`](./farm.config.ts) for Vercel.
 
 ## Commands
 
 ```bash
 pnpm dev         # start the development server
+pnpm auth:migrate # apply Better Auth database migrations
 pnpm type-check  # run TypeScript checks
 pnpm build       # create the production build
 pnpm check       # type-check and build

--- a/packages/create-farm-app/templates/better-auth/farm.config.ts
+++ b/packages/create-farm-app/templates/better-auth/farm.config.ts
@@ -16,6 +16,14 @@ export default defineConfig({
   experimental: {
     serverComponents: true,
   },
+  migrations: {
+    commands: [
+      {
+        name: "Better Auth schema",
+        command: "pnpm auth:migrate",
+      },
+    ],
+  },
   vite: {
     server: {
       port: 3000,

--- a/packages/create-farm-app/templates/better-auth/package.json
+++ b/packages/create-farm-app/templates/better-auth/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "farm dev",
     "build": "farm build",
+    "auth:migrate": "node --experimental-strip-types src/lib/migrate-auth.ts",
     "check": "pnpm type-check && pnpm build",
     "deploy": "farm deploy",
     "type-check": "tsc --noEmit"

--- a/packages/create-farm-app/templates/better-auth/src/lib/auth.ts
+++ b/packages/create-farm-app/templates/better-auth/src/lib/auth.ts
@@ -1,5 +1,4 @@
 import { betterAuth } from "better-auth";
-import { getMigrations } from "better-auth/db/migration";
 import { Pool, type PoolConfig } from "pg";
 
 const authBaseUrl = process.env.BETTER_AUTH_URL ?? "http://localhost:3000";
@@ -32,12 +31,12 @@ const poolConfig: PoolConfig & { enableChannelBinding: boolean } = {
   allowExitOnIdle: true,
 };
 
-const database = new Pool(poolConfig);
+export const authDatabase = new Pool(poolConfig);
 
 export const auth = betterAuth({
   appName: "FARMJS Better Auth Starter",
   baseURL: authBaseUrl,
-  database,
+  database: authDatabase,
   emailAndPassword: {
     enabled: true,
     minPasswordLength: 8,
@@ -45,6 +44,3 @@ export const auth = betterAuth({
   secret,
   trustedOrigins: [new URL(authBaseUrl).origin],
 });
-
-const migrations = await getMigrations(auth.options);
-await migrations.runMigrations();

--- a/packages/create-farm-app/templates/better-auth/src/lib/migrate-auth.ts
+++ b/packages/create-farm-app/templates/better-auth/src/lib/migrate-auth.ts
@@ -1,0 +1,10 @@
+import { getMigrations } from "better-auth/db/migration";
+import { auth, authDatabase } from "./auth.ts";
+
+try {
+  const migrations = await getMigrations(auth.options);
+  await migrations.runMigrations();
+  console.log("Better Auth migrations completed.");
+} finally {
+  await authDatabase.end();
+}

--- a/packages/create-farm-app/test/create-app.test.mjs
+++ b/packages/create-farm-app/test/create-app.test.mjs
@@ -698,6 +698,8 @@ test("generates renderer-native Better Auth starters", async () => {
         await readFile(path.join(generatedDir, "package.json"), "utf8"),
       );
       const config = await readFile(path.join(generatedDir, "farm.config.ts"), "utf8");
+      const auth = await readFile(path.join(generatedDir, "src/lib/auth.ts"), "utf8");
+      const migration = await readFile(path.join(generatedDir, "src/lib/migrate-auth.ts"), "utf8");
       const home = await readFile(path.join(generatedDir, "src/app", renderer.page), "utf8");
       const form = await readFile(path.join(generatedDir, "src/components", renderer.form), "utf8");
       const authClient = await readFile(path.join(generatedDir, "src/lib/auth-client.ts"), "utf8");
@@ -708,12 +710,20 @@ test("generates renderer-native Better Auth starters", async () => {
         templatePackage.dependencies["@farm.js/better-auth"],
       );
       assert.equal(packageJson.dependencies["better-auth"], "1.6.25");
+      assert.equal(
+        packageJson.scripts["auth:migrate"],
+        "node --experimental-strip-types src/lib/migrate-auth.ts",
+      );
       assert.equal(packageJson.dependencies.react, undefined);
       assert.equal(packageJson.dependencies["react-dom"], undefined);
       assert.equal(packageJson.devDependencies["@types/react"], undefined);
       assert.equal(packageJson.devDependencies["@types/react-dom"], undefined);
       assert.match(config, new RegExp(`renderer: ${renderer.name}\\(\\)`));
       assert.match(config, /auth: betterAuth\(\{ instance: auth \}\)/);
+      assert.match(config, /command: "pnpm auth:migrate"/);
+      assert.doesNotMatch(auth, /runMigrations/);
+      assert.match(migration, /await migrations\.runMigrations\(\)/);
+      assert.match(migration, /await authDatabase\.end\(\)/);
       assert.match(home, new RegExp(`FARMJS / ${renderer.label} \\+ Better Auth`));
       assert.match(home, /Get started/);
       assert.match(form, renderer.nativePattern);


### PR DESCRIPTION
## Problem

The Better Auth starter runs schema migrations while its auth module is imported. Farm loads that module while resolving configuration, so a build can connect to Postgres and mutate the schema before deployment.

## Root cause

Runtime auth setup and one-shot schema migration were coupled through top-level module evaluation.

## Change

Move migration execution into `src/lib/migrate-auth.ts`, add an `auth:migrate` script, and register it with Farm's migration command. Apply the migration entry to every renderer overlay and update generated setup guidance.

## Safety and compatibility

Normal auth setup still uses the same Better Auth instance and Postgres pool. Development and production builds no longer run schema changes; users run `pnpm auth:migrate` or `farm migrate` explicitly before serving traffic.

## Verification

- `pnpm --filter @farm.js/create-app test` (16 tests)
- Focused `oxlint` on changed TypeScript and JavaScript files
- Generator coverage verifies every renderer receives the command and that auth module evaluation no longer calls `runMigrations`

## Documentation and release

Updated the Better Auth starter README and generated CLI setup instructions. No release metadata changed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves Better Auth migrations out of the module import path so builds no longer connect to Postgres and alter the schema. Migrations now run only via a new `pnpm auth:migrate` script.

- The auth module no longer calls `runMigrations`; a new `src/lib/migrate-auth.ts` runs them explicitly.
- All renderer overlays (Preact, Solid, Svelte, Vue) register the migration command in their Farm configs.
- Setup instructions and the starter README now tell users to run `pnpm auth:migrate` before starting or deploying.

<sup>Written for commit dbaa1709250a647f7fbbc85fcb65babd4cf5e504. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/818?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

