### PR TITLE
fix(route-rules): reject normalized source collisions

### DIFF
--- a/packages/farm/src/__tests__/config.test.ts
+++ b/packages/farm/src/__tests__/config.test.ts
@@ -754,6 +754,20 @@ describe("resolveConfig", () => {
     }
   });
 
+  it("rejects route-rule keys that normalize to the same pathname", async () => {
+    await expect(
+      resolveConfig(
+        {
+          routeRules: {
+            "docs/**": { headers: { "x-first": "1" } },
+            "/docs/**": { cors: true },
+          },
+        },
+        "production",
+      ),
+    ).rejects.toThrow('Route rules "docs/**" and "/docs/**" both normalize to "/docs/**"');
+  });
+
   it("rejects non-redirect status codes in configured redirects", async () => {
     await expect(
       resolveConfig(

--- a/packages/farm/src/route-rules.ts
+++ b/packages/farm/src/route-rules.ts
@@ -39,10 +39,18 @@ export function normalizeRouteRules(routeRules: FarmRouteRules | undefined): Far
   if (!routeRules) return {};
 
   const normalized: FarmRouteRules = {};
+  const normalizedSources = new Map<string, string>();
   for (const [source, rule] of Object.entries(routeRules)) {
     if (!rule) continue;
     const normalizedSource = normalizeRuleSource(source);
     validateConfigRouteSource(normalizedSource, `Route rule "${source}" source`);
+    const existingSource = normalizedSources.get(normalizedSource);
+    if (existingSource !== undefined) {
+      throw new Error(
+        `Route rules "${existingSource}" and "${source}" both normalize to "${normalizedSource}".`,
+      );
+    }
+    normalizedSources.set(normalizedSource, source);
     if (
       typeof rule.redirect === "object" &&
       rule.redirect.statusCode !== undefined &&


### PR DESCRIPTION
## Problem

Two route-rule keys such as docs/** and /docs/** normalize to the same pathname, allowing the later entry to silently overwrite the earlier rule.

## Root cause

Normalization wrote directly into an object without tracking which original source already owned the normalized key.

## Change

Track normalized sources and fail config resolution with both original keys and the colliding pathname.

## Safety and compatibility

Unique route-rule sources are unchanged. Ambiguous configurations now fail early instead of depending on object insertion order.

## Verification

- pnpm --filter @farm.js/core type-check
- Config test file: 55 tests passed
- oxfmt, oxlint, and git diff checks

## Documentation and release

None.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route rules that normalize to the same pathname (e.g. `docs/**` and `/docs/**`) now fail config resolution with an error naming both original keys and the colliding pathname, instead of silently letting the later rule overwrite the earlier one.

<sup>Written for commit fb480119918595b58ffea31062366e7cfe226200. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/840?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

