### PR TITLE
fix(cli): validate dev and start ports

### DIFF
--- a/packages/farm-cli/bin/farm.js
+++ b/packages/farm-cli/bin/farm.js
@@ -35,6 +35,17 @@ function collectOption(value, previous) {
   return [...(previous || []), value];
 }
 
+function parsePortOption(value) {
+  if (!/^\d+$/.test(value)) {
+    throw new Error("--port must be an integer between 1 and 65535.");
+  }
+  const port = Number(value);
+  if (!Number.isSafeInteger(port) || port < 1 || port > 65535) {
+    throw new Error("--port must be an integer between 1 and 65535.");
+  }
+  return port;
+}
+
 function telemetryCommandPath(command) {
   const segments = [];
   let current = command;
@@ -81,7 +92,7 @@ program
         {
           root: options.root,
         },
-        options.port === undefined ? undefined : parseInt(options.port, 10),
+        options.port === undefined ? undefined : parsePortOption(options.port),
       );
       if (options.cron) {
         const { startFarmCronScheduler } = require("../dist/index.js");

--- a/packages/farm-cli/src/start.ts
+++ b/packages/farm-cli/src/start.ts
@@ -38,7 +38,21 @@ const PLATFORM_HINTS: Record<string, string> = {
   netlify: "Deploy it with `farm deploy --netlify`",
 };
 
+function resolveStartPort(value: FarmStartOptions["port"]): string | undefined {
+  if (value === undefined || value === "") return undefined;
+  const input = String(value);
+  if (!/^\d+$/.test(input)) {
+    throw new Error("--port must be an integer between 1 and 65535.");
+  }
+  const port = Number(input);
+  if (!Number.isSafeInteger(port) || port < 1 || port > 65535) {
+    throw new Error("--port must be an integer between 1 and 65535.");
+  }
+  return String(port);
+}
+
 export async function createFarmStartPlan(options: FarmStartOptions = {}): Promise<FarmStartPlan> {
+  const port = resolveStartPort(options.port);
   const root = path.resolve(options.root || process.cwd());
   const userConfig = await loadConfig(root, undefined, "production");
   const deployConfig = resolveDeployConfig(userConfig || {});
@@ -71,7 +85,7 @@ export async function createFarmStartPlan(options: FarmStartOptions = {}): Promi
   }
 
   const env: Record<string, string> = {};
-  if (options.port !== undefined && options.port !== "") env.NITRO_PORT = String(options.port);
+  if (port !== undefined) env.NITRO_PORT = port;
   if (options.host) env.NITRO_HOST = options.host;
 
   return {

--- a/packages/farm-cli/test/port-validation.test.mjs
+++ b/packages/farm-cli/test/port-validation.test.mjs
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+import test from "node:test";
+
+const execFileAsync = promisify(execFile);
+const testDir = path.dirname(fileURLToPath(import.meta.url));
+const cliBin = path.resolve(testDir, "../bin/farm.js");
+
+test("farm dev rejects partially numeric ports", async () => {
+  await assert.rejects(
+    execFileAsync(process.execPath, [cliBin, "dev", "--port", "3000oops"], {
+      env: { ...process.env, FARM_TELEMETRY_DISABLED: "1" },
+    }),
+    (error) => {
+      assert.equal(error.code, 1);
+      assert.match(error.stderr, /--port must be an integer between 1 and 65535/);
+      return true;
+    },
+  );
+});

--- a/packages/farm-cli/test/start.test.mjs
+++ b/packages/farm-cli/test/start.test.mjs
@@ -42,6 +42,15 @@ test("resolves a start plan for the node target and maps port/host to Nitro env 
   });
 });
 
+test("rejects invalid start ports before spawning the server", async () => {
+  for (const port of ["3000oops", "1.5", 0, 65536]) {
+    await assert.rejects(
+      createFarmStartPlan({ port }),
+      /--port must be an integer between 1 and 65535/,
+    );
+  }
+});
+
 test("defaults to the node-server preset when no deploy target is configured", async () => {
   await withTempRoot("farm-cli-start-default-", async (root) => {
     await writeFile(path.join(root, "farm.config.mjs"), "export default {};\n");


### PR DESCRIPTION
## Problem

`farm dev --port 3000oops` is accepted as port 3000, while `farm start` forwards arbitrary port strings to Nitro. Users receive surprising behavior or a delayed runtime failure.

## Root cause

The dev command used permissive `parseInt`, and the start plan stringified port input without validating it.

## Change

Validate dev and start ports as whole integers from 1 through 65535 before starting either server.

## Safety and compatibility

Omitted ports continue to use existing defaults, and valid numeric/string ports retain their behavior. Invalid explicit values now fail immediately with one consistent message.

## Verification

- `pnpm --filter @farm.js/cli build`
- `node --test packages/farm-cli/test/start.test.mjs packages/farm-cli/test/port-validation.test.mjs` (7 tests)
- `pnpm --filter @farm.js/cli type-check`
- Focused `oxlint`

The CLI regression test exercises the published bin path and proves partially numeric values are rejected before the dev server loads.

## Documentation and release

None; the documented port interface is unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects invalid `--port` values in `farm dev` and `farm start` so misconfigured ports fail immediately at startup instead of silently coercing or crashing later. Previously `farm dev --port 3000oops` was accepted as 3000, and `farm start` forwarded arbitrary port strings to Nitro; now both commands exit with a consistent error unless the port is an integer from 1 through 65535.

- Omitted ports still use existing defaults; valid numeric and string ports keep the same behavior.
- Adds regression tests for partially numeric, decimal, zero, and out-of-range ports.

<sup>Written for commit ad1e0bd517cb0bcd1ffdacec5ff8e4db3f99c6c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/820?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

