### PR TITLE
fix(markdown): decode malformed numeric entities safely

### DIFF
--- a/packages/farm/src/__tests__/markdown.test.ts
+++ b/packages/farm/src/__tests__/markdown.test.ts
@@ -306,6 +306,16 @@ describe("htmlToMarkdown", () => {
     ).toContain("[Read docs](/docs)");
   });
 
+  it("decodes entities once and replaces invalid numeric code points", () => {
+    expect(htmlToMarkdown("<p>&amp;lt; stays literal</p>", { includeMetadata: false })).toBe(
+      "&lt; stays literal\n",
+    );
+    expect(htmlToMarkdown("<p>&#x1F680;</p>", { includeMetadata: false })).toBe("🚀\n");
+    expect(htmlToMarkdown("<p>&#1114112; &#xD800; &#0;</p>", { includeMetadata: false })).toBe(
+      "� � �\n",
+    );
+  });
+
   it("prefers page content over layout chrome", () => {
     expect(
       htmlToMarkdown(

--- a/packages/farm/src/markdown.ts
+++ b/packages/farm/src/markdown.ts
@@ -436,13 +436,26 @@ function stripTags(input: string): string {
 }
 
 function decodeHtml(input: string): string {
-  return input
-    .replace(/&nbsp;/g, " ")
-    .replace(/&amp;/g, "&")
-    .replace(/&lt;/g, "<")
-    .replace(/&gt;/g, ">")
-    .replace(/&quot;/g, '"')
-    .replace(/&#39;/g, "'")
-    .replace(/&#x([0-9a-f]+);/gi, (_, code) => String.fromCodePoint(Number.parseInt(code, 16)))
-    .replace(/&#(\d+);/g, (_, code) => String.fromCodePoint(Number.parseInt(code, 10)));
+  return input.replace(/&(?:nbsp|amp|lt|gt|quot|#39|#(?:x|X)[0-9a-fA-F]+|#[0-9]+);/g, (entity) => {
+    switch (entity) {
+      case "&nbsp;":
+        return " ";
+      case "&amp;":
+        return "&";
+      case "&lt;":
+        return "<";
+      case "&gt;":
+        return ">";
+      case "&quot;":
+        return '"';
+      case "&#39;":
+        return "'";
+    }
+
+    const hexadecimal = entity[2] === "x" || entity[2] === "X";
+    const codePoint = Number.parseInt(entity.slice(hexadecimal ? 3 : 2, -1), hexadecimal ? 16 : 10);
+    return codePoint === 0 || codePoint > 0x10ffff || (codePoint >= 0xd800 && codePoint <= 0xdfff)
+      ? "\uFFFD"
+      : String.fromCodePoint(codePoint);
+  });
 }


### PR DESCRIPTION
## Problem

Markdown conversion can throw on out-of-range numeric HTML entities and can decode nested entities more than once.

## Root cause

Numeric entities were passed directly to String.fromCodePoint, while sequential replacement passes allowed text produced by ampersand decoding to be decoded again.

## Change

Decode supported entities in one pass and replace invalid Unicode scalar values with the replacement character.

## Safety and compatibility

Valid named and numeric entities retain their existing output. Invalid numeric references no longer crash conversion, and nested encoded text stays literal after one decode pass.

## Verification

- pnpm --filter @farm.js/core type-check
- Markdown test file: 19 tests passed
- oxfmt, oxlint, and git diff checks

## Documentation and release

None.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes markdown entity decoding so out-of-range numeric entities no longer crash and nested entities aren't decoded twice.

- Replaces invalid codepoints (zero, surrogates, above U+10FFFF) with the replacement character U+FFFD.
- Decodes entities in a single pass, so `&amp;lt;` stays literal as `&lt;` instead of becoming `<`.

<sup>Written for commit 71221fbae750463e2ee1244874e89bea0bf51d6b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/838?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

