### PR TITLE
fix(images): reject unsafe optimizer paths

### DIFF
--- a/docs/src/app/docs/images/page.md
+++ b/docs/src/app/docs/images/page.md
@@ -134,19 +134,19 @@ export default defineConfig({
 });
 ```
 
-| Option                | Behavior                                                                                                                 |
-| --------------------- | ------------------------------------------------------------------------------------------------------------------------ |
-| `provider`            | `auto` uses Sharp on Node, Vercel, and Netlify, and Cloudflare Images on Cloudflare. Use `none` to disable optimization. |
-| `path`                | Public optimizer endpoint used by `Image` and the server runtime.                                                        |
-| `deviceSizes`         | Responsive viewport widths accepted by the endpoint.                                                                     |
-| `imageSizes`          | Smaller fixed image widths accepted by the endpoint.                                                                     |
-| `qualities`           | Quality allowlist. `Image` selects the nearest configured value.                                                         |
-| `formats`             | Preferred modern output formats, negotiated through the request `Accept` header and its quality values.                  |
-| `minimumCacheTTL`     | Browser and in-process transformed-image cache lifetime in seconds.                                                      |
-| `maximumResponseBody` | Maximum source and transformed body size. Accepts bytes or values such as `"10mb"`.                                      |
-| `maximumRedirects`    | Maximum remote redirects; every destination is checked again.                                                            |
-| `localPatterns`       | Allowed same-origin paths. The default is `/**`.                                                                         |
-| `remotePatterns`      | Allowed remote protocols, hostnames, ports, paths, and queries.                                                          |
+| Option                | Behavior                                                                                                                                       |
+| --------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `provider`            | `auto` uses Sharp on Node, Vercel, and Netlify, and Cloudflare Images on Cloudflare. Use `none` to disable optimization.                       |
+| `path`                | Root-relative optimizer endpoint used by `Image` and the server runtime. URLs, dot segments, backslashes, and encoded separators are rejected. |
+| `deviceSizes`         | Responsive viewport widths accepted by the endpoint.                                                                                           |
+| `imageSizes`          | Smaller fixed image widths accepted by the endpoint.                                                                                           |
+| `qualities`           | Quality allowlist. `Image` selects the nearest configured value.                                                                               |
+| `formats`             | Preferred modern output formats, negotiated through the request `Accept` header and its quality values.                                        |
+| `minimumCacheTTL`     | Browser and in-process transformed-image cache lifetime in seconds.                                                                            |
+| `maximumResponseBody` | Maximum source and transformed body size. Accepts bytes or values such as `"10mb"`.                                                            |
+| `maximumRedirects`    | Maximum remote redirects; every destination is checked again.                                                                                  |
+| `localPatterns`       | Allowed same-origin paths. The default is `/**`.                                                                                               |
+| `remotePatterns`      | Allowed remote protocols, hostnames, ports, paths, and queries.                                                                                |
 
 Pass a `loader` prop when an application already uses an image CDN. The loader receives `src`, `width`, and the configured `quality` and must return the final URL.
 

--- a/packages/farm/src/__tests__/image-config.test.ts
+++ b/packages/farm/src/__tests__/image-config.test.ts
@@ -51,6 +51,14 @@ describe("image config", () => {
 
   it("rejects unsafe or unusable config", () => {
     expect(() => resolveFarmImageConfig({ path: "images" })).toThrow("absolute pathname");
+    expect(() => resolveFarmImageConfig({ path: "//images.example.com/optimize" })).toThrow(
+      "absolute pathname",
+    );
+    expect(() => resolveFarmImageConfig({ path: "/images/../private" })).toThrow("path segments");
+    expect(() => resolveFarmImageConfig({ path: "/images/%2Fprivate" })).toThrow(
+      "percent-encoded path separators",
+    );
+    expect(() => resolveFarmImageConfig({ path: "/images\\private" })).toThrow("backslashes");
     expect(() => resolveFarmImageConfig({ qualities: [0, 101] })).toThrow("no greater than 100");
     expect(() => resolveFarmImageConfig({ deviceSizes: [] })).toThrow("must contain at least one");
     expect(() =>

--- a/packages/farm/src/image-config.ts
+++ b/packages/farm/src/image-config.ts
@@ -151,10 +151,41 @@ export function getPublicFarmImageConfig(
 }
 
 function normalizeImagePath(value: string): string {
+  const hasUnstableCharacters = (candidate: string) =>
+    candidate.includes("\\") ||
+    Array.from(candidate).some((character) => {
+      const code = character.charCodeAt(0);
+      return code <= 31 || (code >= 127 && code <= 159);
+    });
+
+  if (hasUnstableCharacters(value)) {
+    throw new TypeError("images.path cannot contain backslashes or control characters");
+  }
+
   const path = value.trim().replace(/\/+$/, "") || "/";
-  if (!path.startsWith("/") || path.includes("?") || path.includes("#")) {
+  if (!path.startsWith("/") || path.startsWith("//") || path.includes("?") || path.includes("#")) {
     throw new TypeError("images.path must be an absolute pathname without a query or hash");
   }
+
+  for (const segment of path.split("/")) {
+    let decoded = segment;
+    try {
+      decoded = decodeURIComponent(segment);
+    } catch {
+      // Malformed escapes remain literal and cannot conceal a path separator
+      // or dot segment.
+    }
+    if (hasUnstableCharacters(decoded)) {
+      throw new TypeError("images.path cannot contain backslashes or control characters");
+    }
+    if (decoded.includes("/")) {
+      throw new TypeError("images.path cannot contain percent-encoded path separators");
+    }
+    if (decoded === "." || decoded === "..") {
+      throw new TypeError('images.path cannot contain "." or ".." path segments');
+    }
+  }
+
   return path;
 }
 


### PR DESCRIPTION
## Problem

`images.path` accepted network-path references such as `//images.example.com/optimize` and ambiguous paths containing dot segments, backslashes, controls, or encoded separators. The generated browser image URL could therefore resolve to another origin or disagree with the mounted optimizer route.

## Root cause

Image configuration only checked for a leading slash, query, and hash. It did not apply the pathname safety rules already used by Farm's application mount paths.

## Change

Validate raw and decoded optimizer path segments, rejecting network-path URLs, unstable characters, dot segments, and percent-encoded separators. Document the accepted root-relative pathname contract.

## Safety and compatibility

The default endpoint and ordinary custom endpoints are unchanged. Previously accepted paths that browsers or servers reinterpret now fail during configuration with an actionable error.

## Verification

- `pnpm --filter @farm.js/core exec vitest run src/__tests__/image-config.test.ts src/__tests__/image.test.tsx src/__tests__/image-server.test.ts`
- `pnpm --filter @farm.js/core type-check`
- `pnpm exec oxlint packages/farm/src/image-config.ts packages/farm/src/__tests__/image-config.test.ts`

The regression cases fail without the change because protocol-relative, dot-segment, encoded-separator, and backslash paths are accepted.

## Documentation and release

Updated the Images configuration reference with the endpoint-path requirements.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects unsafe `images.path` values so the generated browser image URL cannot resolve to another origin or disagree with the mounted optimizer route. Previously accepted network-path references (like `//images.example.com/optimize`), dot segments, backslashes, control characters, and percent-encoded separators; these now fail during configuration with an actionable error. The default endpoint and ordinary custom endpoints are unchanged. Docs updated to describe the root-relative pathname contract.

<sup>Written for commit b645d098a8ec9288bb4119e219685007478f978d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/826?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

