### PR TITLE
chore(plugins): remove redundant enabled options

### DIFF
--- a/docs/src/app/docs/plugins/analyzer/page.md
+++ b/docs/src/app/docs/plugins/analyzer/page.md
@@ -114,9 +114,11 @@ analyzer({
 
 ## Options
 
+Adding `analyzer()` to `plugins` enables analysis. Remove it from the array when analysis is not
+needed.
+
 | Option    | Type                          | Default              | Purpose                                      |
 | --------- | ----------------------------- | -------------------- | -------------------------------------------- |
-| `enabled` | `boolean`                     | `true`               | Temporarily disable analysis.                |
 | `output`  | `string \| false`             | `.farm/analyze.html` | HTML report path, or no HTML report.         |
 | `json`    | `boolean \| string`           | `false`              | Write companion JSON or use a custom path.   |
 | `open`    | `boolean`                     | `false`              | Open the HTML report after the build.        |

--- a/docs/src/app/docs/plugins/msw/page.md
+++ b/docs/src/app/docs/plugins/msw/page.md
@@ -87,9 +87,11 @@ msw({
   browser: true,
   server: true,
   onUnhandledRequest: "bypass",
-  enabled: true,
 });
 ```
+
+Adding `msw()` to `plugins` enables mocking in development. Remove it from the array to disable
+both runtimes.
 
 | Option               | Default    | Purpose                                                             |
 | -------------------- | ---------- | ------------------------------------------------------------------- |
@@ -97,7 +99,6 @@ msw({
 | `browser`            | `true`     | Start the browser service worker.                                   |
 | `server`             | `true`     | Start the Node interceptor used by development SSR and server code. |
 | `onUnhandledRequest` | `"bypass"` | Bypass, warn about, or reject requests without a matching handler.  |
-| `enabled`            | `true`     | Disable both runtimes without removing the config block.            |
 
 Use `onUnhandledRequest: "error"` when the mock environment should be completely deterministic.
 The default is `"bypass"` because a Farm development server also makes ordinary framework and

--- a/docs/src/app/docs/plugins/pwa/page.md
+++ b/docs/src/app/docs/plugins/pwa/page.md
@@ -191,9 +191,11 @@ worker and reloads once the new worker controls the page.
 
 ## Options
 
+Adding `pwa()` to `plugins` enables service worker generation and registration. Remove it from the
+array when the app should not ship a service worker.
+
 | Option          | Default    | Description                                                         |
 | --------------- | ---------- | ------------------------------------------------------------------- |
-| `enabled`       | `true`     | Generate or copy and then register the worker.                      |
 | `offline`       | `false`    | Static fallback route for the generated worker.                     |
 | `update`        | `"prompt"` | Prompt or automatically activate and reload for a waiting worker.   |
 | `cache`         | `"auto"`   | Generated-worker caching, a custom object, or build assets only.    |

--- a/docs/src/app/docs/plugins/webmcp/page.md
+++ b/docs/src/app/docs/plugins/webmcp/page.md
@@ -162,15 +162,15 @@ confirmation flow in the application.
 
 ```ts
 webmcp({
-  enabled: true,
   unsupported: "warn",
   debug: true,
 });
 ```
 
+Adding `webmcp()` to `plugins` enables the browser adapter. Remove it from the array to disable it.
+
 | Option        | Default                             | Purpose                                                        |
 | ------------- | ----------------------------------- | -------------------------------------------------------------- |
-| `enabled`     | `true`                              | Start or disable the browser adapter.                          |
 | `unsupported` | `"warn"` in dev, `"ignore"` in prod | Warn, ignore, or report an unavailable browser API.            |
 | `debug`       | `true` in dev, `false` in prod      | Expose `window.__FARM_WEBMCP__` and log tool execution errors. |
 

--- a/packages/farm-analyzer/src/config.test.ts
+++ b/packages/farm-analyzer/src/config.test.ts
@@ -4,7 +4,6 @@ import { parseAnalyzerSize, resolveAnalyzerOptions } from "./config";
 describe("resolveAnalyzerOptions", () => {
   it("creates a useful report with no configuration", () => {
     expect(resolveAnalyzerOptions()).toEqual({
-      enabled: true,
       output: ".farm/analyze.html",
       json: false,
       open: false,
@@ -42,6 +41,9 @@ describe("resolveAnalyzerOptions", () => {
   });
 
   it("rejects contradictory or unclear options", () => {
+    expect(() => resolveAnalyzerOptions({ enabled: false } as never)).toThrow(
+      "remove analyzer() from plugins",
+    );
     expect(() => resolveAnalyzerOptions({ output: false, open: true })).toThrow(
       "needs an HTML output",
     );

--- a/packages/farm-analyzer/src/config.ts
+++ b/packages/farm-analyzer/src/config.ts
@@ -14,8 +14,6 @@ export interface AnalyzerLimits {
 }
 
 export interface AnalyzerOptions {
-  /** Set false to keep the plugin configured without analyzing builds. */
-  enabled?: boolean;
   /** HTML report path relative to the project root. Set false to skip it. */
   output?: string | false;
   /** Also write JSON. True uses the HTML report name with a .json extension. */
@@ -38,7 +36,6 @@ export interface ResolvedAnalyzerLimits {
 }
 
 export interface ResolvedAnalyzerOptions {
-  enabled: boolean;
   output: string | false;
   json: string | false;
   open: boolean;
@@ -50,6 +47,11 @@ export interface ResolvedAnalyzerOptions {
 const DEFAULT_OUTPUT = ".farm/analyze.html";
 
 export function resolveAnalyzerOptions(options: AnalyzerOptions = {}): ResolvedAnalyzerOptions {
+  if ("enabled" in options) {
+    throw new TypeError(
+      "Analyzer no longer accepts enabled; remove analyzer() from plugins to disable it",
+    );
+  }
   const output = normalizeOutput(options.output ?? DEFAULT_OUTPUT, "output");
   if (options.open && output === false) {
     throw new TypeError("Analyzer open needs an HTML output path");
@@ -66,7 +68,6 @@ export function resolveAnalyzerOptions(options: AnalyzerOptions = {}): ResolvedA
   }
 
   return {
-    enabled: options.enabled !== false,
     output,
     json: resolveJsonOutput(options.json ?? false, output),
     open: options.open ?? false,

--- a/packages/farm-analyzer/src/index.ts
+++ b/packages/farm-analyzer/src/index.ts
@@ -37,7 +37,7 @@ export function analyzer(options: AnalyzerOptions = {}) {
 
     build: {
       async after(result) {
-        if (!resolved.enabled || !result.success) return;
+        if (!result.success) return;
 
         const outputDir = path.resolve(
           result.root,

--- a/packages/farm-msw/src/config.test.ts
+++ b/packages/farm-msw/src/config.test.ts
@@ -8,7 +8,6 @@ describe("resolveMswOptions", () => {
       browser: true,
       server: true,
       onUnhandledRequest: "bypass",
-      enabled: true,
     });
   });
 
@@ -18,13 +17,11 @@ describe("resolveMswOptions", () => {
         handlers: "src/mocks/handlers.ts",
         browser: false,
         server: false,
-        enabled: false,
         onUnhandledRequest: "error",
       }),
     ).toMatchObject({
       browser: false,
       server: false,
-      enabled: false,
       onUnhandledRequest: "error",
     });
   });
@@ -33,7 +30,7 @@ describe("resolveMswOptions", () => {
     [{ handlers: "" }, "handlers"],
     [{ handlers: "mocks.ts", browser: "yes" }, "browser"],
     [{ handlers: "mocks.ts", server: 1 }, "server"],
-    [{ handlers: "mocks.ts", enabled: "no" }, "enabled"],
+    [{ handlers: "mocks.ts", enabled: false }, "remove msw() from plugins"],
     [{ handlers: "mocks.ts", onUnhandledRequest: "ignore" }, "onUnhandledRequest"],
   ])("rejects invalid options %#", (options, message) => {
     expect(() => resolveMswOptions(options as never)).toThrow(message);

--- a/packages/farm-msw/src/config.ts
+++ b/packages/farm-msw/src/config.ts
@@ -9,8 +9,6 @@ export interface MswPluginOptions {
   server?: boolean;
   /** How MSW handles requests that have no matching handler. Defaults to bypass. */
   onUnhandledRequest?: MswUnhandledRequestBehavior;
-  /** Set false to leave the plugin configured without starting either runtime. */
-  enabled?: boolean;
 }
 
 export interface ResolvedMswOptions {
@@ -18,7 +16,6 @@ export interface ResolvedMswOptions {
   browser: boolean;
   server: boolean;
   onUnhandledRequest: MswUnhandledRequestBehavior;
-  enabled: boolean;
 }
 
 export function resolveMswOptions(options: MswPluginOptions): ResolvedMswOptions {
@@ -28,9 +25,11 @@ export function resolveMswOptions(options: MswPluginOptions): ResolvedMswOptions
   if (typeof options.handlers !== "string" || !options.handlers.trim()) {
     throw new TypeError("msw handlers must be a non-empty module path");
   }
+  if ("enabled" in options) {
+    throw new TypeError("msw no longer accepts enabled; remove msw() from plugins to disable it");
+  }
   assertBoolean(options.browser, "browser");
   assertBoolean(options.server, "server");
-  assertBoolean(options.enabled, "enabled");
 
   if (
     options.onUnhandledRequest !== undefined &&
@@ -46,7 +45,6 @@ export function resolveMswOptions(options: MswPluginOptions): ResolvedMswOptions
     browser: options.browser ?? true,
     server: options.server ?? true,
     onUnhandledRequest: options.onUnhandledRequest ?? "bypass",
-    enabled: options.enabled ?? true,
   };
 }
 

--- a/packages/farm-msw/src/index.ts
+++ b/packages/farm-msw/src/index.ts
@@ -85,20 +85,19 @@ export function msw(options: MswPluginOptions) {
 
   const browserClient:
     | FarmPluginClientConfig<MswBrowserState | undefined, typeof publicConfig>
-    | undefined =
-    resolved.enabled && resolved.browser
-      ? {
-          public: publicConfig,
-          async setup({ public: config, isDev }) {
-            if (!isDev) return undefined;
-            const runtime = await import("@farm.js/msw/client");
-            return runtime.startMswBrowserRuntime(config);
-          },
-          close({ state }) {
-            state?.stop();
-          },
-        }
-      : undefined;
+    | undefined = resolved.browser
+    ? {
+        public: publicConfig,
+        async setup({ public: config, isDev }) {
+          if (!isDev) return undefined;
+          const runtime = await import("@farm.js/msw/client");
+          return runtime.startMswBrowserRuntime(config);
+        },
+        close({ state }) {
+          state?.stop();
+        },
+      }
+    : undefined;
 
   let plugin: FarmPlugin<
     MswPluginState,
@@ -116,7 +115,7 @@ export function msw(options: MswPluginOptions) {
     enforce: "pre",
 
     configure(config, context) {
-      if (!resolved.enabled || context.isProd) {
+      if (context.isProd) {
         return withoutPlugin(config, plugin);
       }
 
@@ -151,7 +150,7 @@ export function msw(options: MswPluginOptions) {
 
     dev: {
       async server(viteServer, { state }) {
-        if (!resolved.enabled || !resolved.server) return;
+        if (!resolved.server) return;
 
         const server = viteServer as unknown as FarmViteDevServer;
         const handlers = await loadHandlers(server, handlersFile);

--- a/packages/farm-pwa/src/config.test.ts
+++ b/packages/farm-pwa/src/config.test.ts
@@ -4,7 +4,6 @@ import { parsePwaDuration, resolvePwaOptions } from "./config";
 describe("resolvePwaOptions", () => {
   it("uses the automatic cache preset by default", () => {
     const expected = {
-      enabled: true,
       offline: "/offline",
       update: "prompt",
       serviceWorker: false,
@@ -89,8 +88,8 @@ describe("resolvePwaOptions", () => {
 
   it("rejects invalid top-level options instead of changing behavior silently", () => {
     expect(() => resolvePwaOptions(null as never)).toThrow("options must be an object");
-    expect(() => resolvePwaOptions({ enabled: "false" as never })).toThrow(
-      "enabled must be boolean",
+    expect(() => resolvePwaOptions({ enabled: false } as never)).toThrow(
+      "remove pwa() from plugins",
     );
     expect(() => resolvePwaOptions({ update: "manual" as never })).toThrow(
       'update must be "prompt" or "auto"',

--- a/packages/farm-pwa/src/config.ts
+++ b/packages/farm-pwa/src/config.ts
@@ -26,8 +26,6 @@ export interface PwaServiceWorkerOptions {
 }
 
 export interface PwaPluginOptions {
-  /** Set false to keep the plugin registered without emitting or registering a worker. */
-  enabled?: boolean;
   /** Static route to serve after an offline navigation misses the cache. */
   offline?: string | false;
   /** How a waiting service worker becomes active. */
@@ -45,7 +43,6 @@ export interface ResolvedPwaImageCacheOptions {
 }
 
 export interface ResolvedPwaOptions {
-  enabled: boolean;
   offline: string | false;
   update: "prompt" | "auto";
   serviceWorker: Required<PwaServiceWorkerOptions> | false;
@@ -62,8 +59,8 @@ export function resolvePwaOptions(options: PwaPluginOptions = {}): ResolvedPwaOp
   if (!options || typeof options !== "object" || Array.isArray(options)) {
     throw new TypeError("PWA options must be an object");
   }
-  if (options.enabled !== undefined && typeof options.enabled !== "boolean") {
-    throw new TypeError("PWA enabled must be boolean");
+  if ("enabled" in options) {
+    throw new TypeError("PWA no longer accepts enabled; remove pwa() from plugins to disable it");
   }
   if (
     options.offline !== undefined &&
@@ -98,7 +95,6 @@ export function resolvePwaOptions(options: PwaPluginOptions = {}): ResolvedPwaOp
   const customCache = typeof cache === "object" ? cache : undefined;
 
   return {
-    enabled: options.enabled !== false,
     offline: serviceWorker ? false : normalizeRoute(options.offline ?? false, "offline"),
     update: options.update ?? "prompt",
     serviceWorker,

--- a/packages/farm-pwa/src/index.ts
+++ b/packages/farm-pwa/src/index.ts
@@ -47,7 +47,6 @@ export function pwa(options: PwaPluginOptions = {}) {
   let configuredBasePath = "/";
   let configuredOutputDir = ".farm/.output";
   const publicConfig = {
-    enabled: resolved.enabled,
     workerUrl: "/sw.js",
     scope: "/",
     update: resolved.update,
@@ -68,8 +67,6 @@ export function pwa(options: PwaPluginOptions = {}) {
 
     build: {
       configure(nitroConfig) {
-        if (!resolved.enabled) return nitroConfig;
-
         let generated = false;
         const hooks = nitroConfig.hooks ?? {};
         const previousPrerenderDone = hooks["prerender:done"];
@@ -114,7 +111,7 @@ export function pwa(options: PwaPluginOptions = {}) {
       public: publicConfig,
 
       async setup({ public: config, isProd }) {
-        if (!config.enabled || !isProd || !("serviceWorker" in navigator)) return undefined;
+        if (!isProd || !("serviceWorker" in navigator)) return undefined;
 
         const registration = await navigator.serviceWorker.register(
           config.workerUrl,

--- a/packages/farm-webmcp/src/client.test.ts
+++ b/packages/farm-webmcp/src/client.test.ts
@@ -337,7 +337,6 @@ describe("webmcp Farm plugin", () => {
     const plugin = webmcp();
     expect(plugin.name).toBe("farm:webmcp");
     expect(plugin.client?.public).toEqual({
-      enabled: true,
       unsupported: null,
       debug: null,
     });
@@ -345,6 +344,7 @@ describe("webmcp Farm plugin", () => {
   });
 
   it("validates plugin options", () => {
+    expect(() => webmcp({ enabled: false } as never)).toThrow("remove webmcp() from plugins");
     expect(() => webmcp({ unsupported: "silent" as "ignore" })).toThrow(
       'unsupported must be "ignore", "warn", or "error"',
     );

--- a/packages/farm-webmcp/src/index.ts
+++ b/packages/farm-webmcp/src/index.ts
@@ -4,8 +4,6 @@ export type { FarmWebMCPRuntime } from "./types.js";
 export type { WebMCPUnsupportedBehavior } from "./client.js";
 
 export interface WebMCPPluginOptions {
-  /** Set false to keep the plugin configured without starting its browser runtime. */
-  enabled?: boolean;
   /** Behavior when `document.modelContext` is unavailable. Defaults to warn in development. */
   unsupported?: "ignore" | "warn" | "error";
   /** Expose `window.__FARM_WEBMCP__` for inspection. Defaults to true in development. */
@@ -20,12 +18,10 @@ export function webmcp(options: WebMCPPluginOptions = {}) {
     name: "farm:webmcp",
     client: {
       public: {
-        enabled: options.enabled ?? true,
         unsupported: options.unsupported ?? null,
         debug: options.debug ?? null,
       },
       async setup({ public: config, isDev }) {
-        if (!config.enabled) return undefined;
         const runtime = await import("@farm.js/webmcp/client");
         return runtime.startWebMCPRuntime({
           unsupported: config.unsupported ?? (isDev ? "warn" : "ignore"),
@@ -45,8 +41,10 @@ export function webmcp(options: WebMCPPluginOptions = {}) {
 }
 
 function assertOptions(options: WebMCPPluginOptions): void {
-  if (options.enabled !== undefined && typeof options.enabled !== "boolean") {
-    throw new TypeError("webmcp enabled must be boolean");
+  if ("enabled" in options) {
+    throw new TypeError(
+      "webmcp no longer accepts enabled; remove webmcp() from plugins to disable it",
+    );
   }
   if (options.debug !== undefined && typeof options.debug !== "boolean") {
     throw new TypeError("webmcp debug must be boolean");


### PR DESCRIPTION
## Problem

Analyzer, MSW, PWA, and WebMCP each required an app to add the plugin, but also exposed a top-level `enabled` switch. That gave the same lifecycle decision two configuration surfaces.

## Root cause

The initial plugin APIs modeled a disabled state inside each options object even though the Farm plugin array already owns registration and removal.

## Change

- Remove the top-level `enabled` option from Analyzer, MSW, PWA, and WebMCP.
- Use plugin presence as the single enablement signal.
- Reject legacy `enabled` values at runtime with an actionable migration message instead of silently enabling old JavaScript configurations.
- Keep controls for real subfeatures such as MSW browser and server runtimes, PWA caching, and WebMCP debug mode.

## Safety and compatibility

Default behavior is unchanged for every registered plugin. Omitting the plugin disables all of its work. TypeScript now rejects the removed field, and JavaScript receives a clear migration error.

Sentry is intentionally unchanged because its option coordinates both early `registerSentry()` instrumentation and the Farm plugin lifecycle, so it is not only a duplicate of plugin presence.

## Verification

- `pnpm --filter @farm.js/analyzer test`
- `pnpm --filter @farm.js/analyzer type-check`
- `pnpm --filter @farm.js/analyzer build`
- `pnpm --filter @farm.js/msw test`
- `pnpm --filter @farm.js/msw type-check`
- `pnpm --filter @farm.js/msw build`
- `pnpm --filter @farm.js/pwa test`
- `pnpm --filter @farm.js/pwa type-check`
- `pnpm --filter @farm.js/pwa build`
- `pnpm --filter @farm.js/webmcp test`
- `pnpm --filter @farm.js/webmcp type-check`
- `pnpm --filter @farm.js/webmcp build`
- Focused `oxlint` on changed TypeScript files
- `pnpm docs:check-navigation`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm docs:build`

All 55 focused package tests pass. The docs production build succeeds with the Vercel preset.

## Documentation and release

Updated each affected plugin options page and documented plugin presence as the enablement contract. No version files or generated routes changed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the redundant `enabled` option from the Analyzer, MSW, PWA, and WebMCP plugins so plugin presence in the `plugins` array is the single enablement signal. Previously these plugins exposed both an `enabled` switch and registration in the array to control the same lifecycle. Legacy `enabled` values now throw a TypeError with a migration message instead of being silently accepted, and TypeScript rejects the removed field.

- Subfeature controls are unchanged: MSW browser/server runtimes, PWA caching and update behavior, and WebMCP debug mode.
- `@farm.js/sentry` keeps its `enabled` option because it coordinates early `registerSentry()` instrumentation, not just plugin presence.
- Default behavior is identical for registered plugins; omitting a plugin disables all of its work.
- Docs updated on all four plugin pages.

<sup>Written for commit f465ad216ff952911fb290a720223d6930a4ee8f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/833?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

