### PR TITLE
fix(openapi): report failed development generation

### DIFF
--- a/packages/farm/src/__tests__/openapi-dev-status.test.ts
+++ b/packages/farm/src/__tests__/openapi-dev-status.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it, vi } from "vitest";
+import { reportOpenAPIDevGenerationResult } from "../openapi/dev-status";
+
+describe("OpenAPI development status", () => {
+  it("reports success only when generation returns a specification", () => {
+    const output = { success: vi.fn(), warn: vi.fn() };
+
+    reportOpenAPIDevGenerationResult(null, output);
+    expect(output.success).not.toHaveBeenCalled();
+    expect(output.warn).toHaveBeenCalledWith(
+      "OpenAPI documentation is enabled, but its specification failed to generate.",
+    );
+
+    output.warn.mockClear();
+    reportOpenAPIDevGenerationResult({ openapi: "3.1.0" }, output);
+    expect(output.success).toHaveBeenCalledWith("✅ OpenAPI documentation enabled");
+    expect(output.warn).not.toHaveBeenCalled();
+  });
+});

--- a/packages/farm/src/openapi/dev-status.ts
+++ b/packages/farm/src/openapi/dev-status.ts
@@ -1,0 +1,18 @@
+import { logger } from "../utils";
+
+interface OpenAPIDevStatusLogger {
+  success(message: string): void;
+  warn(message: string): void;
+}
+
+export function reportOpenAPIDevGenerationResult(
+  spec: unknown,
+  output: OpenAPIDevStatusLogger = logger,
+): void {
+  if (spec) {
+    output.success("✅ OpenAPI documentation enabled");
+    return;
+  }
+
+  output.warn("OpenAPI documentation is enabled, but its specification failed to generate.");
+}

--- a/packages/farm/src/vite.ts
+++ b/packages/farm/src/vite.ts
@@ -102,6 +102,7 @@ import {
 import { resolveFarmPageDataFailure } from "./navigation/page-data-error";
 import { FARM_CONFIG_REWRITES_PLUGIN_NAME } from "./plugins/rewrites";
 import { resolveFarmRequestURL } from "./server/request";
+import { reportOpenAPIDevGenerationResult } from "./openapi/dev-status";
 
 interface FarmVitePluginOptions extends FarmConfig {
   openapi?: FarmUserConfig["openapi"];
@@ -1094,8 +1095,8 @@ export function farmPlugin(
       if (options.openapi?.enabled) {
         const { OpenAPIManager } = await loadFarmOpenAPIDevRuntime();
         openAPIManager = new OpenAPIManager(appDirs, options.openapi);
-        await openAPIManager.generateSpec();
-        logger.success("✅ OpenAPI documentation enabled");
+        const spec = await openAPIManager.generateSpec();
+        reportOpenAPIDevGenerationResult(spec);
       }
 
       refreshRouteDiscovery = async (reason: string) => {


### PR DESCRIPTION
## Problem

Development startup logs OpenAPI documentation as enabled even when specification generation catches an error and returns null.

## Root cause

The startup path ignored the generateSpec result and always emitted the success message.

## Change

Report success only for a generated specification and emit a warning when generation fails. Add a focused status regression test.

## Safety and compatibility

Successful generation keeps the existing success message. Generation remains non-blocking; failures warn instead of preventing the development server from starting.

## Verification

- pnpm --filter @farm.js/core type-check
- Focused OpenAPI development status test
- oxfmt, oxlint, and git diff checks

## Documentation and release

None.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the development startup log so OpenAPI documentation is only reported as enabled when specification generation succeeds; failures now emit a warning instead of a success message. Generation stays non-blocking, so a failed spec warns without preventing the dev server from starting.

<sup>Written for commit 969f412954bfb0e9a93061d178d7629876de89ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/841?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

