### PR TITLE
perf(react): optimize terminal structural maps

### DIFF
--- a/docs/src/app/docs/renderers/react/page.md
+++ b/docs/src/app/docs/renderers/react/page.md
@@ -1280,8 +1280,8 @@ controlled inputs, focus, and text selection stay attached to their keys. Multip
 map-and-reorder setters queued before one compiler flush compose against the same committed
 collection and expose only the final state.
 
-Safe maps can also appear before or between index-independent filter and slice steps before the
-final native reorder:
+Safe maps can also appear before or between index-independent filter and slice steps. A final native
+reorder is optional when the concise pipeline ends with a safe map:
 
 ```tsx
 setItems((current) =>
@@ -1291,15 +1291,24 @@ setItems((current) =>
     .slice(0, limit)
     .toSorted((left, right) => left.rank - right.rank),
 );
+
+setItems((current) =>
+  current
+    .filter((item) => item.visible)
+    .slice(0, limit)
+    .map((item) => (item.id === editedId ? { ...item, label: nextLabel } : item)),
+);
 ```
 
 Each callback still evaluates in normal JavaScript order. Farm carries both proofs across the
 pipeline: which committed rows survived and which surviving items replaced their source items. It
-validates every survivor and key before the first DOM write, removes rejected rows, performs only
-the final LIS moves, and patches bindings only for changed survivors. A changed item that a later
-structural step removes needs no row patch. This combined path is limited to one concise functional
-setter. A map after the structural pipeline has reordered, structural work split across setter
-calls, or any failed runtime proof keeps complete reconciliation.
+validates every survivor and key before the first DOM write, removes rejected rows, performs LIS
+moves only when a reorder needs them, and patches bindings only for changed survivors. A changed
+item that a later structural step removes needs no row patch. Without a reorder, the last operation
+must be the safe map so its newest lineage reaches the commit. This combined path is limited to one
+concise functional setter. A later structural call, a map after the structural pipeline has
+reordered, structural work split across setter calls, or any failed runtime proof keeps complete
+reconciliation.
 
 A safe map may also be the final pipeline step:
 
@@ -2270,10 +2279,11 @@ The package and example test suites verify more than generated code:
   moved-row events with the newest item and index, preserve controlled-input focus and selection,
   and cover changed-key, custom-method, and Array-subclass fallback, Strict Mode hydration, and
   unmount-before-flush cleanup;
-- 2,000 deterministic mapped structural removals and another 2,000 randomized updates with maps
-  interleaved between filter/slice steps match normal React; targeted tests preserve surviving DOM
-  identity and controlled-input focus/selection, patch only changed survivors, and cover
-  changed-key and custom-method fallback, Strict Mode hydration, and unmount-before-flush cleanup;
+- 2,000 deterministic mapped structural removals, another 2,000 randomized updates with maps
+  interleaved between filter/slice steps and a final reorder, and 2,000 randomized terminal
+  structural-map row transitions match normal React; targeted tests preserve surviving DOM identity
+  and controlled-input focus/selection, patch only changed survivors, and cover changed-key and
+  custom-method fallback, Strict Mode hydration, and unmount-before-flush cleanup;
 - 2,000 deterministic native reversals or sorts followed by consecutive same-key edits match normal
   React; targeted tests require exact reversal to use `n - 1` direct DOM moves without a generic
   source-item map, require ambiguous sorting to use one validated keyed reconciliation, and cover

--- a/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
+++ b/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
@@ -2,6 +2,42 @@
 
 Latest run: 2026-09-09
 
+## Terminal structural maps — 2026-09-09
+
+A concise keyed-row setter may now finish an index-independent `filter()` or `slice()` pipeline
+with a safe same-key `map()`. Farm keeps the survivor and replacement lineage through the final
+map, validates the complete result before touching the DOM, removes rejected rows, and patches only
+changed surviving bindings. No synthetic reverse or sort is needed, and a failed key, ownership, or
+native-method proof still falls back before any compiler-owned DOM write.
+
+The maintained 10,000-row workload filters one row and updates another. Its block-bodied compiled
+control performs the same native JavaScript work through complete keyed reconciliation. Every
+value, surviving position, DOM identity, and removed-row connection is checked after each sample.
+
+| Mode   | Terminal map | Compiled control | vs React | vs control |
+| ------ | -----------: | ---------------: | -------: | ---------: |
+| Static |      5.00 ms |         10.50 ms |   10.59x |      2.10x |
+| Hybrid |      5.90 ms |         10.50 ms |    8.97x |      1.78x |
+
+Both modes passed the unchanged 2x React and 1.25x compiled-control floors in two complete bracketed
+runs. The correctness oracle, broad 10% regression gate, optimization-persistence gate, and zero
+compiled owner executions also passed twice. One unrelated isolated timing gate was noisy in each
+run, but the failing workload changed between runs: queued-window refresh and 20,000-row swap in the
+first, then the older static multi-map reorder in the confirmation run. Each passed in the other
+unchanged run; their code and thresholds were not changed.
+
+Compiler and runtime tests cover terminal filter/map and slice/map pipelines, maps interleaved
+between structural steps, exact survivor identity, one changed-row binding read, custom-map and
+changed-key atomic fallback, controlled-input focus and selection, Strict Mode hydration,
+unmount-before-flush cleanup, and 2,000 randomized terminal structural-map row transitions matched
+with normal React. React 18.3.1 and 19.2.8 compatibility passes. The isolated optional runtime gzip
+sizes are unchanged.
+
+Numbers are conservative medians from the confirmation run: 10 samples per compiler mode and 20
+bracketing React samples using Chrome 153.0.8010.36, Node.js 23.11.0, and Apple M1 macOS arm64.
+Timing varies by machine; deterministic parity, fallback, DOM-identity, compatibility, and runtime-
+size checks are the primary safety controls.
+
 ## Maps interleaved with structural steps — 2026-09-09
 
 A concise keyed-row setter may now keep same-key replacement lineage when a safe `map()` follows

--- a/examples/react-compiler-dashboard/README.md
+++ b/examples/react-compiler-dashboard/README.md
@@ -269,15 +269,15 @@ same four native updates through complete reconciliation. Both compiler modes mu
 final committed order, every original DOM identity and connection, and both changed values. Package tests
 also cover mixed reverse/sort chains, chain boundaries, and 2,000 randomized differential updates.
 
-Mapped structural reorders have a separate 10,000-row comparison. One concise setter filters out
-one row, changes a surviving row through a following map, and applies two reversals that preserve
-survivor order. The block-bodied control performs the same native work through complete keyed
+Terminal structural maps have a separate 10,000-row comparison. One concise setter filters out one
+row and changes a surviving row through its final map, with no synthetic reorder needed to retain
+the compiler proof. The block-bodied control performs the same native work through complete keyed
 reconciliation. Both compiler modes must remain at least 2x faster than React and 1.25x faster than
 the compiled control. The assertion checks the changed values, rejected-row cleanup, full survivor
 order, and every surviving DOM identity. Package tests also cover maps interleaved with
-filter/slice/sort/reverse steps, controlled-input focus and selection, changed-key and custom-method
-fallback, Strict Mode hydration, cleanup, and 2,000 randomized interleaved removals matched with
-normal React. The benchmark lifecycle rebuilds
+filter/slice/sort/reverse steps, terminal filter/slice maps, controlled-input focus and selection,
+changed-key and custom-method fallback, Strict Mode hydration, cleanup, and separate 2,000-row
+differential runs for final-reorder and terminal pipelines. The benchmark lifecycle rebuilds
 `@farm.js/react` first and then verifies the emitted hint counts, so local source changes cannot be
 silently measured through stale package output.
 

--- a/examples/react-compiler-dashboard/scripts/benchmark.mjs
+++ b/examples/react-compiler-dashboard/scripts/benchmark.mjs
@@ -147,8 +147,8 @@ async function inspectBuild(compilerMode) {
       "The compiler build did not emit the keyed-array exact-position hints.",
     );
     assert(
-      compilerReport.summary.keyedArrayReorderHints >= 19,
-      "The compiler build did not emit every keyed-array reorder pipeline step.",
+      compilerReport.summary.keyedArrayReorderHints >= 17,
+      "The compiler build did not emit every native keyed-array reorder pipeline step.",
     );
     assert(
       compilerReport.summary.keyedArraySortHints > 0,
@@ -1209,7 +1209,7 @@ async function measureTrial(browser, trial, compilerMode, port) {
           );
           const amount = Number(target?.querySelector("td:nth-child(4)")?.textContent?.slice(1));
           if (!target || !removed || !Number.isFinite(amount)) {
-            throw new Error("Mapped structural-reorder source rows are invalid.");
+            throw new Error("Terminal structural-map source rows are invalid.");
           }
           return {
             amount: amount + 1,
@@ -1239,7 +1239,7 @@ async function measureTrial(browser, trial, compilerMode, port) {
               rows.some((row) => row !== removed && !row.isConnected)
             ) {
               throw new Error(
-                "Mapped structural-reorder rows do not match the expected filtered order.",
+                "Terminal structural-map rows do not match the expected filtered order.",
               );
             }
           };
@@ -2972,9 +2972,9 @@ const keyedStructuralReorderRegressions = keyedStructuralReorderResults.filter(
     !Number.isFinite(snapshotSpeedup) ||
     snapshotSpeedup < keyedStructuralReorderMinimumSnapshotSpeedup,
 );
-// A safe map between filter and reorder changes row data, membership, and order in one setter. The
-// interleaved structural path must patch the changed survivor, remove the rejected row, and
-// validate the final order once instead of dropping to complete keyed reconciliation.
+// A safe map after a filter changes row data and membership in one setter. The terminal structural
+// path must patch the changed survivor and remove the rejected row instead of dropping to complete
+// keyed reconciliation merely because no reorder follows.
 const keyedMappedStructuralReorderMinimumSpeedup = 2;
 const keyedMappedStructuralReorderMinimumSnapshotSpeedup = 1.25;
 const keyedMappedStructuralReorderResults = ["static", "hybrid"].map((mode) => {

--- a/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
+++ b/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
@@ -881,15 +881,13 @@ export function StandardTableBenchmark() {
                   row.id % 10_000 === 5_001
                     ? { ...row, amount: row.amount + 1, label: `${row.label} reviewed` }
                     : row,
-                )
-                .toReversed()
-                .toReversed(),
+                ),
             );
-            setOperation("review one row, filter another, and preserve order");
+            setOperation("filter one row and review another");
             setRevision((value) => value + 1);
           }}
         >
-          Review + filter + reorder
+          Filter + terminal map
         </button>
         <button
           data-action="table-map-structural-reorder-pipeline-snapshot"
@@ -902,15 +900,13 @@ export function StandardTableBenchmark() {
                   row.id % 10_000 === 5_001
                     ? { ...row, amount: row.amount + 1, label: `${row.label} reviewed` }
                     : row,
-                )
-                .toReversed()
-                .toReversed();
+                );
             });
-            setOperation("review, filter, and reorder rows (snapshot control)");
+            setOperation("filter and review rows (snapshot control)");
             setRevision((value) => value + 1);
           }}
         >
-          Review + filter + reorder (snapshot control)
+          Filter + terminal map (snapshot control)
         </button>
         <button
           data-action="table-map-reorder-pipeline"

--- a/packages/farm-react/README.md
+++ b/packages/farm-react/README.md
@@ -468,8 +468,9 @@ An exact reverse uses the minimum-move reverse path without a general source-ite
 sort remains an ambiguous permutation, so Farm performs one validated source lookup and LIS pass.
 Safe maps on both sides of a reorder flatten their replacements back to the same committed rows.
 
-Safe maps may also run before or between index-independent `filter` or `slice` steps and a final
-native reorder in one concise functional setter:
+Safe maps may also run before or between index-independent `filter` or `slice` steps in one concise
+functional setter. A final native reorder is optional when the pipeline itself ends with a safe
+map:
 
 ```tsx
 setItems((current) =>
@@ -479,13 +480,22 @@ setItems((current) =>
     .slice(0, limit)
     .toSorted((left, right) => left.rank - right.rank),
 );
+
+setItems((current) =>
+  current
+    .filter((item) => item.visible)
+    .slice(0, limit)
+    .map((item) => (item.id === editedId ? { ...item, label: nextLabel } : item)),
+);
 ```
 
 The structural helpers retain both the committed survivor indices and mapped-item sources across
-each accepted step. The final commit removes rejected rows, performs only its final LIS moves, and
-patches bindings only for changed survivors. Every native callback and method still runs in
-JavaScript order. A map after the structural pipeline has already reordered, structural work split
-across setters, unsafe callbacks, and failed runtime validation keep complete keyed reconciliation.
+each accepted step. The final commit removes rejected rows, performs LIS moves only when a reorder
+needs them, and patches bindings only for changed survivors. Every native callback and method still
+runs in JavaScript order. Without a reorder, the last operation must be the safe map so its newest
+lineage reaches the commit. A later structural operation, a map after the structural pipeline has
+already reordered, structural work split across setters, unsafe callbacks, and failed runtime
+validation keep complete keyed reconciliation.
 
 The reorder and safe maps may also be adjacent setter calls in the same synchronous block:
 

--- a/packages/farm-react/src/__tests__/compiler-keyed-array-sort-hints.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-keyed-array-sort-hints.test.ts
@@ -568,6 +568,43 @@ describe("React AOT keyed-array sort hints", () => {
     expect(result.code).not.toContain("createCompilerKeyedArrayMapReorder");
   });
 
+  it("keeps structural lineage when a safe map ends the pipeline", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Table({ editedId, nextLabel, limit }) {
+        const [rows, setRows] = useState([
+          { id: "a", label: "Alpha", visible: true },
+          { id: "b", label: "Beta", visible: false },
+          { id: "c", label: "Gamma", visible: true },
+        ]);
+        return <section>
+          <button onClick={() => setRows((current) => current
+            .filter((row) => row.visible)
+            .map((row) => row.id === editedId ? { ...row, label: nextLabel } : row)
+          )}>Filter and update</button>
+          <button onClick={() => setRows((current) => current
+            .slice(0, limit)
+            .map((row) => row.id === editedId ? { ...row, label: nextLabel } : row)
+          )}>Slice and update</button>
+          <ul>{rows.map((row) => <li key={row.id}>{row.label}</li>)}</ul>
+        </section>;
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Table"]);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.optimizations.keyedMapUpdateHints).toBe(2);
+    expect(result.optimizations.keyedArrayFilterHints).toBe(1);
+    expect(result.optimizations.keyedArraySliceHints).toBe(1);
+    expect(result.optimizations.keyedArrayReorderHints).toBe(0);
+    expect(result.code.match(/createCompilerKeyedArrayMapPipeline\(/g)).toHaveLength(2);
+    expect(result.code).toContain("createCompilerKeyedArrayFilter");
+    expect(result.code).toContain("createCompilerKeyedArraySlice");
+    expect(result.code).toContain("keyedRowsEveryHintedRuntimeFeature");
+    expect(result.code).not.toContain("createCompilerKeyedArrayStructuralReorder");
+    expect(result.code).not.toContain("createCompilerKeyedArrayMapReorder");
+  });
+
   it("carries consecutive maps through slice and reverse steps", async () => {
     const result = await compile(`
       import { useState } from "react";

--- a/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-structural-reorder-hints.test.tsx
+++ b/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-structural-reorder-hints.test.tsx
@@ -105,9 +105,18 @@ function createHarness(initialItems: Item[]) {
     removed: ReadonlySet<string>,
     limit: number,
   ) => void = () => undefined;
+  let filterMapSliceMap: (
+    editedId: string,
+    nextLabel: string,
+    nextRank: number,
+    removed: ReadonlySet<string>,
+    limit: number,
+  ) => void = () => undefined;
   let invalidIdentity: () => void = () => undefined;
   let invalidMappedIdentity: () => void = () => undefined;
+  let invalidTerminalMappedIdentity: () => void = () => undefined;
   let customMapStructural: () => void = () => undefined;
+  let customMapTerminal: () => void = () => undefined;
   let customSortAfterFilter: (removed: ReadonlySet<string>) => void = () => undefined;
   const Table = createCompiledComponent({
     displayName: "StructuralReorderTable",
@@ -188,6 +197,20 @@ function createHarness(initialItems: Item[]) {
             ),
           ),
         );
+      filterMapSliceMap = (editedId, nextLabel, nextRank, removed, limit) =>
+        state[0].set((previous) =>
+          hintedMap(
+            hintedSlice(
+              hintedMap(
+                hintedFilter(previous as Item[], (item) => !removed.has(item.id)),
+                (item) => (item.id === editedId ? { ...item, rank: nextRank } : item),
+              ),
+              0,
+              limit,
+            ),
+            (item) => (item.id === editedId ? { ...item, label: nextLabel } : item),
+          ),
+        );
       invalidIdentity = () =>
         state[0].set((previous) => {
           const next = hintedReverse(hintedFilter(previous as Item[], (item) => item.id !== "b"));
@@ -204,6 +227,14 @@ function createHarness(initialItems: Item[]) {
             ),
           ),
         );
+      invalidTerminalMappedIdentity = () =>
+        state[0].set((previous) =>
+          hintedMap(
+            hintedFilter(previous as Item[], (item) => item.id !== "c"),
+            (item) =>
+              item.id === "b" ? { ...item, id: "replacement", label: "Replacement" } : item,
+          ),
+        );
       customMapStructural = () =>
         state[0].set((previous) => {
           const filtered = hintedFilter(previous as Item[], (item) => item.id !== "c");
@@ -217,6 +248,19 @@ function createHarness(initialItems: Item[]) {
             item.id === "a" ? { ...item, label: "Custom map" } : item,
           ) as Item[];
           return hintedSort(mapped, (left, right) => left.rank - right.rank);
+        });
+      customMapTerminal = () =>
+        state[0].set((previous) => {
+          const filtered = hintedFilter(previous as Item[], (item) => item.id !== "c");
+          const customMap = function (
+            this: Item[],
+            callback: (item: Item, index: number, items: Item[]) => Item,
+          ) {
+            return Array.prototype.map.call(this, callback);
+          };
+          return createCompilerKeyedArrayMapPipeline(filtered, customMap, (item: Item) =>
+            item.id === "a" ? { ...item, label: "Custom terminal map" } : item,
+          ) as Item[];
         });
       customSortAfterFilter = (removed) =>
         state[0].set((previous) => {
@@ -281,6 +325,14 @@ function createHarness(initialItems: Item[]) {
     counters,
     customSortAfterFilter: (removed: ReadonlySet<string>) => customSortAfterFilter(removed),
     customMapStructural: () => customMapStructural(),
+    customMapTerminal: () => customMapTerminal(),
+    filterMapSliceMap: (
+      editedId: string,
+      nextLabel: string,
+      nextRank: number,
+      removed: ReadonlySet<string>,
+      limit: number,
+    ) => filterMapSliceMap(editedId, nextLabel, nextRank, removed, limit),
     filterMapSliceMapSortReverse: (
       editedId: string,
       nextLabel: string,
@@ -294,6 +346,7 @@ function createHarness(initialItems: Item[]) {
     filterThenQueuedSort: (removed: ReadonlySet<string>) => filterThenQueuedSort(removed),
     invalidIdentity: () => invalidIdentity(),
     invalidMappedIdentity: () => invalidMappedIdentity(),
+    invalidTerminalMappedIdentity: () => invalidTerminalMappedIdentity(),
     mapFilterDoubleReverse: (editedId: string, nextLabel: string, removed: ReadonlySet<string>) =>
       mapFilterDoubleReverse(editedId, nextLabel, removed),
     mapFilterSortReverse: (
@@ -467,6 +520,42 @@ describe("compiled keyed-array structural reorder hints", () => {
     expect(harness.counters.bindings).toBe(1);
   });
 
+  it("removes rows and patches a mapped survivor when the safe map is terminal", async () => {
+    const items: Item[] = [
+      { id: "a", label: "Alpha", rank: 4, visible: true },
+      { id: "b", label: "Beta", rank: 1, visible: false },
+      { id: "c", label: "Gamma", rank: 3, visible: true },
+      { id: "d", label: "Delta", rank: 2, visible: true },
+    ];
+    const harness = createHarness(items);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Table />));
+    const alpha = container.querySelector('[data-key="a"]');
+    const gamma = container.querySelector('[data-key="c"]');
+    harness.counters.bindings = 0;
+    harness.counters.descriptors = 0;
+    harness.counters.keys = 0;
+
+    await act(async () => {
+      harness.filterMapSliceMap("c", "Gamma terminal", 0, new Set(["b"]), 2);
+      await flushCompilerUpdates();
+    });
+
+    expect(labels(container)).toEqual(["Alpha", "Gamma terminal"]);
+    expect(container.querySelector('[data-key="a"]')).toBe(alpha);
+    expect(container.querySelector('[data-key="c"]')).toBe(gamma);
+    expect(container.querySelector('[data-key="b"]')).toBeNull();
+    expect(container.querySelector('[data-key="d"]')).toBeNull();
+    expect(harness.counters.executions).toBe(1);
+    expect(harness.counters.renders).toBe(1);
+    expect(harness.counters.keys).toBe(2);
+    expect(harness.counters.descriptors).toBe(0);
+    expect(harness.counters.bindings).toBe(1);
+  });
+
   it("falls back safely for custom methods and identity mismatches", async () => {
     const items: Item[] = [
       { id: "a", label: "Alpha", rank: 2, visible: true },
@@ -532,6 +621,44 @@ describe("compiled keyed-array structural reorder hints", () => {
     expect(changedKey.counters.descriptors).toBeGreaterThan(0);
   });
 
+  it("falls back atomically for terminal custom maps and changed keys", async () => {
+    const items: Item[] = [
+      { id: "a", label: "Alpha", rank: 2, visible: true },
+      { id: "b", label: "Beta", rank: 1, visible: true },
+      { id: "c", label: "Gamma", rank: 3, visible: true },
+    ];
+    const custom = createHarness(items);
+    const customContainer = document.createElement("div");
+    document.body.append(customContainer);
+    const customRoot = createRoot(customContainer);
+    roots.push(customRoot);
+    await act(async () => customRoot.render(<custom.Table />));
+    custom.counters.bindings = 0;
+    custom.counters.descriptors = 0;
+    await act(async () => {
+      custom.customMapTerminal();
+      await flushCompilerUpdates();
+    });
+    expect(labels(customContainer)).toEqual(["Custom terminal map", "Beta"]);
+    expect(custom.counters.bindings).toBeGreaterThan(0);
+
+    const changedKey = createHarness(items);
+    const changedKeyContainer = document.createElement("div");
+    document.body.append(changedKeyContainer);
+    const changedKeyRoot = createRoot(changedKeyContainer);
+    roots.push(changedKeyRoot);
+    await act(async () => changedKeyRoot.render(<changedKey.Table />));
+    changedKey.counters.bindings = 0;
+    changedKey.counters.descriptors = 0;
+    await act(async () => {
+      changedKey.invalidTerminalMappedIdentity();
+      await flushCompilerUpdates();
+    });
+    expect(labels(changedKeyContainer)).toEqual(["Alpha", "Replacement"]);
+    expect(changedKey.counters.bindings).toBeGreaterThan(0);
+    expect(changedKey.counters.descriptors).toBeGreaterThan(0);
+  });
+
   it("preserves a surviving controlled input, focus, and selection", async () => {
     const items: Item[] = [
       { id: "a", label: "Alpha", rank: 3, visible: true },
@@ -546,15 +673,13 @@ describe("compiled keyed-array structural reorder hints", () => {
         const rows = () => state[0].get() as Item[];
         update = () =>
           state[0].set((previous) =>
-            hintedReverse(
+            hintedMap(
               hintedSlice(
-                hintedMap(
-                  hintedFilter(previous as Item[], (item) => item.id !== "a"),
-                  (item) => (item.id === "b" ? { ...item, label: "Beta newest" } : item),
-                ),
+                hintedFilter(previous as Item[], (item) => item.id !== "a"),
                 0,
                 1,
               ),
+              (item) => (item.id === "b" ? { ...item, label: "Beta newest" } : item),
             ),
           );
         return (
@@ -835,6 +960,83 @@ describe("compiled keyed-array structural reorder hints", () => {
     expect(harness.counters.executions).toBe(1);
   }, 20_000);
 
+  it("matches React across 2,000 randomized terminal structural-map row transitions", async () => {
+    const initialItems = Array.from(
+      { length: 2_001 },
+      (_, index): Item => ({
+        id: `row-${index}`,
+        label: `Row ${index}`,
+        rank: (index * 1_229) % 2_003,
+        visible: true,
+      }),
+    );
+    const harness = createHarness(initialItems);
+    let updateReact: (
+      editedId: string,
+      nextLabel: string,
+      nextRank: number,
+      removed: ReadonlySet<string>,
+      limit: number,
+    ) => void = () => undefined;
+    function Normal() {
+      const [items, setItems] = useState(initialItems);
+      updateReact = (editedId, nextLabel, nextRank, removed, limit) =>
+        setItems((previous) =>
+          previous
+            .filter((item) => !removed.has(item.id))
+            .map((item) => (item.id === editedId ? { ...item, rank: nextRank } : item))
+            .slice(0, limit)
+            .map((item) => (item.id === editedId ? { ...item, label: nextLabel } : item)),
+        );
+      return (
+        <ol>
+          {items.map((item) => (
+            <li data-key={item.id} key={item.id}>
+              {item.label}
+            </li>
+          ))}
+        </ol>
+      );
+    }
+    const compiledContainer = document.createElement("div");
+    const reactContainer = document.createElement("div");
+    document.body.append(compiledContainer, reactContainer);
+    const compiledRoot = createRoot(compiledContainer);
+    const reactRoot = createRoot(reactContainer);
+    roots.push(compiledRoot, reactRoot);
+    await act(async () => {
+      compiledRoot.render(<harness.Table />);
+      reactRoot.render(<Normal />);
+    });
+
+    let seed = 0xb5297a4d;
+    let active = initialItems.map((item) => item.id);
+    for (let batch = 0; batch < 100; batch += 1) {
+      const removed = new Set<string>();
+      for (let update = 0; update < 15; update += 1) {
+        seed = (Math.imul(seed, 1_664_525) + 1_013_904_223) >>> 0;
+        const available = active.filter((id) => !removed.has(id));
+        removed.add(available[seed % available.length]);
+      }
+      const survivors = active.filter((id) => !removed.has(id));
+      const limit = survivors.length - 5;
+      seed = (Math.imul(seed, 1_664_525) + 1_013_904_223) >>> 0;
+      const editedId = survivors[seed % limit];
+      const nextLabel = `Terminal ${batch}`;
+      const nextRank = seed % 2_003;
+      await act(async () => {
+        harness.filterMapSliceMap(editedId, nextLabel, nextRank, removed, limit);
+        updateReact(editedId, nextLabel, nextRank, removed, limit);
+        await flushCompilerUpdates();
+      });
+      expect(labels(compiledContainer)).toEqual(labels(reactContainer));
+      active = [...reactContainer.querySelectorAll<HTMLElement>("li")].map(
+        (row) => row.dataset.key!,
+      );
+    }
+    expect(harness.counters.executions).toBe(1);
+  }, 20_000);
+
   it("hydrates in StrictMode and drops a queued pipeline after unmount", async () => {
     const items: Item[] = [
       { id: "a", label: "Alpha", rank: 3, visible: true },
@@ -858,7 +1060,7 @@ describe("compiled keyed-array structural reorder hints", () => {
     });
     roots.push(root);
     await act(async () => {
-      hydration.filterMapSliceMapSortReverse("b", "Beta hydrated", 2, new Set(), 2);
+      hydration.filterMapSliceMap("b", "Beta hydrated", 2, new Set(), 2);
       await flushCompilerUpdates();
     });
     expect(labels(container)).toEqual(["Alpha", "Beta hydrated"]);
@@ -870,7 +1072,7 @@ describe("compiled keyed-array structural reorder hints", () => {
     const unmountRoot = createRoot(unmountContainer);
     await act(async () => unmountRoot.render(<unmounted.Table />));
     act(() => {
-      unmounted.filterMapSliceMapSortReverse("c", "Gamma queued", 2, new Set(["a"]), 2);
+      unmounted.filterMapSliceMap("c", "Gamma queued", 2, new Set(["a"]), 2);
       unmountRoot.unmount();
     });
     await flushCompilerUpdates();

--- a/packages/farm-react/src/compiler-runtime.tsx
+++ b/packages/farm-react/src/compiler-runtime.tsx
@@ -6278,10 +6278,10 @@ function reconcileCompilerKeyedArrayReorderWithMapAndStructural(
 ): ReadonlyMap<string, CompilerKeyedRowInstance> | undefined {
   const prepared = prepareCompilerKeyedArrayReorder(args);
   if (!prepared) return undefined;
-  const reconcile = prepared.update?.mapped
-    ? reconcileCompilerKeyedArrayMapReorder
-    : prepared.update?.structuralUpdate
-      ? reconcileCompilerKeyedArrayStructuralReorder
+  const reconcile = prepared.update?.structuralUpdate
+    ? reconcileCompilerKeyedArrayStructuralReorder
+    : prepared.update?.mapped
+      ? reconcileCompilerKeyedArrayMapReorder
       : reconcileCompilerKeyedArrayReorder;
   return reconcile(args[0], args[1], args[2], args[3], args[4], args[5], prepared);
 }

--- a/packages/farm-react/src/compiler.ts
+++ b/packages/farm-react/src/compiler.ts
@@ -2019,7 +2019,10 @@ function keyedArrayReorderPipeline(
       reorderSteps += 1;
     }
   }
-  if (reorderSteps < 1) return undefined;
+  if (reorderSteps < 1) {
+    const finalStep = steps[steps.length - 1];
+    return structuralSteps > 0 && finalStep?.kind === "map" ? steps : undefined;
+  }
   if (mapSteps > 0 && reorderSteps >= 1) return steps;
   if (structuralSteps < 1 && reorderSteps < 2) return undefined;
   return steps;
@@ -2049,6 +2052,7 @@ function rewriteKeyedArrayReorderPipelineHints(
   sliceCount: number;
   sortCount: number;
   structuralReorderCount: number;
+  terminalStructuralMapCount: number;
   structuralSortCount: number;
   stateIndices: ReadonlySet<number>;
 } {
@@ -2063,6 +2067,7 @@ function rewriteKeyedArrayReorderPipelineHints(
       sliceCount: 0,
       sortCount: 0,
       structuralReorderCount: 0,
+      terminalStructuralMapCount: 0,
       structuralSortCount: 0,
       stateIndices: new Set(),
     };
@@ -2077,6 +2082,7 @@ function rewriteKeyedArrayReorderPipelineHints(
   let sliceCount = 0;
   let sortCount = 0;
   let structuralReorderCount = 0;
+  let terminalStructuralMapCount = 0;
   let structuralSortCount = 0;
   traverse(file, {
     CallExpression(path) {
@@ -2104,6 +2110,9 @@ function rewriteKeyedArrayReorderPipelineHints(
       );
       const mapPipeline = steps.some((step) => step.kind === "map");
       if (mapPipeline && !allowMapPipelines) return;
+      const terminalStructuralMap =
+        structuralPipeline &&
+        steps.every((step) => step.kind !== "reverse" && step.kind !== "sort");
 
       const previous = t.cloneNode(updater.params[0]);
       const statements: t.Statement[] = [];
@@ -2254,6 +2263,7 @@ function rewriteKeyedArrayReorderPipelineHints(
         }
       }
       statements.push(t.returnStatement(t.cloneNode(value)));
+      if (terminalStructuralMap) terminalStructuralMapCount += 1;
       path.node.arguments[0] = t.arrowFunctionExpression(
         [t.cloneNode(previous)],
         t.blockStatement(statements),
@@ -2272,6 +2282,7 @@ function rewriteKeyedArrayReorderPipelineHints(
     sliceCount,
     sortCount,
     structuralReorderCount,
+    terminalStructuralMapCount,
     structuralSortCount,
     stateIndices,
   };
@@ -8106,7 +8117,9 @@ function compileCandidate(
       appliedPipelineFilterHints = reorderPipelineHintedRoot.filterCount;
       appliedPipelineMapHints = reorderPipelineHintedRoot.mapCount;
       appliedKeyedMapUpdateHints += reorderPipelineHintedRoot.mapCount;
-      appliedPipelineReorderHints = reorderPipelineHintedRoot.reorderCount;
+      appliedPipelineReorderHints =
+        reorderPipelineHintedRoot.reorderCount +
+        reorderPipelineHintedRoot.terminalStructuralMapCount;
       appliedPipelineSliceHints = reorderPipelineHintedRoot.sliceCount;
       appliedPipelineSortHints = reorderPipelineHintedRoot.sortCount;
       appliedPipelineHintedStateIndices = reorderPipelineHintedRoot.stateIndices;

--- a/packages/farm-react/vitest.stress.config.ts
+++ b/packages/farm-react/vitest.stress.config.ts
@@ -21,7 +21,7 @@ export default defineConfig({
     ],
     setupFiles: ["src/__tests__/stress.setup.ts"],
     testNamePattern:
-      /2,000 deterministic mapped reorder updates|2,000 deterministic mapped reversal parity updates|2,000 queued reverse, map, and reverse updates|2,000 reverse-or-sort then map updates|2,000 queued reorder then standalone map updates|2,000 queued map then reorder updates|2,000 queued map and consecutive reorder updates|2,000 mapped structural removals|2,000 randomized interleaved map and structural removals|3,000 deterministic recursive updates|4,096 rows/,
+      /2,000 deterministic mapped reorder updates|2,000 deterministic mapped reversal parity updates|2,000 queued reverse, map, and reverse updates|2,000 reverse-or-sort then map updates|2,000 queued reorder then standalone map updates|2,000 queued map then reorder updates|2,000 queued map and consecutive reorder updates|2,000 mapped structural removals|2,000 randomized interleaved map and structural removals|2,000 randomized terminal structural-map row transitions|3,000 deterministic recursive updates|4,096 rows/,
     testTimeout: 30_000,
   },
 });


### PR DESCRIPTION
## Problem

Concise keyed-row pipelines could retain same-key map lineage through filter and slice only when a native reorder followed. A common filter or slice ending in a safe map therefore dropped to complete keyed reconciliation even though membership and replacement ownership were already proven.

## Root cause

The compiler accepted structural map pipelines only when it counted at least one reverse or sort. Terminal structural maps also produced both mapped and structural runtime metadata, while the combined dispatcher preferred the non-structural reconciler and rejected that metadata.

## Change

- Accept a filter or slice pipeline with at least one structural step when its final operation is a safe inline same-key map.
- Route combined metadata through structural reconciliation before plain mapped-reorder reconciliation.
- Keep terminal maps out of the public native-reorder count and avoid importing unused reorder helpers.
- Exercise filter-map and slice-map compilation, exact survivor reuse, one changed binding, controlled-input identity, Strict Mode hydration, unmount cleanup, custom-method and changed-key fallback, and 2,000 randomized row transitions.
- Replace the maintained synthetic double-reverse workload with the natural terminal-map form and document the behavior and limits.

## Safety and compatibility

Eligibility remains limited to concise functional setters over compiler-owned host keyed rows. Native callbacks and methods execute in source order. Farm validates every survivor and replacement key before the first DOM write. Later structural operations, post-reorder maps, custom methods, changed keys, ambiguous ownership, and failed validation retain complete React reconciliation.

There is no public API or configuration change. The feature remains behind the existing experimental React compiler and adds no runtime gzip bytes. React 18.3.1 and 19.2.8 compatibility pass.

## Verification

- pnpm --filter @farm.js/react test — 72 files, 738 passed, 10 skipped
- pnpm --filter @farm.js/react test:stress — 13 passed, 62 selectively skipped
- focused compiler/runtime suite — 57 passed
- pnpm --filter @farm.js/react type-check
- pnpm --filter @farm.js/react test:compat
- pnpm --filter @farm.js/react test:runtime-size — unchanged isolated gzip sizes
- pnpm --filter farm-react-compiler-dashboard-example type-check
- pnpm --filter farm-react-compiler-dashboard-example build
- pnpm docs:check-navigation
- NODE_OPTIONS=--max-old-space-size=8192 pnpm docs:build
- focused oxfmt and oxlint checks

Two complete Chrome 153 benchmark runs passed the correctness oracle, broad 10 percent regression gate, optimization-persistence gate, and zero compiled owner executions. The conservative confirmation medians were 5.00 ms static and 5.90 ms hybrid: 10.59x and 8.97x faster than React, and 2.10x and 1.78x faster than the matched compiled control. A different untouched isolated legacy timing gate was noisy in each run and passed in the other run; no thresholds were changed.

## Documentation and release

Updated the React renderer docs, package README, dashboard README, maintained benchmark workload, and benchmark results. No release version or template change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up `@farm.js/react` keyed-row filter/slice pipelines that end with a safe same-key `map`, removing the requirement that a reverse or sort follow for structural reconciliation.

Previously those pipelines dropped to complete keyed reconciliation. Survivor and replacement lineage now carries through the final map, the combined dispatcher prefers the structural reconciler, and terminal maps stay out of the public native-reorder count.

- Only concise functional setters over compiler-owned keyed rows are eligible; later structural steps, maps after a reorder, custom methods, changed keys, ambiguous ownership, or failed validation still use complete React reconciliation.
- No public API or config change; runtime gzip size is unchanged.

<sup>Written for commit 35e5f38155af9e274b93501c4273d3ed18a5227a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/843?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

