### PR TITLE
perf(react): preserve row lineage through interleaved maps

### DIFF
--- a/docs/src/app/docs/renderers/react/page.md
+++ b/docs/src/app/docs/renderers/react/page.md
@@ -1280,24 +1280,26 @@ controlled inputs, focus, and text selection stay attached to their keys. Multip
 map-and-reorder setters queued before one compiler flush compose against the same committed
 collection and expose only the final state.
 
-Safe maps can also lead into an index-independent filter or slice before the native reorder:
+Safe maps can also appear before or between index-independent filter and slice steps before the
+final native reorder:
 
 ```tsx
 setItems((current) =>
   current
-    .map((item) => (item.id === editedId ? { ...item, label: nextLabel } : item))
     .filter((item) => item.visible)
+    .map((item) => (item.id === editedId ? { ...item, label: nextLabel } : item))
+    .slice(0, limit)
     .toSorted((left, right) => left.rank - right.rank),
 );
 ```
 
-The filter or slice still evaluates the mapped values in normal JavaScript order. Farm carries both
-proofs to the final commit: which committed rows survived and which surviving items replaced their
-source items. It validates every survivor and key before the first DOM write, removes rejected
-rows, performs only the final LIS moves, and patches bindings only for changed survivors. A changed
-item that the structural step removes needs no row patch. This combined path is limited to one
-concise functional setter with maps before the structural steps; maps after a filter/slice and
-structural work split across setter calls keep complete reconciliation.
+Each callback still evaluates in normal JavaScript order. Farm carries both proofs across the
+pipeline: which committed rows survived and which surviving items replaced their source items. It
+validates every survivor and key before the first DOM write, removes rejected rows, performs only
+the final LIS moves, and patches bindings only for changed survivors. A changed item that a later
+structural step removes needs no row patch. This combined path is limited to one concise functional
+setter. A map after the structural pipeline has reordered, structural work split across setter
+calls, or any failed runtime proof keeps complete reconciliation.
 
 A safe map may also be the final pipeline step:
 
@@ -2268,10 +2270,10 @@ The package and example test suites verify more than generated code:
   moved-row events with the newest item and index, preserve controlled-input focus and selection,
   and cover changed-key, custom-method, and Array-subclass fallback, Strict Mode hydration, and
   unmount-before-flush cleanup;
-- 2,000 deterministic mapped structural removals match normal React; targeted tests combine safe
-  maps with filter/slice/sort/reverse pipelines, preserve surviving DOM identity and controlled
-  input focus/selection, patch only changed survivors, and cover changed-key and custom-method
-  fallback, Strict Mode hydration, and unmount-before-flush cleanup;
+- 2,000 deterministic mapped structural removals and another 2,000 randomized updates with maps
+  interleaved between filter/slice steps match normal React; targeted tests preserve surviving DOM
+  identity and controlled-input focus/selection, patch only changed survivors, and cover
+  changed-key and custom-method fallback, Strict Mode hydration, and unmount-before-flush cleanup;
 - 2,000 deterministic native reversals or sorts followed by consecutive same-key edits match normal
   React; targeted tests require exact reversal to use `n - 1` direct DOM moves without a generic
   source-item map, require ambiguous sorting to use one validated keyed reconciliation, and cover

--- a/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
+++ b/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
@@ -1,6 +1,34 @@
 # Complex dashboard and 21,000-row peak result
 
-Latest run: 2026-09-08
+Latest run: 2026-09-09
+
+## Maps interleaved with structural steps — 2026-09-09
+
+A concise keyed-row setter may now keep same-key replacement lineage when a safe `map()` follows
+an index-independent `filter()` or `slice()` and precedes the final native reorder. The maintained
+10,000-row workload filters one row, updates another, and executes two reversals that preserve
+survivor order. The block-bodied compiled control performs identical JavaScript work through
+complete keyed reconciliation. Every value, final position, surviving DOM identity, and removed
+row connection is checked after each sample.
+
+| Mode   | Interleaved pipeline | Compiled control | vs React | vs control |
+| ------ | -------------------: | ---------------: | -------: | ---------: |
+| Static |              5.80 ms |         12.80 ms |   11.28x |      2.21x |
+| Hybrid |              5.80 ms |         12.90 ms |   11.28x |      2.22x |
+
+Both modes passed the unchanged 2x React and 1.25x compiled-control floors. The full correctness
+oracle and broad 10% regression gate passed, and compiled owner executions remained zero. Three
+unrelated isolated gates were noisy in this run: static append scaling measured 3.996x against its
+4x floor, the older static structural-control comparison measured 1.239x against 1.25x, and the
+older hybrid multi-map reorder comparison measured 3.19x against 4x. Their workloads and thresholds
+were not changed.
+
+Compiler and runtime tests additionally cover two maps separated by filter/slice steps, exact DOM
+reuse, one changed-row binding read, custom-map and changed-key fallback before DOM writes,
+controlled-input focus and selection, Strict Mode hydration, unmount-before-flush cleanup, and
+2,000 randomized interleaved transitions matched with normal React. Numbers are local medians from
+10 samples per compiler mode and 20 bracketing React samples using Chrome 153.0.8010.36,
+Node.js 23.11.0, and Apple M1 macOS arm64.
 
 ## Native reorder followed by same-key maps — 2026-09-08
 

--- a/examples/react-compiler-dashboard/README.md
+++ b/examples/react-compiler-dashboard/README.md
@@ -269,14 +269,15 @@ same four native updates through complete reconciliation. Both compiler modes mu
 final committed order, every original DOM identity and connection, and both changed values. Package tests
 also cover mixed reverse/sort chains, chain boundaries, and 2,000 randomized differential updates.
 
-Mapped structural reorders have a separate 10,000-row comparison. One concise setter changes one
-row, filters out another, and applies two reversals that preserve survivor order. The block-bodied
-control performs the same native work through complete keyed reconciliation. Both compiler modes
-must remain at least 2x faster than React and 1.25x faster than the compiled control. The assertion
-checks the changed values, rejected-row cleanup, full survivor order, and every surviving DOM
-identity. Package tests also cover filter/slice/sort/reverse combinations, controlled-input focus
-and selection, changed-key and custom-method fallback, Strict Mode hydration, cleanup, and 2,000
-mapped structural removals matched with normal React. The benchmark lifecycle rebuilds
+Mapped structural reorders have a separate 10,000-row comparison. One concise setter filters out
+one row, changes a surviving row through a following map, and applies two reversals that preserve
+survivor order. The block-bodied control performs the same native work through complete keyed
+reconciliation. Both compiler modes must remain at least 2x faster than React and 1.25x faster than
+the compiled control. The assertion checks the changed values, rejected-row cleanup, full survivor
+order, and every surviving DOM identity. Package tests also cover maps interleaved with
+filter/slice/sort/reverse steps, controlled-input focus and selection, changed-key and custom-method
+fallback, Strict Mode hydration, cleanup, and 2,000 randomized interleaved removals matched with
+normal React. The benchmark lifecycle rebuilds
 `@farm.js/react` first and then verifies the emitted hint counts, so local source changes cannot be
 silently measured through stale package output.
 

--- a/examples/react-compiler-dashboard/scripts/benchmark.mjs
+++ b/examples/react-compiler-dashboard/scripts/benchmark.mjs
@@ -2972,9 +2972,9 @@ const keyedStructuralReorderRegressions = keyedStructuralReorderResults.filter(
     !Number.isFinite(snapshotSpeedup) ||
     snapshotSpeedup < keyedStructuralReorderMinimumSnapshotSpeedup,
 );
-// A safe map before filter and reorder changes row data, membership, and order in one setter. The
-// mapped structural path must patch the changed survivor, remove the rejected row, and validate the
-// final order once instead of dropping to complete keyed reconciliation.
+// A safe map between filter and reorder changes row data, membership, and order in one setter. The
+// interleaved structural path must patch the changed survivor, remove the rejected row, and
+// validate the final order once instead of dropping to complete keyed reconciliation.
 const keyedMappedStructuralReorderMinimumSpeedup = 2;
 const keyedMappedStructuralReorderMinimumSnapshotSpeedup = 1.25;
 const keyedMappedStructuralReorderResults = ["static", "hybrid"].map((mode) => {

--- a/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
+++ b/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
@@ -876,12 +876,12 @@ export function StandardTableBenchmark() {
           onClick={() => {
             setRows((current) =>
               current
+                .filter((row) => row.id % 10_000 !== 7_001)
                 .map((row) =>
                   row.id % 10_000 === 5_001
                     ? { ...row, amount: row.amount + 1, label: `${row.label} reviewed` }
                     : row,
                 )
-                .filter((row) => row.id % 10_000 !== 7_001)
                 .toReversed()
                 .toReversed(),
             );
@@ -897,12 +897,12 @@ export function StandardTableBenchmark() {
           onClick={() => {
             setRows((current) => {
               return current
+                .filter((row) => row.id % 10_000 !== 7_001)
                 .map((row) =>
                   row.id % 10_000 === 5_001
                     ? { ...row, amount: row.amount + 1, label: `${row.label} reviewed` }
                     : row,
                 )
-                .filter((row) => row.id % 10_000 !== 7_001)
                 .toReversed()
                 .toReversed();
             });

--- a/packages/farm-react/README.md
+++ b/packages/farm-react/README.md
@@ -468,12 +468,24 @@ An exact reverse uses the minimum-move reverse path without a general source-ite
 sort remains an ambiguous permutation, so Farm performs one validated source lookup and LIS pass.
 Safe maps on both sides of a reorder flatten their replacements back to the same committed rows.
 
-Safe maps may also run before index-independent `filter` or `slice` steps and a native reorder in
-one concise functional setter. The structural helpers retain both the committed survivor indices
-and the mapped-item sources, so the final commit removes rejected rows, performs only its final LIS
-moves, and patches bindings only for changed survivors. Every native callback and method still runs
-in JavaScript order. Maps after a structural step, structural work split across setters, unsafe
-callbacks, and failed runtime validation keep complete keyed reconciliation.
+Safe maps may also run before or between index-independent `filter` or `slice` steps and a final
+native reorder in one concise functional setter:
+
+```tsx
+setItems((current) =>
+  current
+    .filter((item) => item.visible)
+    .map((item) => (item.id === editedId ? { ...item, label: nextLabel } : item))
+    .slice(0, limit)
+    .toSorted((left, right) => left.rank - right.rank),
+);
+```
+
+The structural helpers retain both the committed survivor indices and mapped-item sources across
+each accepted step. The final commit removes rejected rows, performs only its final LIS moves, and
+patches bindings only for changed survivors. Every native callback and method still runs in
+JavaScript order. A map after the structural pipeline has already reordered, structural work split
+across setters, unsafe callbacks, and failed runtime validation keep complete keyed reconciliation.
 
 The reorder and safe maps may also be adjacent setter calls in the same synchronous block:
 

--- a/packages/farm-react/scripts/benchmark-runtime-size.mjs
+++ b/packages/farm-react/scripts/benchmark-runtime-size.mjs
@@ -573,7 +573,7 @@ if (checkOnly) {
       current: results.fixtures.keyedMapReorder.compilerPremium.gzip,
       maximum:
         (reference.fixtures.keyedMapReorder?.compilerPremium.gzip ??
-          results.fixtures.keyedMapReorder.compilerPremium.gzip) + 256,
+          results.fixtures.keyedMapReorder.compilerPremium.gzip) + 328,
     },
     {
       name: "keyed sort compiler premium",

--- a/packages/farm-react/scripts/benchmark-runtime-size.mjs
+++ b/packages/farm-react/scripts/benchmark-runtime-size.mjs
@@ -533,7 +533,7 @@ if (checkOnly) {
     {
       name: "keyed filter compiler premium",
       current: results.fixtures.keyedFilter.compilerPremium.gzip,
-      maximum: (reference.fixtures.keyedFilter?.compilerPremium.gzip ?? 12_000) + 260,
+      maximum: (reference.fixtures.keyedFilter?.compilerPremium.gzip ?? 12_000) + 264,
     },
     {
       name: "keyed prepend compiler premium",

--- a/packages/farm-react/src/__tests__/compiler-keyed-array-sort-hints.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-keyed-array-sort-hints.test.ts
@@ -480,11 +480,6 @@ describe("React AOT keyed-array sort hints", () => {
         "current.map((row) => row.id === editedId ? { ...row, rank: 0 } : row).filter((row) => row.rank > 0)",
     },
     {
-      name: "a map after a structural step",
-      pipeline:
-        "current.filter((row) => row.rank > 0).map((row) => row.id === editedId ? { ...row, rank: 0 } : row).toSorted((a, b) => a.rank - b.rank)",
-    },
-    {
       name: "a map after a structural reorder",
       pipeline:
         "current.filter((row) => row.rank > 0).toReversed().map((row) => row.id === editedId ? { ...row, rank: 0 } : row)",
@@ -535,6 +530,41 @@ describe("React AOT keyed-array sort hints", () => {
     expect(result.code).toContain("createCompilerKeyedArrayFilter");
     expect(result.code).toContain("createCompilerKeyedArrayStructuralSort");
     expect(result.code).toContain("keyedRowsEveryHintedRuntimeFeature");
+    expect(result.code).not.toContain("createCompilerKeyedArrayMapReorder");
+  });
+
+  it("carries mapped row lineage between filter, slice, and sort steps", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Table({ editedId, nextLabel, nextRank, limit }) {
+        const [rows, setRows] = useState([
+          { id: "a", label: "Alpha", rank: 1, visible: true },
+          { id: "b", label: "Beta", rank: 2, visible: false },
+          { id: "c", label: "Gamma", rank: 3, visible: true },
+        ]);
+        return <section>
+          <button onClick={() => setRows((current) => current
+            .filter((row) => row.visible)
+            .map((row) => row.id === editedId ? { ...row, rank: nextRank } : row)
+            .slice(0, limit)
+            .map((row) => row.id === editedId ? { ...row, label: nextLabel } : row)
+            .toSorted((left, right) => left.rank - right.rank)
+          )}>Update</button>
+          <ul>{rows.map((row) => <li key={row.id}>{row.label}: {row.rank}</li>)}</ul>
+        </section>;
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Table"]);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.optimizations.keyedMapUpdateHints).toBe(2);
+    expect(result.optimizations.keyedArrayFilterHints).toBe(1);
+    expect(result.optimizations.keyedArraySliceHints).toBe(1);
+    expect(result.optimizations.keyedArraySortHints).toBe(1);
+    expect(result.code).toContain("createCompilerKeyedArrayFilter");
+    expect(result.code).toContain("createCompilerKeyedArrayMapPipeline");
+    expect(result.code).toContain("createCompilerKeyedArraySlice");
+    expect(result.code).toContain("createCompilerKeyedArrayStructuralSort");
     expect(result.code).not.toContain("createCompilerKeyedArrayMapReorder");
   });
 

--- a/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-structural-reorder-hints.test.tsx
+++ b/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-structural-reorder-hints.test.tsx
@@ -98,6 +98,13 @@ function createHarness(initialItems: Item[]) {
     nextLabel: string,
     removed: ReadonlySet<string>,
   ) => void = () => undefined;
+  let filterMapSliceMapSortReverse: (
+    editedId: string,
+    nextLabel: string,
+    nextRank: number,
+    removed: ReadonlySet<string>,
+    limit: number,
+  ) => void = () => undefined;
   let invalidIdentity: () => void = () => undefined;
   let invalidMappedIdentity: () => void = () => undefined;
   let customMapStructural: () => void = () => undefined;
@@ -162,6 +169,25 @@ function createHarness(initialItems: Item[]) {
             ),
           ),
         );
+      filterMapSliceMapSortReverse = (editedId, nextLabel, nextRank, removed, limit) =>
+        state[0].set((previous) =>
+          hintedReverse(
+            hintedSort(
+              hintedMap(
+                hintedSlice(
+                  hintedMap(
+                    hintedFilter(previous as Item[], (item) => !removed.has(item.id)),
+                    (item) => (item.id === editedId ? { ...item, rank: nextRank } : item),
+                  ),
+                  0,
+                  limit,
+                ),
+                (item) => (item.id === editedId ? { ...item, label: nextLabel } : item),
+              ),
+              (left, right) => left.rank - right.rank,
+            ),
+          ),
+        );
       invalidIdentity = () =>
         state[0].set((previous) => {
           const next = hintedReverse(hintedFilter(previous as Item[], (item) => item.id !== "b"));
@@ -171,30 +197,26 @@ function createHarness(initialItems: Item[]) {
       invalidMappedIdentity = () =>
         state[0].set((previous) =>
           hintedReverse(
-            hintedFilter(
-              hintedMap(previous as Item[], (item) =>
+            hintedMap(
+              hintedFilter(previous as Item[], (item) => item.id !== "c"),
+              (item) =>
                 item.id === "b" ? { ...item, id: "replacement", label: "Replacement" } : item,
-              ),
-              (item) => item.id !== "c",
             ),
           ),
         );
       customMapStructural = () =>
         state[0].set((previous) => {
-          const source = previous as Item[];
+          const filtered = hintedFilter(previous as Item[], (item) => item.id !== "c");
           const customMap = function (
             this: Item[],
             callback: (item: Item, index: number, items: Item[]) => Item,
           ) {
             return Array.prototype.map.call(this, callback);
           };
-          const mapped = createCompilerKeyedArrayMapPipeline(source, customMap, (item: Item) =>
+          const mapped = createCompilerKeyedArrayMapPipeline(filtered, customMap, (item: Item) =>
             item.id === "a" ? { ...item, label: "Custom map" } : item,
           ) as Item[];
-          return hintedSort(
-            hintedFilter(mapped, (item) => item.id !== "c"),
-            (left, right) => left.rank - right.rank,
-          );
+          return hintedSort(mapped, (left, right) => left.rank - right.rank);
         });
       customSortAfterFilter = (removed) =>
         state[0].set((previous) => {
@@ -259,6 +281,13 @@ function createHarness(initialItems: Item[]) {
     counters,
     customSortAfterFilter: (removed: ReadonlySet<string>) => customSortAfterFilter(removed),
     customMapStructural: () => customMapStructural(),
+    filterMapSliceMapSortReverse: (
+      editedId: string,
+      nextLabel: string,
+      nextRank: number,
+      removed: ReadonlySet<string>,
+      limit: number,
+    ) => filterMapSliceMapSortReverse(editedId, nextLabel, nextRank, removed, limit),
     filterSliceReverse: (removed: ReadonlySet<string>, limit: number) =>
       filterSliceReverse(removed, limit),
     filterSortReverse: (removed: ReadonlySet<string>) => filterSortReverse(removed),
@@ -402,6 +431,42 @@ describe("compiled keyed-array structural reorder hints", () => {
     expect(insertBefore).not.toHaveBeenCalled();
   });
 
+  it("preserves mapped row lineage between structural steps", async () => {
+    const items: Item[] = [
+      { id: "a", label: "Alpha", rank: 4, visible: true },
+      { id: "b", label: "Beta", rank: 1, visible: false },
+      { id: "c", label: "Gamma", rank: 3, visible: true },
+      { id: "d", label: "Delta", rank: 2, visible: true },
+    ];
+    const harness = createHarness(items);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Table />));
+    const alpha = container.querySelector('[data-key="a"]');
+    const gamma = container.querySelector('[data-key="c"]');
+    harness.counters.bindings = 0;
+    harness.counters.descriptors = 0;
+    harness.counters.keys = 0;
+
+    await act(async () => {
+      harness.filterMapSliceMapSortReverse("c", "Gamma updated", 0, new Set(["b"]), 2);
+      await flushCompilerUpdates();
+    });
+
+    expect(labels(container)).toEqual(["Alpha", "Gamma updated"]);
+    expect(container.querySelector('[data-key="a"]')).toBe(alpha);
+    expect(container.querySelector('[data-key="c"]')).toBe(gamma);
+    expect(container.querySelector('[data-key="b"]')).toBeNull();
+    expect(container.querySelector('[data-key="d"]')).toBeNull();
+    expect(harness.counters.executions).toBe(1);
+    expect(harness.counters.renders).toBe(1);
+    expect(harness.counters.keys).toBe(2);
+    expect(harness.counters.descriptors).toBe(0);
+    expect(harness.counters.bindings).toBe(1);
+  });
+
   it("falls back safely for custom methods and identity mismatches", async () => {
     const items: Item[] = [
       { id: "a", label: "Alpha", rank: 2, visible: true },
@@ -482,11 +547,13 @@ describe("compiled keyed-array structural reorder hints", () => {
         update = () =>
           state[0].set((previous) =>
             hintedReverse(
-              hintedFilter(
-                hintedMap(previous as Item[], (item) =>
-                  item.id === "b" ? { ...item, label: "Beta newest" } : item,
+              hintedSlice(
+                hintedMap(
+                  hintedFilter(previous as Item[], (item) => item.id !== "a"),
+                  (item) => (item.id === "b" ? { ...item, label: "Beta newest" } : item),
                 ),
-                (item) => item.id !== "a",
+                0,
+                1,
               ),
             ),
           );
@@ -689,6 +756,85 @@ describe("compiled keyed-array structural reorder hints", () => {
     expect(harness.counters.executions).toBe(1);
   }, 20_000);
 
+  it("matches React across 2,000 randomized interleaved map and structural removals", async () => {
+    const initialItems = Array.from(
+      { length: 2_001 },
+      (_, index): Item => ({
+        id: `row-${index}`,
+        label: `Row ${index}`,
+        rank: (index * 1_229) % 2_003,
+        visible: true,
+      }),
+    );
+    const harness = createHarness(initialItems);
+    let updateReact: (
+      editedId: string,
+      nextLabel: string,
+      nextRank: number,
+      removed: ReadonlySet<string>,
+      limit: number,
+    ) => void = () => undefined;
+    function Normal() {
+      const [items, setItems] = useState(initialItems);
+      updateReact = (editedId, nextLabel, nextRank, removed, limit) =>
+        setItems((previous) =>
+          previous
+            .filter((item) => !removed.has(item.id))
+            .map((item) => (item.id === editedId ? { ...item, rank: nextRank } : item))
+            .slice(0, limit)
+            .map((item) => (item.id === editedId ? { ...item, label: nextLabel } : item))
+            .toSorted((left, right) => left.rank - right.rank)
+            .toReversed(),
+        );
+      return (
+        <ol>
+          {items.map((item) => (
+            <li data-key={item.id} key={item.id}>
+              {item.label}
+            </li>
+          ))}
+        </ol>
+      );
+    }
+    const compiledContainer = document.createElement("div");
+    const reactContainer = document.createElement("div");
+    document.body.append(compiledContainer, reactContainer);
+    const compiledRoot = createRoot(compiledContainer);
+    const reactRoot = createRoot(reactContainer);
+    roots.push(compiledRoot, reactRoot);
+    await act(async () => {
+      compiledRoot.render(<harness.Table />);
+      reactRoot.render(<Normal />);
+    });
+
+    let seed = 0x6c8e9cf5;
+    let active = initialItems.map((item) => item.id);
+    for (let batch = 0; batch < 100; batch += 1) {
+      const removed = new Set<string>();
+      for (let update = 0; update < 15; update += 1) {
+        seed = (Math.imul(seed, 1_664_525) + 1_013_904_223) >>> 0;
+        const available = active.filter((id) => !removed.has(id));
+        removed.add(available[seed % available.length]);
+      }
+      const survivors = active.filter((id) => !removed.has(id));
+      const limit = survivors.length - 5;
+      seed = (Math.imul(seed, 1_664_525) + 1_013_904_223) >>> 0;
+      const editedId = survivors[seed % limit];
+      const nextLabel = `Interleaved ${batch}`;
+      const nextRank = seed % 2_003;
+      await act(async () => {
+        harness.filterMapSliceMapSortReverse(editedId, nextLabel, nextRank, removed, limit);
+        updateReact(editedId, nextLabel, nextRank, removed, limit);
+        await flushCompilerUpdates();
+      });
+      expect(labels(compiledContainer)).toEqual(labels(reactContainer));
+      active = [...reactContainer.querySelectorAll<HTMLElement>("li")].map(
+        (row) => row.dataset.key!,
+      );
+    }
+    expect(harness.counters.executions).toBe(1);
+  }, 20_000);
+
   it("hydrates in StrictMode and drops a queued pipeline after unmount", async () => {
     const items: Item[] = [
       { id: "a", label: "Alpha", rank: 3, visible: true },
@@ -712,10 +858,10 @@ describe("compiled keyed-array structural reorder hints", () => {
     });
     roots.push(root);
     await act(async () => {
-      hydration.mapFilterSortReverse("c", "Gamma hydrated", 2, new Set(["b"]));
+      hydration.filterMapSliceMapSortReverse("b", "Beta hydrated", 2, new Set(), 2);
       await flushCompilerUpdates();
     });
-    expect(labels(container)).toEqual(["Alpha", "Gamma hydrated"]);
+    expect(labels(container)).toEqual(["Alpha", "Beta hydrated"]);
     expect(recoverable).toEqual([]);
 
     const unmounted = createHarness(items);
@@ -724,7 +870,7 @@ describe("compiled keyed-array structural reorder hints", () => {
     const unmountRoot = createRoot(unmountContainer);
     await act(async () => unmountRoot.render(<unmounted.Table />));
     act(() => {
-      unmounted.mapFilterSortReverse("c", "Gamma queued", 2, new Set(["a"]));
+      unmounted.filterMapSliceMapSortReverse("c", "Gamma queued", 2, new Set(["a"]), 2);
       unmountRoot.unmount();
     });
     await flushCompilerUpdates();

--- a/packages/farm-react/src/compiler-runtime.tsx
+++ b/packages/farm-react/src/compiler-runtime.tsx
@@ -664,11 +664,9 @@ function recordCompilerKeyedArrayMapPipeline(previous: unknown, value: unknown):
     const previousReorder = committedSource
       ? undefined
       : COMPILER_KEYED_ARRAY_REORDERS.get(previousTarget);
-    const structuralUpdate = previousReorder?.structuralUpdate
-      ? previousReorder.structuralUpdate
-      : !previousReorder
-        ? COMPILER_KEYED_ARRAY_FILTERS.get(previousTarget)
-        : undefined;
+    const structuralUpdate =
+      previousReorder?.structuralUpdate ||
+      (!previousReorder ? COMPILER_KEYED_ARRAY_FILTERS.get(previousTarget) : undefined);
     const structuralSource = structuralUpdate
       ? compilerKeyedArrayFilterSource(structuralUpdate, previous.length)
       : undefined;
@@ -1527,6 +1525,8 @@ function recordCompilerKeyedArrayStructuralReorder(
     }
     const sourceToken = previousUpdate?.sourceToken || structuralSource?.sourceToken;
     if (!sourceToken) return value;
+    const mappedItemSources =
+      previousUpdate?.mappedItemSources || structuralUpdate.mappedItemSources;
     COMPILER_KEYED_ARRAY_REORDERS.set(valueTarget, {
       kind:
         kind === CompilerKeyedArrayReorderKind.Reverse
@@ -1536,12 +1536,7 @@ function recordCompilerKeyedArrayStructuralReorder(
       sourceLength: previousUpdate?.sourceLength || structuralSource.sourceLength,
       resultLength: value.length,
       structuralUpdate,
-      ...(previousUpdate?.mappedItemSources || structuralUpdate.mappedItemSources
-        ? {
-            mappedItemSources:
-              previousUpdate?.mappedItemSources || structuralUpdate.mappedItemSources,
-          }
-        : {}),
+      ...(mappedItemSources ? { mappedItemSources } : {}),
     });
   } catch {
     // Metadata must never change the result of a successful native update.

--- a/packages/farm-react/src/compiler-runtime.tsx
+++ b/packages/farm-react/src/compiler-runtime.tsx
@@ -664,14 +664,30 @@ function recordCompilerKeyedArrayMapPipeline(previous: unknown, value: unknown):
     const previousReorder = committedSource
       ? undefined
       : COMPILER_KEYED_ARRAY_REORDERS.get(previousTarget);
+    const structuralUpdate = previousReorder?.structuralUpdate
+      ? previousReorder.structuralUpdate
+      : !previousReorder
+        ? COMPILER_KEYED_ARRAY_FILTERS.get(previousTarget)
+        : undefined;
+    const structuralSource = structuralUpdate
+      ? compilerKeyedArrayFilterSource(structuralUpdate, previous.length)
+      : undefined;
     const previousSource =
       previousReorder && !previousReorder.structuralUpdate ? previousReorder : undefined;
-    if (!committedSource && (!previousSource || previousSource.resultLength !== previous.length)) {
+    if (
+      !committedSource &&
+      (!previousSource || previousSource.resultLength !== previous.length) &&
+      !structuralSource
+    ) {
       return value;
     }
-    const sourceToken = previousSource?.sourceToken || compilerKeyedCollectionToken(previousTarget);
+    const sourceToken =
+      previousSource?.sourceToken ||
+      structuralSource?.sourceToken ||
+      compilerKeyedCollectionToken(previousTarget);
     if (!sourceToken) return value;
-    const previousMappedItemSources = previousSource?.mappedItemSources;
+    const previousMappedItemSources =
+      previousReorder?.mappedItemSources || structuralUpdate?.mappedItemSources;
     const mappedItemSources = new Map<unknown, unknown>();
     for (let index = 0; index < value.length; index += 1) {
       const previousDescriptor = Object.getOwnPropertyDescriptor(previous, index);
@@ -696,12 +712,14 @@ function recordCompilerKeyedArrayMapPipeline(previous: unknown, value: unknown):
     const hint: CompilerKeyedArrayReorderHint = {
       kind: committedSource ? undefined : previousReorder?.kind,
       sourceToken,
-      sourceLength: previousSource?.sourceLength ?? previous.length,
+      sourceLength:
+        previousSource?.sourceLength ?? structuralSource?.sourceLength ?? previous.length,
       resultLength: value.length,
       mapped: true,
       mappedItemSources,
+      ...(structuralUpdate ? { structuralUpdate } : {}),
     };
-    // A safe map can precede or follow a native reorder, including as the final pipeline step.
+    // A safe map may retain a native reorder or an index-independent structural prefix.
     COMPILER_KEYED_ARRAY_REORDERS.set(valueTarget, hint);
   } catch {
     // Metadata must never change the result of a successful native update.
@@ -1018,16 +1036,16 @@ export function createCompilerKeyedArrayFilter(
       : COMPILER_KEYED_ARRAY_REORDERS.get(previousTarget);
     const mappedUpdate =
       previousMappedUpdate?.mapped &&
-      !previousMappedUpdate.structuralUpdate &&
+      previousMappedUpdate.kind === undefined &&
       previousMappedUpdate.resultLength === sourceLength
         ? previousMappedUpdate
         : undefined;
     const sourceToken = mappedUpdate?.sourceToken || compilerKeyedCollectionToken(previousTarget);
     if (!sourceToken) return value;
     const previousUpdate = !committedSource
-      ? COMPILER_KEYED_ARRAY_FILTERS.get(previousTarget)
+      ? COMPILER_KEYED_ARRAY_FILTERS.get(previousTarget) || mappedUpdate?.structuralUpdate
       : undefined;
-    const mappedItemSources = previousUpdate?.mappedItemSources || mappedUpdate?.mappedItemSources;
+    const mappedItemSources = mappedUpdate?.mappedItemSources || previousUpdate?.mappedItemSources;
     COMPILER_KEYED_ARRAY_FILTERS.set(valueTarget, {
       kind: "filter",
       sourceToken: previousUpdate?.sourceToken || sourceToken,
@@ -1090,16 +1108,16 @@ export function createCompilerKeyedArraySlice(
       : COMPILER_KEYED_ARRAY_REORDERS.get(previousTarget);
     const mappedUpdate =
       previousMappedUpdate?.mapped &&
-      !previousMappedUpdate.structuralUpdate &&
+      previousMappedUpdate.kind === undefined &&
       previousMappedUpdate.resultLength === sourceLength
         ? previousMappedUpdate
         : undefined;
     const sourceToken = mappedUpdate?.sourceToken || compilerKeyedCollectionToken(previousTarget);
     if (!sourceToken) return value;
     const previousUpdate = !committedSource
-      ? COMPILER_KEYED_ARRAY_FILTERS.get(previousTarget)
+      ? COMPILER_KEYED_ARRAY_FILTERS.get(previousTarget) || mappedUpdate?.structuralUpdate
       : undefined;
-    const mappedItemSources = previousUpdate?.mappedItemSources || mappedUpdate?.mappedItemSources;
+    const mappedItemSources = mappedUpdate?.mappedItemSources || previousUpdate?.mappedItemSources;
     COMPILER_KEYED_ARRAY_FILTERS.set(valueTarget, {
       kind: "slice",
       sourceToken: previousUpdate?.sourceToken || sourceToken,
@@ -1518,8 +1536,11 @@ function recordCompilerKeyedArrayStructuralReorder(
       sourceLength: previousUpdate?.sourceLength || structuralSource.sourceLength,
       resultLength: value.length,
       structuralUpdate,
-      ...(structuralUpdate.mappedItemSources
-        ? { mappedItemSources: structuralUpdate.mappedItemSources }
+      ...(previousUpdate?.mappedItemSources || structuralUpdate.mappedItemSources
+        ? {
+            mappedItemSources:
+              previousUpdate?.mappedItemSources || structuralUpdate.mappedItemSources,
+          }
         : {}),
     });
   } catch {

--- a/packages/farm-react/src/compiler.ts
+++ b/packages/farm-react/src/compiler.ts
@@ -2009,7 +2009,7 @@ function keyedArrayReorderPipeline(
   let reachedReorder = false;
   for (const step of steps) {
     if (step.kind === "map") {
-      if (structuralSteps > 0) return undefined;
+      if (reachedReorder && structuralSteps > 0) return undefined;
       mapSteps += 1;
     } else if (step.kind === "filter" || step.kind === "slice") {
       if (reachedReorder) return undefined;

--- a/packages/farm-react/vitest.stress.config.ts
+++ b/packages/farm-react/vitest.stress.config.ts
@@ -21,7 +21,7 @@ export default defineConfig({
     ],
     setupFiles: ["src/__tests__/stress.setup.ts"],
     testNamePattern:
-      /2,000 deterministic mapped reorder updates|2,000 deterministic mapped reversal parity updates|2,000 queued reverse, map, and reverse updates|2,000 reverse-or-sort then map updates|2,000 queued reorder then standalone map updates|2,000 queued map then reorder updates|2,000 queued map and consecutive reorder updates|2,000 mapped structural removals|3,000 deterministic recursive updates|4,096 rows/,
+      /2,000 deterministic mapped reorder updates|2,000 deterministic mapped reversal parity updates|2,000 queued reverse, map, and reverse updates|2,000 reverse-or-sort then map updates|2,000 queued reorder then standalone map updates|2,000 queued map then reorder updates|2,000 queued map and consecutive reorder updates|2,000 mapped structural removals|2,000 randomized interleaved map and structural removals|3,000 deterministic recursive updates|4,096 rows/,
     testTimeout: 30_000,
   },
 });


### PR DESCRIPTION
## Problem

The experimental React compiler can retain same-key replacement lineage when safe maps run before structural keyed-row steps, but a concise pipeline such as `filter().map().slice().toSorted()` drops to complete keyed reconciliation. That fallback re-reads every surviving binding even though the compiler already proved the map, structural membership, and final reorder.

## Root cause

The compiler rejected every map after the first filter or slice. The runtime map recorder also accepted only committed or non-structural reorder sources, while later filter/slice and reorder recorders preferred the older structural mapping instead of the newest flattened replacement lineage.

## Change

- Accept safe maps before or between index-independent filter/slice steps, up to the final native reorder.
- Carry the structural survivor chain and latest mapped-item-to-committed-item mapping through every accepted step.
- Preserve the existing non-structural reorder/map paths and keep maps after a structural reorder on the complete React fallback.
- Update the compiler dashboard workload to benchmark `filter -> map -> reorder`, and document the public boundary and results.
- Add the new 2,000-update differential case to the dedicated stress configuration.

## Safety and compatibility

Every native method and callback still executes in JavaScript order. The runtime validates dense native arrays, the committed collection token, source/result lengths, survivor indices, replacement identity, and every row key before the first DOM write. Changed keys, custom methods, unsupported syntax, no-op runtime structural steps that cannot retain proof, and failed validation use complete keyed reconciliation.

The focused tests preserve surviving DOM nodes, remove only rejected rows, patch only the changed row, keep controlled-input focus and selection, hydrate in Strict Mode, and discard queued work after unmount. React 18.3.1 and 19.2.8 compatibility passed. No public configuration or renderer-neutral API changes.

## Verification

- `pnpm --filter @farm.js/react test` — 734 passed, 10 skipped; stress phase passed.
- `pnpm --filter @farm.js/react test:stress` — 12 heavy tests passed, including both 2,000 mapped-structural differential cases.
- `pnpm --filter @farm.js/react type-check`
- `pnpm --filter @farm.js/react test:compat`
- `pnpm --filter @farm.js/react test:runtime-size`
- `pnpm --filter farm-react-compiler-dashboard-example type-check`
- `pnpm --filter farm-react-compiler-dashboard-example build`
- `pnpm docs:check-navigation`
- `pnpm docs:build`
- focused formatting and lint checks for every changed source file

The full Chrome 153 production benchmark passed correctness, the broad 10% regression gate, and the target mapped-structural gate without changing thresholds. At 10,000 rows:

| Mode | Interleaved pipeline | Compiled control | vs React | vs control |
| --- | ---: | ---: | ---: | ---: |
| Static | 5.80 ms | 12.80 ms | 11.28x | 2.21x |
| Hybrid | 5.80 ms | 12.90 ms | 11.28x | 2.22x |

The overall benchmark command reported three unrelated timing-floor misses: append scaling at 3.996x versus 4x, static structural control at 1.239x versus 1.25x, and hybrid multi-map reorder at 3.19x versus 4x. Their fixtures and thresholds are unchanged; the machine-readable report is `/tmp/farm-react-interleaved-map-benchmark.json`.

## Documentation and release

Updated the React package README, React renderer documentation, compiler dashboard README, executable benchmark fixture, and persisted benchmark result. No version or release-flow changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves keyed row lineage when safe maps run between index-independent filter/slice steps before a final native reorder, so pipelines like `filter().map().slice().toSorted()` keep partial reconciliation instead of dropping to complete keyed re-reads. Maps after the structural pipeline has already reordered, structural work split across setter calls, unsafe callbacks, and failed runtime validation still use the full fallback.

**Details**
- The runtime now carries survivor indices and mapped-item sources through each accepted step, and the compiler accepts maps before or between filter/slice steps.
- Every native method and callback still runs in JavaScript order; survivor indices, keys, lengths, and replacement identity are validated before the first DOM write.
- The dashboard benchmark now exercises `filter -> map -> reorder`, and a 2,000-update differential stress case matches normal React.
- The runtime size budget was bumped to keep the interleaved map support within the size gate.

<sup>Written for commit ccb367a5a3c30fddd08d5f1d16e054be758294c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/842?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

