### PR TITLE
perf(react): retain queued maps through reorder setters

### DIFF
--- a/docs/src/app/docs/renderers/react/page.md
+++ b/docs/src/app/docs/renderers/react/page.md
@@ -1286,6 +1286,23 @@ structural filter/slice reorder, an unsupported map, or host-backed/nested row s
 specialized chain and preserves the existing complete fallback. Map-only components do not retain
 the optional map-and-reorder runtime.
 
+The maps may come first as separate queued setters too:
+
+```tsx
+setItems((current) =>
+  current.map((item) => (item.id === editedId ? { ...item, label: nextLabel } : item)),
+);
+setItems((current) =>
+  current.map((item) => (item.id === editedId ? { ...item, rank: nextRank } : item)),
+);
+setItems((current) => current.toReversed());
+```
+
+Farm records safe replacement lineage from the committed collection, then carries it into the
+following native reverse or sort. This produces the same final result as React's queued functional
+setters while reconciling the keyed block once. Only adjacent concise calls to the same setter are
+linked; any statement or unsupported update between them keeps the existing fallback.
+
 Exact reverse proof can also cross a setter boundary in the same batch:
 
 ```tsx

--- a/examples/react-compiler-dashboard/README.md
+++ b/examples/react-compiler-dashboard/README.md
@@ -375,6 +375,9 @@ The default JSON report is `/tmp/farm-react-dashboard-benchmark.json`; change it
 - The queued reorder-then-map control performs the same reverse and two maps in three adjacent
   setter calls. Its block-bodied equivalent keeps complete reconciliation; the hinted path carries
   one committed reorder token through both queued maps and patches only the changed row.
+- The queued map-then-reorder control performs two maps and a reverse in three adjacent setter
+  calls. Its block-bodied equivalent keeps complete reconciliation; the hinted path records safe
+  replacements from the committed rows and carries them into the final exact reverse.
 - The multi-map reverse-parity control changes the same row through two native maps and then
   reverses twice. Its block-bodied equivalent keeps complete reconciliation; the hinted path
   validates exact committed order, patches the row once, and performs no generic item-map, LIS, or

--- a/examples/react-compiler-dashboard/scripts/benchmark.mjs
+++ b/examples/react-compiler-dashboard/scripts/benchmark.mjs
@@ -1397,6 +1397,12 @@ async function measureTrial(browser, trial, compilerMode, port) {
         const tableQueuedReorderThenMapPipelineSnapshot = await measureMultiMapReverseTable(() =>
           tableButton("table-queued-reorder-then-map-pipeline-snapshot").click(),
         );
+        const tableQueuedMapThenReorderPipeline = await measureMultiMapReverseTable(() =>
+          tableButton("table-queued-map-then-reorder-pipeline").click(),
+        );
+        const tableQueuedMapThenReorderPipelineSnapshot = await measureMultiMapReverseTable(() =>
+          tableButton("table-queued-map-then-reorder-pipeline-snapshot").click(),
+        );
 
         const tableSort = await measureTable(
           async () => create10000(),
@@ -1882,6 +1888,8 @@ async function measureTrial(browser, trial, compilerMode, port) {
             reorderThenMapPipelineSnapshot: tableReorderThenMapPipelineSnapshot,
             queuedReorderThenMapPipeline: tableQueuedReorderThenMapPipeline,
             queuedReorderThenMapPipelineSnapshot: tableQueuedReorderThenMapPipelineSnapshot,
+            queuedMapThenReorderPipeline: tableQueuedMapThenReorderPipeline,
+            queuedMapThenReorderPipelineSnapshot: tableQueuedMapThenReorderPipelineSnapshot,
             mapLookup: tableMapLookup,
             membership: tableMembership,
             prepend: tablePrepend,
@@ -2027,6 +2035,10 @@ async function measureTrial(browser, trial, compilerMode, port) {
         queuedReorderThenMapPipeline: timingSummary(result.table.queuedReorderThenMapPipeline),
         queuedReorderThenMapPipelineSnapshot: timingSummary(
           result.table.queuedReorderThenMapPipelineSnapshot,
+        ),
+        queuedMapThenReorderPipeline: timingSummary(result.table.queuedMapThenReorderPipeline),
+        queuedMapThenReorderPipelineSnapshot: timingSummary(
+          result.table.queuedMapThenReorderPipelineSnapshot,
         ),
         mapLookup: timingSummary(result.table.mapLookup),
         membership: timingSummary(result.table.membership),
@@ -2225,6 +2237,8 @@ const tableMetrics = [
   "reorderThenMapPipelineSnapshot",
   "queuedReorderThenMapPipeline",
   "queuedReorderThenMapPipelineSnapshot",
+  "queuedMapThenReorderPipeline",
+  "queuedMapThenReorderPipelineSnapshot",
   "snapshotMembership",
   "snapshotMapLookup",
   "slicePrefix",
@@ -3019,6 +3033,28 @@ const keyedQueuedReorderThenMapRegressions = keyedQueuedReorderThenMapResults.fi
     !Number.isFinite(snapshotSpeedup) ||
     snapshotSpeedup < keyedQueuedReorderThenMapMinimumSnapshotSpeedup,
 );
+// The mirror queued sequence must retain safe map lineage into a following native reorder.
+// Compare three concise setters with React and block-bodied complete reconciliation.
+const keyedQueuedMapThenReorderMinimumSpeedup = 4;
+const keyedQueuedMapThenReorderMinimumSnapshotSpeedup = 1.2;
+const keyedQueuedMapThenReorderResults = ["static", "hybrid"].map((mode) => {
+  const pipelineMedianMs = comparisons.table.queuedMapThenReorderPipeline[mode].medianMs;
+  const snapshotMedianMs = comparisons.table.queuedMapThenReorderPipelineSnapshot[mode].medianMs;
+  return {
+    mode,
+    pipelineMedianMs,
+    snapshotMedianMs,
+    snapshotSpeedup: snapshotMedianMs / pipelineMedianMs,
+    speedup: comparisons.table.queuedMapThenReorderPipeline[`${mode}VsBaseline`].speedup,
+  };
+});
+const keyedQueuedMapThenReorderRegressions = keyedQueuedMapThenReorderResults.filter(
+  ({ snapshotSpeedup, speedup }) =>
+    !Number.isFinite(speedup) ||
+    speedup < keyedQueuedMapThenReorderMinimumSpeedup ||
+    !Number.isFinite(snapshotSpeedup) ||
+    snapshotSpeedup < keyedQueuedMapThenReorderMinimumSnapshotSpeedup,
+);
 // A direct native toSorted() exposes a permutation while preserving every keyed row object. The
 // hinted path validates that permutation by item identity, uses LIS to move only the required DOM
 // nodes, and avoids key, descriptor, and binding reads. Compare it with React and the equivalent
@@ -3214,6 +3250,7 @@ const passed =
   keyedQueuedMapReverseParityRegressions.length === 0 &&
   keyedReorderThenMapRegressions.length === 0 &&
   keyedQueuedReorderThenMapRegressions.length === 0 &&
+  keyedQueuedMapThenReorderRegressions.length === 0 &&
   keyedSortRegressions.length === 0 &&
   keyedFilterRegressions.length === 0 &&
   keyedIdentityRegressions.length === 0 &&
@@ -3428,6 +3465,13 @@ const report = {
     regressions: keyedQueuedReorderThenMapRegressions,
     results: keyedQueuedReorderThenMapResults,
     status: keyedQueuedReorderThenMapRegressions.length === 0 ? "PASS" : "FAIL",
+  },
+  keyedQueuedMapThenReorderHintGate: {
+    minimumSnapshotSpeedup: keyedQueuedMapThenReorderMinimumSnapshotSpeedup,
+    minimumSpeedup: keyedQueuedMapThenReorderMinimumSpeedup,
+    regressions: keyedQueuedMapThenReorderRegressions,
+    results: keyedQueuedMapThenReorderResults,
+    status: keyedQueuedMapThenReorderRegressions.length === 0 ? "PASS" : "FAIL",
   },
   keyedSortHintGate: {
     minimumSnapshotSpeedup: keyedSortMinimumSnapshotSpeedup,

--- a/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
+++ b/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
@@ -1155,6 +1155,50 @@ export function StandardTableBenchmark() {
           Queue reverse + review one row (snapshot control)
         </button>
         <button
+          data-action="table-queued-map-then-reorder-pipeline"
+          type="button"
+          onClick={() => {
+            setRows((current) =>
+              current.map((row) =>
+                row.id % 10_000 === 5_001 ? { ...row, label: `${row.label} reviewed` } : row,
+              ),
+            );
+            setRows((current) =>
+              current.map((row) =>
+                row.id % 10_000 === 5_001 ? { ...row, amount: row.amount + 1 } : row,
+              ),
+            );
+            setRows((current) => current.toReversed());
+            setOperation("queue review and reprice, then reverse rows");
+            setRevision((value) => value + 1);
+          }}
+        >
+          Queue review + reverse rows
+        </button>
+        <button
+          data-action="table-queued-map-then-reorder-pipeline-snapshot"
+          type="button"
+          onClick={() => {
+            setRows((current) => {
+              return current.map((row) =>
+                row.id % 10_000 === 5_001 ? { ...row, label: `${row.label} reviewed` } : row,
+              );
+            });
+            setRows((current) => {
+              return current.map((row) =>
+                row.id % 10_000 === 5_001 ? { ...row, amount: row.amount + 1 } : row,
+              );
+            });
+            setRows((current) => {
+              return current.toReversed();
+            });
+            setOperation("queue review and reprice, then reverse rows (snapshot control)");
+            setRevision((value) => value + 1);
+          }}
+        >
+          Queue review + reverse rows (snapshot control)
+        </button>
+        <button
           data-action="table-sort"
           type="button"
           onClick={() => {

--- a/packages/farm-react/README.md
+++ b/packages/farm-react/README.md
@@ -486,6 +486,11 @@ sort-permutation path at commit. An intervening statement, another setter, a str
 filter/slice reorder, an unsupported map, or a changed key keeps the ordinary complete fallback.
 Standalone map-only components do not retain the map-and-reorder runtime.
 
+The mirror order is supported as well: two or more adjacent concise same-key map setters may be
+followed by a concise native reverse or sort setter. Farm records their replacement lineage from
+the committed collection and carries it into the final reorder. Only adjacent calls to the same
+setter are linked; intervening work and unsupported updates retain complete reconciliation.
+
 A reverse before the safe map pipeline may be queued in a separate setter:
 
 ```tsx

--- a/packages/farm-react/src/__tests__/compiler-keyed-array-queued-map-reorder-hints.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-keyed-array-queued-map-reorder-hints.test.ts
@@ -1,0 +1,195 @@
+// @vitest-environment node
+
+import { describe, expect, it } from "vitest";
+import { transformWithEsbuild } from "vite";
+import { compileReactModule } from "../compiler";
+import { normalizeReactCompilerOptions } from "../index";
+
+const infer = normalizeReactCompilerOptions(true, "/app");
+
+async function compile(source: string) {
+  return compileReactModule(source, "/app/QueuedMapReorderHints.tsx", infer);
+}
+
+describe("React AOT queued map then reorder hints", () => {
+  it("retains two adjacent same-state maps through a following sort", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Table({ editedId, nextLabel, nextRank }) {
+        const [rows, setRows] = useState([
+          { id: "a", label: "Alpha", rank: 1 },
+          { id: "b", label: "Beta", rank: 2 },
+        ]);
+        return <section>
+          <button onClick={() => {
+            setRows((current) => current.map((row) =>
+              row.id === editedId ? { ...row, label: nextLabel } : row
+            ));
+            setRows((current) => current.map((row) =>
+              row.id === editedId ? { ...row, rank: nextRank } : row
+            ));
+            setRows((current) => current.toSorted((left, right) => left.rank - right.rank));
+          }}>Edit and sort</button>
+          <ul>{rows.map((row) => <li key={row.id}>{row.label}: {row.rank}</li>)}</ul>
+        </section>;
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Table"]);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.optimizations.keyedMapUpdateHints).toBe(2);
+    expect(result.optimizations.keyedArraySortHints).toBe(1);
+    expect(result.code.match(/createCompilerKeyedArrayQueuedMapPipeline\(/g)).toHaveLength(2);
+    expect(result.code.match(/createCompilerKeyedArrayMapReorder\(/g)).toHaveLength(1);
+    expect(result.code).not.toContain("createCompilerKeyedArrayMapPipeline");
+    expect(result.code).not.toContain("createCompilerKeyedArraySort");
+    expect(result.code).toContain("keyedRowsMapReorderHintedRuntimeFeature");
+    await expect(
+      transformWithEsbuild(result.code, "/app/QueuedMapReorderHints.tsx", {
+        loader: "tsx",
+        jsx: "automatic",
+      }),
+    ).resolves.toMatchObject({
+      code: expect.stringContaining("createCompilerKeyedArrayQueuedMapPipeline"),
+    });
+  });
+
+  it("retains one standalone safe map through a following reverse", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Table({ editedId, nextLabel }) {
+        const [rows, setRows] = useState([
+          { id: "a", label: "Alpha" },
+          { id: "b", label: "Beta" },
+        ]);
+        return <section>
+          <button onClick={() => {
+            setRows((current) => current.map((row) =>
+              row.id === editedId ? { ...row, label: nextLabel } : row
+            ));
+            setRows((current) => current.toReversed());
+          }}>Edit and reverse</button>
+          <ul>{rows.map((row) => <li key={row.id}>{row.label}</li>)}</ul>
+        </section>;
+      }
+    `);
+
+    expect(result.optimizations.keyedMapUpdateHints).toBe(1);
+    expect(result.optimizations.keyedArrayReorderHints).toBe(1);
+    expect(result.code.match(/createCompilerKeyedArrayQueuedMapPipeline\(/g)).toHaveLength(1);
+    expect(result.code.match(/createCompilerKeyedArrayMapReorder\(/g)).toHaveLength(1);
+    expect(result.code).not.toContain("createCompilerKeyedArrayMapPipeline");
+    expect(result.code).not.toContain("createCompilerKeyedArrayReorder");
+  });
+
+  it("composes maps and reorders on both sides of the same queued chain", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Table({ editedId, nextLabel, nextRank }) {
+        const [rows, setRows] = useState([
+          { id: "a", label: "Alpha", rank: 1 },
+          { id: "b", label: "Beta", rank: 2 },
+        ]);
+        return <section>
+          <button onClick={() => {
+            setRows((current) => current.map((row) =>
+              row.id === editedId ? { ...row, label: nextLabel } : row
+            ));
+            setRows((current) => current.toReversed());
+            setRows((current) => current.map((row) =>
+              row.id === editedId ? { ...row, rank: nextRank } : row
+            ));
+            setRows((current) => current.toReversed());
+          }}>Edit and preserve order</button>
+          <ul>{rows.map((row) => <li key={row.id}>{row.label}: {row.rank}</li>)}</ul>
+        </section>;
+      }
+    `);
+
+    expect(result.optimizations.keyedMapUpdateHints).toBe(2);
+    expect(result.optimizations.keyedArrayReorderHints).toBe(2);
+    expect(result.code.match(/createCompilerKeyedArrayQueuedMapPipeline\(/g)).toHaveLength(2);
+    expect(result.code.match(/createCompilerKeyedArrayMapReorder\(/g)).toHaveLength(2);
+    expect(result.code).not.toContain("createCompilerKeyedArrayMapPipeline");
+    expect(result.code).not.toContain("createCompilerKeyedArrayReorder");
+  });
+
+  it.each([
+    {
+      name: "an intervening statement",
+      body: `
+        setRows((current) => current.map((row) =>
+          row.id === editedId ? { ...row, label: nextLabel } : row
+        ));
+        onMapped();
+        setRows((current) => current.toReversed());
+      `,
+    },
+    {
+      name: "a different state setter",
+      body: `
+        setRows((current) => current.map((row) =>
+          row.id === editedId ? { ...row, label: nextLabel } : row
+        ));
+        setOther((current) => current + 1);
+        setRows((current) => current.toReversed());
+      `,
+    },
+    {
+      name: "a structural reorder",
+      body: `
+        setRows((current) => current.map((row) =>
+          row.id === editedId ? { ...row, label: nextLabel } : row
+        ));
+        setRows((current) => current.filter((row) => row.visible).toReversed());
+      `,
+    },
+  ])("does not connect maps across $name", async ({ body }) => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Table({ editedId, nextLabel, onMapped }) {
+        const [rows, setRows] = useState([
+          { id: "a", label: "Alpha", visible: true },
+          { id: "b", label: "Beta", visible: false },
+        ]);
+        const [other, setOther] = useState(0);
+        return <section>
+          <button onClick={() => { ${body} }}>Update</button>
+          <output>{other}</output>
+          <ul>{rows.map((row) => <li key={row.id}>{row.label}</li>)}</ul>
+        </section>;
+      }
+    `);
+
+    expect(result.code).not.toContain("createCompilerKeyedArrayQueuedMapPipeline");
+    expect(result.code).not.toContain("keyedRowsMapReorderHintedRuntimeFeature");
+  });
+
+  it("does not lower queued map and reorder hints for host-backed rows", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Table({ editedId, nextLabel }) {
+        const [rows, setRows] = useState([
+          { id: "a", label: "Alpha", visible: true },
+          { id: "b", label: "Beta", visible: false },
+        ]);
+        return <section>
+          <button onClick={() => {
+            setRows((current) => current.map((row) =>
+              row.id === editedId ? { ...row, label: nextLabel } : row
+            ));
+            setRows((current) => current.toReversed());
+          }}>Edit and reverse</button>
+          <ul>{rows.map((row) => <li key={row.id}>
+            <span>{row.label}</span>
+            <div>{row.visible && <strong>{row.label}</strong>}</div>
+          </li>)}</ul>
+        </section>;
+      }
+    `);
+
+    expect(result.code).toContain("keyedRowsHostReorderHintedRuntimeFeature");
+    expect(result.code).not.toContain("createCompilerKeyedArrayQueuedMapPipeline");
+    expect(result.code).not.toContain("createCompilerKeyedArrayMapReorder");
+  });
+});

--- a/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-map-reorder-hints.test.tsx
+++ b/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-map-reorder-hints.test.tsx
@@ -195,6 +195,12 @@ function createHarness(initialItems: Item[]) {
     rank: number,
     label: string,
   ) => void = () => undefined;
+  let queueMapsThenReorder: (
+    kind: "reverse" | "sort",
+    id: string,
+    rank: number,
+    label: string,
+  ) => void = () => undefined;
   let reverseThenMap: (id: string, rank: number, label: string) => void = () => undefined;
   let sortThenMap: (id: string, rank: number, label: string) => void = () => undefined;
   let queueSortThenMapReverse: () => void = () => undefined;
@@ -202,9 +208,11 @@ function createHarness(initialItems: Item[]) {
   let customMap: () => void = () => undefined;
   let customMapAfterReverse: () => void = () => undefined;
   let queueCustomMapAfterReverse: () => void = () => undefined;
+  let queueCustomMapBeforeReverse: () => void = () => undefined;
   let customSecondMap: () => void = () => undefined;
   let invalidateKeyAfterReverse: () => void = () => undefined;
   let queueInvalidateKeyAfterReverse: () => void = () => undefined;
+  let queueInvalidateKeyBeforeReverse: () => void = () => undefined;
   const Table = createCompiledComponent({
     displayName: "MapReorderTable",
     initialize: () => [initialItems],
@@ -265,6 +273,21 @@ function createHarness(initialItems: Item[]) {
           queuedHintedMap(previous as Item[], (item) =>
             item.id === id ? { ...item, rank } : item,
           ),
+        );
+      };
+      queueMapsThenReorder = (kind, id, rank, label) => {
+        state[0].set((previous) =>
+          queuedHintedMap(previous as Item[], (item) =>
+            item.id === id ? { ...item, label } : item,
+          ),
+        );
+        state[0].set((previous) =>
+          queuedHintedMap(previous as Item[], (item) =>
+            item.id === id ? { ...item, rank } : item,
+          ),
+        );
+        state[0].set((previous) =>
+          kind === "reverse" ? hintedReverse(previous as Item[]) : hintedSort(previous as Item[]),
         );
       };
       reverseThenMap = (id, rank, label) =>
@@ -357,6 +380,23 @@ function createHarness(initialItems: Item[]) {
           );
         });
       };
+      queueCustomMapBeforeReverse = () => {
+        state[0].set((previous) => {
+          const source = previous as Item[];
+          const customMap = function (
+            this: Item[],
+            callback: (item: Item, index: number, items: Item[]) => Item,
+          ) {
+            return Array.prototype.map.call(this, callback);
+          };
+          return queuedHintedMap(
+            source,
+            (item) => (item.id === "a" ? { ...item, label: "Queued custom before reverse" } : item),
+            customMap,
+          );
+        });
+        state[0].set((previous) => hintedReverse(previous as Item[]));
+      };
       customSecondMap = () =>
         state[0].set((previous) => {
           const second = createCompilerKeyedArrayMapPipeline(
@@ -402,6 +442,16 @@ function createHarness(initialItems: Item[]) {
               : item,
           ),
         );
+      };
+      queueInvalidateKeyBeforeReverse = () => {
+        state[0].set((previous) =>
+          queuedHintedMap(previous as Item[], (item) =>
+            item.id === "b"
+              ? { ...item, id: "queued-replacement", label: "Queued replacement before reverse" }
+              : item,
+          ),
+        );
+        state[0].set((previous) => hintedReverse(previous as Item[]));
       };
       return (
         <section>
@@ -455,6 +505,7 @@ function createHarness(initialItems: Item[]) {
     customMap: () => customMap(),
     customMapAfterReverse: () => customMapAfterReverse(),
     queueCustomMapAfterReverse: () => queueCustomMapAfterReverse(),
+    queueCustomMapBeforeReverse: () => queueCustomMapBeforeReverse(),
     customSecondMap: () => customSecondMap(),
     editAndSort: (id: string, rank: number, label?: string) => editAndSort(id, rank, label),
     editTwoAndSort: (labelId: string, rankId: string) => editTwoAndSort(labelId, rankId),
@@ -468,12 +519,15 @@ function createHarness(initialItems: Item[]) {
     invalidateKey: () => invalidateKey(),
     invalidateKeyAfterReverse: () => invalidateKeyAfterReverse(),
     queueInvalidateKeyAfterReverse: () => queueInvalidateKeyAfterReverse(),
+    queueInvalidateKeyBeforeReverse: () => queueInvalidateKeyBeforeReverse(),
     queueEdits: (edits: readonly { id: string; rank: number; label: string }[]) =>
       queueEdits(edits),
     queueReverseThenMapReverse: (id: string, rank: number, label: string) =>
       queueReverseThenMapReverse(id, rank, label),
     queueReorderThenMaps: (kind: "reverse" | "sort", id: string, rank: number, label: string) =>
       queueReorderThenMaps(kind, id, rank, label),
+    queueMapsThenReorder: (kind: "reverse" | "sort", id: string, rank: number, label: string) =>
+      queueMapsThenReorder(kind, id, rank, label),
     queueSortThenMapReverse: () => queueSortThenMapReverse(),
     reverseThenMap: (id: string, rank: number, label: string) => reverseThenMap(id, rank, label),
     sortThenMap: (id: string, rank: number, label: string) => sortThenMap(id, rank, label),
@@ -897,6 +951,43 @@ describe("compiled keyed-array map and reorder hints", () => {
     expect(harness.counters.executions).toBe(1);
   });
 
+  it("takes the exact reverse path when adjacent queued maps precede the reorder", async () => {
+    const initialItems: Item[] = [
+      { id: "a", label: "Alpha", rank: 1 },
+      { id: "b", label: "Beta", rank: 2 },
+      { id: "c", label: "Gamma", rank: 3 },
+    ];
+    const harness = createHarness(initialItems);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Table />));
+    const rows = [...container.querySelectorAll("li")];
+    const list = container.querySelector("ul")!;
+    const insertBefore = vi.spyOn(list, "insertBefore");
+    const mapSet = vi.spyOn(Map.prototype, "set");
+    const descriptorRead = vi.spyOn(Object, "getOwnPropertyDescriptor");
+    harness.counters.bindings = 0;
+    harness.counters.descriptors = 0;
+    harness.counters.keys = 0;
+
+    await act(async () => {
+      harness.queueMapsThenReorder("reverse", "b", 5, "Beta queued first");
+      await flushCompilerUpdates();
+    });
+
+    expect(labels(container)).toEqual(["Gamma:3", "Beta queued first:5", "Alpha:1"]);
+    expect([...container.querySelectorAll("li")]).toEqual(rows.toReversed());
+    expect(insertBefore).toHaveBeenCalledTimes(2);
+    expect(mapSet.mock.calls.filter(([key]) => initialItems.includes(key as Item))).toHaveLength(0);
+    expect(descriptorRead).toHaveBeenCalledTimes(initialItems.length * 2);
+    expect(harness.counters.keys).toBe(1);
+    expect(harness.counters.descriptors).toBe(0);
+    expect(harness.counters.bindings).toBe(1);
+    expect(harness.counters.executions).toBe(1);
+  });
+
   it("runs one validated permutation reconciliation when safe maps follow a sort", async () => {
     const initialItems: Item[] = [
       { id: "a", label: "Alpha", rank: 3 },
@@ -962,6 +1053,42 @@ describe("compiled keyed-array map and reorder hints", () => {
       rows.get("b"),
       rows.get("c"),
       rows.get("a"),
+    ]);
+    expect(harness.counters.keys).toBe(1);
+    expect(harness.counters.descriptors).toBe(0);
+    expect(harness.counters.bindings).toBe(1);
+    expect(harness.counters.executions).toBe(1);
+  });
+
+  it("retains mapped lineage when adjacent queued maps precede a sort", async () => {
+    const initialItems: Item[] = [
+      { id: "a", label: "Alpha", rank: 3 },
+      { id: "b", label: "Beta", rank: 1 },
+      { id: "c", label: "Gamma", rank: 2 },
+    ];
+    const harness = createHarness(initialItems);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Table />));
+    const rows = new Map(
+      [...container.querySelectorAll("li")].map((row) => [row.dataset.key, row]),
+    );
+    harness.counters.bindings = 0;
+    harness.counters.descriptors = 0;
+    harness.counters.keys = 0;
+
+    await act(async () => {
+      harness.queueMapsThenReorder("sort", "c", 4, "Gamma queued first");
+      await flushCompilerUpdates();
+    });
+
+    expect(labels(container)).toEqual(["Beta:1", "Alpha:3", "Gamma queued first:4"]);
+    expect([...container.querySelectorAll("li")]).toEqual([
+      rows.get("b"),
+      rows.get("a"),
+      rows.get("c"),
     ]);
     expect(harness.counters.keys).toBe(1);
     expect(harness.counters.descriptors).toBe(0);
@@ -1047,6 +1174,37 @@ describe("compiled keyed-array map and reorder hints", () => {
       await flushCompilerUpdates();
     });
     expect(labels(container)).toEqual(["Queued custom after reverse:2", "Queued replacement:1"]);
+    expect(harness.counters.bindings).toBe(2);
+  });
+
+  it("falls back safely when a queued custom map or changed key precedes a reorder", async () => {
+    const harness = createHarness([
+      { id: "a", label: "Alpha", rank: 2 },
+      { id: "b", label: "Beta", rank: 1 },
+    ]);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Table />));
+    harness.counters.bindings = 0;
+
+    await act(async () => {
+      harness.queueCustomMapBeforeReverse();
+      await flushCompilerUpdates();
+    });
+    expect(labels(container)).toEqual(["Beta:1", "Queued custom before reverse:2"]);
+    expect(harness.counters.bindings).toBe(2);
+
+    harness.counters.bindings = 0;
+    await act(async () => {
+      harness.queueInvalidateKeyBeforeReverse();
+      await flushCompilerUpdates();
+    });
+    expect(labels(container)).toEqual([
+      "Queued custom before reverse:2",
+      "Queued replacement before reverse:1",
+    ]);
     expect(harness.counters.bindings).toBe(2);
   });
 
@@ -1153,14 +1311,14 @@ describe("compiled keyed-array map and reorder hints", () => {
       initialize: () => [initialItems],
       render(_props: Record<string, never>, state, blocks) {
         const items = () => state[0].get() as Item[];
-        update = () =>
+        update = () => {
           state[0].set((previous) =>
-            hintedReverse(
-              hintedMap(previous as Item[], (item) =>
-                item.id === "a" ? { ...item, label: "Alpha newest" } : item,
-              ),
+            queuedHintedMap(previous as Item[], (item) =>
+              item.id === "a" ? { ...item, label: "Alpha newest" } : item,
             ),
           );
+          state[0].set((previous) => hintedReverse(previous as Item[]));
+        };
         return (
           <section>
             <blocks.KeyedRows
@@ -1236,14 +1394,14 @@ describe("compiled keyed-array map and reorder hints", () => {
       ],
       render(_props: Record<string, never>, state, blocks) {
         const items = () => state[0].get() as Item[];
-        update = () =>
+        update = () => {
           state[0].set((previous) =>
-            hintedReverse(
-              hintedMap(previous as Item[], (item) =>
-                item.id === "b" ? { ...item, rank: 0, label: "Beta newest" } : item,
-              ),
+            queuedHintedMap(previous as Item[], (item) =>
+              item.id === "b" ? { ...item, rank: 0, label: "Beta newest" } : item,
             ),
           );
+          state[0].set((previous) => hintedReverse(previous as Item[]));
+        };
         return (
           <section>
             <blocks.KeyedRows
@@ -1644,6 +1802,75 @@ describe("compiled keyed-array map and reorder hints", () => {
     120_000,
   );
 
+  stressIt(
+    "matches React through 2,000 queued map then reorder updates",
+    async () => {
+      const initialItems = Array.from(
+        { length: 31 },
+        (_, index): Item => ({ id: `row-${index}`, label: `Row ${index}`, rank: index }),
+      );
+      const harness = createHarness(initialItems);
+      let updateReact: (
+        kind: "reverse" | "sort",
+        id: string,
+        rank: number,
+        label: string,
+      ) => void = () => undefined;
+      function Normal() {
+        const [items, setItems] = useState(initialItems);
+        updateReact = (kind, id, rank, label) => {
+          setItems((previous) =>
+            previous.map((item) => (item.id === id ? { ...item, label } : item)),
+          );
+          setItems((previous) =>
+            previous.map((item) => (item.id === id ? { ...item, rank } : item)),
+          );
+          setItems((previous) =>
+            kind === "reverse"
+              ? previous.toReversed()
+              : previous.toSorted((left, right) => left.rank - right.rank),
+          );
+        };
+        return (
+          <ol>
+            {items.map((item) => (
+              <li data-key={item.id} key={item.id}>
+                {item.label}:{item.rank}
+              </li>
+            ))}
+          </ol>
+        );
+      }
+      const compiledContainer = document.createElement("div");
+      const reactContainer = document.createElement("div");
+      document.body.append(compiledContainer, reactContainer);
+      const compiledRoot = createRoot(compiledContainer);
+      const reactRoot = createRoot(reactContainer);
+      roots.push(compiledRoot, reactRoot);
+      await act(async () => {
+        compiledRoot.render(<harness.Table />);
+        reactRoot.render(<Normal />);
+      });
+
+      let seed = 0x7f4a7c15;
+      for (let update = 0; update < 2_000; update += 1) {
+        seed = (Math.imul(seed, 1_664_525) + 1_013_904_223) >>> 0;
+        const kind = seed & 1 ? "reverse" : "sort";
+        const id = `row-${seed % initialItems.length}`;
+        const rank = (seed ^ (seed >>> 16)) % 4_003;
+        const label = `Queued map reorder ${update}`;
+        await act(async () => {
+          harness.queueMapsThenReorder(kind, id, rank, label);
+          updateReact(kind, id, rank, label);
+          await flushCompilerUpdates();
+        });
+        expect(labels(compiledContainer)).toEqual(labels(reactContainer));
+      }
+      expect(harness.counters.executions).toBe(1);
+    },
+    120_000,
+  );
+
   it("hydrates in StrictMode and drops a queued update after unmount", async () => {
     const initialItems: Item[] = [
       { id: "a", label: "Alpha", rank: 1 },
@@ -1684,6 +1911,17 @@ describe("compiled keyed-array map and reorder hints", () => {
     ]);
     expect([...container.querySelectorAll("li")]).toEqual(hydratedRows.toReversed());
     expect(recoverable).toEqual([]);
+    await act(async () => {
+      hydration.queueMapsThenReorder("reverse", "c", 8, "Gamma mapped hydration");
+      await flushCompilerUpdates();
+    });
+    expect(labels(container)).toEqual([
+      "Alpha hydrated:5",
+      "Beta reordered hydration:7",
+      "Gamma mapped hydration:8",
+    ]);
+    expect([...container.querySelectorAll("li")]).toEqual(hydratedRows);
+    expect(recoverable).toEqual([]);
 
     const unmounted = createHarness(initialItems);
     const unmountContainer = document.createElement("div");
@@ -1691,7 +1929,7 @@ describe("compiled keyed-array map and reorder hints", () => {
     const unmountRoot = createRoot(unmountContainer);
     await act(async () => unmountRoot.render(<unmounted.Table />));
     act(() => {
-      unmounted.queueReorderThenMaps("sort", "b", 8, "Never committed");
+      unmounted.queueMapsThenReorder("sort", "b", 8, "Never committed");
       unmountRoot.unmount();
     });
     await flushCompilerUpdates();

--- a/packages/farm-react/src/compiler-runtime.tsx
+++ b/packages/farm-react/src/compiler-runtime.tsx
@@ -749,15 +749,22 @@ function recordCompilerKeyedArrayQueuedMapPipeline(previous: unknown, value: unk
       return value;
     }
 
-    const previousReorder = COMPILER_KEYED_ARRAY_REORDERS.get(previousTarget);
+    const committedSource = COMPILER_KEYED_COMMITTED_COLLECTIONS.has(previousTarget);
+    const previousReorder = committedSource
+      ? undefined
+      : COMPILER_KEYED_ARRAY_REORDERS.get(previousTarget);
     if (
-      !previousReorder ||
-      previousReorder.structuralUpdate ||
-      previousReorder.resultLength !== previous.length
+      !committedSource &&
+      (!previousReorder ||
+        previousReorder.structuralUpdate ||
+        previousReorder.resultLength !== previous.length)
     ) {
       return value;
     }
-    const sourceItems = previousReorder.mappedItemSources?.queuedSourceItems || previous;
+    const sourceToken =
+      previousReorder?.sourceToken || compilerKeyedCollectionToken(previousTarget);
+    if (!sourceToken) return value;
+    const sourceItems = previousReorder?.mappedItemSources?.queuedSourceItems || previous;
     let mappedItemSources: Map<unknown, unknown> | undefined;
     const readMappedItemSources = (): Map<unknown, unknown> => {
       if (mappedItemSources) return mappedItemSources;
@@ -781,12 +788,12 @@ function recordCompilerKeyedArrayQueuedMapPipeline(previous: unknown, value: unk
       return sources;
     };
     COMPILER_KEYED_ARRAY_REORDERS.set(valueTarget, {
-      kind: previousReorder.kind,
-      sourceToken: previousReorder.sourceToken,
-      sourceLength: previousReorder.sourceLength,
+      kind: previousReorder?.kind,
+      sourceToken,
+      sourceLength: previousReorder?.sourceLength ?? previous.length,
       resultLength: value.length,
       mapped: true,
-      // Array.map preserves positions. Retain the first post-reorder collection and validate its
+      // Array.map preserves positions. Retain the first queued source collection and validate its
       // data properties against the final collection once, immediately before the DOM commit.
       // This avoids rescanning every intermediate Array produced by separately queued setters.
       mappedItemSources: {
@@ -801,7 +808,7 @@ function recordCompilerKeyedArrayQueuedMapPipeline(previous: unknown, value: unk
   return value;
 }
 
-/** @internal Executes a queued native map after a compiler-proven keyed-array reorder. */
+/** @internal Executes a queued native map next to a compiler-proven keyed-array reorder. */
 export function createCompilerKeyedArrayQueuedMapPipeline(
   previous: unknown,
   pipeline: (...values: readonly unknown[]) => unknown,

--- a/packages/farm-react/src/compiler.ts
+++ b/packages/farm-react/src/compiler.ts
@@ -2403,6 +2403,155 @@ function rewriteQueuedKeyedArrayReorderMapHints(
   };
 }
 
+function rewriteQueuedKeyedArrayMapReorderHints(
+  root: t.JSXElement,
+  statesBySetter: ReadonlyMap<string, StateBinding>,
+  mapUpdateIdentifier: t.Identifier,
+  queuedMapPipelineIdentifier: t.Identifier,
+  mapReorderIdentifier: t.Identifier,
+  reorderIdentifier: t.Identifier,
+  sortIdentifier: t.Identifier,
+  structuralReorderIdentifier: t.Identifier,
+  structuralSortIdentifier: t.Identifier,
+  allowed: boolean,
+): {
+  root: t.JSXElement;
+  mapCount: number;
+  mapReorderCount: number;
+  mapSortCount: number;
+} {
+  if (!allowed) {
+    return {
+      root: t.cloneNode(root, true),
+      mapCount: 0,
+      mapReorderCount: 0,
+      mapSortCount: 0,
+    };
+  }
+  const file = expressionFile(t.cloneNode(root, true));
+  let mapCount = 0;
+  let mapReorderCount = 0;
+  let mapSortCount = 0;
+
+  traverse(file, {
+    BlockStatement(path) {
+      let pendingMaps: Array<{
+        count: number;
+        stateIndex: number;
+        updater: t.ArrowFunctionExpression & { body: t.CallExpression };
+      }> = [];
+      const statements = path.get("body") as NodePath<t.Statement>[];
+      for (const statementPath of statements) {
+        const statement = statementPath.node;
+        if (!t.isExpressionStatement(statement) || !t.isCallExpression(statement.expression)) {
+          pendingMaps = [];
+          continue;
+        }
+        const setterCall = statement.expression;
+        if (
+          !t.isIdentifier(setterCall.callee) ||
+          statementPath.scope.hasBinding(setterCall.callee.name) ||
+          setterCall.arguments.length !== 1
+        ) {
+          pendingMaps = [];
+          continue;
+        }
+        const state = statesBySetter.get(setterCall.callee.name);
+        const updater = setterCall.arguments[0];
+        if (
+          !state ||
+          !t.isArrowFunctionExpression(updater) ||
+          updater.async ||
+          updater.generator ||
+          updater.params.length !== 1 ||
+          !t.isIdentifier(updater.params[0])
+        ) {
+          pendingMaps = [];
+          continue;
+        }
+
+        if (
+          t.isCallExpression(updater.body) &&
+          t.isIdentifier(updater.body.callee, { name: mapUpdateIdentifier.name }) &&
+          updater.body.arguments.length === 2
+        ) {
+          const pipeline = updater.body.arguments[1];
+          let pipelineMapCount = 0;
+          if (
+            t.isArrowFunctionExpression(pipeline) &&
+            pipeline.params.length === 2 &&
+            t.isIdentifier(pipeline.params[1])
+          ) {
+            const applyMapName = pipeline.params[1].name;
+            t.traverseFast(pipeline.body, (node) => {
+              if (t.isCallExpression(node) && t.isIdentifier(node.callee, { name: applyMapName })) {
+                pipelineMapCount += 1;
+              }
+            });
+          }
+          if (pipelineMapCount > 0) {
+            const candidate = {
+              count: pipelineMapCount,
+              stateIndex: state.index,
+              updater: updater as t.ArrowFunctionExpression & { body: t.CallExpression },
+            };
+            pendingMaps =
+              pendingMaps[0]?.stateIndex === state.index
+                ? [...pendingMaps, candidate]
+                : [candidate];
+            continue;
+          }
+        }
+
+        const reorderCalls: Array<{
+          call: t.CallExpression;
+          kind: "reverse" | "sort";
+        }> = [];
+        let structural = false;
+        t.traverseFast(updater.body, (node) => {
+          if (!t.isCallExpression(node) || !t.isIdentifier(node.callee)) return;
+          if (
+            node.callee.name === structuralReorderIdentifier.name ||
+            node.callee.name === structuralSortIdentifier.name
+          ) {
+            structural = true;
+          } else if (node.callee.name === reorderIdentifier.name) {
+            reorderCalls.push({ call: node, kind: "reverse" });
+          } else if (node.callee.name === sortIdentifier.name) {
+            reorderCalls.push({ call: node, kind: "sort" });
+          }
+        });
+        if (
+          structural ||
+          reorderCalls.length === 0 ||
+          pendingMaps.length === 0 ||
+          pendingMaps[0].stateIndex !== state.index
+        ) {
+          pendingMaps = [];
+          continue;
+        }
+
+        for (const candidate of pendingMaps) {
+          candidate.updater.body.callee = t.cloneNode(queuedMapPipelineIdentifier);
+          mapCount += candidate.count;
+        }
+        for (const { call, kind } of reorderCalls) {
+          call.callee = t.cloneNode(mapReorderIdentifier);
+          if (kind === "reverse") mapReorderCount += 1;
+          else mapSortCount += 1;
+        }
+        pendingMaps = [];
+      }
+    },
+  });
+  return {
+    root: (file.program.body[0] as t.ExpressionStatement).expression as t.JSXElement,
+    mapCount,
+    mapReorderCount,
+    mapSortCount,
+  };
+}
+
 function rewriteKeyedArraySortHints(
   root: t.JSXElement,
   hintedStateIndices: ReadonlySet<number>,
@@ -8102,7 +8251,7 @@ function compileCandidate(
       optimizationCounts.keyedArrayFilterHints += filterHintedRoot.count;
     }
   }
-  const queuedReorderMapHintedRoot = rewriteQueuedKeyedArrayReorderMapHints(
+  const queuedMapReorderHintedRoot = rewriteQueuedKeyedArrayMapReorderHints(
     expandedReactiveRoot,
     statesBySetter,
     keyedMapUpdateIdentifier,
@@ -8114,8 +8263,21 @@ function compileCandidate(
     keyedArrayStructuralSortIdentifier,
     allowKeyedArrayMapPipelines,
   );
+  const queuedReorderMapHintedRoot = rewriteQueuedKeyedArrayReorderMapHints(
+    queuedMapReorderHintedRoot.root,
+    statesBySetter,
+    keyedMapUpdateIdentifier,
+    keyedArrayQueuedMapPipelineIdentifier,
+    keyedArrayMapReorderIdentifier,
+    keyedArrayReorderIdentifier,
+    keyedArraySortIdentifier,
+    keyedArrayStructuralReorderIdentifier,
+    keyedArrayStructuralSortIdentifier,
+    allowKeyedArrayMapPipelines,
+  );
   let appliedQueuedReorderMapHints = 0;
-  if (queuedReorderMapHintedRoot.mapCount > 0) {
+  const queuedMapCount = queuedMapReorderHintedRoot.mapCount + queuedReorderMapHintedRoot.mapCount;
+  if (queuedMapCount > 0) {
     const hintedBlockAnalysis = analyzeComposableBlocks(
       queuedReorderMapHintedRoot.root,
       reactiveByValue,
@@ -8136,9 +8298,11 @@ function compileCandidate(
       expandedReactiveRoot = queuedReorderMapHintedRoot.root;
       blockAnalysis = hintedBlockAnalysis;
       analysis = hintedAnalysis;
-      appliedQueuedReorderMapHints = queuedReorderMapHintedRoot.mapCount;
-      compilerUsage.keyedArrayMapUpdateHints += queuedReorderMapHintedRoot.mapCount;
-      compilerUsage.keyedArrayQueuedMapUpdateHints += queuedReorderMapHintedRoot.mapCount;
+      appliedQueuedReorderMapHints = queuedMapCount;
+      compilerUsage.keyedArrayMapUpdateHints += queuedMapCount;
+      compilerUsage.keyedArrayQueuedMapUpdateHints += queuedMapCount;
+      compilerUsage.keyedArrayMapReorderHints += queuedMapReorderHintedRoot.mapReorderCount;
+      compilerUsage.keyedArrayMapSortHints += queuedMapReorderHintedRoot.mapSortCount;
     }
   }
   const keyedCollectionTargetKinds = new Map<number, KeyedCollectionTargetKind>();
@@ -8614,6 +8778,8 @@ export async function compileReactModule(
 
         const hasEagerKeyedArrayMapUpdateHints =
           compilerUsage.keyedArrayMapUpdateHints > compilerUsage.keyedArrayQueuedMapUpdateHints;
+        const hasKeyedArrayMapReorderHints =
+          compilerUsage.keyedArrayMapReorderHints + compilerUsage.keyedArrayMapSortHints > 0;
         if (compiled.length > 0) {
           programPath.unshiftContainer(
             "body",
@@ -8637,6 +8803,10 @@ export async function compileReactModule(
                         keyedArrayMapPipelineIdentifier,
                         t.identifier("createCompilerKeyedArrayMapPipeline"),
                       ),
+                    ]
+                  : []),
+                ...(hasKeyedArrayMapReorderHints
+                  ? [
                       t.importSpecifier(
                         keyedArrayMapReorderIdentifier,
                         t.identifier("createCompilerKeyedArrayMapReorder"),

--- a/packages/farm-react/vitest.stress.config.ts
+++ b/packages/farm-react/vitest.stress.config.ts
@@ -20,7 +20,7 @@ export default defineConfig({
     ],
     setupFiles: ["src/__tests__/stress.setup.ts"],
     testNamePattern:
-      /2,000 deterministic mapped reorder updates|2,000 deterministic mapped reversal parity updates|2,000 queued reverse, map, and reverse updates|2,000 reverse-or-sort then map updates|2,000 queued reorder then standalone map updates|3,000 deterministic recursive updates|4,096 rows/,
+      /2,000 deterministic mapped reorder updates|2,000 deterministic mapped reversal parity updates|2,000 queued reverse, map, and reverse updates|2,000 reverse-or-sort then map updates|2,000 queued reorder then standalone map updates|2,000 queued map then reorder updates|3,000 deterministic recursive updates|4,096 rows/,
     testTimeout: 30_000,
   },
 });


### PR DESCRIPTION
## Problem

Farm can retain keyed reorder proof when a concise reorder setter is followed by adjacent safe map setters, but the mirror sequence loses the proof:

```tsx
setRows((current) => current.map(updateLabel));
setRows((current) => current.map(updateRank));
setRows((current) => current.toReversed());
```

React still produces the correct state, but the compiler falls back to complete keyed reconciliation instead of carrying same-key replacement lineage into the final reverse or sort.

## Root cause

The compiler only linked standalone queued map helpers after a proven reorder. The queued runtime helper likewise required an existing reorder token, so it could not start lineage from the committed keyed collection.

## Change

- Detect adjacent concise same-state safe map setters followed by a native `toReversed()` or `toSorted()` setter.
- Record queued map lineage from either the committed collection or an existing reorder token.
- Reuse the existing map/reorder runtime and exact-reverse or permutation reconciliation paths.
- Keep the eager map-pipeline helper tree-shaken from queued-only output.
- Add a production benchmark control and documentation for the supported sequence.

## Safety and compatibility

Every native map, reverse, and sort still executes normally. Before optimized DOM work, the runtime validates ordinary dense arrays, native methods, committed collection ownership, equal lengths, replacement lineage, and unchanged unique keys. Intervening statements, a different setter, structural updates, host-backed rows, custom methods, changed keys, sparse/subclassed arrays, or failed validation use complete React-compatible reconciliation.

No public API or configuration is added. Compiler-disabled builds are unchanged, and queued-only output does not import the eager map-pipeline helper.

## Verification

- `pnpm --filter @farm.js/react type-check`
- Focused compiler/runtime tests: 34 passed, 6 skipped stress cases
- New deterministic differential stress: 2,000 updates passed
- Full React unit run: 719 passed; one unrelated nested-row stress test hit its existing 20-second limit under full-suite concurrency and passed alone in 2.29 seconds
- `pnpm --filter @farm.js/react test:stress`: 9 passed
- `pnpm --filter @farm.js/react test:compat`: React 18.3.1 and 19.2.8 passed
- `pnpm --filter @farm.js/react test:runtime-size`: passed
- Node 22.13.1 runtime-size check: existing keyed map/reorder premium remains 13,341 B gzip
- Dashboard type-check and production build: passed
- Docs navigation and Vercel production build: passed
- Full production browser benchmark: correctness, primary regression, optimization persistence, and every feature gate passed
- New 10,000-row queued map-then-reorder gate:
  - static: 21.9 ms, 12.25x faster than React, 1.70x faster than complete reconciliation
  - hybrid: 22.6 ms, 11.87x faster than React, 1.58x faster than complete reconciliation

## Documentation and release

Updated the React renderer guide, package README, and compiler dashboard benchmark README. No version or release-flow change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lets the compiler carry keyed replacement lineage through queued map setters into a following native reverse or sort setter, so those sequences reconcile once instead of falling back to complete keyed reconciliation.

**Details**
- Records queued map lineage from the committed collection or an existing reorder token.
- Only adjacent concise same-setter calls are linked; intervening statements or unsupported updates keep the fallback.
- Adds a production benchmark gate and documentation for the supported sequence.
- No public API or configuration changes.

<sup>Written for commit fca93f286142e557c7060aeec642cf53146500ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/822?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

