### PR TITLE
fix(routing): match production routes beneath basePath

### DIFF
--- a/packages/farm/src/__tests__/production-prebuilt-ssr.test.ts
+++ b/packages/farm/src/__tests__/production-prebuilt-ssr.test.ts
@@ -371,6 +371,37 @@ async function expectNitroFallback(root: string): Promise<void> {
 }
 
 describe("production prebuilt SSR output", () => {
+  it("matches application routes beneath the configured basePath", async () => {
+    const root = await createProductionFixture();
+
+    try {
+      const config = await resolveConfig(
+        {
+          root,
+          srcDir: "src",
+          basePath: "/workspace",
+          images: { provider: "none" },
+          telemetry: false,
+          generateBuildId: () => "production-base-path-test",
+        },
+        "production",
+      );
+
+      await build(config, { root, preset: "node-server" });
+
+      await runProductionRequest(
+        path.join(root, ".farm", ".output", "server"),
+        async (response) => {
+          expect(response.status).toBe(200);
+          await expect(response.text()).resolves.toContain("prebuilt SSR output");
+        },
+        "/workspace",
+      );
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  }, 120_000);
+
   it("serves the configured OpenAPI reference in production", async () => {
     const root = await createProductionFixture();
     const apiDir = path.join(root, "src", "app", "api", "health");

--- a/packages/farm/src/nitro/production-runtime.ts
+++ b/packages/farm/src/nitro/production-runtime.ts
@@ -66,7 +66,7 @@ export {
   resolveFarmTrailingSlashRedirect,
   setFarmTrailingSlashPreference,
 } from "../trailing-slash";
-export { applyFarmBasePath, setFarmBasePath } from "../base-path";
+export { applyFarmBasePath, setFarmBasePath, stripFarmBasePath } from "../base-path";
 export { appendFarmRedirectQuery } from "../redirect-query";
 
 export function appendFarmLinkHeader(headers: Headers, value: string): void {

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -4432,6 +4432,7 @@ function generateVirtualEntryCode(
   searchParamsToObject,
   setFarmBasePath,
   setFarmTrailingSlashPreference,
+  stripFarmBasePath,
   stripFarmLocaleFromPathname,
   withFarmRouteContext,
 } from "@farm.js/core/internal/production-runtime";`;
@@ -4945,8 +4946,8 @@ function getFarmI18nSnapshot() {
 
 function getFarmRoutePathname(pathname) {
   return farmI18nRuntime
-    ? stripFarmLocaleFromPathname(pathname, farmI18nConfig)
-    : pathname;
+    ? stripFarmLocaleFromPathname(stripFarmBasePath(pathname), farmI18nConfig)
+    : stripFarmBasePath(pathname);
 }
 
 function serializeFarmInlineValue(value) {


### PR DESCRIPTION
## Problem

Production Node output returns a route miss when an application route is requested beneath a configured basePath.

## Root cause

The generated production route matcher compared the public pathname, including basePath, with an application manifest whose routes do not include that prefix.

## Change

Strip the configured basePath before locale normalization and manifest matching in the generated production runtime.

## Safety and compatibility

The public request URL and emitted links remain prefixed. Only the internal application-route lookup changes. Applications without basePath keep the existing behavior.

## Verification

- pnpm --filter @farm.js/core type-check
- Focused production-prebuilt-ssr regression using a built node-server output
- oxfmt, oxlint, and git diff checks

The regression returns 404 without this fix and 200 with it.

## Documentation and release

None. This restores the documented basePath behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes production route matching for applications with a configured basePath so routes beneath it return 200 instead of 404. The public request URL and emitted links are unchanged; only the internal application-route lookup strips the basePath before locale normalization and manifest matching.

<sup>Written for commit a1b92d82b670ac7fea9d511a5cfb636b172c8540. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/835?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

