### PR TITLE
fix(server): handle malformed Host headers safely

### DIFF
--- a/packages/farm/src/__tests__/config-route-plugins.test.ts
+++ b/packages/farm/src/__tests__/config-route-plugins.test.ts
@@ -48,6 +48,39 @@ describe("config route plugins", () => {
     ).toThrow('Redirect "/old" statusCode must be one of 301, 302, 303, 307, or 308');
   });
 
+  it("falls back safely when a request carries a malformed Host header", async () => {
+    const redirectRequest = createRequest("/old");
+    redirectRequest.headers.host = "%";
+    const redirectResponse = createResponse();
+    await runBeforeRequest(
+      createRedirectsPlugin([{ source: "/old", destination: "/new" }]),
+      redirectRequest,
+      redirectResponse,
+    );
+    expect(redirectResponse.writeHead).toHaveBeenCalledWith(307, { Location: "/new" });
+
+    const rewriteRequest = createRequest("/legacy");
+    rewriteRequest.headers.host = "%";
+    await runBeforeRequest(
+      createRewritesPlugin([{ source: "/legacy", destination: "/current" }]),
+      rewriteRequest,
+      createResponse(),
+    );
+    expect(rewriteRequest.url).toBe("/current");
+
+    const headersRequest = createRequest("/docs");
+    headersRequest.headers.host = "%";
+    const headersResponse = createResponse();
+    await runBeforeRequest(
+      createHeadersPlugin([
+        { source: "/docs", headers: [{ key: "x-farm-safe-host", value: "1" }] },
+      ]),
+      headersRequest,
+      headersResponse,
+    );
+    expect(headersResponse.setHeader).toHaveBeenCalledWith("x-farm-safe-host", "1");
+  });
+
   it("keeps named and plain redirect captures in source order", async () => {
     const plugin = createRedirectsPlugin([
       {

--- a/packages/farm/src/__tests__/middleware-function-matcher.test.ts
+++ b/packages/farm/src/__tests__/middleware-function-matcher.test.ts
@@ -86,3 +86,23 @@ describe.each([
     expect(seen).toEqual([{ path: "/dashboard/reports", params: { section: "reports" } }]);
   });
 });
+
+describe("dev middleware request URL parsing", () => {
+  it("matches safely when Host is malformed", async () => {
+    const seen: string[] = [];
+    const manager = new MiddlewareManager("/tmp", undefined, [
+      {
+        matcher: "/dashboard/:path*",
+        async handler(ctx, next) {
+          seen.push(ctx.pathname);
+          await next();
+        },
+      },
+    ]);
+    const request = createRequest("/dashboard/reports");
+    request.headers.host = "%";
+
+    await expect(manager.execute(request, new ServerResponse(request))).resolves.toBe(false);
+    expect(seen).toEqual(["/dashboard/reports"]);
+  });
+});

--- a/packages/farm/src/middleware/manager.ts
+++ b/packages/farm/src/middleware/manager.ts
@@ -27,6 +27,7 @@ import type { ResolvedFarmI18nConfig } from "../i18n/types";
 import { createCliColors } from "../cli-colors";
 import { appendMiddlewareRoutePath } from "./path";
 import type { FarmServerConfig, ResolvedFarmServerConfig } from "../server-http";
+import { resolveFarmRequestURL } from "../server/request";
 
 export interface DiscoveredMiddleware {
   path: string;
@@ -203,7 +204,7 @@ export class MiddlewareManager {
    * Execute middleware for a request
    */
   async execute(req: IncomingMessage, res: ServerResponse): Promise<boolean> {
-    const url = new URL(req.url || "/", `http://${req.headers.host || "localhost"}`);
+    const url = resolveFarmRequestURL(req, { trustProxy: this.server?.trustProxy });
     const pathname = url.pathname;
     const routePathname = this.i18n?.enabled
       ? stripFarmLocaleFromPathname(pathname, this.i18n)

--- a/packages/farm/src/plugins/headers.ts
+++ b/packages/farm/src/plugins/headers.ts
@@ -2,6 +2,7 @@ import type { FarmPlugin, FarmPluginContext } from "../plugin";
 import type { HeaderConfig } from "../config";
 import type { FarmRequest, FarmResponse } from "../types";
 import type { ResolvedFarmI18nConfig } from "../i18n/types";
+import { resolveFarmRequestURL } from "../server/request";
 import { compileConfigRoutePattern, resolveConfigRoutePathname } from "./route-pattern";
 
 const FARM_CONFIG_HEADERS_FINALIZER = Symbol.for("farm.configHeadersFinalizer");
@@ -109,7 +110,7 @@ export function createHeadersPlugin(
       if (overrideBeforeRequest) {
         await overrideBeforeRequest(req, res, context);
       }
-      const url = new URL(req.url || "/", `http://${req.headers.host}`);
+      const url = resolveFarmRequestURL(req);
       const pathname = resolveConfigRoutePathname(url.pathname, i18n).pathname;
       const matchedHeaders = compiledHeaders
         .filter(({ pattern }) => pattern.regex.test(pathname))

--- a/packages/farm/src/plugins/redirects.ts
+++ b/packages/farm/src/plugins/redirects.ts
@@ -4,6 +4,7 @@ import type { FarmRequest, FarmResponse } from "../types";
 import type { ResolvedFarmI18nConfig } from "../i18n/types";
 import { isFarmRedirectStatus } from "../navigation-errors";
 import { appendFarmRedirectQuery } from "../redirect-query";
+import { resolveFarmRequestURL } from "../server/request";
 import {
   compileConfigRoutePattern,
   interpolateConfigRouteDestination,
@@ -50,7 +51,7 @@ export function createRedirectsPlugin(
       if (overrideBeforeRequest) {
         await overrideBeforeRequest(req, res, context);
       }
-      const url = new URL(req.url || "/", `http://${req.headers.host}`);
+      const url = resolveFarmRequestURL(req);
       const routePath = resolveConfigRoutePathname(url.pathname, i18n);
       const pathname = routePath.pathname;
 

--- a/packages/farm/src/plugins/rewrites.ts
+++ b/packages/farm/src/plugins/rewrites.ts
@@ -2,6 +2,7 @@ import type { FarmPlugin, FarmPluginContext } from "../plugin";
 import type { RewriteConfig } from "../config";
 import type { FarmRequest, FarmResponse } from "../types";
 import type { ResolvedFarmI18nConfig } from "../i18n/types";
+import { resolveFarmRequestURL } from "../server/request";
 import {
   compileConfigRoutePattern,
   interpolateConfigRouteDestination,
@@ -44,7 +45,7 @@ export function createRewritesPlugin(
       if (overrideBeforeRequest) {
         await overrideBeforeRequest(req, res, context);
       }
-      const url = new URL(req.url || "/", `http://${req.headers.host}`);
+      const url = resolveFarmRequestURL(req);
       const routePath = resolveConfigRoutePathname(url.pathname, i18n);
       const pathname = routePath.pathname;
 

--- a/packages/farm/src/server/renderer.ts
+++ b/packages/farm/src/server/renderer.ts
@@ -32,7 +32,11 @@ import {
   getRegisteredIntegrationAPIManifest,
   isFarmIntegrationProviderComponentReference,
 } from "../integrations";
-import { _runWithCurrentRequest, createWebRequestFromFarmRequest } from "./request";
+import {
+  _runWithCurrentRequest,
+  createWebRequestFromFarmRequest,
+  resolveFarmRequestURL,
+} from "./request";
 import { createFarmCacheKey, getFarmDataCache, normalizeRevalidatePath } from "../cache";
 import { resolveFarmNotFoundComponentPath } from "../not-found";
 import { getFarmAppDirectories } from "../layers";
@@ -1069,7 +1073,7 @@ export class ServerRenderer {
     };
 
     try {
-      const url = new URL(req.url || "/", `http://${req.headers.host}`);
+      const url = resolveFarmRequestURL(req, { trustProxy: this.config.server?.trustProxy });
       pathname = url.pathname;
       emitFarmEvent({ type: "render.start", route: pathname, pathname });
       searchParamsObject = searchParamsToObject(url.searchParams);
@@ -2027,7 +2031,9 @@ export class ServerRenderer {
     }
 
     const etag = `"${image.staticInfo.hash}"`;
-    const requestUrl = new URL(req.url || "/", `http://${req.headers.host || "localhost"}`);
+    const requestUrl = resolveFarmRequestURL(req, {
+      trustProxy: this.config.server?.trustProxy,
+    });
     const isVersioned = requestUrl.searchParams.get("v") === image.staticInfo.hash;
 
     res.setHeader("Content-Type", image.staticInfo.contentType);
@@ -2683,7 +2689,9 @@ ${getFarmI18nClientSnapshot() ? `window.__FARM_I18N__ = ${serializeInlineValue(g
   private async render404(req: FarmRequest, res: FarmResponse): Promise<void> {
     res.statusCode = 404;
 
-    const pathname = new URL(req.url || "/", `http://${req.headers.host || "localhost"}`).pathname;
+    const pathname = resolveFarmRequestURL(req, {
+      trustProxy: this.config.server?.trustProxy,
+    }).pathname;
 
     try {
       // Look for custom not-found page
@@ -2762,7 +2770,9 @@ ${getFarmI18nClientSnapshot() ? `window.__FARM_I18N__ = ${serializeInlineValue(g
 
     res.statusCode = statusCode;
     const isDev = process.env.NODE_ENV === "development";
-    const requestUrl = new URL(req.url || "/", `http://${req.headers.host || "localhost"}`);
+    const requestUrl = resolveFarmRequestURL(req, {
+      trustProxy: this.config.server?.trustProxy,
+    });
     const diagnostics = isDev
       ? createDefaultErrorDiagnostics(error, this.config.root || process.cwd())
       : undefined;

--- a/packages/farm/src/vite.ts
+++ b/packages/farm/src/vite.ts
@@ -1,5 +1,5 @@
 import type { ConfigEnv, Plugin, UserConfig, ViteDevServer, HmrContext, Connect } from "vite";
-import type { FarmConfig } from "./types";
+import type { FarmConfig, FarmRequest } from "./types";
 import { FarmApp } from "./app";
 import { logger, toPosixPath, toViteModuleId } from "./utils";
 import { defaultGlobalCSS } from "./default-styles";
@@ -101,6 +101,7 @@ import {
 } from "./navigation/render-plan";
 import { resolveFarmPageDataFailure } from "./navigation/page-data-error";
 import { FARM_CONFIG_REWRITES_PLUGIN_NAME } from "./plugins/rewrites";
+import { resolveFarmRequestURL } from "./server/request";
 
 interface FarmVitePluginOptions extends FarmConfig {
   openapi?: FarmUserConfig["openapi"];
@@ -1324,11 +1325,13 @@ window.__FARM_MANIFEST__ = ${inlineValue({
         withFarmRequestTracing(async (req, res, next) => {
           const requestUrl = req.url || "/";
           const requestMethod = req.method || "GET";
-          const fullUrl = `http://${req.headers.host || "localhost:3000"}${requestUrl}`;
-          const parsedRequestUrl = new URL(fullUrl);
-          const requestPathname = parsedRequestUrl.pathname;
           const currentConfig = farmApp?.getConfig() ?? options;
           const currentServerConfig = resolveFarmServerConfig(currentConfig.server);
+          const parsedRequestUrl = resolveFarmRequestURL(req as FarmRequest, {
+            trustProxy: currentServerConfig.trustProxy,
+          });
+          const fullUrl = parsedRequestUrl.toString();
+          const requestPathname = parsedRequestUrl.pathname;
 
           if (imageHandler && requestPathname === farmConfig.images.path) {
             const imageResponse = await imageHandler(
@@ -1947,7 +1950,7 @@ window.__FARM_MANIFEST__ = ${inlineValue({
 
           // Handle SPA page-data requests for client-side navigation
           if (req.url?.startsWith("/__farm/page-data")) {
-            const urlObj = new URL(req.url, `http://${req.headers.host || "localhost:3000"}`);
+            const urlObj = parsedRequestUrl;
             const targetPath = urlObj.searchParams.get("path") || "/";
 
             try {


### PR DESCRIPTION
## Problem

A malformed Host header can make URL construction throw before redirects, rewrites, configured headers, middleware, rendering, or development page-data handling can respond.

## Root cause

Several request paths constructed URL instances directly from the untrusted Host header instead of using the existing validated request URL resolver.

## Change

Route all affected request consumers through resolveFarmRequestURL and preserve trustProxy handling where server configuration is available.

## Safety and compatibility

Valid Host and trusted forwarded headers keep their existing behavior. Invalid authority values fall back to localhost for internal parsing and no longer become request-level 500 errors.

## Verification

- pnpm --filter @farm.js/core type-check
- Config route plugin, middleware matcher, and server request tests
- 33 focused tests passed
- oxfmt, oxlint, and git diff checks

## Documentation and release

None. Existing trustProxy documentation already describes the authority contract.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops malformed Host headers from throwing during URL construction, which previously caused request-level 500s before redirects, rewrites, headers, middleware, rendering, or development page-data handling could respond. All affected request paths now resolve URLs through `resolveFarmRequestURL`, which falls back to localhost for internal parsing when the authority is invalid; valid hosts and trusted forwarded headers behave exactly as before.

**Bug Fixes**
- Routes redirect, rewrite, and header plugins, middleware matching, server rendering, and Vite dev request parsing through `resolveFarmRequestURL`.
- Preserves `trustProxy` handling where server configuration is available.
- Adds regression tests for malformed Host headers across config plugins and dev middleware.
- No docs or migration steps required; existing `trustProxy` docs already describe the authority contract.

<sup>Written for commit c1320a1e5b5791238bc57e69dd328ae8f9cf172b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/837?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

