### PR TITLE
fix(pwa): reject invalid plugin options

### DIFF
--- a/packages/farm-pwa/src/config.test.ts
+++ b/packages/farm-pwa/src/config.test.ts
@@ -86,6 +86,28 @@ describe("resolvePwaOptions", () => {
       "positive integer",
     );
   });
+
+  it("rejects invalid top-level options instead of changing behavior silently", () => {
+    expect(() => resolvePwaOptions(null as never)).toThrow("options must be an object");
+    expect(() => resolvePwaOptions({ enabled: "false" as never })).toThrow(
+      "enabled must be boolean",
+    );
+    expect(() => resolvePwaOptions({ update: "manual" as never })).toThrow(
+      'update must be "prompt" or "auto"',
+    );
+    expect(() => resolvePwaOptions({ cache: null as never })).toThrow("PWA cache must be");
+    expect(() => resolvePwaOptions({ cache: "unknown" as never })).toThrow("PWA cache must be");
+    expect(() => resolvePwaOptions({ cache: { staticRoutes: "all" as never } })).toThrow(
+      "staticRoutes must be boolean or an array",
+    );
+    expect(() => resolvePwaOptions({ cache: { images: null as never } })).toThrow(
+      'image cache strategy must be "swr"',
+    );
+    expect(() => resolvePwaOptions({ offline: 42 as never })).toThrow("offline must be a route");
+    expect(() => resolvePwaOptions({ serviceWorker: null as never })).toThrow(
+      "serviceWorker must be an options object",
+    );
+  });
 });
 
 describe("parsePwaDuration", () => {

--- a/packages/farm-pwa/src/config.ts
+++ b/packages/farm-pwa/src/config.ts
@@ -59,6 +59,23 @@ const DEFAULT_IMAGE_LIMIT = 100;
 const DEFAULT_IMAGE_TTL = "30d";
 
 export function resolvePwaOptions(options: PwaPluginOptions = {}): ResolvedPwaOptions {
+  if (!options || typeof options !== "object" || Array.isArray(options)) {
+    throw new TypeError("PWA options must be an object");
+  }
+  if (options.enabled !== undefined && typeof options.enabled !== "boolean") {
+    throw new TypeError("PWA enabled must be boolean");
+  }
+  if (
+    options.offline !== undefined &&
+    options.offline !== false &&
+    typeof options.offline !== "string"
+  ) {
+    throw new TypeError('PWA offline must be a route starting with "/" or false');
+  }
+  if (options.update !== undefined && options.update !== "prompt" && options.update !== "auto") {
+    throw new TypeError('PWA update must be "prompt" or "auto"');
+  }
+
   const serviceWorker = resolveServiceWorker(options.serviceWorker);
   if (serviceWorker && (options.offline !== undefined || options.cache !== undefined)) {
     throw new TypeError(
@@ -66,7 +83,17 @@ export function resolvePwaOptions(options: PwaPluginOptions = {}): ResolvedPwaOp
     );
   }
 
-  const cache = options.cache ?? "auto";
+  const configuredCache = options.cache;
+  if (
+    configuredCache !== undefined &&
+    configuredCache !== false &&
+    configuredCache !== "auto" &&
+    configuredCache !== "recommended" &&
+    (!configuredCache || typeof configuredCache !== "object" || Array.isArray(configuredCache))
+  ) {
+    throw new TypeError('PWA cache must be "auto", "recommended", an options object, or false');
+  }
+  const cache = configuredCache ?? "auto";
   const usesAutomaticCache = cache === "auto" || cache === "recommended";
   const customCache = typeof cache === "object" ? cache : undefined;
 
@@ -82,14 +109,16 @@ export function resolvePwaOptions(options: PwaPluginOptions = {}): ResolvedPwaOp
           ? true
           : cache === false
             ? false
-            : normalizeStaticRoutes(customCache?.staticRoutes ?? false),
+            : normalizeStaticRoutes(
+                customCache?.staticRoutes === undefined ? false : customCache.staticRoutes,
+              ),
       images: serviceWorker
         ? false
         : usesAutomaticCache
           ? resolveImageCache("swr")
           : cache === false
             ? false
-            : resolveImageCache(customCache?.images ?? false),
+            : resolveImageCache(customCache?.images === undefined ? false : customCache.images),
     },
   };
 }
@@ -97,7 +126,13 @@ export function resolvePwaOptions(options: PwaPluginOptions = {}): ResolvedPwaOp
 function resolveServiceWorker(
   value: PwaServiceWorkerOptions | undefined,
 ): Required<PwaServiceWorkerOptions> | false {
-  if (!value) return false;
+  if (value === undefined) return false;
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new TypeError("PWA serviceWorker must be an options object");
+  }
+  if (typeof value.source !== "string") {
+    throw new TypeError("PWA serviceWorker source must be a non-empty path");
+  }
   const source = value.source.trim();
   if (!source) throw new TypeError("PWA serviceWorker source must be a non-empty path");
   if (value.type !== undefined && value.type !== "classic" && value.type !== "module") {
@@ -136,7 +171,11 @@ export function parsePwaDuration(value: PwaDuration): number {
 
 function resolveImageCache(value: PwaImageCache): ResolvedPwaImageCacheOptions | false {
   if (value === false) return false;
-  if (value !== true && value !== "swr" && value.strategy !== "swr") {
+  if (
+    value !== true &&
+    value !== "swr" &&
+    (!value || typeof value !== "object" || Array.isArray(value) || value.strategy !== "swr")
+  ) {
     throw new TypeError('PWA image cache strategy must be "swr"');
   }
 
@@ -154,7 +193,10 @@ function resolveImageCache(value: PwaImageCache): ResolvedPwaImageCacheOptions |
 }
 
 function normalizeStaticRoutes(value: boolean | string[]): boolean | string[] {
-  if (!Array.isArray(value)) return value;
+  if (typeof value === "boolean") return value;
+  if (!Array.isArray(value)) {
+    throw new TypeError("PWA cache staticRoutes must be boolean or an array of routes");
+  }
   return [...new Set(value.map((route) => normalizeRoute(route, "static route")))];
 }
 


### PR DESCRIPTION
## Problem

Malformed PWA options supplied from JavaScript can be coerced into defaults or fail later with incidental property errors instead of reporting an invalid configuration.

## Root cause

The resolver relied on TypeScript types and applied truthiness/nullish defaults before validating runtime object and enum shapes.

## Change

Validate the top-level options, update mode, cache mode, custom worker, static route, and image-cache shapes before resolving defaults.

## Safety and compatibility

All documented typed configurations keep their existing resolved behavior. Invalid JavaScript inputs now fail early with an actionable PWA-specific error.

## Verification

- `pnpm --filter @farm.js/pwa test` (19 tests)
- `pnpm --filter @farm.js/pwa type-check`
- `pnpm --filter @farm.js/pwa build`
- Focused `oxlint`

Regression coverage includes invalid enum values, arrays, null cache values, nested null image configuration, and malformed custom workers.

## Documentation and release

None; the accepted public options are unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds runtime validation to PWA plugin options so malformed config fails early with a clear, PWA-specific error instead of silently coercing to defaults or failing later with incidental property errors.

- Validates top-level options, update mode, cache mode, custom worker source, static routes, and image cache shapes before resolving defaults.
- Documented typed configurations keep their existing resolved behavior.
- Adds regression tests for invalid enum values, arrays, null cache values, nested null image config, and malformed custom workers.

<sup>Written for commit cffe75f3167aabee4a5f2731bb31518f3cfbf6a3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/819?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

