### PR TITLE
fix(api): reject ambiguous API mount paths

### DIFF
--- a/docs/src/app/docs/configuration/page.md
+++ b/docs/src/app/docs/configuration/page.md
@@ -331,7 +331,9 @@ A root-relative API root is also mounted by Farm in development and production. 
 `api: { basePath: "/v2/api" }` makes a route declared at `app/api/users/route.ts` available at
 `/v2/api/users`. Farm treats an absolute `baseURL` as external and does not remount the current
 application's API routes for it. `basePath` rejects backslashes, control characters, and `.` or
-`..` segments so the server mount and browser URL cannot normalize to different paths.
+`..` segments, including encoded path separators. Root-relative `baseURL` and `basePath` values
+must begin with one slash; network-path references such as `//api.example.com` are rejected so the
+server mount and browser URL cannot resolve to different origins or paths.
 
 The option configures `createAPIClient()` automatically. An explicit per-client `baseURL` still
 takes precedence.

--- a/packages/farm/src/__tests__/api-config.test.ts
+++ b/packages/farm/src/__tests__/api-config.test.ts
@@ -98,6 +98,21 @@ describe("Farm API config", () => {
     expect(() => normalizeFarmAPIConfig({ basePath: "/api/%2e%2e/admin" })).toThrow(
       'cannot contain "." or ".." path segments',
     );
+    expect(() => normalizeFarmAPIConfig({ basePath: "/api/%2Fadmin" })).toThrow(
+      "cannot contain percent-encoded path separators",
+    );
+    expect(() => normalizeFarmAPIConfig({ basePath: "//api.example.com" })).toThrow(
+      "must be a pathname",
+    );
+    expect(() => normalizeFarmAPIConfig({ baseURL: "//api.example.com" })).toThrow(
+      "not a network-path reference",
+    );
+    expect(() => normalizeFarmAPIConfig({ baseURL: "/api/%2fadmin" })).toThrow(
+      "cannot contain percent-encoded path separators",
+    );
+    expect(() =>
+      normalizeFarmAPIConfig({ baseURL: "https://api.example.com/api/%2Fadmin" }),
+    ).toThrow("cannot contain percent-encoded path separators");
   });
 
   it("replaces the canonical /api prefix when the API root has a path", () => {

--- a/packages/farm/src/api/config.ts
+++ b/packages/farm/src/api/config.ts
@@ -54,6 +54,12 @@ export function normalizeFarmAPIConfig(
     return { baseURL: basePath, basePath };
   }
 
+  if (baseURL.startsWith("//")) {
+    throw new Error(
+      'Farm api.baseURL must be an absolute URL or a root-relative path such as "/api", not a network-path reference.',
+    );
+  }
+
   if (baseURL.startsWith("/")) {
     const url = parseRootRelativeBaseURL(baseURL);
     if (url.pathname !== "/") {
@@ -112,6 +118,9 @@ export function normalizeFarmAPIBasePath(value: string): string {
   if (path.includes("?") || path.includes("#")) {
     throw new Error("Farm api.basePath cannot contain a query string or hash.");
   }
+  if (path.startsWith("//")) {
+    throw new Error('Farm api.basePath must be a pathname such as "/api", not a URL.');
+  }
   for (const segment of path.split("/")) {
     let decoded = segment;
     try {
@@ -122,6 +131,9 @@ export function normalizeFarmAPIBasePath(value: string): string {
     }
     if (hasUnstableCharacters(decoded)) {
       throw new Error("Farm api.basePath cannot contain backslashes or control characters.");
+    }
+    if (decoded.includes("/")) {
+      throw new Error("Farm api.basePath cannot contain percent-encoded path separators.");
     }
     if (decoded === "." || decoded === "..") {
       throw new Error('Farm api.basePath cannot contain "." or ".." path segments.');


### PR DESCRIPTION
## Problem

API configuration accepted encoded path separators such as `/api/%2Fadmin` and network-path references such as `//api.example.com`. Browsers, URL parsers, proxies, and route matchers can interpret those values differently; a network-path `baseURL` was silently reduced to the default `/api` mount.

## Root cause

`api.basePath` validated decoded controls and dot segments but omitted decoded `/`. The root-relative `baseURL` branch also treated every string beginning with `/` as a same-origin pathname.

## Change

Reject encoded separators in root-relative and absolute API paths, and reject network-path references for both `baseURL` and `basePath`. Document the single-leading-slash contract.

## Safety and compatibility

Ordinary root-relative paths, origin-only URLs, absolute URLs with paths, and configuration resolver functions are unchanged. Ambiguous values now fail during config loading instead of being silently remapped.

## Verification

- `pnpm --filter @farm.js/core exec vitest run src/__tests__/api-config.test.ts src/__tests__/config.test.ts`
- `pnpm --filter @farm.js/core type-check`
- `pnpm exec oxlint packages/farm/src/api/config.ts packages/farm/src/__tests__/api-config.test.ts`
- `pnpm docs:check-navigation`

The regression cases fail without the change because encoded separators and network-path references are accepted.

## Documentation and release

Updated the API client base URL configuration reference.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects ambiguous API mount paths so `baseURL` and `basePath` values that browsers, proxies, or route matchers could interpret differently now fail during config loading instead of being silently remapped.

**Bug Fixes**
- Percent-encoded path separators such as `%2F` are rejected in both `baseURL` and `basePath`.
- Network-path references such as `//api.example.com` are rejected for both options.
- Root-relative `baseURL` and `basePath` values must start with exactly one slash; the docs document this contract.
- Valid root-relative paths, origin-only URLs, absolute URLs with paths, and resolver functions behave as before.

<sup>Written for commit e821eee2b23d66c55a39c54a6af4ca0802dc6e05. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/828?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

