### PR TITLE
fix(create-app): point starters to farmjs.dev

### DIFF
--- a/packages/create-farm-app/src/index.ts
+++ b/packages/create-farm-app/src/index.ts
@@ -676,7 +676,7 @@ ${environmentSetup}pnpm dev
 Open [${integration.route}](http://localhost:3000${integration.route}) for the integration UI.
 
 ${wiring}
-See the [${integration.label} integration guide](https://farm.js.dev${integration.docsPath}) for provider setup and production guidance.
+See the [${integration.label} integration guide](https://farmjs.dev${integration.docsPath}) for provider setup and production guidance.
 `;
 
   await fs.writeFile(path.join(projectPath, "README.md"), source, "utf8");

--- a/packages/create-farm-app/templates/_integrations/better-auth/svelte/src/components/resource-links.svelte
+++ b/packages/create-farm-app/templates/_integrations/better-auth/svelte/src/components/resource-links.svelte
@@ -16,7 +16,7 @@
   {/if}
   <span class="resource-link-item">
     {#if primary}<span class="resource-separator" aria-hidden="true">/</span>{/if}
-    <a href="https://farm.js.dev">
+    <a href="https://farmjs.dev">
       <svg
         class="resource-icon"
         viewBox="0 0 24 24"

--- a/packages/create-farm-app/templates/_integrations/better-auth/vue/src/components/resource-links.vue
+++ b/packages/create-farm-app/templates/_integrations/better-auth/vue/src/components/resource-links.vue
@@ -11,7 +11,7 @@ defineProps<{
     </span>
     <span class="resource-link-item">
       <span v-if="primary" class="resource-separator" aria-hidden="true">/</span>
-      <a href="https://farm.js.dev">
+      <a href="https://farmjs.dev">
         <svg
           class="resource-icon"
           viewBox="0 0 24 24"

--- a/packages/create-farm-app/templates/_renderers/preact/src/components/resource-links.tsx
+++ b/packages/create-farm-app/templates/_renderers/preact/src/components/resource-links.tsx
@@ -54,7 +54,7 @@ export function ResourceLinks({ className, primary }: ResourceLinksProps) {
       ) : null}
       <span className="resource-link-item">
         {primary ? <ResourceSeparator /> : null}
-        <a href="https://farm.js.dev">
+        <a href="https://farmjs.dev">
           <DocsIcon />
           <span>Docs</span>
         </a>

--- a/packages/create-farm-app/templates/_renderers/solid/src/components/resource-links.tsx
+++ b/packages/create-farm-app/templates/_renderers/solid/src/components/resource-links.tsx
@@ -54,7 +54,7 @@ export function ResourceLinks(props: ResourceLinksProps) {
       ) : null}
       <span class="resource-link-item">
         {props.primary ? <ResourceSeparator /> : null}
-        <a href="https://farm.js.dev">
+        <a href="https://farmjs.dev">
           <DocsIcon />
           <span>Docs</span>
         </a>

--- a/packages/create-farm-app/templates/_renderers/svelte/src/components/resource-links.svelte
+++ b/packages/create-farm-app/templates/_renderers/svelte/src/components/resource-links.svelte
@@ -1,6 +1,6 @@
 <nav aria-label="Starter resources">
   <span class="resource-link-item">
-    <a href="https://farm.js.dev">
+    <a href="https://farmjs.dev">
       <svg
         class="resource-icon"
         viewBox="0 0 24 24"

--- a/packages/create-farm-app/templates/_renderers/vue/src/components/resource-links.vue
+++ b/packages/create-farm-app/templates/_renderers/vue/src/components/resource-links.vue
@@ -1,7 +1,7 @@
 <template>
   <nav aria-label="Starter resources">
     <span class="resource-link-item">
-      <a href="https://farm.js.dev">
+      <a href="https://farmjs.dev">
         <svg
           class="resource-icon"
           viewBox="0 0 24 24"

--- a/packages/create-farm-app/templates/auth/src/app/docs/page.md
+++ b/packages/create-farm-app/templates/auth/src/app/docs/page.md
@@ -25,5 +25,5 @@ manual wiring required.
 
 ## Learn more
 
-- [Farm.js documentation](https://farm.js.dev/docs)
-- [Configuration guide](https://farm.js.dev/docs/configuration)
+- [Farm.js documentation](https://farmjs.dev/docs)
+- [Configuration guide](https://farmjs.dev/docs/configuration)

--- a/packages/create-farm-app/templates/auth/src/components/resource-links.tsx
+++ b/packages/create-farm-app/templates/auth/src/components/resource-links.tsx
@@ -61,7 +61,7 @@ export function ResourceLinks({ className, primary }: ResourceLinksProps) {
       ) : null}
       <span className="resource-link-item">
         {primary ? <ResourceSeparator /> : null}
-        <a href="https://farm.js.dev">
+        <a href="https://farmjs.dev">
           <DocsIcon />
           <span>Docs</span>
         </a>

--- a/packages/create-farm-app/templates/auth/src/components/site-header.tsx
+++ b/packages/create-farm-app/templates/auth/src/components/site-header.tsx
@@ -21,7 +21,7 @@ export function SiteHeader({ user }: SiteHeaderProps) {
       </a>
 
       <nav className="header-nav" aria-label="Primary navigation">
-        <a href="https://farm.js.dev">Docs</a>
+        <a href="https://farmjs.dev">Docs</a>
         {user ? (
           <a className="header-account" href="/dashboard">
             <span className="avatar" aria-hidden="true">

--- a/packages/create-farm-app/templates/basic/src/app/docs/page.md
+++ b/packages/create-farm-app/templates/basic/src/app/docs/page.md
@@ -25,5 +25,5 @@ manual wiring required.
 
 ## Learn more
 
-- [Farm.js documentation](https://farm.js.dev/docs)
-- [Configuration guide](https://farm.js.dev/docs/configuration)
+- [Farm.js documentation](https://farmjs.dev/docs)
+- [Configuration guide](https://farmjs.dev/docs/configuration)

--- a/packages/create-farm-app/templates/basic/src/components/resource-links.tsx
+++ b/packages/create-farm-app/templates/basic/src/components/resource-links.tsx
@@ -61,7 +61,7 @@ export function ResourceLinks({ className, primary }: ResourceLinksProps) {
       ) : null}
       <span className="resource-link-item">
         {primary ? <ResourceSeparator /> : null}
-        <a href="https://farm.js.dev">
+        <a href="https://farmjs.dev">
           <DocsIcon />
           <span>Docs</span>
         </a>

--- a/packages/create-farm-app/templates/better-auth/src/app/docs/page.md
+++ b/packages/create-farm-app/templates/better-auth/src/app/docs/page.md
@@ -25,5 +25,5 @@ manual wiring required.
 
 ## Learn more
 
-- [Farm.js documentation](https://farm.js.dev/docs)
-- [Configuration guide](https://farm.js.dev/docs/configuration)
+- [Farm.js documentation](https://farmjs.dev/docs)
+- [Configuration guide](https://farmjs.dev/docs/configuration)

--- a/packages/create-farm-app/templates/better-auth/src/components/resource-links.tsx
+++ b/packages/create-farm-app/templates/better-auth/src/components/resource-links.tsx
@@ -61,7 +61,7 @@ export function ResourceLinks({ className, primary }: ResourceLinksProps) {
       ) : null}
       <span className="resource-link-item">
         {primary ? <ResourceSeparator /> : null}
-        <a href="https://farm.js.dev">
+        <a href="https://farmjs.dev">
           <DocsIcon />
           <span>Docs</span>
         </a>

--- a/packages/create-farm-app/templates/better-auth/src/components/site-header.tsx
+++ b/packages/create-farm-app/templates/better-auth/src/components/site-header.tsx
@@ -21,7 +21,7 @@ export function SiteHeader({ user }: SiteHeaderProps) {
       </a>
 
       <nav className="header-nav" aria-label="Primary navigation">
-        <a href="https://farm.js.dev">Docs</a>
+        <a href="https://farmjs.dev">Docs</a>
         {user ? (
           <a className="header-account" href="/dashboard">
             <span className="avatar" aria-hidden="true">

--- a/packages/create-farm-app/templates/react-compiler/README.md
+++ b/packages/create-farm-app/templates/react-compiler/README.md
@@ -58,5 +58,5 @@ For batching, multiple bindings, safe keyed-list fallback, and the full compiler
 see the maintained
 [React Compiler example](https://github.com/farming-labs/farm.js/tree/main/examples/react-compiler).
 
-Read the [React compiler guide](https://farm.js.dev/docs/renderers/react#experimental-aot-compiler)
+Read the [React compiler guide](https://farmjs.dev/docs/renderers/react#experimental-aot-compiler)
 for the supported component contract and rollout guidance.

--- a/packages/create-farm-app/templates/react-compiler/src/app/docs/page.md
+++ b/packages/create-farm-app/templates/react-compiler/src/app/docs/page.md
@@ -25,5 +25,5 @@ manual wiring required.
 
 ## Learn more
 
-- [Farm.js documentation](https://farm.js.dev/docs)
-- [Configuration guide](https://farm.js.dev/docs/configuration)
+- [Farm.js documentation](https://farmjs.dev/docs)
+- [Configuration guide](https://farmjs.dev/docs/configuration)

--- a/packages/create-farm-app/templates/react-compiler/src/components/resource-links.tsx
+++ b/packages/create-farm-app/templates/react-compiler/src/components/resource-links.tsx
@@ -61,7 +61,7 @@ export function ResourceLinks({ className, primary }: ResourceLinksProps) {
       ) : null}
       <span className="resource-link-item">
         {primary ? <ResourceSeparator /> : null}
-        <a href="https://farm.js.dev">
+        <a href="https://farmjs.dev">
           <DocsIcon />
           <span>Docs</span>
         </a>

--- a/packages/create-farm-app/test/create-app.test.mjs
+++ b/packages/create-farm-app/test/create-app.test.mjs
@@ -247,8 +247,8 @@ test("generates a buildable starter application", async () => {
     assert.match(generatedResourceLinks, /function ResourceSeparator\(\)/);
     assert.match(generatedResourceLinks, /className="resource-separator"/);
     assert.match(generatedResourceLinks, /aria-hidden="true"/);
-    assert.match(generatedResourceLinks, /href="https:\/\/farm\.js\.dev"/);
-    assert.doesNotMatch(generatedResourceLinks, /https:\/\/farmjs\.dev/);
+    assert.match(generatedResourceLinks, /href="https:\/\/farmjs\.dev"/);
+    assert.doesNotMatch(generatedResourceLinks, /https:\/\/farm\.js\.dev/);
     assert.doesNotMatch(generatedResourceLinks, /Docs ↗|GitHub ↗/);
 
     const generatedStyles = await readFile(
@@ -829,16 +829,16 @@ for (const template of [
       assert.match(generatedResourceLinks, /function ResourceSeparator\(\)/);
       assert.match(generatedResourceLinks, /className="resource-separator"/);
       assert.match(generatedResourceLinks, /aria-hidden="true"/);
-      assert.match(generatedResourceLinks, /href="https:\/\/farm\.js\.dev"/);
-      assert.doesNotMatch(generatedResourceLinks, /https:\/\/farmjs\.dev/);
+      assert.match(generatedResourceLinks, /href="https:\/\/farmjs\.dev"/);
+      assert.doesNotMatch(generatedResourceLinks, /https:\/\/farm\.js\.dev/);
       assert.doesNotMatch(generatedResourceLinks, /Docs ↗|GitHub ↗/);
 
       const generatedSiteHeader = await readFile(
         path.join(generatedDir, "src/components/site-header.tsx"),
         "utf8",
       );
-      assert.match(generatedSiteHeader, /href="https:\/\/farm\.js\.dev"/);
-      assert.doesNotMatch(generatedSiteHeader, /https:\/\/farmjs\.dev/);
+      assert.match(generatedSiteHeader, /href="https:\/\/farmjs\.dev"/);
+      assert.doesNotMatch(generatedSiteHeader, /https:\/\/farm\.js\.dev/);
 
       const generatedStyles = await readFile(
         path.join(generatedDir, "src/app/globals.css"),
@@ -1047,7 +1047,8 @@ test("generates every official integration starter", async () => {
       assert.match(styles, /\[data-theme="dark"\] \{/);
       assert.doesNotMatch(styles, /^\.dark \{/m);
       assert.match(readme, new RegExp(`^# FARMJS ${escapeRegExp(template.label)} Starter`, "m"));
-      assert.match(readme, /https:\/\/farm\.js\.dev\/docs\/integrations/);
+      assert.match(readme, /https:\/\/farmjs\.dev\/docs\/integrations/);
+      assert.doesNotMatch(readme, /https:\/\/farm\.js\.dev/);
       await readFile(
         path.join(generatedDir, "src/app/integrations", template.route, "page.tsx"),
         "utf8",


### PR DESCRIPTION
## Problem

Generated starters link to `farm.js.dev`, while the live documentation is hosted at `farmjs.dev`. The stale hostname leaves new users with broken Docs and integration-guide links.

## Root cause

The old hostname was duplicated across renderer overlays, starter templates, and dynamically generated integration README content.

## Change

Use the canonical `https://farmjs.dev` hostname across every generated starter surface and lock it in generator tests.

## Safety and compatibility

Only outbound documentation links change. Generated application behavior, renderer output, and package dependencies are unaffected.

## Verification

- `pnpm --filter @farm.js/create-app test` (16 tests)
- Confirmed no legacy hostname remains in generator source or templates
- Confirmed `https://farmjs.dev/docs` responds successfully
- Focused `oxlint`

## Documentation and release

Updated generated template documentation and resource links. No release metadata changed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Points all generated starters and template files to the canonical `farmjs.dev` documentation hostname, replacing the outdated `farm.js.dev` links so new users get working docs and integration guides.

- Updates the hostname in renderer overlays, starter templates, and dynamically generated README content.
- Adjusts generator tests to assert for the new hostname and forbid the old one.

<sup>Written for commit f8548ff9888adce7dcd6952dbb4b2fd9faf81149. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/821?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

