### PR TITLE
fix(cron): reject ambiguous route paths

### DIFF
--- a/docs/src/app/docs/cron/page.md
+++ b/docs/src/app/docs/cron/page.md
@@ -43,6 +43,10 @@ Each entry has one job:
 | `description` | no       | Human-readable purpose shown by CLI output and the build manifest.   |
 | `enabled`     | no       | Set to `false` to keep an entry in config without scheduling it.     |
 
+`path` must be a root-relative application pathname. Farm rejects hosts, query strings, hashes,
+dot segments, backslashes, control characters, and encoded path separators so local invocations
+and deployment schedulers call the same route.
+
 Use an array when the same route should run at more than one time:
 
 ```ts

--- a/packages/farm/src/__tests__/cron.test.ts
+++ b/packages/farm/src/__tests__/cron.test.ts
@@ -104,6 +104,23 @@ describe("Farm cron", () => {
         },
       }),
     ).toThrow('path must start with "/"');
+
+    for (const path of [
+      "/api/../admin",
+      "/api/%2e%2e/admin",
+      "/api/%2Fadmin",
+      "/api\\admin",
+      "/api/%0Aadmin",
+    ]) {
+      expect(() =>
+        resolveCronConfig({
+          unsafePath: {
+            schedule: "0 2 * * *",
+            path,
+          },
+        }),
+      ).toThrow();
+    }
   });
 
   it("generates Nitro tasks, grouped schedules, and a portable manifest", async () => {

--- a/packages/farm/src/cron.ts
+++ b/packages/farm/src/cron.ts
@@ -288,11 +288,46 @@ function normalizeCronPath(name: string, value: unknown): string {
     throw new TypeError(`Farm cron ${JSON.stringify(name)} path must start with "/".`);
   }
 
+  const hasUnstableCharacters = (candidate: string) =>
+    candidate.includes("\\") ||
+    Array.from(candidate).some((character) => {
+      const code = character.charCodeAt(0);
+      return code <= 31 || (code >= 127 && code <= 159);
+    });
+  if (hasUnstableCharacters(value)) {
+    throw new TypeError(
+      `Farm cron ${JSON.stringify(name)} path cannot contain backslashes or control characters.`,
+    );
+  }
+
   const path = value.trim();
   if (path.startsWith("//") || path.includes("?") || path.includes("#")) {
     throw new TypeError(
       `Farm cron ${JSON.stringify(name)} path must be an application pathname without a host, query, or hash.`,
     );
+  }
+  for (const segment of path.split("/")) {
+    let decoded = segment;
+    try {
+      decoded = decodeURIComponent(segment);
+    } catch {
+      // Malformed escapes remain literal and cannot conceal a separator or dot segment.
+    }
+    if (hasUnstableCharacters(decoded)) {
+      throw new TypeError(
+        `Farm cron ${JSON.stringify(name)} path cannot contain backslashes or control characters.`,
+      );
+    }
+    if (decoded.includes("/")) {
+      throw new TypeError(
+        `Farm cron ${JSON.stringify(name)} path cannot contain percent-encoded path separators.`,
+      );
+    }
+    if (decoded === "." || decoded === "..") {
+      throw new TypeError(
+        `Farm cron ${JSON.stringify(name)} path cannot contain "." or ".." path segments.`,
+      );
+    }
   }
   return path.length > 1 ? path.replace(/\/+$/, "") : path;
 }


### PR DESCRIPTION
## Problem

Cron entries accepted dot segments, backslashes, controls, and encoded path separators. Provider manifests, URL constructors, proxies, and Farm's local scheduler could normalize those values to a route different from the one shown in configuration.

## Root cause

Cron path validation only required a leading slash and rejected hosts, queries, and hashes.

## Change

Validate raw and decoded cron path segments before emitting local tasks or deployment manifests, and document the portable pathname requirements.

## Safety and compatibility

Ordinary application API paths and trailing-slash normalization are unchanged. Ambiguous values now fail during config resolution rather than scheduling a different route.

## Verification

- `pnpm --filter @farm.js/core exec vitest run src/__tests__/cron.test.ts`
- `pnpm --filter @farm.js/core type-check`
- `pnpm exec oxlint packages/farm/src/cron.ts packages/farm/src/__tests__/cron.test.ts`
- `pnpm docs:check-navigation`

The new path cases fail without the change because dot segments, encoded separators, backslashes, and controls are accepted.

## Documentation and release

Updated the Cron configuration guide with the portable route-path contract.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects ambiguous cron path segments so configured routes match the routes actually called. Previously only a leading slash was required; now dot segments, backslashes, control characters, and encoded separators cause config resolution to fail. This prevents silent route mismatches between local invocations and deployment schedulers. Ordinary paths and trailing-slash normalization are unchanged.

<sup>Written for commit 4639170265f71ec1b64865891937be234189761b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/830?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

