### PR TITLE
fix(config): reject impossible route source patterns

### DIFF
--- a/docs/src/app/docs/configuration/page.md
+++ b/docs/src/app/docs/configuration/page.md
@@ -614,7 +614,9 @@ syntax. `:name` captures one path segment, while `:name*` and plain `*` capture 
 characters. Redirect and rewrite destinations can reuse named captures or use numbered captures
 such as `$1`. Captured path segments are decoded and safely re-encoded before interpolation;
 empty segments in catch-all captures are removed consistently in development and production. All
-other source characters are matched literally.
+other source characters are matched literally. Sources must be pathname patterns beginning with
+`/`; query strings and hashes belong in redirect or rewrite destinations and are rejected in
+sources because matching operates on the request pathname.
 For redirects and rewrites, the incoming query string is preserved when the destination has no
 query. A query written in the destination replaces the incoming query string.
 Rewrites use after-files semantics in development and production: an existing Farm page, API,

--- a/packages/farm/src/__tests__/config.test.ts
+++ b/packages/farm/src/__tests__/config.test.ts
@@ -740,6 +740,20 @@ describe("resolveConfig", () => {
     });
   });
 
+  it("rejects config route sources that cannot match a URL pathname", async () => {
+    for (const config of [
+      { redirects: [{ source: "/old?campaign=launch", destination: "/new" }] },
+      { rewrites: [{ source: "/legacy#details", destination: "/current" }] },
+      {
+        headers: [{ source: "docs/:path*", headers: [{ key: "x-docs", value: "enabled" }] }],
+      },
+      { routeRules: { "/api/**?private=1": { cors: true } } },
+      { routeRules: { "": { cors: true } } },
+    ]) {
+      await expect(resolveConfig(config, "production")).rejects.toThrow();
+    }
+  });
+
   it("rejects non-redirect status codes in configured redirects", async () => {
     await expect(
       resolveConfig(

--- a/packages/farm/src/config.ts
+++ b/packages/farm/src/config.ts
@@ -73,6 +73,7 @@ import {
   type ResolvedFarmAuthConfig,
 } from "./auth-config";
 import { resolveFarmPerformanceConfig, type ResolvedFarmPerformanceConfig } from "./preload";
+import { validateConfigRouteSource } from "./plugins/route-pattern";
 import {
   getFarmSecurityHeader,
   resolveFarmSecurityConfig,
@@ -855,6 +856,7 @@ export async function resolveDocsConfig(
 
 function validateRedirectConfigs(redirects: RedirectConfig[], field: string): RedirectConfig[] {
   for (const [index, redirect] of redirects.entries()) {
+    validateConfigRouteSource(redirect.source, `${field}[${index}].source`);
     if (redirect.statusCode !== undefined && !isFarmRedirectStatus(redirect.statusCode)) {
       throw new RangeError(
         `${field}[${index}].statusCode must be one of 301, 302, 303, 307, or 308.`,
@@ -862,6 +864,13 @@ function validateRedirectConfigs(redirects: RedirectConfig[], field: string): Re
     }
   }
   return redirects;
+}
+
+function validateConfigRouteSources<T extends { source: string }>(routes: T[], field: string): T[] {
+  for (const [index, route] of routes.entries()) {
+    validateConfigRouteSource(route.source, `${field}[${index}].source`);
+  }
+  return routes;
 }
 
 export async function resolveConfig(
@@ -906,11 +915,13 @@ export async function resolveConfig(
     typeof userConfig.rewrites === "function"
       ? await userConfig.rewrites()
       : userConfig.rewrites || [];
+  validateConfigRouteSources(rewrites, "rewrites");
 
   const headers =
     typeof userConfig.headers === "function"
       ? await userConfig.headers()
       : userConfig.headers || [];
+  validateConfigRouteSources(headers, "headers");
   const routeRules = normalizeRouteRules(userConfig.routeRules);
   const routeRuleRedirects = routeRulesToRedirects(routeRules);
   const routeRuleHeaders = routeRulesToHeaders(routeRules);

--- a/packages/farm/src/plugins/route-pattern.ts
+++ b/packages/farm/src/plugins/route-pattern.ts
@@ -10,6 +10,31 @@ export interface CompiledConfigRoutePattern {
   tokens: ConfigRoutePatternToken[];
 }
 
+export function validateConfigRouteSource(source: string, field = "Config route source"): string {
+  if (typeof source !== "string" || source.length === 0) {
+    throw new TypeError(`${field} must be a non-empty pathname pattern.`);
+  }
+  if (source.trim() !== source) {
+    throw new Error(`${field} cannot contain leading or trailing whitespace.`);
+  }
+  if (!source.startsWith("/")) {
+    throw new Error(`${field} must start with "/".`);
+  }
+  if (source.includes("?") || source.includes("#")) {
+    throw new Error(`${field} must be a pathname without a query string or hash.`);
+  }
+  if (
+    source.includes("\\") ||
+    Array.from(source).some((character) => {
+      const code = character.charCodeAt(0);
+      return code <= 31 || (code >= 127 && code <= 159);
+    })
+  ) {
+    throw new Error(`${field} cannot contain backslashes or control characters.`);
+  }
+  return source;
+}
+
 export function resolveConfigRoutePathname(
   pathname: string,
   i18n?: ResolvedFarmI18nConfig,
@@ -32,6 +57,7 @@ function escapeRegexCharacter(character: string): string {
 }
 
 export function compileConfigRoutePattern(source: string): CompiledConfigRoutePattern {
+  validateConfigRouteSource(source);
   const tokens: ConfigRoutePatternToken[] = [];
   let pattern = "";
   let captureIndex = 1;

--- a/packages/farm/src/route-rules.ts
+++ b/packages/farm/src/route-rules.ts
@@ -2,6 +2,7 @@ import type { HeaderConfig, RedirectConfig } from "./config";
 import { isFarmRedirectStatus, type FarmRedirectStatus } from "./navigation-errors";
 import type { FarmRouteRuntimeConfig } from "./route-runtime";
 import { normalizeFarmRouteRuntimeConfig } from "./route-runtime";
+import { validateConfigRouteSource } from "./plugins/route-pattern";
 
 export type FarmRouteRuleRenderMode = "static" | "dynamic";
 
@@ -39,8 +40,9 @@ export function normalizeRouteRules(routeRules: FarmRouteRules | undefined): Far
 
   const normalized: FarmRouteRules = {};
   for (const [source, rule] of Object.entries(routeRules)) {
-    if (!source || !rule) continue;
+    if (!rule) continue;
     const normalizedSource = normalizeRuleSource(source);
+    validateConfigRouteSource(normalizedSource, `Route rule "${source}" source`);
     if (
       typeof rule.redirect === "object" &&
       rule.redirect.statusCode !== undefined &&
@@ -157,6 +159,8 @@ function normalizeList(value: string | readonly string[] | undefined): string | 
 
 function normalizeRuleSource(source: string): string {
   const trimmed = source.trim();
-  if (!trimmed) return "/";
+  if (!trimmed) {
+    throw new TypeError("Route rule source must be a non-empty pathname pattern.");
+  }
   return trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
 }


### PR DESCRIPTION
## Problem

Redirect, rewrite, header, and route-rule sources can include values that can never match a request pathname, such as query strings, hashes, missing leading slashes, or control characters.

## Root cause

Source patterns were compiled without a shared validation boundary even though matching operates only on normalized URL pathnames.

## Change

Add shared source validation during config resolution and direct pattern compilation. Empty route-rule sources now fail instead of being silently skipped. Document the pathname-only source contract.

## Safety and compatibility

Valid pathname patterns and normalized route-rule keys retain their behavior. Query strings and hashes remain supported in redirect and rewrite destinations.

## Verification

- pnpm --filter @farm.js/core type-check
- Config and config-route-plugin tests: 68 tests passed
- oxfmt, oxlint, and git diff checks

## Documentation and release

Updated the configuration route-pattern documentation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects redirect, rewrite, header, and route-rule sources that can never match a request pathname, such as query strings, hashes, missing leading slashes, or control characters. Empty route-rule sources now fail during config resolution instead of being silently skipped.

**Behavior changes**
- Invalid sources throw at startup, during both config resolution and direct pattern compilation.
- Valid pathname patterns and normalized route-rule keys behave the same; query strings and hashes remain supported in destinations.
- Configuration docs now state that sources must be pathname patterns starting with `/`.

<sup>Written for commit 5ad1bc4fa114dfe1c0f02fa2857f1505989abded. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/839?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

