### PR TITLE
fix(i18n): validate locale cookie settings

### DIFF
--- a/docs/src/app/docs/internationalization/page.md
+++ b/docs/src/app/docs/internationalization/page.md
@@ -368,6 +368,10 @@ export default defineConfig({
 | `cookie`         | `farm_locale`, one year | Name, lifetime, path, SameSite, and Secure behavior.                    |
 | `direction`      | Inferred                | Per-locale `ltr` or `rtl` overrides.                                    |
 
+The locale cookie `path` must be a root-relative pathname; cookie attributes, URL queries and
+hashes, dot segments, backslashes, and encoded path separators are rejected. `sameSite` accepts
+`"lax"`, `"strict"`, or `"none"`.
+
 For a custom catalog layout, include `{locale}` in the path:
 
 ```ts

--- a/packages/farm/src/__tests__/i18n.test.ts
+++ b/packages/farm/src/__tests__/i18n.test.ts
@@ -4,7 +4,11 @@ import { join, resolve } from "node:path";
 import { tmpdir } from "node:os";
 import { readFarmI18nCatalogs } from "../i18n/catalog";
 import { resolveFarmI18nConfig } from "../i18n/config";
-import { getFarmLocaleVaryHeaders, resolveFarmLocaleRequest } from "../i18n/resolver";
+import {
+  createFarmLocaleCookie,
+  getFarmLocaleVaryHeaders,
+  resolveFarmLocaleRequest,
+} from "../i18n/resolver";
 import { FarmI18nRuntime } from "../i18n/runtime";
 import {
   _runWithFarmI18nRequest,
@@ -52,6 +56,35 @@ describe("Farm i18n configuration", () => {
 
     expect(() => resolveFarmI18nConfig({ locales: ["en", "en"], defaultLocale: "en" })).toThrow(
       "must not contain duplicate locales",
+    );
+  });
+
+  it("rejects cookie settings that cannot be serialized safely", () => {
+    const base = { locales: ["en"], defaultLocale: "en" } as const;
+
+    expect(() => resolveFarmI18nConfig({ ...base, cookie: { path: "/; HttpOnly" } })).toThrow(
+      "without attributes",
+    );
+    expect(() => resolveFarmI18nConfig({ ...base, cookie: { path: "/docs\\admin" } })).toThrow(
+      "backslashes",
+    );
+    expect(() => resolveFarmI18nConfig({ ...base, cookie: { path: "/docs/%2Fadmin" } })).toThrow(
+      "percent-encoded path separators",
+    );
+    expect(() =>
+      resolveFarmI18nConfig({ ...base, cookie: { sameSite: "invalid" as "lax" } }),
+    ).toThrow('must be "lax", "strict", or "none"');
+  });
+
+  it("serializes a validated custom locale cookie", () => {
+    const config = resolveFarmI18nConfig({
+      locales: ["en"],
+      defaultLocale: "en",
+      cookie: { path: "/docs", sameSite: "strict", secure: true },
+    });
+
+    expect(createFarmLocaleCookie("en", config)).toBe(
+      "farm_locale=en; Max-Age=31536000; Path=/docs; SameSite=Strict; Secure",
     );
   });
 });

--- a/packages/farm/src/i18n/config.ts
+++ b/packages/farm/src/i18n/config.ts
@@ -59,6 +59,10 @@ export function resolveFarmI18nConfig(
   }
 
   const detection = resolveDetection(input);
+  const sameSite = input.cookie?.sameSite ?? "lax";
+  if (sameSite !== "lax" && sameSite !== "strict" && sameSite !== "none") {
+    throw new Error('i18n.cookie.sameSite must be "lax", "strict", or "none".');
+  }
   const direction: Record<string, FarmI18nDirection> = {};
   for (const [rawLocale, value] of Object.entries(input.direction || {})) {
     const locale = canonicalizeLocale(rawLocale);
@@ -87,8 +91,8 @@ export function resolveFarmI18nConfig(
         DEFAULT_FARM_I18N_COOKIE_MAX_AGE,
         "i18n.cookie.maxAge",
       ),
-      path: input.cookie?.path || "/",
-      sameSite: input.cookie?.sameSite || "lax",
+      path: normalizeCookiePath(input.cookie?.path),
+      sameSite,
       secure: input.cookie?.secure ?? options.mode === "production",
     },
     direction,
@@ -145,4 +149,56 @@ function normalizePositiveInteger(
     throw new Error(`${name} must be a positive integer.`);
   }
   return value;
+}
+
+function normalizeCookiePath(value: string | undefined): string {
+  if (value === undefined) return "/";
+  if (typeof value !== "string") {
+    throw new Error("i18n.cookie.path must be a root-relative pathname.");
+  }
+
+  const hasUnstableCharacters = (candidate: string) =>
+    candidate.includes("\\") ||
+    Array.from(candidate).some((character) => {
+      const code = character.charCodeAt(0);
+      return code <= 31 || (code >= 127 && code <= 159);
+    });
+
+  if (hasUnstableCharacters(value)) {
+    throw new Error("i18n.cookie.path cannot contain backslashes or control characters.");
+  }
+
+  const pathname = value.trim();
+  if (
+    !pathname ||
+    !pathname.startsWith("/") ||
+    pathname.startsWith("//") ||
+    pathname.includes(";") ||
+    pathname.includes("?") ||
+    pathname.includes("#")
+  ) {
+    throw new Error(
+      "i18n.cookie.path must be a root-relative pathname without attributes, a query, or a hash.",
+    );
+  }
+
+  for (const segment of pathname.split("/")) {
+    let decoded = segment;
+    try {
+      decoded = decodeURIComponent(segment);
+    } catch {
+      // Malformed escapes remain literal and cannot conceal a separator or dot segment.
+    }
+    if (hasUnstableCharacters(decoded)) {
+      throw new Error("i18n.cookie.path cannot contain backslashes or control characters.");
+    }
+    if (decoded.includes("/")) {
+      throw new Error("i18n.cookie.path cannot contain percent-encoded path separators.");
+    }
+    if (decoded === "." || decoded === "..") {
+      throw new Error('i18n.cookie.path cannot contain "." or ".." path segments.');
+    }
+  }
+
+  return pathname;
 }


### PR DESCRIPTION
## Problem

JavaScript configuration could pass an i18n cookie path containing `;` and inject extra `Set-Cookie` attributes, or supply an unsupported `sameSite` value that browsers ignore. Ambiguous URL-like paths could also produce cookies that never match the intended application route.

## Root cause

The typed cookie fields were copied directly into the serialized header without runtime validation.

## Change

Validate `sameSite` against its supported values and require cookie paths to be safe root-relative pathnames without attributes, URL suffixes, unstable characters, dot segments, or encoded separators. Add serialization and rejection coverage and document the contract.

## Safety and compatibility

Default and ordinary custom cookie settings are unchanged. Invalid JavaScript or untyped configuration now fails during startup instead of emitting an unsafe or ineffective cookie.

## Verification

- `pnpm --filter @farm.js/core exec vitest run src/__tests__/i18n.test.ts`
- `pnpm --filter @farm.js/core type-check`
- `pnpm exec oxlint packages/farm/src/i18n/config.ts packages/farm/src/__tests__/i18n.test.ts`
- `pnpm docs:check-navigation`

The new regression cases fail without the change because attribute-bearing paths, encoded separators, backslashes, and invalid SameSite values are accepted.

## Documentation and release

Updated the internationalization cookie configuration reference.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validates i18n locale cookie `path` and `sameSite` settings at startup so invalid JavaScript config fails fast instead of emitting unsafe or ineffective `Set-Cookie` headers.

- Cookie paths must be root-relative pathnames; attributes, queries, hashes, dot segments, backslashes, control characters, and percent-encoded path separators are rejected.
- `sameSite` accepts only `"lax"`, `"strict"`, or `"none"`.
- Default and existing valid custom settings keep serializing the same; regression tests cover the new rejections and the config docs state the contract.

<sup>Written for commit 30cdad89f21bc068afc0d4758f4881afbc0d5388. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/829?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

