### PR TITLE
perf(react): retain mapped lineage across reorder chains

### DIFF
--- a/docs/src/app/docs/renderers/react/page.md
+++ b/docs/src/app/docs/renderers/react/page.md
@@ -1303,6 +1303,23 @@ following native reverse or sort. This produces the same final result as React's
 setters while reconciling the keyed block once. Only adjacent concise calls to the same setter are
 linked; any statement or unsupported update between them keeps the existing fallback.
 
+The mapped lineage can continue through more than one adjacent native reorder setter:
+
+```tsx
+setItems((current) =>
+  current.map((item) => (item.id === editedId ? { ...item, rank: nextRank } : item)),
+);
+setItems((current) => current.toReversed());
+setItems((current) => current.toSorted((left, right) => left.rank - right.rank));
+setItems((current) => current.toReversed());
+```
+
+Farm still executes every updater and native method in order. Each accepted reverse or sort carries
+the same committed-row proof forward, so the final value needs one validated keyed reconciliation
+rather than losing map lineage after the first reorder. A `map().toReversed()` pipeline can start
+the same adjacent chain. An intervening statement, another setter, a structural update, or an
+unsupported method ends the chain before later setters are considered.
+
 Exact reverse proof can also cross a setter boundary in the same batch:
 
 ```tsx

--- a/examples/react-compiler-dashboard/README.md
+++ b/examples/react-compiler-dashboard/README.md
@@ -262,6 +262,13 @@ connection, and both changed values. Package tests also compare 2,000 determinis
 reverse-or-sort/map sequences with normal React and cover Strict Mode hydration and
 unmount-before-flush cleanup.
 
+Queued map/reorder chains have a separate 10,000-row comparison. Two concise map setters update
+one row, followed by two adjacent concise reverse setters. The block-bodied control performs the
+same four native updates through complete reconciliation. Both compiler modes must remain at least
+4x faster than React and 1.2x faster than the compiled control. The assertion verifies the complete
+final committed order, every original DOM identity and connection, and both changed values. Package tests
+also cover mixed reverse/sort chains, chain boundaries, and 2,000 randomized differential updates.
+
 Mapped reverse parity has an independent 10,000-row comparison. Two safe native maps update one
 row, then two native reversals restore committed order. Farm must patch the changed row without
 moving any DOM row or constructing the generic source-item map/LIS sequence. Both compiler modes
@@ -378,6 +385,10 @@ The default JSON report is `/tmp/farm-react-dashboard-benchmark.json`; change it
 - The queued map-then-reorder control performs two maps and a reverse in three adjacent setter
   calls. Its block-bodied equivalent keeps complete reconciliation; the hinted path records safe
   replacements from the committed rows and carries them into the final exact reverse.
+- The queued map/reorder-chain control performs two maps and two reversals in four adjacent
+  setter calls. Its block-bodied equivalent drops to complete reconciliation; the hinted path
+  carries one committed replacement proof through both reversals, patches the changed row, and
+  moves no DOM row when the reversals cancel.
 - The multi-map reverse-parity control changes the same row through two native maps and then
   reverses twice. Its block-bodied equivalent keeps complete reconciliation; the hinted path
   validates exact committed order, patches the row once, and performs no generic item-map, LIS, or

--- a/examples/react-compiler-dashboard/scripts/benchmark.mjs
+++ b/examples/react-compiler-dashboard/scripts/benchmark.mjs
@@ -1403,6 +1403,14 @@ async function measureTrial(browser, trial, compilerMode, port) {
         const tableQueuedMapThenReorderPipelineSnapshot = await measureMultiMapReverseTable(() =>
           tableButton("table-queued-map-then-reorder-pipeline-snapshot").click(),
         );
+        const tableQueuedMapReorderChain = await measureMultiMapReverseTable(
+          () => tableButton("table-queued-map-reorder-chain").click(),
+          false,
+        );
+        const tableQueuedMapReorderChainSnapshot = await measureMultiMapReverseTable(
+          () => tableButton("table-queued-map-reorder-chain-snapshot").click(),
+          false,
+        );
 
         const tableSort = await measureTable(
           async () => create10000(),
@@ -1890,6 +1898,8 @@ async function measureTrial(browser, trial, compilerMode, port) {
             queuedReorderThenMapPipelineSnapshot: tableQueuedReorderThenMapPipelineSnapshot,
             queuedMapThenReorderPipeline: tableQueuedMapThenReorderPipeline,
             queuedMapThenReorderPipelineSnapshot: tableQueuedMapThenReorderPipelineSnapshot,
+            queuedMapReorderChain: tableQueuedMapReorderChain,
+            queuedMapReorderChainSnapshot: tableQueuedMapReorderChainSnapshot,
             mapLookup: tableMapLookup,
             membership: tableMembership,
             prepend: tablePrepend,
@@ -2040,6 +2050,8 @@ async function measureTrial(browser, trial, compilerMode, port) {
         queuedMapThenReorderPipelineSnapshot: timingSummary(
           result.table.queuedMapThenReorderPipelineSnapshot,
         ),
+        queuedMapReorderChain: timingSummary(result.table.queuedMapReorderChain),
+        queuedMapReorderChainSnapshot: timingSummary(result.table.queuedMapReorderChainSnapshot),
         mapLookup: timingSummary(result.table.mapLookup),
         membership: timingSummary(result.table.membership),
         prepend: timingSummary(result.table.prepend),
@@ -2239,6 +2251,8 @@ const tableMetrics = [
   "queuedReorderThenMapPipelineSnapshot",
   "queuedMapThenReorderPipeline",
   "queuedMapThenReorderPipelineSnapshot",
+  "queuedMapReorderChain",
+  "queuedMapReorderChainSnapshot",
   "snapshotMembership",
   "snapshotMapLookup",
   "slicePrefix",
@@ -3055,6 +3069,28 @@ const keyedQueuedMapThenReorderRegressions = keyedQueuedMapThenReorderResults.fi
     !Number.isFinite(snapshotSpeedup) ||
     snapshotSpeedup < keyedQueuedMapThenReorderMinimumSnapshotSpeedup,
 );
+// Mapped lineage should survive every adjacent native reorder setter, not only the first one.
+// Compare maps plus two concise reversals with React and block-bodied complete reconciliation.
+const keyedQueuedMapReorderChainMinimumSpeedup = 4;
+const keyedQueuedMapReorderChainMinimumSnapshotSpeedup = 1.2;
+const keyedQueuedMapReorderChainResults = ["static", "hybrid"].map((mode) => {
+  const pipelineMedianMs = comparisons.table.queuedMapReorderChain[mode].medianMs;
+  const snapshotMedianMs = comparisons.table.queuedMapReorderChainSnapshot[mode].medianMs;
+  return {
+    mode,
+    pipelineMedianMs,
+    snapshotMedianMs,
+    snapshotSpeedup: snapshotMedianMs / pipelineMedianMs,
+    speedup: comparisons.table.queuedMapReorderChain[`${mode}VsBaseline`].speedup,
+  };
+});
+const keyedQueuedMapReorderChainRegressions = keyedQueuedMapReorderChainResults.filter(
+  ({ snapshotSpeedup, speedup }) =>
+    !Number.isFinite(speedup) ||
+    speedup < keyedQueuedMapReorderChainMinimumSpeedup ||
+    !Number.isFinite(snapshotSpeedup) ||
+    snapshotSpeedup < keyedQueuedMapReorderChainMinimumSnapshotSpeedup,
+);
 // A direct native toSorted() exposes a permutation while preserving every keyed row object. The
 // hinted path validates that permutation by item identity, uses LIS to move only the required DOM
 // nodes, and avoids key, descriptor, and binding reads. Compare it with React and the equivalent
@@ -3251,6 +3287,7 @@ const passed =
   keyedReorderThenMapRegressions.length === 0 &&
   keyedQueuedReorderThenMapRegressions.length === 0 &&
   keyedQueuedMapThenReorderRegressions.length === 0 &&
+  keyedQueuedMapReorderChainRegressions.length === 0 &&
   keyedSortRegressions.length === 0 &&
   keyedFilterRegressions.length === 0 &&
   keyedIdentityRegressions.length === 0 &&
@@ -3472,6 +3509,13 @@ const report = {
     regressions: keyedQueuedMapThenReorderRegressions,
     results: keyedQueuedMapThenReorderResults,
     status: keyedQueuedMapThenReorderRegressions.length === 0 ? "PASS" : "FAIL",
+  },
+  keyedQueuedMapReorderChainHintGate: {
+    minimumSnapshotSpeedup: keyedQueuedMapReorderChainMinimumSnapshotSpeedup,
+    minimumSpeedup: keyedQueuedMapReorderChainMinimumSpeedup,
+    regressions: keyedQueuedMapReorderChainRegressions,
+    results: keyedQueuedMapReorderChainResults,
+    status: keyedQueuedMapReorderChainRegressions.length === 0 ? "PASS" : "FAIL",
   },
   keyedSortHintGate: {
     minimumSnapshotSpeedup: keyedSortMinimumSnapshotSpeedup,

--- a/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
+++ b/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
@@ -1199,6 +1199,54 @@ export function StandardTableBenchmark() {
           Queue review + reverse rows (snapshot control)
         </button>
         <button
+          data-action="table-queued-map-reorder-chain"
+          type="button"
+          onClick={() => {
+            setRows((current) =>
+              current.map((row) =>
+                row.id % 10_000 === 5_001 ? { ...row, label: `${row.label} reviewed` } : row,
+              ),
+            );
+            setRows((current) =>
+              current.map((row) =>
+                row.id % 10_000 === 5_001 ? { ...row, amount: row.amount + 1 } : row,
+              ),
+            );
+            setRows((current) => current.toReversed());
+            setRows((current) => current.toReversed());
+            setOperation("queue review, then reverse rows twice");
+            setRevision((value) => value + 1);
+          }}
+        >
+          Queue review + two reversals
+        </button>
+        <button
+          data-action="table-queued-map-reorder-chain-snapshot"
+          type="button"
+          onClick={() => {
+            setRows((current) => {
+              return current.map((row) =>
+                row.id % 10_000 === 5_001 ? { ...row, label: `${row.label} reviewed` } : row,
+              );
+            });
+            setRows((current) => {
+              return current.map((row) =>
+                row.id % 10_000 === 5_001 ? { ...row, amount: row.amount + 1 } : row,
+              );
+            });
+            setRows((current) => {
+              return current.toReversed();
+            });
+            setRows((current) => {
+              return current.toReversed();
+            });
+            setOperation("queue review, then reverse rows twice (snapshot control)");
+            setRevision((value) => value + 1);
+          }}
+        >
+          Queue review + two reversals (snapshot control)
+        </button>
+        <button
           data-action="table-sort"
           type="button"
           onClick={() => {

--- a/packages/farm-react/README.md
+++ b/packages/farm-react/README.md
@@ -491,6 +491,13 @@ followed by a concise native reverse or sort setter. Farm records their replacem
 the committed collection and carries it into the final reorder. Only adjacent calls to the same
 setter are linked; intervening work and unsupported updates retain complete reconciliation.
 
+Mapped lineage also continues through multiple adjacent native reorder setters. For example,
+`map -> reverse -> sort -> reverse` keeps the same committed-row proof until the final value, then
+performs one validated keyed reconciliation. A concise `map().toReversed()` pipeline may start the
+same chain. Every updater and native method still executes in order; another setter, intervening
+work, a structural update, or an unsupported method ends the chain and preserves the complete
+fallback.
+
 A reverse before the safe map pipeline may be queued in a separate setter:
 
 ```tsx

--- a/packages/farm-react/src/__tests__/compiler-keyed-array-queued-map-reorder-hints.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-keyed-array-queued-map-reorder-hints.test.ts
@@ -114,6 +114,115 @@ describe("React AOT queued map then reorder hints", () => {
     expect(result.code).not.toContain("createCompilerKeyedArrayReorder");
   });
 
+  it("retains mapped lineage through consecutive adjacent reorders", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Table({ editedId, nextRank }) {
+        const [rows, setRows] = useState([
+          { id: "a", rank: 1 },
+          { id: "b", rank: 2 },
+          { id: "c", rank: 3 },
+        ]);
+        return <section>
+          <button onClick={() => {
+            setRows((current) => current.map((row) =>
+              row.id === editedId ? { ...row, rank: nextRank } : row
+            ));
+            setRows((current) => current.toReversed());
+            setRows((current) => current.toSorted((left, right) => left.rank - right.rank));
+            setRows((current) => current.toReversed());
+          }}>Edit and reorder</button>
+          <ul>{rows.map((row) => <li key={row.id}>{row.rank}</li>)}</ul>
+        </section>;
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Table"]);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.optimizations.keyedMapUpdateHints).toBe(1);
+    expect(result.optimizations.keyedArrayReorderHints).toBe(2);
+    expect(result.optimizations.keyedArraySortHints).toBe(1);
+    expect(result.code.match(/createCompilerKeyedArrayQueuedMapPipeline\(/g)).toHaveLength(1);
+    expect(result.code.match(/createCompilerKeyedArrayMapReorder\(/g)).toHaveLength(3);
+    expect(result.code).not.toContain("createCompilerKeyedArrayMapPipeline");
+    expect(result.code).not.toContain("createCompilerKeyedArrayReorder");
+    expect(result.code).not.toContain("createCompilerKeyedArraySort");
+  });
+
+  it("continues a same-setter map and reorder pipeline across later reorder setters", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Table({ editedId, nextRank }) {
+        const [rows, setRows] = useState([
+          { id: "a", rank: 1 },
+          { id: "b", rank: 2 },
+          { id: "c", rank: 3 },
+        ]);
+        return <section>
+          <button onClick={() => {
+            setRows((current) => current
+              .map((row) => row.id === editedId ? { ...row, rank: nextRank } : row)
+              .toReversed()
+            );
+            setRows((current) => current.toSorted((left, right) => left.rank - right.rank));
+            setRows((current) => current.toReversed());
+          }}>Edit and reorder</button>
+          <ul>{rows.map((row) => <li key={row.id}>{row.rank}</li>)}</ul>
+        </section>;
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Table"]);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.optimizations.keyedMapUpdateHints).toBe(1);
+    expect(result.optimizations.keyedArrayReorderHints).toBe(2);
+    expect(result.optimizations.keyedArraySortHints).toBe(1);
+    expect(result.code.match(/createCompilerKeyedArrayMapReorder\(/g)).toHaveLength(3);
+    expect(result.code).not.toContain("createCompilerKeyedArrayReorder");
+    expect(result.code).not.toContain("createCompilerKeyedArraySort");
+  });
+
+  it.each([
+    {
+      name: "an intervening statement",
+      between: "onReordered();",
+    },
+    {
+      name: "a different state setter",
+      between: "setOther((current) => current + 1);",
+    },
+    {
+      name: "a structural update",
+      between: "setRows((current) => current.filter((row) => row.visible));",
+    },
+  ])("ends consecutive reorder lineage at $name", async ({ between }) => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Table({ editedId, nextRank, onReordered }) {
+        const [rows, setRows] = useState([
+          { id: "a", rank: 1, visible: true },
+          { id: "b", rank: 2, visible: false },
+        ]);
+        const [other, setOther] = useState(0);
+        return <section>
+          <button onClick={() => {
+            setRows((current) => current.map((row) =>
+              row.id === editedId ? { ...row, rank: nextRank } : row
+            ));
+            setRows((current) => current.toReversed());
+            ${between}
+            setRows((current) => current.toReversed());
+          }}>Edit and reorder</button>
+          <output>{other}</output>
+          <ul>{rows.map((row) => <li key={row.id}>{row.rank}</li>)}</ul>
+        </section>;
+      }
+    `);
+
+    expect(result.code.match(/createCompilerKeyedArrayMapReorder\(/g)).toHaveLength(1);
+    expect(result.code.match(/createCompilerKeyedArrayReorder\(/g)).toHaveLength(1);
+  });
+
   it.each([
     {
       name: "an intervening statement",

--- a/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-map-reorder-hints.test.tsx
+++ b/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-map-reorder-hints.test.tsx
@@ -201,6 +201,12 @@ function createHarness(initialItems: Item[]) {
     rank: number,
     label: string,
   ) => void = () => undefined;
+  let queueMapsThenReorders: (
+    kinds: readonly ("reverse" | "sort")[],
+    id: string,
+    rank: number,
+    label: string,
+  ) => void = () => undefined;
   let reverseThenMap: (id: string, rank: number, label: string) => void = () => undefined;
   let sortThenMap: (id: string, rank: number, label: string) => void = () => undefined;
   let queueSortThenMapReverse: () => void = () => undefined;
@@ -289,6 +295,23 @@ function createHarness(initialItems: Item[]) {
         state[0].set((previous) =>
           kind === "reverse" ? hintedReverse(previous as Item[]) : hintedSort(previous as Item[]),
         );
+      };
+      queueMapsThenReorders = (kinds, id, rank, label) => {
+        state[0].set((previous) =>
+          queuedHintedMap(previous as Item[], (item) =>
+            item.id === id ? { ...item, label } : item,
+          ),
+        );
+        state[0].set((previous) =>
+          queuedHintedMap(previous as Item[], (item) =>
+            item.id === id ? { ...item, rank } : item,
+          ),
+        );
+        for (const kind of kinds) {
+          state[0].set((previous) =>
+            kind === "reverse" ? hintedReverse(previous as Item[]) : hintedSort(previous as Item[]),
+          );
+        }
       };
       reverseThenMap = (id, rank, label) =>
         state[0].set((previous) =>
@@ -528,6 +551,12 @@ function createHarness(initialItems: Item[]) {
       queueReorderThenMaps(kind, id, rank, label),
     queueMapsThenReorder: (kind: "reverse" | "sort", id: string, rank: number, label: string) =>
       queueMapsThenReorder(kind, id, rank, label),
+    queueMapsThenReorders: (
+      kinds: readonly ("reverse" | "sort")[],
+      id: string,
+      rank: number,
+      label: string,
+    ) => queueMapsThenReorders(kinds, id, rank, label),
     queueSortThenMapReverse: () => queueSortThenMapReverse(),
     reverseThenMap: (id: string, rank: number, label: string) => reverseThenMap(id, rank, label),
     sortThenMap: (id: string, rank: number, label: string) => sortThenMap(id, rank, label),
@@ -981,6 +1010,48 @@ describe("compiled keyed-array map and reorder hints", () => {
     expect([...container.querySelectorAll("li")]).toEqual(rows.toReversed());
     expect(insertBefore).toHaveBeenCalledTimes(2);
     expect(mapSet.mock.calls.filter(([key]) => initialItems.includes(key as Item))).toHaveLength(0);
+    expect(descriptorRead).toHaveBeenCalledTimes(initialItems.length * 2);
+    expect(harness.counters.keys).toBe(1);
+    expect(harness.counters.descriptors).toBe(0);
+    expect(harness.counters.bindings).toBe(1);
+    expect(harness.counters.executions).toBe(1);
+  });
+
+  it("retains queued map lineage through adjacent reverse and sort setters", async () => {
+    const initialItems: Item[] = [
+      { id: "a", label: "Alpha", rank: 1 },
+      { id: "b", label: "Beta", rank: 2 },
+      { id: "c", label: "Gamma", rank: 3 },
+    ];
+    const harness = createHarness(initialItems);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Table />));
+    const rows = new Map(
+      [...container.querySelectorAll("li")].map((row) => [row.dataset.key, row]),
+    );
+    const mapSet = vi.spyOn(Map.prototype, "set");
+    const descriptorRead = vi.spyOn(Object, "getOwnPropertyDescriptor");
+    harness.counters.bindings = 0;
+    harness.counters.descriptors = 0;
+    harness.counters.keys = 0;
+
+    await act(async () => {
+      harness.queueMapsThenReorders(["reverse", "sort", "reverse"], "b", 5, "Beta chain");
+      await flushCompilerUpdates();
+    });
+
+    expect(labels(container)).toEqual(["Beta chain:5", "Gamma:3", "Alpha:1"]);
+    expect([...container.querySelectorAll("li")]).toEqual([
+      rows.get("b"),
+      rows.get("c"),
+      rows.get("a"),
+    ]);
+    expect(mapSet.mock.calls.filter(([key]) => initialItems.includes(key as Item))).toHaveLength(
+      initialItems.length,
+    );
     expect(descriptorRead).toHaveBeenCalledTimes(initialItems.length * 2);
     expect(harness.counters.keys).toBe(1);
     expect(harness.counters.descriptors).toBe(0);
@@ -1862,6 +1933,80 @@ describe("compiled keyed-array map and reorder hints", () => {
         await act(async () => {
           harness.queueMapsThenReorder(kind, id, rank, label);
           updateReact(kind, id, rank, label);
+          await flushCompilerUpdates();
+        });
+        expect(labels(compiledContainer)).toEqual(labels(reactContainer));
+      }
+      expect(harness.counters.executions).toBe(1);
+    },
+    120_000,
+  );
+
+  stressIt(
+    "matches React through 2,000 queued map and consecutive reorder updates",
+    async () => {
+      const initialItems = Array.from(
+        { length: 31 },
+        (_, index): Item => ({ id: `row-${index}`, label: `Row ${index}`, rank: index }),
+      );
+      const harness = createHarness(initialItems);
+      let updateReact: (
+        kinds: readonly ("reverse" | "sort")[],
+        id: string,
+        rank: number,
+        label: string,
+      ) => void = () => undefined;
+      function Normal() {
+        const [items, setItems] = useState(initialItems);
+        updateReact = (kinds, id, rank, label) => {
+          setItems((previous) =>
+            previous.map((item) => (item.id === id ? { ...item, label } : item)),
+          );
+          setItems((previous) =>
+            previous.map((item) => (item.id === id ? { ...item, rank } : item)),
+          );
+          for (const kind of kinds) {
+            setItems((previous) =>
+              kind === "reverse"
+                ? previous.toReversed()
+                : previous.toSorted((left, right) => left.rank - right.rank),
+            );
+          }
+        };
+        return (
+          <ol>
+            {items.map((item) => (
+              <li data-key={item.id} key={item.id}>
+                {item.label}:{item.rank}
+              </li>
+            ))}
+          </ol>
+        );
+      }
+      const compiledContainer = document.createElement("div");
+      const reactContainer = document.createElement("div");
+      document.body.append(compiledContainer, reactContainer);
+      const compiledRoot = createRoot(compiledContainer);
+      const reactRoot = createRoot(reactContainer);
+      roots.push(compiledRoot, reactRoot);
+      await act(async () => {
+        compiledRoot.render(<harness.Table />);
+        reactRoot.render(<Normal />);
+      });
+
+      let seed = 0x6d2b79f5;
+      for (let update = 0; update < 2_000; update += 1) {
+        seed = (Math.imul(seed, 1_664_525) + 1_013_904_223) >>> 0;
+        const reorderCount = 2 + ((seed >>> 3) % 3);
+        const kinds = Array.from({ length: reorderCount }, (_, index) =>
+          seed & (1 << (index + 8)) ? ("reverse" as const) : ("sort" as const),
+        );
+        const id = `row-${seed % initialItems.length}`;
+        const rank = (seed ^ (seed >>> 16)) % 4_003;
+        const label = `Queued reorder chain ${update}`;
+        await act(async () => {
+          harness.queueMapsThenReorders(kinds, id, rank, label);
+          updateReact(kinds, id, rank, label);
           await flushCompilerUpdates();
         });
         expect(labels(compiledContainer)).toEqual(labels(reactContainer));

--- a/packages/farm-react/src/compiler.ts
+++ b/packages/farm-react/src/compiler.ts
@@ -2435,6 +2435,7 @@ function rewriteQueuedKeyedArrayMapReorderHints(
 
   traverse(file, {
     BlockStatement(path) {
+      let mappedReorderState: number | undefined;
       let pendingMaps: Array<{
         count: number;
         stateIndex: number;
@@ -2444,6 +2445,7 @@ function rewriteQueuedKeyedArrayMapReorderHints(
       for (const statementPath of statements) {
         const statement = statementPath.node;
         if (!t.isExpressionStatement(statement) || !t.isCallExpression(statement.expression)) {
+          mappedReorderState = undefined;
           pendingMaps = [];
           continue;
         }
@@ -2453,6 +2455,7 @@ function rewriteQueuedKeyedArrayMapReorderHints(
           statementPath.scope.hasBinding(setterCall.callee.name) ||
           setterCall.arguments.length !== 1
         ) {
+          mappedReorderState = undefined;
           pendingMaps = [];
           continue;
         }
@@ -2466,6 +2469,7 @@ function rewriteQueuedKeyedArrayMapReorderHints(
           updater.params.length !== 1 ||
           !t.isIdentifier(updater.params[0])
         ) {
+          mappedReorderState = undefined;
           pendingMaps = [];
           continue;
         }
@@ -2499,10 +2503,12 @@ function rewriteQueuedKeyedArrayMapReorderHints(
               pendingMaps[0]?.stateIndex === state.index
                 ? [...pendingMaps, candidate]
                 : [candidate];
+            if (mappedReorderState !== state.index) mappedReorderState = undefined;
             continue;
           }
         }
 
+        let containsMappedReorder = false;
         const reorderCalls: Array<{
           call: t.CallExpression;
           kind: "reverse" | "sort";
@@ -2515,31 +2521,51 @@ function rewriteQueuedKeyedArrayMapReorderHints(
             node.callee.name === structuralSortIdentifier.name
           ) {
             structural = true;
+          } else if (node.callee.name === mapReorderIdentifier.name) {
+            containsMappedReorder = true;
           } else if (node.callee.name === reorderIdentifier.name) {
             reorderCalls.push({ call: node, kind: "reverse" });
           } else if (node.callee.name === sortIdentifier.name) {
             reorderCalls.push({ call: node, kind: "sort" });
           }
         });
-        if (
-          structural ||
-          reorderCalls.length === 0 ||
-          pendingMaps.length === 0 ||
-          pendingMaps[0].stateIndex !== state.index
-        ) {
+        if (structural) {
+          mappedReorderState = undefined;
           pendingMaps = [];
           continue;
         }
 
-        for (const candidate of pendingMaps) {
-          candidate.updater.body.callee = t.cloneNode(queuedMapPipelineIdentifier);
-          mapCount += candidate.count;
+        const hasPendingMaps = pendingMaps.length > 0 && pendingMaps[0].stateIndex === state.index;
+        if (containsMappedReorder && reorderCalls.length === 0) {
+          // A mapped reorder can start the next adjacent segment only when no unlinked map setter
+          // sits before it. The later reorder-to-map pass handles proven maps after an existing
+          // mapped reorder; an earlier unproven map must not be skipped when establishing lineage.
+          mappedReorderState = pendingMaps.length === 0 ? state.index : undefined;
+          pendingMaps = [];
+          continue;
+        }
+        if (
+          containsMappedReorder ||
+          reorderCalls.length === 0 ||
+          (!hasPendingMaps && mappedReorderState !== state.index)
+        ) {
+          mappedReorderState = undefined;
+          pendingMaps = [];
+          continue;
+        }
+
+        if (hasPendingMaps) {
+          for (const candidate of pendingMaps) {
+            candidate.updater.body.callee = t.cloneNode(queuedMapPipelineIdentifier);
+            mapCount += candidate.count;
+          }
         }
         for (const { call, kind } of reorderCalls) {
           call.callee = t.cloneNode(mapReorderIdentifier);
           if (kind === "reverse") mapReorderCount += 1;
           else mapSortCount += 1;
         }
+        mappedReorderState = state.index;
         pendingMaps = [];
       }
     },
@@ -8277,7 +8303,9 @@ function compileCandidate(
   );
   let appliedQueuedReorderMapHints = 0;
   const queuedMapCount = queuedMapReorderHintedRoot.mapCount + queuedReorderMapHintedRoot.mapCount;
-  if (queuedMapCount > 0) {
+  const queuedMapReorderCount =
+    queuedMapReorderHintedRoot.mapReorderCount + queuedMapReorderHintedRoot.mapSortCount;
+  if (queuedMapCount > 0 || queuedMapReorderCount > 0) {
     const hintedBlockAnalysis = analyzeComposableBlocks(
       queuedReorderMapHintedRoot.root,
       reactiveByValue,
@@ -8298,7 +8326,7 @@ function compileCandidate(
       expandedReactiveRoot = queuedReorderMapHintedRoot.root;
       blockAnalysis = hintedBlockAnalysis;
       analysis = hintedAnalysis;
-      appliedQueuedReorderMapHints = queuedMapCount;
+      appliedQueuedReorderMapHints = queuedMapCount + queuedMapReorderCount;
       compilerUsage.keyedArrayMapUpdateHints += queuedMapCount;
       compilerUsage.keyedArrayQueuedMapUpdateHints += queuedMapCount;
       compilerUsage.keyedArrayMapReorderHints += queuedMapReorderHintedRoot.mapReorderCount;

--- a/packages/farm-react/vitest.stress.config.ts
+++ b/packages/farm-react/vitest.stress.config.ts
@@ -20,7 +20,7 @@ export default defineConfig({
     ],
     setupFiles: ["src/__tests__/stress.setup.ts"],
     testNamePattern:
-      /2,000 deterministic mapped reorder updates|2,000 deterministic mapped reversal parity updates|2,000 queued reverse, map, and reverse updates|2,000 reverse-or-sort then map updates|2,000 queued reorder then standalone map updates|2,000 queued map then reorder updates|3,000 deterministic recursive updates|4,096 rows/,
+      /2,000 deterministic mapped reorder updates|2,000 deterministic mapped reversal parity updates|2,000 queued reverse, map, and reverse updates|2,000 reverse-or-sort then map updates|2,000 queued reorder then standalone map updates|2,000 queued map then reorder updates|2,000 queued map and consecutive reorder updates|3,000 deterministic recursive updates|4,096 rows/,
     testTimeout: 30_000,
   },
 });


### PR DESCRIPTION
## Problem

After adjacent safe map setters establish keyed replacement lineage, Farm currently retains that proof through only the first native reverse or sort setter:

```tsx
setRows((current) => current.map(updateRow));
setRows((current) => current.toReversed());
setRows((current) => current.toReversed());
```

The second reorder still produces the correct React state, but it uses the ordinary reorder helper, drops mapped-item lineage, and makes the final keyed commit use complete reconciliation.

## Root cause

The queued map-to-reorder compiler pass cleared its state after rewriting the first reorder. The ordinary reorder runtime deliberately carries only order proof, so it cannot recover the changed-row source identities that the map-aware helper retained.

## Change

- Track a proven mapped reorder segment across adjacent concise calls to the same state setter.
- Rewrite every following compiler-proven native `toReversed()` or `toSorted()` operation to the existing map-aware reorder helper.
- Allow an existing concise `map().toReversed()` or map/sort pipeline to start the adjacent segment.
- End the segment at intervening work, another setter, a structural update, mixed unsupported helpers, or any existing compiler fallback boundary.
- Add a 10,000-row browser benchmark and document the supported chain.

## Safety and compatibility

Every functional updater and native array method still executes in JavaScript order. This pass only links helpers that earlier compiler analysis already proved eligible, inside one synchronous direct-statement block and for one state setter. It does not infer across arbitrary control flow.

The existing runtime still validates native dense arrays, committed collection ownership, source length, mapped replacement lineage, unique unchanged keys, and the final identity/reverse or permutation before a DOM write. Failed validation uses complete React-compatible reconciliation. React-owned or host-backed unsupported rows, custom methods, sparse/subclassed arrays, structural operations, changed keys, and ambiguous syntax retain their existing fallbacks.

No public API, configuration, or runtime helper is added. Compiler-disabled output is unchanged, and the optional runtime-size premium is unchanged.

## Verification

- `pnpm exec oxlint <changed TypeScript and JavaScript files>`: 0 warnings, 0 errors
- `pnpm --filter @farm.js/react type-check`: passed
- Focused compiler/runtime suites: 40 passed, 7 stress cases skipped
- `pnpm --filter @farm.js/react test`: 72 files passed; 726 tests passed, 10 skipped
- `pnpm --filter @farm.js/react test:stress`: 10 passed, including the new 2,000-update map/reorder-chain differential test
- `pnpm --filter @farm.js/react test:compat`: React 18.3.1 and React 19.2.8 passed
- `pnpm --filter @farm.js/react test:runtime-size`: passed
- Exact Node 22.13.1 size check: keyed map/reorder premium remains 13,341 B gzip
- Dashboard type-check and production build: passed
- Docs navigation and Vercel production build: passed
- Reduced browser smoke: correctness and the new gate passed in static and hybrid modes
- Full production browser benchmark: correctness, primary regression, optimization persistence, and all 38 feature gates passed
- New 10,000-row queued map/reorder-chain gate:
  - static: 4.5 ms, 12.36x faster than React and 3.18x faster than complete reconciliation
  - hybrid: 5.3 ms, 10.49x faster than React and 3.11x faster than complete reconciliation
- Existing queued map-then-reorder gate remained 11.94x faster than React in static mode and 12.35x in hybrid mode
- Compiled dashboard and table component execution counts remained zero during measured updates

## Documentation and release

Updated the React renderer guide, `@farm.js/react` README, and compiler dashboard benchmark README. The maintained dashboard example now includes concise and block-bodied controls for two maps followed by two queued reversals. No version, template, or release-flow change.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retains mapped keyed replacement lineage across consecutive native reorder setters, so multiple adjacent `toReversed()`/`toSorted()` calls now reconcile once instead of dropping back to complete reconciliation after the first reorder.

- Extends the queued map-to-reorder pass to carry proven replacement lineage through every following reorder setter in the same statement block, not just the first one.
- Rewrites each proven `toReversed()`/`toSorted()` in the chain to the map-aware helper, and allows a concise `map().toReversed()` pipeline to start the chain.
- Ends the chain at an intervening statement, another setter, a structural update, an unsupported method, or a compiler fallback boundary; those cases keep existing fallbacks.
- Adds a 10,000-row browser benchmark gate, a 2,000-update differential stress test, and documentation for the supported chain.

<sup>Written for commit de697625ce3087c07d01199f1a4bdb0d0a3dabe0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/831?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

