### PR TITLE
fix(navigation): preserve native link handling in development

### DIFF
--- a/packages/farm/src/__tests__/vite-config.test.ts
+++ b/packages/farm/src/__tests__/vite-config.test.ts
@@ -54,6 +54,21 @@ describe("Farm Vite publicDir", () => {
   });
 });
 
+describe("Farm Vite link delegation", () => {
+  it("preserves download links and application click cancellation", async () => {
+    const plugin = farmPlugin({});
+    const source = await (plugin.load as (id: string) => Promise<string>)("/@farm/client");
+    const start = source.indexOf("// ====== EVENT DELEGATION FOR LINKS ======");
+    const end = source.indexOf("if (import.meta.hot)", start);
+    const delegation = source.slice(start, end);
+
+    expect(delegation).toContain("if (target.hasAttribute('download')) return;");
+    expect(delegation).toContain("if (event.defaultPrevented) return;");
+    expect(delegation).toContain("hasAbsoluteNavigationHref(href)");
+    expect(delegation).not.toContain("}, true)");
+  });
+});
+
 describe("Farm Vite type artifacts", () => {
   it("warns when startup generation leaves farm.d.ts stale", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "farm-vite-type-warning-"));

--- a/packages/farm/src/vite.ts
+++ b/packages/farm/src/vite.ts
@@ -5022,8 +5022,8 @@ function isModifierEvent(e) {
   return !!(e.metaKey || e.altKey || e.ctrlKey || e.shiftKey);
 }
 
-function isExternalUrl(href) {
-  return href.startsWith('http://') || href.startsWith('https://') || href.startsWith('//');
+function hasAbsoluteNavigationHref(href) {
+  return /^[a-zA-Z][a-zA-Z\\d+.-]*:/.test(href) || href.startsWith('//');
 }
 
 document.addEventListener('click', function(event) {
@@ -5039,9 +5039,10 @@ document.addEventListener('click', function(event) {
   
   const href = target.getAttribute('href');
   if (!href) return;
+  if (target.hasAttribute('download')) return;
   
-  // Don't intercept external links
-  if (isExternalUrl(href)) return;
+  // Leave absolute URLs and non-HTTP schemes to the browser.
+  if (hasAbsoluteNavigationHref(href)) return;
   
   // Don't intercept hash-only links
   if (href.startsWith('#')) return;
@@ -5069,7 +5070,7 @@ document.addEventListener('click', function(event) {
     : viewTransitionValue === 'true';
   
   spaRouter.navigate(href, { replace, scroll, viewTransition });
-}, true);  // Use capture phase to handle before React
+});
 
 if (import.meta.hot) {
   import.meta.hot.on('vite:beforeUpdate', () => {


### PR DESCRIPTION
## Problem

Development's document-level link delegation ran in the capture phase, before React or application bubble handlers could cancel a click. It also intercepted internal anchors carrying `download`, unlike both Farm's `Link` component and the production runtime.

## Root cause

The generated Vite client used an older standalone click handler whose opt-outs and event phase had drifted from the production navigation contract.

## Change

Run document delegation during normal bubbling, skip download anchors, and recognize every absolute URI scheme before invoking the SPA router.

## Safety and compatibility

Ordinary unmodified same-origin links still use SPA navigation. Application `preventDefault()`, downloads, targets, modifier clicks, hash links, external URLs, and non-HTTP schemes stay under native browser control. Production behavior is unchanged.

## Verification

- `pnpm --filter @farm.js/core exec vitest run src/__tests__/vite-config.test.ts src/__tests__/link.test.tsx src/__tests__/client-component.test.ts`
- `pnpm --filter @farm.js/core type-check`
- `pnpm exec oxlint packages/farm/src/vite.ts packages/farm/src/__tests__/vite-config.test.ts`

The generated-client regression fails without this change because it contains capture-phase registration and no download opt-out.

## Documentation and release

None. This restores the existing documented `Link` and native-anchor behavior in development.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes dev-mode link delegation so native browser control is preserved for download links, application `preventDefault()` calls, modified clicks, targets, hash links, and non-HTTP schemes.

- The delegation listener now runs during bubbling instead of capture, so app handlers run first.
- Absolute URLs and anchors with a `download` attribute are left to the browser; unmodified same-origin links still navigate via the SPA router.

<sup>Written for commit 3d5b19a4cd07a240c6fa97d987ffb5590f4e0f11. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/825?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

