### PR TITLE
fix(routing): reject reserved parameter names

### DIFF
--- a/docs/src/app/docs/routing/page.md
+++ b/docs/src/app/docs/routing/page.md
@@ -183,6 +183,8 @@ the `edit` segment and make the route unreachable.
 
 Each dynamic segment in one route must have a unique parameter name. Farm rejects paths such as
 `teams/[id]/members/[id]/page.tsx` instead of silently replacing the outer `id` value.
+The prototype-sensitive names `__proto__`, `constructor`, and `prototype` are reserved because
+JavaScript cannot represent them safely in the plain `params` object.
 For navigation state, `router.isActive(pattern, pathname, { exact: false })` also matches
 descendants after dynamic segments, such as `/users/42/settings` for `/users/[id]`.
 

--- a/packages/farm/src/__tests__/api-route-manager.test.ts
+++ b/packages/farm/src/__tests__/api-route-manager.test.ts
@@ -92,6 +92,19 @@ describe("APIRouteManager", () => {
     await expect(manager.discoverRoutes()).rejects.toThrow('Duplicate route parameter "id"');
   });
 
+  it("fails discovery for prototype-sensitive API parameter names", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "farm-api-route-"));
+    tempDirs.push(root);
+    const routeDir = path.join(root, "api", "users", "[__proto__]");
+    fs.mkdirSync(routeDir, { recursive: true });
+    fs.writeFileSync(path.join(routeDir, "route.ts"), "export const GET = () => new Response();\n");
+    const manager = new APIRouteManager(root, {
+      ssrLoadModule: async () => ({ GET: async () => new Response() }),
+    } as any);
+
+    await expect(manager.discoverRoutes()).rejects.toThrow('Route parameter "__proto__"');
+  });
+
   it("ignores empty programmatic routes and preserves API-literal syntax", async () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), "farm-api-route-"));
     tempDirs.push(root);

--- a/packages/farm/src/__tests__/router.test.ts
+++ b/packages/farm/src/__tests__/router.test.ts
@@ -57,6 +57,15 @@ describe("createFarmRouter", () => {
     );
   });
 
+  it("rejects prototype-sensitive names in router patterns", () => {
+    expect(() => createFarmRouter(["/users/:constructor"])).toThrow(
+      'Route parameter "constructor"',
+    );
+    expect(() => matchFarmRoute("/docs/*__proto__", "/docs/core/routing")).toThrow(
+      'Route parameter "__proto__"',
+    );
+  });
+
   it("rejects routes that differ only by parameter names", () => {
     expect(() => createFarmRouter(["/users/[id]", "/users/[slug]"])).toThrow(
       'Ambiguous route patterns "/users/[id]" and "/users/[slug]" match the same URLs.',

--- a/packages/farm/src/__tests__/utils.test.ts
+++ b/packages/farm/src/__tests__/utils.test.ts
@@ -136,6 +136,18 @@ describe("parseRoutePath", () => {
     }
   });
 
+  it("rejects prototype-sensitive parameter names in file routes", () => {
+    expect(() => parseRoutePath("users/[__proto__]/page.tsx")).toThrow(
+      'Route parameter "__proto__"',
+    );
+    expect(() => parseRoutePath("docs/[...constructor]/page.tsx")).toThrow(
+      'Route parameter "constructor"',
+    );
+    expect(() => parseRoutePath("docs/[[...prototype]]/page.tsx")).toThrow(
+      'Route parameter "prototype"',
+    );
+  });
+
   it("should parse root page", () => {
     const result = parseRoutePath("page.tsx");
     expect(result.segments).toEqual([]);

--- a/packages/farm/src/routing/specificity.ts
+++ b/packages/farm/src/routing/specificity.ts
@@ -21,6 +21,13 @@ export class DuplicateRouteParameterError extends AmbiguousRouteError {
   }
 }
 
+export class ReservedRouteParameterError extends AmbiguousRouteError {
+  constructor(message: string) {
+    super(message);
+    this.name = "ReservedRouteParameterError";
+  }
+}
+
 const SEGMENT_RANK: Record<RouteSegmentSpecificity, number> = {
   static: 4,
   dynamic: 3,
@@ -54,6 +61,7 @@ const ROUTER_PARAMETER_NAME = "[A-Za-z0-9_$-]+";
 const PAGE_PARAMETER_PATTERN = /^(?:\[\[\.\.\.(.+)\]\]|\[\.\.\.(.+)\]|\[(.+)\])$/;
 const ROUTER_PARAMETER_PATTERN =
   /^(?:\[\[\.\.\.([A-Za-z0-9_$-]+)\]\]|\[\.\.\.([A-Za-z0-9_$-]+)\]|\[([A-Za-z0-9_$-]+)\]|:([A-Za-z0-9_$-]+)|\*([A-Za-z0-9_$-]+)\??)$/;
+const RESERVED_PARAMETER_NAMES = new Set(["__proto__", "constructor", "prototype"]);
 
 export function assertUniqueRouteParameters(
   pattern: string,
@@ -66,6 +74,11 @@ export function assertUniqueRouteParameters(
     const match = parameterPattern.exec(segment);
     const name = match?.slice(1).find(Boolean);
     if (!name) continue;
+    if (RESERVED_PARAMETER_NAMES.has(name)) {
+      throw new ReservedRouteParameterError(
+        `Route parameter "${name}" in route "${pattern}" is reserved. Use a different parameter name.`,
+      );
+    }
     if (names.has(name)) {
       throw new DuplicateRouteParameterError(
         `Duplicate route parameter "${name}" in route "${pattern}". Each dynamic segment must use a unique name.`,


### PR DESCRIPTION
## Problem

Dynamic routes named `__proto__`, `constructor`, or `prototype` passed discovery, but Farm's plain `params` objects could not represent them reliably. A scalar `__proto__` value disappeared, while a catch-all value changed the returned object's prototype.

## Root cause

Route validation rejected duplicates and unreachable catch-alls but did not reject property names with special behavior on ordinary JavaScript objects.

## Change

Reject prototype-sensitive names through the shared route-specificity validator. Cover file routes, router patterns, programmatic routes, and API discovery, and document the reserved names.

## Safety and compatibility

All working parameter names retain their current behavior. The newly rejected routes did not expose the declared parameter correctly before this change. Every routing syntax now fails early with the same actionable error.

## Verification

- `pnpm --filter @farm.js/core exec vitest run src/__tests__/utils.test.ts src/__tests__/router.test.ts src/__tests__/api-route-manager.test.ts src/__tests__/programmatic-routes.test.ts`
- `pnpm --filter @farm.js/core type-check`
- `pnpm exec oxlint packages/farm/src/routing/specificity.ts packages/farm/src/__tests__/utils.test.ts packages/farm/src/__tests__/router.test.ts packages/farm/src/__tests__/api-route-manager.test.ts`
- `pnpm docs:check-navigation`

The new tests fail without the validator because each reserved route is accepted and produces an unusable parameter object.

## Documentation and release

Updated the routing guide's dynamic-parameter contract.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects dynamic routes that use the reserved parameter names `__proto__`, `constructor`, and `prototype` because JavaScript cannot safely represent them in the plain `params` object. Previously such routes were accepted but produced unreliable params (missing values or changed prototype). Now all routing paths — file routes, router patterns, programmatic routes, and API discovery — fail with the same actionable error. Valid parameter names are unaffected, and the routing guide now lists the reserved names.

<sup>Written for commit 87b00ba7fd4730d84fe52eb36b8a7bb665ab6e02. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/827?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

