### PR TITLE
perf(react): retain mapped lineage through structural reorders

### DIFF
--- a/docs/src/app/docs/renderers/react/page.md
+++ b/docs/src/app/docs/renderers/react/page.md
@@ -1250,6 +1250,25 @@ controlled inputs, focus, and text selection stay attached to their keys. Multip
 map-and-reorder setters queued before one compiler flush compose against the same committed
 collection and expose only the final state.
 
+Safe maps can also lead into an index-independent filter or slice before the native reorder:
+
+```tsx
+setItems((current) =>
+  current
+    .map((item) => (item.id === editedId ? { ...item, label: nextLabel } : item))
+    .filter((item) => item.visible)
+    .toSorted((left, right) => left.rank - right.rank),
+);
+```
+
+The filter or slice still evaluates the mapped values in normal JavaScript order. Farm carries both
+proofs to the final commit: which committed rows survived and which surviving items replaced their
+source items. It validates every survivor and key before the first DOM write, removes rejected
+rows, performs only the final LIS moves, and patches bindings only for changed survivors. A changed
+item that the structural step removes needs no row patch. This combined path is limited to one
+concise functional setter with maps before the structural steps; maps after a filter/slice and
+structural work split across setter calls keep complete reconciliation.
+
 A safe map may also be the final pipeline step:
 
 ```tsx
@@ -1342,8 +1361,8 @@ sort or any other order ambiguity keeps the general permutation path.
 The proof requires every map callback to be inline, synchronous, compiler-safe, and to return the
 original item on one conditional branch and an object-spread replacement on the other. It requires
 compiler-owned host rows whose render and key do not observe the index. Referenced or block-bodied
-callbacks, unconditional replacements, changed or duplicate keys, `thisArg`, structural methods in
-the same chain, computed or custom methods, sparse or subclassed arrays, collection-reading
+callbacks, unconditional replacements, changed or duplicate keys, `thisArg`, maps after structural
+steps, computed or custom methods, sparse or subclassed arrays, collection-reading
 bindings, React-owned rows, nested host blocks, row conditionals, unrelated dirty dependencies, or
 failed runtime validation use complete keyed reconciliation before any fast-path DOM write.
 
@@ -2219,6 +2238,10 @@ The package and example test suites verify more than generated code:
   moved-row events with the newest item and index, preserve controlled-input focus and selection,
   and cover changed-key, custom-method, and Array-subclass fallback, Strict Mode hydration, and
   unmount-before-flush cleanup;
+- 2,000 deterministic mapped structural removals match normal React; targeted tests combine safe
+  maps with filter/slice/sort/reverse pipelines, preserve surviving DOM identity and controlled
+  input focus/selection, patch only changed survivors, and cover changed-key and custom-method
+  fallback, Strict Mode hydration, and unmount-before-flush cleanup;
 - 2,000 deterministic native reversals or sorts followed by consecutive same-key edits match normal
   React; targeted tests require exact reversal to use `n - 1` direct DOM moves without a generic
   source-item map, require ambiguous sorting to use one validated keyed reconciliation, and cover

--- a/examples/react-compiler-dashboard/README.md
+++ b/examples/react-compiler-dashboard/README.md
@@ -269,6 +269,17 @@ same four native updates through complete reconciliation. Both compiler modes mu
 final committed order, every original DOM identity and connection, and both changed values. Package tests
 also cover mixed reverse/sort chains, chain boundaries, and 2,000 randomized differential updates.
 
+Mapped structural reorders have a separate 10,000-row comparison. One concise setter changes one
+row, filters out another, and applies two reversals that preserve survivor order. The block-bodied
+control performs the same native work through complete keyed reconciliation. Both compiler modes
+must remain at least 2x faster than React and 1.25x faster than the compiled control. The assertion
+checks the changed values, rejected-row cleanup, full survivor order, and every surviving DOM
+identity. Package tests also cover filter/slice/sort/reverse combinations, controlled-input focus
+and selection, changed-key and custom-method fallback, Strict Mode hydration, cleanup, and 2,000
+mapped structural removals matched with normal React. The benchmark lifecycle rebuilds
+`@farm.js/react` first and then verifies the emitted hint counts, so local source changes cannot be
+silently measured through stale package output.
+
 Mapped reverse parity has an independent 10,000-row comparison. Two safe native maps update one
 row, then two native reversals restore committed order. Farm must patch the changed row without
 moving any DOM row or constructing the generic source-item map/LIS sequence. Both compiler modes

--- a/examples/react-compiler-dashboard/package.json
+++ b/examples/react-compiler-dashboard/package.json
@@ -8,6 +8,7 @@
     "build": "farm build",
     "start": "farm start",
     "type-check": "tsc --noEmit",
+    "prebenchmark": "pnpm --filter @farm.js/react build",
     "benchmark": "node scripts/benchmark.mjs"
   },
   "dependencies": {

--- a/examples/react-compiler-dashboard/scripts/benchmark.mjs
+++ b/examples/react-compiler-dashboard/scripts/benchmark.mjs
@@ -127,7 +127,7 @@ async function inspectBuild(compilerMode) {
       "The compiler build did not emit a keyed Map-lookup target.",
     );
     assert(
-      compilerReport.summary.keyedMapUpdateHints >= 6,
+      compilerReport.summary.keyedMapUpdateHints >= 21,
       "The compiler build did not emit every single-map, consecutive-map, and map-reorder hint.",
     );
     assert(
@@ -135,8 +135,8 @@ async function inspectBuild(compilerMode) {
       "The compiler build did not emit a keyed-array append hint.",
     );
     assert(
-      compilerReport.summary.keyedArrayFilterHints >= 2,
-      "The compiler build did not emit both keyed-array filter hints.",
+      compilerReport.summary.keyedArrayFilterHints >= 3,
+      "The compiler build did not emit every keyed-array filter hint.",
     );
     assert(
       compilerReport.summary.keyedArrayPrependHints > 0,
@@ -147,7 +147,7 @@ async function inspectBuild(compilerMode) {
       "The compiler build did not emit the keyed-array exact-position hints.",
     );
     assert(
-      compilerReport.summary.keyedArrayReorderHints >= 7,
+      compilerReport.summary.keyedArrayReorderHints >= 19,
       "The compiler build did not emit every keyed-array reorder pipeline step.",
     );
     assert(
@@ -1198,6 +1198,81 @@ async function measureTrial(browser, trial, compilerMode, port) {
             ),
         );
 
+        const prepareMapStructuralReorderPipeline = async () => {
+          await create10000();
+          const rows = [...table.querySelectorAll("tbody tr")];
+          const target = rows.find(
+            (row) => Number(row.getAttribute("data-row-id")) % 10_000 === 5_001,
+          );
+          const removed = rows.find(
+            (row) => Number(row.getAttribute("data-row-id")) % 10_000 === 7_001,
+          );
+          const amount = Number(target?.querySelector("td:nth-child(4)")?.textContent?.slice(1));
+          if (!target || !removed || !Number.isFinite(amount)) {
+            throw new Error("Mapped structural-reorder source rows are invalid.");
+          }
+          return {
+            amount: amount + 1,
+            expectedRows: rows.filter((row) => row !== removed),
+            removed,
+            rows,
+            target,
+          };
+        };
+
+        const measureMapStructuralReorderPipeline = async (action, prepared) => {
+          const { amount, expectedRows, removed, rows, target } = prepared;
+          await runTableAction(action, () => {
+            const nextRows = table.querySelectorAll("tbody tr");
+            return (
+              nextRows.length === 9_999 &&
+              target.querySelector("td:nth-child(2)")?.textContent?.endsWith(" reviewed") ===
+                true &&
+              target.querySelector("td:nth-child(4)")?.textContent === `$${amount}` &&
+              !removed.isConnected
+            );
+          });
+          return () => {
+            const nextRows = table.querySelectorAll("tbody tr");
+            if (
+              !rowsMatch(nextRows, expectedRows) ||
+              rows.some((row) => row !== removed && !row.isConnected)
+            ) {
+              throw new Error(
+                "Mapped structural-reorder rows do not match the expected filtered order.",
+              );
+            }
+          };
+        };
+
+        const measureMapStructuralReorderTable = async (action) => {
+          for (let sample = 0; sample < warmupSamples; sample += 1) {
+            const verify = await measureMapStructuralReorderPipeline(
+              action,
+              await prepareMapStructuralReorderPipeline(),
+            );
+            verify();
+          }
+          const timings = [];
+          for (let sample = 0; sample < tableSamples; sample += 1) {
+            const prepared = await prepareMapStructuralReorderPipeline();
+            const startedAt = performance.now();
+            const verify = await measureMapStructuralReorderPipeline(action, prepared);
+            timings.push(performance.now() - startedAt);
+            verify();
+          }
+          return timings;
+        };
+
+        const tableMapStructuralReorderPipeline = await measureMapStructuralReorderTable(() =>
+          tableButton("table-map-structural-reorder-pipeline").click(),
+        );
+
+        const tableMapStructuralReorderPipelineSnapshot =
+          await measureMapStructuralReorderTable(() =>
+            tableButton("table-map-structural-reorder-pipeline-snapshot").click(),
+          );
+
         const prepareMapReorderPipeline = async (expectedAmount) => {
           await create10000();
           const rows = [...table.querySelectorAll("tbody tr")];
@@ -1880,6 +1955,8 @@ async function measureTrial(browser, trial, compilerMode, port) {
             executionsAdded: Number(tableExecutions.textContent) - initialTableExecutions,
             filterReorderPipeline: tableFilterReorderPipeline,
             filterReorderPipelineSnapshot: tableFilterReorderPipelineSnapshot,
+            mapStructuralReorderPipeline: tableMapStructuralReorderPipeline,
+            mapStructuralReorderPipelineSnapshot: tableMapStructuralReorderPipelineSnapshot,
             mapReorderPipeline: tableMapReorderPipeline,
             mapReorderPipelineSnapshot: tableMapReorderPipelineSnapshot,
             multiMapUpdate: tableMultiMapUpdate,
@@ -2022,6 +2099,10 @@ async function measureTrial(browser, trial, compilerMode, port) {
         executionsAdded: result.table.executionsAdded,
         filterReorderPipeline: timingSummary(result.table.filterReorderPipeline),
         filterReorderPipelineSnapshot: timingSummary(result.table.filterReorderPipelineSnapshot),
+        mapStructuralReorderPipeline: timingSummary(result.table.mapStructuralReorderPipeline),
+        mapStructuralReorderPipelineSnapshot: timingSummary(
+          result.table.mapStructuralReorderPipelineSnapshot,
+        ),
         mapReorderPipeline: timingSummary(result.table.mapReorderPipeline),
         mapReorderPipelineSnapshot: timingSummary(result.table.mapReorderPipelineSnapshot),
         multiMapUpdate: timingSummary(result.table.multiMapUpdate),
@@ -2233,6 +2314,8 @@ const tableMetrics = [
   "denseMapLookup",
   "filterReorderPipeline",
   "filterReorderPipelineSnapshot",
+  "mapStructuralReorderPipeline",
+  "mapStructuralReorderPipelineSnapshot",
   "mapReorderPipeline",
   "mapReorderPipelineSnapshot",
   "multiMapUpdate",
@@ -2889,6 +2972,30 @@ const keyedStructuralReorderRegressions = keyedStructuralReorderResults.filter(
     !Number.isFinite(snapshotSpeedup) ||
     snapshotSpeedup < keyedStructuralReorderMinimumSnapshotSpeedup,
 );
+// A safe map before filter and reorder changes row data, membership, and order in one setter. The
+// mapped structural path must patch the changed survivor, remove the rejected row, and validate the
+// final order once instead of dropping to complete keyed reconciliation.
+const keyedMappedStructuralReorderMinimumSpeedup = 2;
+const keyedMappedStructuralReorderMinimumSnapshotSpeedup = 1.25;
+const keyedMappedStructuralReorderResults = ["static", "hybrid"].map((mode) => {
+  const pipelineMedianMs = comparisons.table.mapStructuralReorderPipeline[mode].medianMs;
+  const snapshotMedianMs =
+    comparisons.table.mapStructuralReorderPipelineSnapshot[mode].medianMs;
+  return {
+    mode,
+    pipelineMedianMs,
+    snapshotMedianMs,
+    snapshotSpeedup: snapshotMedianMs / pipelineMedianMs,
+    speedup: comparisons.table.mapStructuralReorderPipeline[`${mode}VsBaseline`].speedup,
+  };
+});
+const keyedMappedStructuralReorderRegressions = keyedMappedStructuralReorderResults.filter(
+  ({ snapshotSpeedup, speedup }) =>
+    !Number.isFinite(speedup) ||
+    speedup < keyedMappedStructuralReorderMinimumSpeedup ||
+    !Number.isFinite(snapshotSpeedup) ||
+    snapshotSpeedup < keyedMappedStructuralReorderMinimumSnapshotSpeedup,
+);
 // Editing one same-key row and immediately sorting it should reuse all keyed DOM rows, patch only
 // the changed bindings, and run one LIS against the final order. Compare the concise hinted setter
 // with React and the equivalent block-bodied compiled control at 10,000 rows.
@@ -3279,6 +3386,7 @@ const passed =
   keyedQueuedReorderRegressions.length === 0 &&
   keyedReorderPipelineRegressions.length === 0 &&
   keyedStructuralReorderRegressions.length === 0 &&
+  keyedMappedStructuralReorderRegressions.length === 0 &&
   keyedMapReorderRegressions.length === 0 &&
   keyedMultiMapReorderRegressions.length === 0 &&
   keyedMultiMapReverseRegressions.length === 0 &&
@@ -3453,6 +3561,13 @@ const report = {
     regressions: keyedStructuralReorderRegressions,
     results: keyedStructuralReorderResults,
     status: keyedStructuralReorderRegressions.length === 0 ? "PASS" : "FAIL",
+  },
+  keyedMappedStructuralReorderHintGate: {
+    minimumSnapshotSpeedup: keyedMappedStructuralReorderMinimumSnapshotSpeedup,
+    minimumSpeedup: keyedMappedStructuralReorderMinimumSpeedup,
+    regressions: keyedMappedStructuralReorderRegressions,
+    results: keyedMappedStructuralReorderResults,
+    status: keyedMappedStructuralReorderRegressions.length === 0 ? "PASS" : "FAIL",
   },
   keyedMapReorderHintGate: {
     minimumSnapshotSpeedup: keyedMapReorderMinimumSnapshotSpeedup,

--- a/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
+++ b/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
@@ -871,6 +871,48 @@ export function StandardTableBenchmark() {
           Filter + reorder pipeline (snapshot control)
         </button>
         <button
+          data-action="table-map-structural-reorder-pipeline"
+          type="button"
+          onClick={() => {
+            setRows((current) =>
+              current
+                .map((row) =>
+                  row.id % 10_000 === 5_001
+                    ? { ...row, amount: row.amount + 1, label: `${row.label} reviewed` }
+                    : row,
+                )
+                .filter((row) => row.id % 10_000 !== 7_001)
+                .toReversed()
+                .toReversed(),
+            );
+            setOperation("review one row, filter another, and preserve order");
+            setRevision((value) => value + 1);
+          }}
+        >
+          Review + filter + reorder
+        </button>
+        <button
+          data-action="table-map-structural-reorder-pipeline-snapshot"
+          type="button"
+          onClick={() => {
+            setRows((current) => {
+              return current
+                .map((row) =>
+                  row.id % 10_000 === 5_001
+                    ? { ...row, amount: row.amount + 1, label: `${row.label} reviewed` }
+                    : row,
+                )
+                .filter((row) => row.id % 10_000 !== 7_001)
+                .toReversed()
+                .toReversed();
+            });
+            setOperation("review, filter, and reorder rows (snapshot control)");
+            setRevision((value) => value + 1);
+          }}
+        >
+          Review + filter + reorder (snapshot control)
+        </button>
+        <button
           data-action="table-map-reorder-pipeline"
           type="button"
           onClick={() => {

--- a/packages/farm-react/README.md
+++ b/packages/farm-react/README.md
@@ -468,6 +468,13 @@ An exact reverse uses the minimum-move reverse path without a general source-ite
 sort remains an ambiguous permutation, so Farm performs one validated source lookup and LIS pass.
 Safe maps on both sides of a reorder flatten their replacements back to the same committed rows.
 
+Safe maps may also run before index-independent `filter` or `slice` steps and a native reorder in
+one concise functional setter. The structural helpers retain both the committed survivor indices
+and the mapped-item sources, so the final commit removes rejected rows, performs only its final LIS
+moves, and patches bindings only for changed survivors. Every native callback and method still runs
+in JavaScript order. Maps after a structural step, structural work split across setters, unsafe
+callbacks, and failed runtime validation keep complete keyed reconciliation.
+
 The reorder and safe maps may also be adjacent setter calls in the same synchronous block:
 
 ```tsx

--- a/packages/farm-react/scripts/benchmark-runtime-size.mjs
+++ b/packages/farm-react/scripts/benchmark-runtime-size.mjs
@@ -533,7 +533,7 @@ if (checkOnly) {
     {
       name: "keyed filter compiler premium",
       current: results.fixtures.keyedFilter.compilerPremium.gzip,
-      maximum: (reference.fixtures.keyedFilter?.compilerPremium.gzip ?? 12_000) + 256,
+      maximum: (reference.fixtures.keyedFilter?.compilerPremium.gzip ?? 12_000) + 260,
     },
     {
       name: "keyed prepend compiler premium",

--- a/packages/farm-react/src/__tests__/compiler-keyed-array-sort-hints.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-keyed-array-sort-hints.test.ts
@@ -475,9 +475,14 @@ describe("React AOT keyed-array sort hints", () => {
         'current["map"]((row) => row.id === editedId ? { ...row, rank: 0 } : row).toSorted((a, b) => a.rank - b.rank)',
     },
     {
-      name: "a structural step after map",
+      name: "a mapped structural update without a final reorder",
       pipeline:
-        "current.map((row) => row.id === editedId ? { ...row, rank: 0 } : row).filter((row) => row.rank > 0).toSorted((a, b) => a.rank - b.rank)",
+        "current.map((row) => row.id === editedId ? { ...row, rank: 0 } : row).filter((row) => row.rank > 0)",
+    },
+    {
+      name: "a map after a structural step",
+      pipeline:
+        "current.filter((row) => row.rank > 0).map((row) => row.id === editedId ? { ...row, rank: 0 } : row).toSorted((a, b) => a.rank - b.rank)",
     },
     {
       name: "a map after a structural reorder",
@@ -500,6 +505,70 @@ describe("React AOT keyed-array sort hints", () => {
     expect(result.optimizations.keyedArraySortHints).toBe(0);
     expect(result.code).not.toContain("createCompilerKeyedArrayMapPipeline");
     expect(result.code).not.toContain("keyedRowsMapReorderHintedRuntimeFeature");
+  });
+
+  it("carries mapped row lineage through a following filter and sort", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Table({ editedId, nextRank }) {
+        const [rows, setRows] = useState([
+          { id: "a", rank: 1, visible: true },
+          { id: "b", rank: 2, visible: false },
+        ]);
+        return <section>
+          <button onClick={() => setRows((current) => current
+            .map((row) => row.id === editedId ? { ...row, rank: nextRank } : row)
+            .filter((row) => row.visible)
+            .toSorted((left, right) => left.rank - right.rank)
+          )}>Update</button>
+          <ul>{rows.map((row) => <li key={row.id}>{row.rank}</li>)}</ul>
+        </section>;
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Table"]);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.optimizations.keyedMapUpdateHints).toBe(1);
+    expect(result.optimizations.keyedArrayFilterHints).toBe(1);
+    expect(result.optimizations.keyedArraySortHints).toBe(1);
+    expect(result.code).toContain("createCompilerKeyedArrayMapPipeline");
+    expect(result.code).toContain("createCompilerKeyedArrayFilter");
+    expect(result.code).toContain("createCompilerKeyedArrayStructuralSort");
+    expect(result.code).toContain("keyedRowsEveryHintedRuntimeFeature");
+    expect(result.code).not.toContain("createCompilerKeyedArrayMapReorder");
+  });
+
+  it("carries consecutive maps through slice and reverse steps", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Table({ editedId, nextLabel, offset }) {
+        const [rows, setRows] = useState([
+          { id: "a", label: "Alpha", rank: 1 },
+          { id: "b", label: "Beta", rank: 2 },
+          { id: "c", label: "Gamma", rank: 3 },
+        ]);
+        return <section>
+          <button onClick={() => setRows((current) => current
+            .map((row) => row.id === editedId ? { ...row, label: nextLabel } : row)
+            .map((row) => row.id === editedId ? { ...row, rank: row.rank + 1 } : row)
+            .slice(offset)
+            .toReversed()
+            .toReversed()
+          )}>Update</button>
+          <ul>{rows.map((row) => <li key={row.id}>{row.label}: {row.rank}</li>)}</ul>
+        </section>;
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Table"]);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.optimizations.keyedMapUpdateHints).toBe(2);
+    expect(result.optimizations.keyedArraySliceHints).toBe(1);
+    expect(result.optimizations.keyedArrayReorderHints).toBe(2);
+    expect(result.code.match(/createCompilerKeyedArrayMapPipeline\(/g)).toHaveLength(1);
+    expect(result.code).toContain("createCompilerKeyedArraySlice");
+    expect(result.code.match(/createCompilerKeyedArrayStructuralReorder\(/g)).toHaveLength(2);
+    expect(result.code).not.toContain("createCompilerKeyedArrayMapReorder");
   });
 
   it.each([

--- a/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-structural-reorder-hints.test.tsx
+++ b/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-structural-reorder-hints.test.tsx
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createCompiledComponent,
   createCompilerKeyedArrayFilter,
+  createCompilerKeyedArrayMapPipeline,
   createCompilerKeyedArraySlice,
   createCompilerKeyedArrayStructuralReorder,
   createCompilerKeyedArrayStructuralSort,
@@ -45,6 +46,10 @@ function hintedFilter(items: Item[], predicate: (item: Item) => boolean): Item[]
   return createCompilerKeyedArrayFilter(items, items.filter, predicate) as Item[];
 }
 
+function hintedMap(items: Item[], mapper: (item: Item) => Item): Item[] {
+  return createCompilerKeyedArrayMapPipeline(items, items.map, mapper) as Item[];
+}
+
 function hintedSlice(items: Item[], start: number, end?: number): Item[] {
   return createCompilerKeyedArraySlice(
     items,
@@ -82,7 +87,20 @@ function createHarness(initialItems: Item[]) {
   let filterSortReverse: (removed: ReadonlySet<string>) => void = () => undefined;
   let filterThenQueuedSort: (removed: ReadonlySet<string>) => void = () => undefined;
   let filterSliceReverse: (removed: ReadonlySet<string>, limit: number) => void = () => undefined;
+  let mapFilterSortReverse: (
+    editedId: string,
+    nextLabel: string,
+    nextRank: number,
+    removed: ReadonlySet<string>,
+  ) => void = () => undefined;
+  let mapFilterDoubleReverse: (
+    editedId: string,
+    nextLabel: string,
+    removed: ReadonlySet<string>,
+  ) => void = () => undefined;
   let invalidIdentity: () => void = () => undefined;
+  let invalidMappedIdentity: () => void = () => undefined;
+  let customMapStructural: () => void = () => undefined;
   let customSortAfterFilter: (removed: ReadonlySet<string>) => void = () => undefined;
   const Table = createCompiledComponent({
     displayName: "StructuralReorderTable",
@@ -117,11 +135,66 @@ function createHarness(initialItems: Item[]) {
             ),
           ),
         );
+      mapFilterSortReverse = (editedId, nextLabel, nextRank, removed) =>
+        state[0].set((previous) =>
+          hintedReverse(
+            hintedSort(
+              hintedFilter(
+                hintedMap(previous as Item[], (item) =>
+                  item.id === editedId ? { ...item, label: nextLabel, rank: nextRank } : item,
+                ),
+                (item) => !removed.has(item.id),
+              ),
+              (left, right) => left.rank - right.rank,
+            ),
+          ),
+        );
+      mapFilterDoubleReverse = (editedId, nextLabel, removed) =>
+        state[0].set((previous) =>
+          hintedReverse(
+            hintedReverse(
+              hintedFilter(
+                hintedMap(previous as Item[], (item) =>
+                  item.id === editedId ? { ...item, label: nextLabel } : item,
+                ),
+                (item) => !removed.has(item.id),
+              ),
+            ),
+          ),
+        );
       invalidIdentity = () =>
         state[0].set((previous) => {
           const next = hintedReverse(hintedFilter(previous as Item[], (item) => item.id !== "b"));
           next[0] = { ...next[0], id: "replacement", label: "Replacement" };
           return next;
+        });
+      invalidMappedIdentity = () =>
+        state[0].set((previous) =>
+          hintedReverse(
+            hintedFilter(
+              hintedMap(previous as Item[], (item) =>
+                item.id === "b" ? { ...item, id: "replacement", label: "Replacement" } : item,
+              ),
+              (item) => item.id !== "c",
+            ),
+          ),
+        );
+      customMapStructural = () =>
+        state[0].set((previous) => {
+          const source = previous as Item[];
+          const customMap = function (
+            this: Item[],
+            callback: (item: Item, index: number, items: Item[]) => Item,
+          ) {
+            return Array.prototype.map.call(this, callback);
+          };
+          const mapped = createCompilerKeyedArrayMapPipeline(source, customMap, (item: Item) =>
+            item.id === "a" ? { ...item, label: "Custom map" } : item,
+          ) as Item[];
+          return hintedSort(
+            hintedFilter(mapped, (item) => item.id !== "c"),
+            (left, right) => left.rank - right.rank,
+          );
         });
       customSortAfterFilter = (removed) =>
         state[0].set((previous) => {
@@ -185,11 +258,21 @@ function createHarness(initialItems: Item[]) {
     Table,
     counters,
     customSortAfterFilter: (removed: ReadonlySet<string>) => customSortAfterFilter(removed),
+    customMapStructural: () => customMapStructural(),
     filterSliceReverse: (removed: ReadonlySet<string>, limit: number) =>
       filterSliceReverse(removed, limit),
     filterSortReverse: (removed: ReadonlySet<string>) => filterSortReverse(removed),
     filterThenQueuedSort: (removed: ReadonlySet<string>) => filterThenQueuedSort(removed),
     invalidIdentity: () => invalidIdentity(),
+    invalidMappedIdentity: () => invalidMappedIdentity(),
+    mapFilterDoubleReverse: (editedId: string, nextLabel: string, removed: ReadonlySet<string>) =>
+      mapFilterDoubleReverse(editedId, nextLabel, removed),
+    mapFilterSortReverse: (
+      editedId: string,
+      nextLabel: string,
+      nextRank: number,
+      removed: ReadonlySet<string>,
+    ) => mapFilterSortReverse(editedId, nextLabel, nextRank, removed),
   };
 }
 
@@ -280,6 +363,45 @@ describe("compiled keyed-array structural reorder hints", () => {
     expect(harness.counters.executions).toBe(1);
   });
 
+  it("patches mapped survivors while removing a row and preserving exact order", async () => {
+    const items: Item[] = [
+      { id: "a", label: "Alpha", rank: 4, visible: true },
+      { id: "b", label: "Beta", rank: 1, visible: false },
+      { id: "c", label: "Gamma", rank: 3, visible: true },
+      { id: "d", label: "Delta", rank: 2, visible: true },
+    ];
+    const harness = createHarness(items);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Table />));
+    const alpha = container.querySelector('[data-key="a"]');
+    const gamma = container.querySelector('[data-key="c"]');
+    const delta = container.querySelector('[data-key="d"]');
+    const insertBefore = vi.spyOn(container.querySelector("ul")!, "insertBefore");
+    harness.counters.bindings = 0;
+    harness.counters.descriptors = 0;
+    harness.counters.keys = 0;
+
+    await act(async () => {
+      harness.mapFilterDoubleReverse("c", "Gamma updated", new Set(["b"]));
+      await flushCompilerUpdates();
+    });
+
+    expect(labels(container)).toEqual(["Alpha", "Gamma updated", "Delta"]);
+    expect(container.querySelector('[data-key="a"]')).toBe(alpha);
+    expect(container.querySelector('[data-key="c"]')).toBe(gamma);
+    expect(container.querySelector('[data-key="d"]')).toBe(delta);
+    expect(container.querySelector('[data-key="b"]')).toBeNull();
+    expect(harness.counters.executions).toBe(1);
+    expect(harness.counters.renders).toBe(1);
+    expect(harness.counters.keys).toBe(3);
+    expect(harness.counters.descriptors).toBe(0);
+    expect(harness.counters.bindings).toBe(1);
+    expect(insertBefore).not.toHaveBeenCalled();
+  });
+
   it("falls back safely for custom methods and identity mismatches", async () => {
     const items: Item[] = [
       { id: "a", label: "Alpha", rank: 2, visible: true },
@@ -307,6 +429,44 @@ describe("compiled keyed-array structural reorder hints", () => {
     expect(harness.counters.bindings).toBeGreaterThan(0);
   });
 
+  it("falls back atomically for a custom map or changed mapped key", async () => {
+    const items: Item[] = [
+      { id: "a", label: "Alpha", rank: 2, visible: true },
+      { id: "b", label: "Beta", rank: 1, visible: true },
+      { id: "c", label: "Gamma", rank: 3, visible: true },
+    ];
+    const custom = createHarness(items);
+    const customContainer = document.createElement("div");
+    document.body.append(customContainer);
+    const customRoot = createRoot(customContainer);
+    roots.push(customRoot);
+    await act(async () => customRoot.render(<custom.Table />));
+    custom.counters.bindings = 0;
+    custom.counters.descriptors = 0;
+    await act(async () => {
+      custom.customMapStructural();
+      await flushCompilerUpdates();
+    });
+    expect(labels(customContainer)).toEqual(["Beta", "Custom map"]);
+    expect(custom.counters.bindings).toBeGreaterThan(0);
+
+    const changedKey = createHarness(items);
+    const changedKeyContainer = document.createElement("div");
+    document.body.append(changedKeyContainer);
+    const changedKeyRoot = createRoot(changedKeyContainer);
+    roots.push(changedKeyRoot);
+    await act(async () => changedKeyRoot.render(<changedKey.Table />));
+    changedKey.counters.bindings = 0;
+    changedKey.counters.descriptors = 0;
+    await act(async () => {
+      changedKey.invalidMappedIdentity();
+      await flushCompilerUpdates();
+    });
+    expect(labels(changedKeyContainer)).toEqual(["Replacement", "Alpha"]);
+    expect(changedKey.counters.bindings).toBeGreaterThan(0);
+    expect(changedKey.counters.descriptors).toBeGreaterThan(0);
+  });
+
   it("preserves a surviving controlled input, focus, and selection", async () => {
     const items: Item[] = [
       { id: "a", label: "Alpha", rank: 3, visible: true },
@@ -321,7 +481,14 @@ describe("compiled keyed-array structural reorder hints", () => {
         const rows = () => state[0].get() as Item[];
         update = () =>
           state[0].set((previous) =>
-            hintedReverse(hintedFilter(previous as Item[], (item) => item.id !== "a")),
+            hintedReverse(
+              hintedFilter(
+                hintedMap(previous as Item[], (item) =>
+                  item.id === "b" ? { ...item, label: "Beta newest" } : item,
+                ),
+                (item) => item.id !== "a",
+              ),
+            ),
           );
         return (
           <section>
@@ -352,7 +519,14 @@ describe("compiled keyed-array structural reorder hints", () => {
                 styles: [],
                 children: [],
               })}
-              bindings={[]}
+              bindings={[
+                {
+                  kind: "attribute",
+                  name: "value",
+                  path: [],
+                  read: (item) => (item as Item).label,
+                },
+              ]}
             />
           </section>
         );
@@ -374,6 +548,7 @@ describe("compiled keyed-array structural reorder hints", () => {
     });
 
     expect(container.querySelector('[data-key="b"]')).toBe(input);
+    expect(input.value).toBe("Beta newest");
     expect(document.activeElement).toBe(input);
     expect([input.selectionStart, input.selectionEnd]).toEqual([1, 3]);
   });
@@ -440,6 +615,80 @@ describe("compiled keyed-array structural reorder hints", () => {
     expect(harness.counters.executions).toBe(1);
   }, 20_000);
 
+  it("matches React across 2,000 mapped structural removals", async () => {
+    const initialItems = Array.from(
+      { length: 2_001 },
+      (_, index): Item => ({
+        id: `row-${index}`,
+        label: `Row ${index}`,
+        rank: (index * 1_229) % 2_003,
+        visible: true,
+      }),
+    );
+    const harness = createHarness(initialItems);
+    let updateReact: (
+      editedId: string,
+      nextLabel: string,
+      nextRank: number,
+      removed: ReadonlySet<string>,
+    ) => void = () => undefined;
+    function Normal() {
+      const [items, setItems] = useState(initialItems);
+      updateReact = (editedId, nextLabel, nextRank, removed) =>
+        setItems((previous) =>
+          previous
+            .map((item) =>
+              item.id === editedId ? { ...item, label: nextLabel, rank: nextRank } : item,
+            )
+            .filter((item) => !removed.has(item.id))
+            .toSorted((left, right) => left.rank - right.rank)
+            .toReversed(),
+        );
+      return (
+        <ol>
+          {items.map((item) => (
+            <li data-key={item.id} key={item.id}>
+              {item.label}
+            </li>
+          ))}
+        </ol>
+      );
+    }
+    const compiledContainer = document.createElement("div");
+    const reactContainer = document.createElement("div");
+    document.body.append(compiledContainer, reactContainer);
+    const compiledRoot = createRoot(compiledContainer);
+    const reactRoot = createRoot(reactContainer);
+    roots.push(compiledRoot, reactRoot);
+    await act(async () => {
+      compiledRoot.render(<harness.Table />);
+      reactRoot.render(<Normal />);
+    });
+
+    let seed = 0xa341316c;
+    const active = initialItems.map((item) => item.id);
+    for (let batch = 0; batch < 100; batch += 1) {
+      seed = (Math.imul(seed, 1_664_525) + 1_013_904_223) >>> 0;
+      const editedId = active[seed % active.length];
+      const nextLabel = `Updated ${batch}`;
+      const nextRank = seed % 2_003;
+      const removed = new Set<string>();
+      for (let update = 0; update < 20; update += 1) {
+        seed = (Math.imul(seed, 1_664_525) + 1_013_904_223) >>> 0;
+        const index = seed % active.length;
+        const [id] = active.splice(index, 1);
+        removed.add(id);
+      }
+      await act(async () => {
+        harness.mapFilterSortReverse(editedId, nextLabel, nextRank, removed);
+        updateReact(editedId, nextLabel, nextRank, removed);
+        await flushCompilerUpdates();
+      });
+      expect(labels(compiledContainer)).toEqual(labels(reactContainer));
+    }
+    expect(harness.counters.executions).toBe(1);
+  }, 20_000);
+
   it("hydrates in StrictMode and drops a queued pipeline after unmount", async () => {
     const items: Item[] = [
       { id: "a", label: "Alpha", rank: 3, visible: true },
@@ -463,10 +712,10 @@ describe("compiled keyed-array structural reorder hints", () => {
     });
     roots.push(root);
     await act(async () => {
-      hydration.filterSortReverse(new Set(["b"]));
+      hydration.mapFilterSortReverse("c", "Gamma hydrated", 2, new Set(["b"]));
       await flushCompilerUpdates();
     });
-    expect(labels(container)).toEqual(["Alpha", "Gamma"]);
+    expect(labels(container)).toEqual(["Alpha", "Gamma hydrated"]);
     expect(recoverable).toEqual([]);
 
     const unmounted = createHarness(items);
@@ -475,7 +724,7 @@ describe("compiled keyed-array structural reorder hints", () => {
     const unmountRoot = createRoot(unmountContainer);
     await act(async () => unmountRoot.render(<unmounted.Table />));
     act(() => {
-      unmounted.filterSortReverse(new Set(["a"]));
+      unmounted.mapFilterSortReverse("c", "Gamma queued", 2, new Set(["a"]));
       unmountRoot.unmount();
     });
     await flushCompilerUpdates();

--- a/packages/farm-react/src/compiler-runtime.tsx
+++ b/packages/farm-react/src/compiler-runtime.tsx
@@ -26,6 +26,7 @@ interface CompilerKeyedArrayFilterHint {
   readonly removedIndices?: readonly number[];
   readonly retainedEnd?: number;
   readonly retainedStart?: number;
+  readonly mappedItemSources?: CompilerMappedItemSources;
   readonly previous?: CompilerKeyedArrayFilterHint;
 }
 
@@ -1011,17 +1012,29 @@ export function createCompilerKeyedArrayFilter(
     ) {
       return value;
     }
-    const sourceToken = compilerKeyedCollectionToken(previousTarget);
+    const committedSource = COMPILER_KEYED_COMMITTED_COLLECTIONS.has(previousTarget);
+    const previousMappedUpdate = committedSource
+      ? undefined
+      : COMPILER_KEYED_ARRAY_REORDERS.get(previousTarget);
+    const mappedUpdate =
+      previousMappedUpdate?.mapped &&
+      !previousMappedUpdate.structuralUpdate &&
+      previousMappedUpdate.resultLength === sourceLength
+        ? previousMappedUpdate
+        : undefined;
+    const sourceToken = mappedUpdate?.sourceToken || compilerKeyedCollectionToken(previousTarget);
     if (!sourceToken) return value;
-    const previousUpdate = !COMPILER_KEYED_COMMITTED_COLLECTIONS.has(previousTarget)
+    const previousUpdate = !committedSource
       ? COMPILER_KEYED_ARRAY_FILTERS.get(previousTarget)
       : undefined;
+    const mappedItemSources = previousUpdate?.mappedItemSources || mappedUpdate?.mappedItemSources;
     COMPILER_KEYED_ARRAY_FILTERS.set(valueTarget, {
       kind: "filter",
       sourceToken: previousUpdate?.sourceToken || sourceToken,
       sourceLength,
       resultLength: value.length,
       removedIndices,
+      ...(mappedItemSources ? { mappedItemSources } : {}),
       ...(previousUpdate ? { previous: previousUpdate } : {}),
     });
   } catch {
@@ -1071,11 +1084,22 @@ export function createCompilerKeyedArraySlice(
     const retainedEnd = args.length === 2 ? normalize(args[1]) : sourceLength;
     const resultLength = Math.max(retainedEnd - retainedStart, 0);
     if (value.length !== resultLength || resultLength >= sourceLength) return value;
-    const sourceToken = compilerKeyedCollectionToken(previousTarget);
+    const committedSource = COMPILER_KEYED_COMMITTED_COLLECTIONS.has(previousTarget);
+    const previousMappedUpdate = committedSource
+      ? undefined
+      : COMPILER_KEYED_ARRAY_REORDERS.get(previousTarget);
+    const mappedUpdate =
+      previousMappedUpdate?.mapped &&
+      !previousMappedUpdate.structuralUpdate &&
+      previousMappedUpdate.resultLength === sourceLength
+        ? previousMappedUpdate
+        : undefined;
+    const sourceToken = mappedUpdate?.sourceToken || compilerKeyedCollectionToken(previousTarget);
     if (!sourceToken) return value;
-    const previousUpdate = !COMPILER_KEYED_COMMITTED_COLLECTIONS.has(previousTarget)
+    const previousUpdate = !committedSource
       ? COMPILER_KEYED_ARRAY_FILTERS.get(previousTarget)
       : undefined;
+    const mappedItemSources = previousUpdate?.mappedItemSources || mappedUpdate?.mappedItemSources;
     COMPILER_KEYED_ARRAY_FILTERS.set(valueTarget, {
       kind: "slice",
       sourceToken: previousUpdate?.sourceToken || sourceToken,
@@ -1083,6 +1107,7 @@ export function createCompilerKeyedArraySlice(
       resultLength,
       retainedEnd: Math.max(retainedEnd, retainedStart),
       retainedStart,
+      ...(mappedItemSources ? { mappedItemSources } : {}),
       ...(previousUpdate ? { previous: previousUpdate } : {}),
     });
   } catch {
@@ -1485,11 +1510,17 @@ function recordCompilerKeyedArrayStructuralReorder(
     const sourceToken = previousUpdate?.sourceToken || structuralSource?.sourceToken;
     if (!sourceToken) return value;
     COMPILER_KEYED_ARRAY_REORDERS.set(valueTarget, {
-      kind: previousUpdate ? CompilerKeyedArrayReorderKind.Permutation : kind,
+      kind:
+        kind === CompilerKeyedArrayReorderKind.Reverse
+          ? reversedCompilerKeyedArrayOrder(previousUpdate?.kind)
+          : CompilerKeyedArrayReorderKind.Permutation,
       sourceToken,
       sourceLength: previousUpdate?.sourceLength || structuralSource.sourceLength,
       resultLength: value.length,
       structuralUpdate,
+      ...(structuralUpdate.mappedItemSources
+        ? { mappedItemSources: structuralUpdate.mappedItemSources }
+        : {}),
     });
   } catch {
     // Metadata must never change the result of a successful native update.
@@ -5966,6 +5997,7 @@ function reconcileCompilerKeyedArrayStructuralReorder(
   if (!survivorResult) return undefined;
 
   const previousInstances = [...instances.values()];
+  const mappedItemSources = update.mappedItemSources;
   const prepared = (() => {
     try {
       const survivors: CompilerKeyedRowInstance[] = [];
@@ -5979,18 +6011,55 @@ function reconcileCompilerKeyedArrayStructuralReorder(
         survivors.push(instance);
       }
 
+      const prepareChangedInstance = (
+        instance: CompilerKeyedRowInstance,
+        item: unknown,
+        targetIndex: number,
+      ) => {
+        if (Object.is(instance.item, item)) return undefined;
+        const bindingUpdates = prepareKeyedRowBindingUpdates(props, instance, item, targetIndex);
+        if (!bindingUpdates) throw new TypeError();
+        return { bindingUpdates, instance, item };
+      };
       let preservesSurvivorOrder = true;
+      const directChanges: Array<{
+        bindingUpdates: CompilerPreparedKeyedRowBindingUpdate[];
+        instance: CompilerKeyedRowInstance;
+        item: unknown;
+      }> = [];
+      if (update.kind !== CompilerKeyedArrayReorderKind.Permutation) {
+        const positionalInstances =
+          update.kind === CompilerKeyedArrayReorderKind.Reverse
+            ? [...survivors].reverse()
+            : survivors;
+        const sequence =
+          update.kind === CompilerKeyedArrayReorderKind.Reverse
+            ? positionalInstances.map((instance) => instance.index)
+            : undefined;
+        for (let targetIndex = 0; targetIndex < finalValue.length; targetIndex += 1) {
+          const item = finalValue[targetIndex];
+          const instance = positionalInstances[targetIndex];
+          if (keyedRowIdentity(props.rowKey(item, targetIndex)) !== instance.key) return undefined;
+          const changed = prepareChangedInstance(instance, item, targetIndex);
+          if (changed) directChanges.push(changed);
+        }
+        return { changed: directChanges, nextInstances: positionalInstances, sequence };
+      }
+
       for (let targetIndex = 0; targetIndex < finalValue.length; targetIndex += 1) {
         const item = finalValue[targetIndex];
         const instance = survivors[targetIndex];
-        if (!Object.is(instance.item, item)) {
+        const sourceItem = mappedItemSources?.has(item) ? mappedItemSources.get(item) : item;
+        if (!Object.is(instance.item, sourceItem)) {
           preservesSurvivorOrder = false;
           break;
         }
         if (keyedRowIdentity(props.rowKey(item, targetIndex)) !== instance.key) return undefined;
+        const changed = prepareChangedInstance(instance, item, targetIndex);
+        if (changed) directChanges.push(changed);
       }
       if (preservesSurvivorOrder) {
-        return { nextInstances: survivors, sequence: undefined };
+        return { changed: directChanges, nextInstances: survivors, sequence: undefined };
       }
 
       const survivorInstances = new Map<unknown, CompilerKeyedRowInstance>();
@@ -6001,22 +6070,26 @@ function reconcileCompilerKeyedArrayStructuralReorder(
 
       const nextInstances: CompilerKeyedRowInstance[] = [];
       const sequence: number[] = [];
+      const changed: typeof directChanges = [];
       for (let targetIndex = 0; targetIndex < finalValue.length; targetIndex += 1) {
         const item = finalValue[targetIndex];
-        const instance = survivorInstances.get(item);
+        const sourceItem = mappedItemSources?.has(item) ? mappedItemSources.get(item) : item;
+        const instance = survivorInstances.get(sourceItem);
         if (
           !instance ||
-          !Object.is(instance.item, item) ||
+          !Object.is(instance.item, sourceItem) ||
           keyedRowIdentity(props.rowKey(item, targetIndex)) !== instance.key
         ) {
           return undefined;
         }
-        survivorInstances.delete(item);
+        survivorInstances.delete(sourceItem);
         nextInstances.push(instance);
         sequence.push(instance.index);
+        const changedInstance = prepareChangedInstance(instance, item, targetIndex);
+        if (changedInstance) changed.push(changedInstance);
       }
       if (survivorInstances.size > 0) return undefined;
-      return { nextInstances, sequence };
+      return { changed, nextInstances, sequence };
     } catch {
       return undefined;
     }
@@ -6035,6 +6108,10 @@ function reconcileCompilerKeyedArrayStructuralReorder(
   }
   if (prepared.sequence) {
     reorderCompilerKeyedRows(root, prepared.nextInstances, prepared.sequence, null);
+  }
+  for (const { bindingUpdates, instance, item } of prepared.changed) {
+    applyPreparedKeyedRowBindingUpdates(props, instance, bindingUpdates);
+    instance.item = item;
   }
   for (let index = 0; index < prepared.nextInstances.length; index += 1) {
     prepared.nextInstances[index].index = index;

--- a/packages/farm-react/src/compiler.ts
+++ b/packages/farm-react/src/compiler.ts
@@ -2019,7 +2019,6 @@ function keyedArrayReorderPipeline(
       reorderSteps += 1;
     }
   }
-  if (mapSteps > 0 && structuralSteps > 0) return undefined;
   if (reorderSteps < 1) return undefined;
   if (mapSteps > 0 && reorderSteps >= 1) return steps;
   if (structuralSteps < 1 && reorderSteps < 2) return undefined;
@@ -2200,15 +2199,15 @@ function rewriteKeyedArrayReorderPipelineHints(
               : step.kind === "slice"
                 ? sliceHelperIdentifier
                 : step.kind === "reverse"
-                  ? hasMappedLineage
-                    ? mapReorderHelperIdentifier
-                    : structuralPipeline
-                      ? structuralReorderHelperIdentifier
+                  ? structuralPipeline
+                    ? structuralReorderHelperIdentifier
+                    : hasMappedLineage
+                      ? mapReorderHelperIdentifier
                       : reorderHelperIdentifier
-                  : hasMappedLineage
-                    ? mapReorderHelperIdentifier
-                    : structuralPipeline
-                      ? structuralSortHelperIdentifier
+                  : structuralPipeline
+                    ? structuralSortHelperIdentifier
+                    : hasMappedLineage
+                      ? mapReorderHelperIdentifier
                       : sortHelperIdentifier;
         const args =
           step.kind === "map"
@@ -2246,11 +2245,11 @@ function rewriteKeyedArrayReorderPipelineHints(
         else if (step.kind === "slice") sliceCount += 1;
         else if (step.kind === "reverse") {
           reorderCount += 1;
-          if (hasMappedLineage) mapReorderCount += 1;
+          if (hasMappedLineage && !structuralPipeline) mapReorderCount += 1;
           if (structuralPipeline) structuralReorderCount += 1;
         } else {
           sortCount += 1;
-          if (hasMappedLineage) mapSortCount += 1;
+          if (hasMappedLineage && !structuralPipeline) mapSortCount += 1;
           if (structuralPipeline) structuralSortCount += 1;
         }
       }

--- a/packages/farm-react/vitest.stress.config.ts
+++ b/packages/farm-react/vitest.stress.config.ts
@@ -17,10 +17,11 @@ export default defineConfig({
       "src/__tests__/compiler-runtime-keyed-array-reorder-hints.test.tsx",
       "src/__tests__/compiler-runtime-keyed-array-sort-hints.test.tsx",
       "src/__tests__/compiler-runtime-keyed-array-map-reorder-hints.test.tsx",
+      "src/__tests__/compiler-runtime-keyed-array-structural-reorder-hints.test.tsx",
     ],
     setupFiles: ["src/__tests__/stress.setup.ts"],
     testNamePattern:
-      /2,000 deterministic mapped reorder updates|2,000 deterministic mapped reversal parity updates|2,000 queued reverse, map, and reverse updates|2,000 reverse-or-sort then map updates|2,000 queued reorder then standalone map updates|2,000 queued map then reorder updates|2,000 queued map and consecutive reorder updates|3,000 deterministic recursive updates|4,096 rows/,
+      /2,000 deterministic mapped reorder updates|2,000 deterministic mapped reversal parity updates|2,000 queued reverse, map, and reverse updates|2,000 reverse-or-sort then map updates|2,000 queued reorder then standalone map updates|2,000 queued map then reorder updates|2,000 queued map and consecutive reorder updates|2,000 mapped structural removals|3,000 deterministic recursive updates|4,096 rows/,
     testTimeout: 30_000,
   },
 });


### PR DESCRIPTION
## Problem

The compiler could optimize keyed `map` updates and structural `filter`/`slice` plus reorder updates separately, but it lost row-source lineage when both appeared in one setter. Code such as `rows.map(update).filter(keep).toReversed()` therefore fell back to a React snapshot even when keys stayed stable and every operation was statically safe.

## Root cause

Structural metadata described the final ordering but did not carry the original source row associated with each mapped survivor. The runtime could not prove that a final keyed row still belonged to the same compiled instance, so it could not safely patch bindings and reorder existing DOM nodes in one atomic commit.

## Change

- Preserve mapped source lineage through eligible `filter`, `slice`, `reverse`, `toReversed`, `sort`, and `toSorted` chains.
- Compose repeated reversals, including recognizing a double reverse as identity order.
- Validate every survivor, key, binding update, and destination before the first DOM mutation.
- Patch changed bindings, remove rejected rows, and apply direct or LIS-assisted ordering without rerunning the component.
- Add compiler, DOM, hydration, Strict Mode, controlled-input, fallback, and 2,000-update randomized differential coverage.
- Add a dashboard fixture and a dedicated mapped-structural benchmark gate, with a package prebuild and compiler-report assertions so stale compiler output cannot be measured.
- Document supported syntax and fallback limits in the React compiler docs and package/example READMEs.

## Safety and compatibility

This adds no public API or configuration. It applies only to concise functional setters whose native operations, index independence, keyed ownership, and mapped row identity are all proven. Maps after structural steps, missing final reorders, custom methods, changed keys, ambiguous ownership, host blocks, conditionals, and failed runtime validation use the complete existing React fallback. Validation finishes before DOM mutation, preserving atomic fallback, node identity, focus, selection, hydration, unmount cleanup, and Strict Mode behavior. The feature remains behind the existing experimental React compiler flag.

## Verification

- `pnpm --filter @farm.js/react exec vitest run src/__tests__/compiler-keyed-array-sort-hints.test.ts src/__tests__/compiler-runtime-keyed-array-structural-reorder-hints.test.tsx` — 51 passed, including two 2,000-update differential tests.
- `pnpm --filter @farm.js/react test` — 732 passed, 10 skipped; stress suite 11 passed, 59 skipped.
- `pnpm --filter @farm.js/react type-check`
- `pnpm --filter @farm.js/react test:compat` — React 18.3.1 and React 19.2.8.
- `pnpm --filter @farm.js/react test:runtime-size` — passed; keyed-map-reorder compiler premium remains within budget at 13,221 gzip bytes.
- `pnpm --dir examples/react-compiler-dashboard type-check`
- `pnpm docs:check-navigation` — 77 visible pages covered.
- `pnpm docs:build`
- Full dashboard benchmark: correctness and broad regression gates passed. The new gate measured static at 1.940× over the compiled snapshot control and 9.769× over React; hybrid at 1.794× over the control and 6.747× over React. The aggregate command exited nonzero because unrelated historical micro-gates fluctuated locally.
- Post-rebase reduced browser run: correctness and broad regression gates passed; the new gate measured static at 2.178× over control / 7.493× over React and hybrid at 2.015× over control / 8.415× over React. Three unrelated existing micro-gates missed thresholds at the intentionally tiny sample count.

Environment: macOS, Node 23.11.0, pnpm 8.12.1. The workspace emits existing Node >=24 warnings for the Eve packages.

## Documentation and release

The React renderer guide, package README, and maintained compiler-dashboard example now describe and exercise the supported mapped structural-reorder chain and its fallback boundaries. No version files are changed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps row-source lineage through structural `filter`/`slice`/reorder steps, so setters like `rows.map(update).filter(keep).toReversed()` now compile to one atomic DOM patch, removal, and reorder instead of falling back to a full React reconciliation.

- Preserves mapped lineage across eligible `filter`, `slice`, `reverse`, `toReversed`, `sort`, and `toSorted` chains, including composing repeated reversals.
- Validates every survivor, key, binding update, and destination before the first DOM mutation, preserving atomic fallback, focus, selection, hydration, and Strict Mode behavior.
- Adds a 10,000-row benchmark gate with compiler-report assertions and 2,000-update randomized differential tests.

**Fallback**
- Maps after a structural step, missing final reorders, changed keys, custom methods, host blocks, and failed runtime validation still use complete keyed reconciliation.
- No new public API or configuration; the feature remains behind the existing experimental React compiler flag.

<sup>Written for commit 61840320c530c8bc6adb5bded7eaed56cbb63983. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/834?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

