### PR TITLE
fix(layers): use valid Vite IDs for external modules

### DIFF
--- a/packages/farm/src/__tests__/layers.test.ts
+++ b/packages/farm/src/__tests__/layers.test.ts
@@ -15,6 +15,7 @@ import {
 import { MiddlewareManager } from "../middleware/manager";
 import { discoverMiddlewareRoutes, hasFarmRuntimeConfigModule } from "../nitro/universal-build";
 import { RouteManager } from "../routing/route-manager";
+import { createProgrammaticRouteModuleId } from "../routes-shared";
 import { farmPlugin } from "../vite";
 
 const temporaryRoots: string[] = [];
@@ -363,6 +364,20 @@ describe("Farm layers", () => {
       "#layers/commerce": path.join(layerRoot, "src"),
     });
     expect(viteConfig.server.fs.allow).toEqual([root, layerRoot]);
+  });
+
+  it("imports an external programmatic route through Vite's filesystem namespace", async () => {
+    const root = createProject();
+    const externalRoot = realpathSync(mkdtempSync(path.join(tmpdir(), "farm-external-layer-")));
+    temporaryRoots.push(externalRoot);
+    const routeFile = writeSource(externalRoot, "src/routes.ts");
+    const plugin = farmPlugin({ root });
+    const moduleId = createProgrammaticRouteModuleId(routeFile, "page", "/reports");
+
+    const source = await (plugin.load as (id: string) => Promise<string>)(moduleId);
+
+    expect(source).toContain(`from ${JSON.stringify(`/@fs${routeFile}`)}`);
+    expect(source).not.toContain(`from ${JSON.stringify(routeFile)}`);
   });
 });
 

--- a/packages/farm/src/__tests__/layers.test.ts
+++ b/packages/farm/src/__tests__/layers.test.ts
@@ -16,6 +16,7 @@ import { MiddlewareManager } from "../middleware/manager";
 import { discoverMiddlewareRoutes, hasFarmRuntimeConfigModule } from "../nitro/universal-build";
 import { RouteManager } from "../routing/route-manager";
 import { createProgrammaticRouteModuleId } from "../routes-shared";
+import { toViteModuleId } from "../utils";
 import { farmPlugin } from "../vite";
 
 const temporaryRoots: string[] = [];
@@ -376,7 +377,7 @@ describe("Farm layers", () => {
 
     const source = await (plugin.load as (id: string) => Promise<string>)(moduleId);
 
-    expect(source).toContain(`from ${JSON.stringify(`/@fs${routeFile}`)}`);
+    expect(source).toContain(`from ${JSON.stringify(toViteModuleId(routeFile, root))}`);
     expect(source).not.toContain(`from ${JSON.stringify(routeFile)}`);
   });
 });

--- a/packages/farm/src/__tests__/server-renderer-route-states.test.tsx
+++ b/packages/farm/src/__tests__/server-renderer-route-states.test.tsx
@@ -535,6 +535,44 @@ describe("file route loading.tsx and error.tsx", () => {
     );
   });
 
+  it("uses Vite filesystem module IDs for routes supplied by an external layer", async () => {
+    const response = createMockResponse();
+    const renderer = createRenderer(
+      {
+        [routeModulePath]: {
+          default: function DashboardPage() {
+            return React.createElement("main", null, "Layer dashboard");
+          },
+        },
+        [layoutModulePath]: {
+          default: function RootLayout({ children }: { children: React.ReactNode }) {
+            return React.createElement("section", null, children);
+          },
+        },
+        [loadingModulePath]: {
+          default: function DashboardLoading() {
+            return React.createElement("p", null, "Loading layer dashboard");
+          },
+        },
+      },
+      {
+        root: "/workspace/app",
+        clientMetadata: { isClientComponent: true, shouldHydrate: true },
+        layoutMetadata: { shouldHydrate: true },
+      },
+    );
+
+    await renderer.renderPage(createMockRequest("/dashboard"), response);
+
+    expect(response.body).toContain(
+      'window.__FARM_PAGE_MODULE__ = "/@fs/test/src/app/dashboard/page.tsx"',
+    );
+    expect(response.body).toContain('"modulePath":"/@fs/test/src/app/layout.tsx"');
+    expect(response.body).toContain(
+      'window.__FARM_LOADING_MODULE__ = "/@fs/test/src/app/dashboard/loading.tsx"',
+    );
+  });
+
   it("renders navigation fragments with stable page and nested layout boundaries", async () => {
     const renderer = createRenderer({});
     const html = await renderer.renderNavigationFragment({
@@ -748,6 +786,7 @@ function createRenderer(
     onGenerateClientManifest?: () => void;
     integrations?: FarmConfig["integrations"];
     basePath?: string;
+    root?: string;
   } = {},
 ) {
   const metadataImageEntry = {
@@ -922,7 +961,7 @@ function createRenderer(
 
   return new ServerRenderer(
     {
-      ...createConfig(),
+      ...createConfig(options.root),
       integrations: options.integrations ?? {},
       basePath: options.basePath ?? "/",
     },
@@ -930,9 +969,9 @@ function createRenderer(
   );
 }
 
-function createConfig(): Required<FarmConfig> {
+function createConfig(root = "/test"): Required<FarmConfig> {
   return {
-    root: "/test",
+    root,
     srcDir: "src",
     outDir: "dist",
     basePath: "/",

--- a/packages/farm/src/server/renderer.ts
+++ b/packages/farm/src/server/renderer.ts
@@ -10,7 +10,7 @@ import type {
   SSGPage,
 } from "../types";
 import type { MatchedRouteSlot, RouteManager } from "../routing/route-manager";
-import { logger, toRootRelativeUrlPath, toViteModuleId } from "../utils";
+import { logger, toViteModuleId } from "../utils";
 import { collectDevStylesheetUrls } from "./dev-styles";
 import {
   composeFarmFullDocument,
@@ -1393,7 +1393,7 @@ export class ServerRenderer {
       );
       const clientLayouts = layouts.map((layout, index) => ({
         pattern: layout.pattern,
-        modulePath: toRootRelativeUrlPath(layout.modulePath, this.config.root) ?? layout.modulePath,
+        modulePath: toViteModuleId(layout.modulePath, this.config.root),
         shouldHydrate: layoutHydrationMetadata[index]?.shouldHydrate === true,
         islandStrategy: layoutHydrationMetadata[index]?.islandStrategy ?? null,
         ...(layoutHydrationMetadata[index]?.hasIsolatedClientBoundaries === true
@@ -1432,9 +1432,7 @@ export class ServerRenderer {
       (req as any).__FARM_ISLAND_STRATEGY__ = hydrationIslandStrategy;
       (req as any).__FARM_HAS_HYDRATABLE_ROUTE_SLOTS__ = hasHydratableRouteSlots;
       (req as any).__FARM_LOADING_MODULE_PATH__ = loadingBoundaryEntry?.modulePath
-        ? loadingBoundaryEntry.modulePath.substring(
-            loadingBoundaryEntry.modulePath.indexOf("/src/app/"),
-          )
+        ? toViteModuleId(loadingBoundaryEntry.modulePath, this.config.root)
         : null;
       (req as any).__FARM_ROUTE_SLOTS__ = renderedRouteSlots.map((slot) => ({
         name: slot.name,
@@ -2208,7 +2206,7 @@ export class ServerRenderer {
           ...slot,
           modulePath:
             typeof slot.modulePath === "string"
-              ? (toRootRelativeUrlPath(slot.modulePath, this.config.root) ?? slot.modulePath)
+              ? toViteModuleId(slot.modulePath, this.config.root)
               : slot.modulePath,
         }),
       );
@@ -2218,7 +2216,7 @@ export class ServerRenderer {
       });
       const pagePath = (req as any).__FARM_PAGE_PATH__;
       const relativePath = pagePath
-        ? (toRootRelativeUrlPath(pagePath, this.config.root) ?? pagePath)
+        ? toViteModuleId(pagePath, this.config.root)
         : "/src/app/page.tsx";
       const deploymentId = this.getDeploymentId();
       const bootstrapScript = `<script>
@@ -2390,7 +2388,7 @@ ${getFarmI18nClientSnapshot() ? `window.__FARM_I18N__ = ${serializeInlineValue(g
       const pagePath = (req as any).__FARM_PAGE_PATH__;
       const isClientComponent = (req as any).__FARM_IS_CLIENT_COMPONENT__ === true;
       const relativePath = pagePath
-        ? (toRootRelativeUrlPath(pagePath, this.config.root) ?? pagePath)
+        ? toViteModuleId(pagePath, this.config.root)
         : "/src/app/page.tsx";
 
       // Generate manifest for client-side SPA navigation (TanStack Start pattern)
@@ -2459,7 +2457,7 @@ ${getFarmI18nClientSnapshot() ? `window.__FARM_I18N__ = ${serializeInlineValue(g
           ...slot,
           modulePath:
             typeof slot.modulePath === "string"
-              ? (toRootRelativeUrlPath(slot.modulePath, this.config.root) ?? slot.modulePath)
+              ? toViteModuleId(slot.modulePath, this.config.root)
               : slot.modulePath,
         }),
       );

--- a/packages/farm/src/vite.ts
+++ b/packages/farm/src/vite.ts
@@ -1201,10 +1201,7 @@ export function farmPlugin(
           ? (hydrationStrategies[0] ?? "load")
           : "load";
         const params = matchedRoute.params || {};
-        const toUrlPath = (absolutePath: string) =>
-          absolutePath.startsWith(farmConfig.root)
-            ? absolutePath.slice(farmConfig.root.length)
-            : absolutePath;
+        const toUrlPath = (absolutePath: string) => toViteModuleId(absolutePath, farmConfig.root);
         const clientLayouts = Object.fromEntries(
           layoutEntries.map((layout) => [
             layout.pattern,
@@ -2157,12 +2154,8 @@ window.__FARM_MANIFEST__ = ${inlineValue({
 
                 // Convert absolute paths to URL paths (relative to project root)
                 const projectRoot = server.config.root;
-                const toUrlPath = (absolutePath: string) => {
-                  if (absolutePath.startsWith(projectRoot)) {
-                    return absolutePath.slice(projectRoot.length);
-                  }
-                  return absolutePath;
-                };
+                const toUrlPath = (absolutePath: string) =>
+                  toViteModuleId(absolutePath, projectRoot);
 
                 const renderPlan = createFarmRouteRenderPlan({
                   pageShouldHydrate: shouldHydrate,
@@ -3522,11 +3515,7 @@ export const OPTIONS = __farmRoute.methods.OPTIONS;
 }
 
 function toProgrammaticRouteImportSpecifier(filePath: string, root?: string): string {
-  if (root && filePath.startsWith(root)) {
-    return filePath.slice(root.length) || "/";
-  }
-
-  return filePath;
+  return root ? toViteModuleId(filePath, root) : filePath;
 }
 
 type RouteModuleLike = {


### PR DESCRIPTION
## Problem

Routes and layouts inherited from a layer outside the application root were exposed to the development browser as raw absolute filesystem paths. Vite requires external files to use its `/@fs/` namespace. A sibling directory that merely shared the root prefix could also be sliced into an invalid relative path.

## Root cause

The docs adapter, page-data response, programmatic route module, and development SSR bootstrap each maintained ad hoc root-prefix slicing instead of using Farm's canonical Vite module-ID conversion.

## Change

Route every browser-reachable development module path through `toViteModuleId()`, including pages, layouts, loading boundaries, named slots, docs adapter layouts, SPA page-data payloads, and programmatic routes.

## Safety and compatibility

Files inside the app root retain their existing root-relative URLs. External files now receive `/@fs/...` URLs with normalized separators. Production output remains unchanged because these paths belong to Vite development rendering and module loading.

## Verification

- `pnpm --filter @farm.js/core exec vitest run src/__tests__/layers.test.ts src/__tests__/server-renderer-route-states.test.tsx src/__tests__/utils.test.ts`
- `pnpm --filter @farm.js/core type-check`
- `pnpm exec oxlint packages/farm/src/server/renderer.ts packages/farm/src/vite.ts packages/farm/src/__tests__/server-renderer-route-states.test.tsx packages/farm/src/__tests__/layers.test.ts`

The new tests fail without the change: external SSR bootstrap paths remain raw filesystem paths and external programmatic routes import without `/@fs`.

## Documentation and release

None. Existing layer support is unchanged; this fixes its development runtime path representation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes development module URLs for routes and layouts inherited from layers outside the app root. They now use Vite’s `/@fs/` namespace instead of raw absolute filesystem paths or invalid root-prefix slices; files inside the app root keep their existing URLs, and production output is unchanged.

- Applies the canonical conversion to page data, SSR bootstrap, loading boundaries, named slots, docs adapter layouts, and programmatic route imports.
- Adds regression coverage for external-layer SSR module paths and programmatic route loading, with assertions normalized through the same conversion.

<sup>Written for commit 6c51c65fe48feb499d31aa2cd52b5ffabdd3f2d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/824?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

