### PR TITLE
fix(route-rules): preserve redirect status and query semantics

### DIFF
--- a/packages/farm/src/__tests__/config.test.ts
+++ b/packages/farm/src/__tests__/config.test.ts
@@ -728,7 +728,7 @@ describe("resolveConfig", () => {
       "/blog/**": { swr: 3600 },
       "/admin/**": { prerender: false },
       "/reports/**": {},
-      "/old": { redirect: "/new" },
+      "/old": { redirect: { to: "/new", status: 308 } },
       "/api/**": {
         cors: true,
         headers: {
@@ -766,6 +766,30 @@ describe("resolveConfig", () => {
         "production",
       ),
     ).rejects.toThrow('Route rules "docs/**" and "/docs/**" both normalize to "/docs/**"');
+  });
+
+  it("preserves route-rule redirect semantics in Nitro", async () => {
+    const config = await resolveConfig(
+      {
+        routeRules: {
+          "/temporary": { redirect: "/next" },
+          "/see-other": { redirect: { to: "/result", statusCode: 303 } },
+          "/permanent": { redirect: { to: "/current", permanent: true } },
+          "/replace-query": { redirect: "/search?view=compact" },
+        },
+      },
+      "production",
+    );
+
+    expect(routeRulesToNitroRouteRules(config.routeRules)).toMatchObject({
+      "/temporary": { redirect: { to: "/next", status: 307 } },
+      "/see-other": { redirect: { to: "/result", status: 303 } },
+      "/permanent": { redirect: { to: "/current", status: 308 } },
+      "/replace-query": {},
+    });
+    expect(routeRulesToNitroRouteRules(config.routeRules)["/replace-query"]).not.toHaveProperty(
+      "redirect",
+    );
   });
 
   it("rejects non-redirect status codes in configured redirects", async () => {

--- a/packages/farm/src/__tests__/production-prebuilt-ssr.test.ts
+++ b/packages/farm/src/__tests__/production-prebuilt-ssr.test.ts
@@ -402,6 +402,51 @@ describe("production prebuilt SSR output", () => {
     }
   }, 120_000);
 
+  it("preserves route-rule redirect status and explicit destination queries", async () => {
+    const root = await createProductionFixture();
+
+    try {
+      const config = await resolveConfig(
+        {
+          root,
+          srcDir: "src",
+          images: { provider: "none" },
+          telemetry: false,
+          routeRules: {
+            "/legacy": { redirect: { to: "/current?view=compact", statusCode: 303 } },
+            "/moved": { redirect: { to: "/current", permanent: true } },
+          },
+          generateBuildId: () => "production-route-rule-redirect-test",
+        },
+        "production",
+      );
+
+      await build(config, { root, preset: "node-server" });
+      const serverDir = path.join(root, ".farm", ".output", "server");
+
+      await runProductionRequest(
+        serverDir,
+        async (response) => {
+          expect(response.status).toBe(303);
+          expect(response.headers.get("location")).toBe("/current?view=compact");
+        },
+        "/legacy?view=full&campaign=launch",
+        { redirect: "manual" },
+      );
+      await runProductionRequest(
+        serverDir,
+        async (response) => {
+          expect(response.status).toBe(308);
+          expect(response.headers.get("location")).toBe("/current?campaign=launch");
+        },
+        "/moved?campaign=launch",
+        { redirect: "manual" },
+      );
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  }, 120_000);
+
   it("serves the configured OpenAPI reference in production", async () => {
     const root = await createProductionFixture();
     const apiDir = path.join(root, "src", "app", "api", "health");

--- a/packages/farm/src/route-rules.ts
+++ b/packages/farm/src/route-rules.ts
@@ -117,10 +117,19 @@ export function routeRulesToNitroRouteRules(routeRules: FarmRouteRules): Record<
       nitroRule.prerender = false;
     }
 
-    if (rule.redirect && typeof rule.redirect !== "string") {
-      nitroRule.redirect = rule.redirect.to;
-      if (rule.redirect.statusCode) {
-        nitroRule.statusCode = rule.redirect.statusCode;
+    if (rule.redirect) {
+      const redirect = typeof rule.redirect === "string" ? { to: rule.redirect } : rule.redirect;
+      if (hasExplicitQuery(redirect.to)) {
+        // Nitro merges the incoming query into redirect targets, including when
+        // the target already declares one. Farm's redirect contract replaces
+        // the incoming query in that case, so let the bundled Farm handler own
+        // these redirects instead of changing their meaning in production.
+        delete nitroRule.redirect;
+      } else {
+        nitroRule.redirect = {
+          to: redirect.to,
+          status: redirect.statusCode ?? (redirect.permanent === true ? 308 : 307),
+        };
       }
     }
 
@@ -171,4 +180,11 @@ function normalizeRuleSource(source: string): string {
     throw new TypeError("Route rule source must be a non-empty pathname pattern.");
   }
   return trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
+}
+
+function hasExplicitQuery(destination: string): boolean {
+  const queryIndex = destination.indexOf("?");
+  if (queryIndex === -1) return false;
+  const hashIndex = destination.indexOf("#");
+  return hashIndex === -1 || queryIndex < hashIndex;
 }


### PR DESCRIPTION
## Problem

Production Nitro redirects can lose the configured redirect status, and a destination with its own query can inherit the incoming query instead of replacing it.

## Root cause

Farm passed only a redirect string to Nitro for some route rules. Nitro then selected its own status and merged request query parameters using semantics that differ from the Farm redirect contract.

## Change

Pass Nitro an explicit redirect object with the resolved status. Redirect destinations containing an explicit query remain owned by the bundled Farm redirect handler so replacement semantics stay consistent.

## Safety and compatibility

Temporary redirects remain 307 and permanent redirects remain 308 by default. Explicit redirect status codes are preserved. Queryless destinations continue preserving the incoming query.

## Verification

- pnpm --filter @farm.js/core type-check
- Full config test file
- Focused production node-server redirect regression
- oxfmt, oxlint, and git diff checks

## Documentation and release

None. This restores already documented redirect behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes route-rule redirects in production so Nitro no longer drops the configured redirect status or merges the incoming query into a destination that already declares its own.

- Passes Nitro an explicit redirect object with the resolved status: 307 by default, 308 when permanent, or the configured `statusCode`.
- Redirects whose destination has an explicit query are kept in the bundled Farm handler so the destination query replaces the incoming one.
- Queryless destinations continue preserving the incoming query.

<sup>Written for commit e76d629826c8d13f3c411f849cfd26bfcba8deb1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/836?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

