### PR TITLE
fix(core): protect public search parameter parsing

### DIFF
--- a/packages/farm/src/__tests__/utils.test.ts
+++ b/packages/farm/src/__tests__/utils.test.ts
@@ -2,6 +2,7 @@ import path from "path";
 import { describe, it, expect } from "vitest";
 import {
   parseRoutePath,
+  parseSearchParams,
   matchRoute,
   matchRoutePrefix,
   segmentsToPattern,
@@ -77,6 +78,17 @@ describe("toRootRelativeUrlPath", () => {
 
   it("returns an empty path for the root itself", () => {
     expect(toRootRelativeUrlPath("/workspace/app", "/workspace/app")).toBe("");
+  });
+});
+
+describe("parseSearchParams", () => {
+  it("drops prototype-poisoning keys without changing the returned prototype", () => {
+    const result = parseSearchParams(
+      new URLSearchParams("__proto__=a&__proto__=b&constructor=c&prototype=d&tag=x&tag=y"),
+    );
+
+    expect(Object.getPrototypeOf(result)).toBe(Object.prototype);
+    expect(result).toEqual({ tag: ["x", "y"] });
   });
 });
 

--- a/packages/farm/src/utils.ts
+++ b/packages/farm/src/utils.ts
@@ -1,6 +1,7 @@
 import type { RouteSegment, ParsedRoute } from "./types";
 import path from "path";
 import { assertTerminalCatchAll, assertUniqueRouteParameters } from "./routing/specificity";
+import { searchParamsToObject } from "./search-params";
 import { decodeRouteSegment } from "./utils/decode";
 
 export function parseRoutePath(filePath: string): ParsedRoute {
@@ -219,22 +220,7 @@ export async function globFiles(pattern: string, cwd: string): Promise<string[]>
 export function parseSearchParams(
   searchParams: URLSearchParams,
 ): Record<string, string | string[]> {
-  const result: Record<string, string | string[]> = {};
-
-  for (const [key, value] of searchParams.entries()) {
-    if (key in result) {
-      const existing = result[key];
-      if (Array.isArray(existing)) {
-        existing.push(value);
-      } else {
-        result[key] = [existing, value];
-      }
-    } else {
-      result[key] = value;
-    }
-  }
-
-  return result;
+  return searchParamsToObject(searchParams) as Record<string, string | string[]>;
 }
 
 export const logger = {


### PR DESCRIPTION
## Problem

The public `parseSearchParams()` helper accepted `__proto__`, `constructor`, and `prototype` keys. Repeated `__proto__` values changed the prototype of the returned object instead of producing an ordinary search parameter.

## Root cause

The legacy helper maintained its own plain-object conversion loop and did not receive the reserved-key hardening already used by Farm's route search-parameter runtime.

## Change

Delegate `parseSearchParams()` to the canonical `searchParamsToObject()` helper and add regression coverage for reserved and repeated keys.

## Safety and compatibility

Ordinary single and repeated search parameters keep the same representation. Only prototype-sensitive property names are dropped, matching the existing API and route-input behavior.

## Verification

- `pnpm --filter @farm.js/core exec vitest run src/__tests__/utils.test.ts src/__tests__/searchparams.test.ts`
- `pnpm --filter @farm.js/core type-check`
- `pnpm exec oxfmt --check packages/farm/src/utils.ts packages/farm/src/__tests__/utils.test.ts`
- `pnpm exec oxlint packages/farm/src/utils.ts packages/farm/src/__tests__/utils.test.ts`

The regression test fails without the delegation because the returned object's prototype becomes an array.

## Documentation and release

None. This aligns an existing public helper with the documented route search-parameter safety behavior.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `parseSearchParams()` so `__proto__`, `constructor`, and `prototype` keys no longer alter the returned object's prototype, matching the safety already used by route search-parameter parsing.

- Delegates parsing to `searchParamsToObject()` instead of maintaining a separate loop.
- Adds a regression test covering reserved keys and repeated values.
- No change for ordinary or repeated search parameters.

<sup>Written for commit 7923401dd2e2970ad626282e88f38c25317b0772. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/823?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

