### PR TITLE
perf(react): optimize maps before structural steps

### DIFF
--- a/docs/src/app/docs/renderers/react/page.md
+++ b/docs/src/app/docs/renderers/react/page.md
@@ -1280,8 +1280,8 @@ controlled inputs, focus, and text selection stay attached to their keys. Multip
 map-and-reorder setters queued before one compiler flush compose against the same committed
 collection and expose only the final state.
 
-Safe maps can also appear before or between index-independent filter and slice steps. A final native
-reorder is optional when the concise pipeline ends with a safe map:
+Safe maps can also appear before, between, or after index-independent filter and slice steps. A
+final native reorder is optional:
 
 ```tsx
 setItems((current) =>
@@ -1294,9 +1294,9 @@ setItems((current) =>
 
 setItems((current) =>
   current
+    .map((item) => (item.id === editedId ? { ...item, label: nextLabel } : item))
     .filter((item) => item.visible)
-    .slice(0, limit)
-    .map((item) => (item.id === editedId ? { ...item, label: nextLabel } : item)),
+    .slice(0, limit),
 );
 ```
 
@@ -1304,10 +1304,9 @@ Each callback still evaluates in normal JavaScript order. Farm carries both proo
 pipeline: which committed rows survived and which surviving items replaced their source items. It
 validates every survivor and key before the first DOM write, removes rejected rows, performs LIS
 moves only when a reorder needs them, and patches bindings only for changed survivors. A changed
-item that a later structural step removes needs no row patch. Without a reorder, the last operation
-must be the safe map so its newest lineage reaches the commit. This combined path is limited to one
-concise functional setter. A later structural call, a map after the structural pipeline has
-reordered, structural work split across setter calls, or any failed runtime proof keeps complete
+item that a later structural step removes needs no row patch. This combined path is limited to one
+concise functional setter. A map after the structural pipeline has reordered, structural work split
+across setter calls, unsupported callbacks, changed keys, or any failed runtime proof keeps complete
 reconciliation.
 
 A safe map may also be the final pipeline step:
@@ -2280,10 +2279,11 @@ The package and example test suites verify more than generated code:
   and cover changed-key, custom-method, and Array-subclass fallback, Strict Mode hydration, and
   unmount-before-flush cleanup;
 - 2,000 deterministic mapped structural removals, another 2,000 randomized updates with maps
-  interleaved between filter/slice steps and a final reorder, and 2,000 randomized terminal
-  structural-map row transitions match normal React; targeted tests preserve surviving DOM identity
-  and controlled-input focus/selection, patch only changed survivors, and cover changed-key and
-  custom-method fallback, Strict Mode hydration, and unmount-before-flush cleanup;
+  interleaved between filter/slice steps and a final reorder, 2,000 randomized terminal
+  structural-map transitions, and 2,000 randomized map-before-terminal-filter/slice transitions
+  match normal React; targeted tests preserve surviving DOM identity and controlled-input
+  focus/selection, patch only changed survivors, and cover changed-key and custom-method fallback,
+  Strict Mode hydration, and unmount-before-flush cleanup;
 - 2,000 deterministic native reversals or sorts followed by consecutive same-key edits match normal
   React; targeted tests require exact reversal to use `n - 1` direct DOM moves without a generic
   source-item map, require ambiguous sorting to use one validated keyed reconciliation, and cover

--- a/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
+++ b/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
@@ -2,6 +2,39 @@
 
 Latest run: 2026-09-09
 
+## Maps before terminal structural steps — 2026-09-09
+
+A concise keyed-row setter may now run a safe same-key `map()` before a terminal native `filter()`
+or `slice()` without losing its compiler proof. Farm carries mapped-item sources and structural
+survivor indices to the final array, validates the complete result before the first DOM write,
+removes rejected rows, and patches only changed surviving bindings. Unsupported callbacks, changed
+keys, ambiguous ownership, and failed native-method checks still take complete React reconciliation.
+
+The maintained 10,000-row workload changes one row and then filters out another. Its block-bodied
+compiled control performs the same native JavaScript work through complete keyed reconciliation.
+Every value, surviving position, DOM identity, and removed-row connection is checked after every
+sample.
+
+| Mode   | Map + filter | Compiled control | vs React | vs control |
+| ------ | -----------: | ---------------: | -------: | ---------: |
+| Static |      4.50 ms |         10.50 ms |   12.60x |      2.33x |
+| Hybrid |      6.70 ms |         11.20 ms |    8.46x |      1.67x |
+
+Both modes passed the unchanged 2x React and 1.25x compiled-control floors. The complete benchmark
+also passed its correctness oracle, broad 10% regression gate, optimization-persistence gate, every
+existing feature-specific performance gate, and zero compiled owner executions.
+
+Compiler and runtime tests cover map/filter, map/slice, and map/filter/slice pipelines; exact
+survivor DOM identity; one changed-row binding read; controlled-input focus and selection; atomic
+fallback for custom maps and changed keys; Strict Mode hydration; unmount-before-flush cleanup; and
+2,000 randomized mapped terminal-structural transitions matched with normal React. React 18.3.1 and
+19.2.8 compatibility passes, and all isolated optional-runtime gzip fixtures are unchanged.
+
+Numbers are medians from one complete bracketed run: 10 samples per compiler mode and 20 surrounding
+React samples using Chrome 153.0.8010.36, Node.js 23.11.0, and Apple M1 macOS arm64. Timing varies by
+machine; deterministic parity, fallback, DOM-identity, compatibility, and runtime-size checks remain
+the primary safety controls.
+
 ## Terminal structural maps — 2026-09-09
 
 A concise keyed-row setter may now finish an index-independent `filter()` or `slice()` pipeline

--- a/examples/react-compiler-dashboard/README.md
+++ b/examples/react-compiler-dashboard/README.md
@@ -269,15 +269,15 @@ same four native updates through complete reconciliation. Both compiler modes mu
 final committed order, every original DOM identity and connection, and both changed values. Package tests
 also cover mixed reverse/sort chains, chain boundaries, and 2,000 randomized differential updates.
 
-Terminal structural maps have a separate 10,000-row comparison. One concise setter filters out one
-row and changes a surviving row through its final map, with no synthetic reorder needed to retain
-the compiler proof. The block-bodied control performs the same native work through complete keyed
-reconciliation. Both compiler modes must remain at least 2x faster than React and 1.25x faster than
-the compiled control. The assertion checks the changed values, rejected-row cleanup, full survivor
-order, and every surviving DOM identity. Package tests also cover maps interleaved with
-filter/slice/sort/reverse steps, terminal filter/slice maps, controlled-input focus and selection,
-changed-key and custom-method fallback, Strict Mode hydration, cleanup, and separate 2,000-row
-differential runs for final-reorder and terminal pipelines. The benchmark lifecycle rebuilds
+Mapped terminal-structural pipelines have a separate 10,000-row comparison. One concise setter
+changes a surviving row through a safe map and then filters out another row, with no synthetic
+reorder needed to retain the compiler proof. The block-bodied control performs the same native work
+through complete keyed reconciliation. Both compiler modes must remain at least 2x faster than React
+and 1.25x faster than the compiled control. The assertion checks the changed values, rejected-row
+cleanup, full survivor order, and every surviving DOM identity. Package tests also cover maps
+before, between, and after filter/slice steps, mapped structural reorders, controlled-input focus and
+selection, changed-key and custom-method fallback, Strict Mode hydration, cleanup, and separate
+2,000-row differential runs for final-reorder and both no-reorder pipeline orders. The benchmark lifecycle rebuilds
 `@farm.js/react` first and then verifies the emitted hint counts, so local source changes cannot be
 silently measured through stale package output.
 

--- a/examples/react-compiler-dashboard/scripts/benchmark.mjs
+++ b/examples/react-compiler-dashboard/scripts/benchmark.mjs
@@ -1209,7 +1209,7 @@ async function measureTrial(browser, trial, compilerMode, port) {
           );
           const amount = Number(target?.querySelector("td:nth-child(4)")?.textContent?.slice(1));
           if (!target || !removed || !Number.isFinite(amount)) {
-            throw new Error("Terminal structural-map source rows are invalid.");
+            throw new Error("Mapped terminal-structural source rows are invalid.");
           }
           return {
             amount: amount + 1,
@@ -1239,7 +1239,7 @@ async function measureTrial(browser, trial, compilerMode, port) {
               rows.some((row) => row !== removed && !row.isConnected)
             ) {
               throw new Error(
-                "Terminal structural-map rows do not match the expected filtered order.",
+                "Mapped terminal-structural rows do not match the expected filtered order.",
               );
             }
           };
@@ -2972,9 +2972,9 @@ const keyedStructuralReorderRegressions = keyedStructuralReorderResults.filter(
     !Number.isFinite(snapshotSpeedup) ||
     snapshotSpeedup < keyedStructuralReorderMinimumSnapshotSpeedup,
 );
-// A safe map after a filter changes row data and membership in one setter. The terminal structural
+// A safe map before a terminal filter changes row data and membership in one setter. The combined
 // path must patch the changed survivor and remove the rejected row instead of dropping to complete
-// keyed reconciliation merely because no reorder follows.
+// keyed reconciliation merely because a structural step follows the map and no reorder follows.
 const keyedMappedStructuralReorderMinimumSpeedup = 2;
 const keyedMappedStructuralReorderMinimumSnapshotSpeedup = 1.25;
 const keyedMappedStructuralReorderResults = ["static", "hybrid"].map((mode) => {

--- a/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
+++ b/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
@@ -876,18 +876,18 @@ export function StandardTableBenchmark() {
           onClick={() => {
             setRows((current) =>
               current
-                .filter((row) => row.id % 10_000 !== 7_001)
                 .map((row) =>
                   row.id % 10_000 === 5_001
                     ? { ...row, amount: row.amount + 1, label: `${row.label} reviewed` }
                     : row,
-                ),
+                )
+                .filter((row) => row.id % 10_000 !== 7_001),
             );
-            setOperation("filter one row and review another");
+            setOperation("review one row, then filter another");
             setRevision((value) => value + 1);
           }}
         >
-          Filter + terminal map
+          Map + terminal filter
         </button>
         <button
           data-action="table-map-structural-reorder-pipeline-snapshot"
@@ -895,18 +895,18 @@ export function StandardTableBenchmark() {
           onClick={() => {
             setRows((current) => {
               return current
-                .filter((row) => row.id % 10_000 !== 7_001)
                 .map((row) =>
                   row.id % 10_000 === 5_001
                     ? { ...row, amount: row.amount + 1, label: `${row.label} reviewed` }
                     : row,
-                );
+                )
+                .filter((row) => row.id % 10_000 !== 7_001);
             });
-            setOperation("filter and review rows (snapshot control)");
+            setOperation("review and filter rows (snapshot control)");
             setRevision((value) => value + 1);
           }}
         >
-          Filter + terminal map (snapshot control)
+          Map + terminal filter (snapshot control)
         </button>
         <button
           data-action="table-map-reorder-pipeline"

--- a/packages/farm-react/README.md
+++ b/packages/farm-react/README.md
@@ -468,9 +468,8 @@ An exact reverse uses the minimum-move reverse path without a general source-ite
 sort remains an ambiguous permutation, so Farm performs one validated source lookup and LIS pass.
 Safe maps on both sides of a reorder flatten their replacements back to the same committed rows.
 
-Safe maps may also run before or between index-independent `filter` or `slice` steps in one concise
-functional setter. A final native reorder is optional when the pipeline itself ends with a safe
-map:
+Safe maps may also run before, between, or after index-independent `filter` or `slice` steps in one
+concise functional setter. A final native reorder is optional:
 
 ```tsx
 setItems((current) =>
@@ -483,19 +482,18 @@ setItems((current) =>
 
 setItems((current) =>
   current
+    .map((item) => (item.id === editedId ? { ...item, label: nextLabel } : item))
     .filter((item) => item.visible)
-    .slice(0, limit)
-    .map((item) => (item.id === editedId ? { ...item, label: nextLabel } : item)),
+    .slice(0, limit),
 );
 ```
 
 The structural helpers retain both the committed survivor indices and mapped-item sources across
 each accepted step. The final commit removes rejected rows, performs LIS moves only when a reorder
 needs them, and patches bindings only for changed survivors. Every native callback and method still
-runs in JavaScript order. Without a reorder, the last operation must be the safe map so its newest
-lineage reaches the commit. A later structural operation, a map after the structural pipeline has
-already reordered, structural work split across setters, unsafe callbacks, and failed runtime
-validation keep complete keyed reconciliation.
+runs in JavaScript order. A map after the structural pipeline has already reordered, structural work
+split across setters, unsafe callbacks, changed keys, and failed runtime validation keep complete
+keyed reconciliation.
 
 The reorder and safe maps may also be adjacent setter calls in the same synchronous block:
 

--- a/packages/farm-react/src/__tests__/compiler-keyed-array-sort-hints.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-keyed-array-sort-hints.test.ts
@@ -475,11 +475,6 @@ describe("React AOT keyed-array sort hints", () => {
         'current["map"]((row) => row.id === editedId ? { ...row, rank: 0 } : row).toSorted((a, b) => a.rank - b.rank)',
     },
     {
-      name: "a mapped structural update without a final reorder",
-      pipeline:
-        "current.map((row) => row.id === editedId ? { ...row, rank: 0 } : row).filter((row) => row.rank > 0)",
-    },
-    {
       name: "a map after a structural reorder",
       pipeline:
         "current.filter((row) => row.rank > 0).toReversed().map((row) => row.id === editedId ? { ...row, rank: 0 } : row)",
@@ -500,6 +495,46 @@ describe("React AOT keyed-array sort hints", () => {
     expect(result.optimizations.keyedArraySortHints).toBe(0);
     expect(result.code).not.toContain("createCompilerKeyedArrayMapPipeline");
     expect(result.code).not.toContain("keyedRowsMapReorderHintedRuntimeFeature");
+  });
+
+  it("keeps mapped lineage when filter or slice ends the pipeline", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Table({ editedId, nextLabel, limit }) {
+        const [rows, setRows] = useState([
+          { id: "a", label: "Alpha", visible: true },
+          { id: "b", label: "Beta", visible: false },
+          { id: "c", label: "Gamma", visible: true },
+        ]);
+        return <section>
+          <button onClick={() => setRows((current) => current
+            .map((row) => row.id === editedId ? { ...row, label: nextLabel } : row)
+            .filter((row) => row.visible)
+          )}>Map and filter</button>
+          <button onClick={() => setRows((current) => current
+            .map((row) => row.id === editedId ? { ...row, label: nextLabel } : row)
+            .slice(1, limit)
+          )}>Map and slice</button>
+          <ul>{rows.map((row) => <li key={row.id}>{row.label}</li>)}</ul>
+        </section>;
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Table"]);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.optimizations.keyedMapUpdateHints).toBe(2);
+    expect(result.optimizations.keyedArrayFilterHints).toBe(1);
+    expect(result.optimizations.keyedArraySliceHints).toBe(1);
+    expect(result.optimizations.keyedArrayReorderHints).toBe(0);
+    expect(result.code.match(/createCompilerKeyedArrayMapPipeline\(/g)).toHaveLength(2);
+    expect(result.code).toContain("createCompilerKeyedArrayFilter");
+    expect(result.code).toContain("createCompilerKeyedArraySlice");
+    expect(result.code.match(/finalizeCompilerKeyedArrayMappedStructuralUpdate\(/g)).toHaveLength(
+      2,
+    );
+    expect(result.code).toContain("keyedRowsEveryHintedRuntimeFeature");
+    expect(result.code).not.toContain("createCompilerKeyedArrayStructuralReorder");
+    expect(result.code).not.toContain("createCompilerKeyedArrayMapReorder");
   });
 
   it("carries mapped row lineage through a following filter and sort", async () => {

--- a/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-structural-reorder-hints.test.tsx
+++ b/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-structural-reorder-hints.test.tsx
@@ -10,6 +10,7 @@ import {
   createCompilerKeyedArraySlice,
   createCompilerKeyedArrayStructuralReorder,
   createCompilerKeyedArrayStructuralSort,
+  finalizeCompilerKeyedArrayMappedStructuralUpdate,
   type CompilerKeyedRowElement,
 } from "../compiler-runtime";
 
@@ -56,6 +57,10 @@ function hintedSlice(items: Item[], start: number, end?: number): Item[] {
     items.slice,
     ...([start, end].filter((value) => value !== undefined) as number[]),
   ) as Item[];
+}
+
+function hintedMappedStructural(items: Item[]): Item[] {
+  return finalizeCompilerKeyedArrayMappedStructuralUpdate(items) as Item[];
 }
 
 function hintedSort(items: Item[], compare: (left: Item, right: Item) => number): Item[] {
@@ -112,11 +117,19 @@ function createHarness(initialItems: Item[]) {
     removed: ReadonlySet<string>,
     limit: number,
   ) => void = () => undefined;
+  let mapFilterSlice: (
+    editedId: string,
+    nextLabel: string,
+    removed: ReadonlySet<string>,
+    limit: number,
+  ) => void = () => undefined;
   let invalidIdentity: () => void = () => undefined;
   let invalidMappedIdentity: () => void = () => undefined;
   let invalidTerminalMappedIdentity: () => void = () => undefined;
+  let invalidMappedStructuralIdentity: () => void = () => undefined;
   let customMapStructural: () => void = () => undefined;
   let customMapTerminal: () => void = () => undefined;
+  let customMapThenFilter: () => void = () => undefined;
   let customSortAfterFilter: (removed: ReadonlySet<string>) => void = () => undefined;
   const Table = createCompiledComponent({
     displayName: "StructuralReorderTable",
@@ -211,6 +224,21 @@ function createHarness(initialItems: Item[]) {
             (item) => (item.id === editedId ? { ...item, label: nextLabel } : item),
           ),
         );
+      mapFilterSlice = (editedId, nextLabel, removed, limit) =>
+        state[0].set((previous) =>
+          hintedMappedStructural(
+            hintedSlice(
+              hintedFilter(
+                hintedMap(previous as Item[], (item) =>
+                  item.id === editedId ? { ...item, label: nextLabel } : item,
+                ),
+                (item) => !removed.has(item.id),
+              ),
+              0,
+              limit,
+            ),
+          ),
+        );
       invalidIdentity = () =>
         state[0].set((previous) => {
           const next = hintedReverse(hintedFilter(previous as Item[], (item) => item.id !== "b"));
@@ -233,6 +261,17 @@ function createHarness(initialItems: Item[]) {
             hintedFilter(previous as Item[], (item) => item.id !== "c"),
             (item) =>
               item.id === "b" ? { ...item, id: "replacement", label: "Replacement" } : item,
+          ),
+        );
+      invalidMappedStructuralIdentity = () =>
+        state[0].set((previous) =>
+          hintedMappedStructural(
+            hintedFilter(
+              hintedMap(previous as Item[], (item) =>
+                item.id === "b" ? { ...item, id: "replacement", label: "Replacement" } : item,
+              ),
+              (item) => item.id !== "c",
+            ),
           ),
         );
       customMapStructural = () =>
@@ -261,6 +300,22 @@ function createHarness(initialItems: Item[]) {
           return createCompilerKeyedArrayMapPipeline(filtered, customMap, (item: Item) =>
             item.id === "a" ? { ...item, label: "Custom terminal map" } : item,
           ) as Item[];
+        });
+      customMapThenFilter = () =>
+        state[0].set((previous) => {
+          const customMap = function (
+            this: Item[],
+            callback: (item: Item, index: number, items: Item[]) => Item,
+          ) {
+            return Array.prototype.map.call(this, callback);
+          };
+          const mapped = createCompilerKeyedArrayMapPipeline(
+            previous as Item[],
+            customMap,
+            (item: Item) =>
+              item.id === "a" ? { ...item, label: "Custom map before filter" } : item,
+          ) as Item[];
+          return hintedMappedStructural(hintedFilter(mapped, (item) => item.id !== "c"));
         });
       customSortAfterFilter = (removed) =>
         state[0].set((previous) => {
@@ -326,6 +381,7 @@ function createHarness(initialItems: Item[]) {
     customSortAfterFilter: (removed: ReadonlySet<string>) => customSortAfterFilter(removed),
     customMapStructural: () => customMapStructural(),
     customMapTerminal: () => customMapTerminal(),
+    customMapThenFilter: () => customMapThenFilter(),
     filterMapSliceMap: (
       editedId: string,
       nextLabel: string,
@@ -346,7 +402,14 @@ function createHarness(initialItems: Item[]) {
     filterThenQueuedSort: (removed: ReadonlySet<string>) => filterThenQueuedSort(removed),
     invalidIdentity: () => invalidIdentity(),
     invalidMappedIdentity: () => invalidMappedIdentity(),
+    invalidMappedStructuralIdentity: () => invalidMappedStructuralIdentity(),
     invalidTerminalMappedIdentity: () => invalidTerminalMappedIdentity(),
+    mapFilterSlice: (
+      editedId: string,
+      nextLabel: string,
+      removed: ReadonlySet<string>,
+      limit: number,
+    ) => mapFilterSlice(editedId, nextLabel, removed, limit),
     mapFilterDoubleReverse: (editedId: string, nextLabel: string, removed: ReadonlySet<string>) =>
       mapFilterDoubleReverse(editedId, nextLabel, removed),
     mapFilterSortReverse: (
@@ -556,6 +619,42 @@ describe("compiled keyed-array structural reorder hints", () => {
     expect(harness.counters.bindings).toBe(1);
   });
 
+  it("patches a mapped survivor when filter and slice end the pipeline", async () => {
+    const items: Item[] = [
+      { id: "a", label: "Alpha", rank: 4, visible: true },
+      { id: "b", label: "Beta", rank: 1, visible: false },
+      { id: "c", label: "Gamma", rank: 3, visible: true },
+      { id: "d", label: "Delta", rank: 2, visible: true },
+    ];
+    const harness = createHarness(items);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Table />));
+    const alpha = container.querySelector('[data-key="a"]');
+    const gamma = container.querySelector('[data-key="c"]');
+    harness.counters.bindings = 0;
+    harness.counters.descriptors = 0;
+    harness.counters.keys = 0;
+
+    await act(async () => {
+      harness.mapFilterSlice("c", "Gamma filtered", new Set(["b"]), 2);
+      await flushCompilerUpdates();
+    });
+
+    expect(labels(container)).toEqual(["Alpha", "Gamma filtered"]);
+    expect(container.querySelector('[data-key="a"]')).toBe(alpha);
+    expect(container.querySelector('[data-key="c"]')).toBe(gamma);
+    expect(container.querySelector('[data-key="b"]')).toBeNull();
+    expect(container.querySelector('[data-key="d"]')).toBeNull();
+    expect(harness.counters.executions).toBe(1);
+    expect(harness.counters.renders).toBe(1);
+    expect(harness.counters.keys).toBe(2);
+    expect(harness.counters.descriptors).toBe(0);
+    expect(harness.counters.bindings).toBe(1);
+  });
+
   it("falls back safely for custom methods and identity mismatches", async () => {
     const items: Item[] = [
       { id: "a", label: "Alpha", rank: 2, visible: true },
@@ -659,6 +758,44 @@ describe("compiled keyed-array structural reorder hints", () => {
     expect(changedKey.counters.descriptors).toBeGreaterThan(0);
   });
 
+  it("falls back atomically when a custom map or changed key precedes filter", async () => {
+    const items: Item[] = [
+      { id: "a", label: "Alpha", rank: 2, visible: true },
+      { id: "b", label: "Beta", rank: 1, visible: true },
+      { id: "c", label: "Gamma", rank: 3, visible: true },
+    ];
+    const custom = createHarness(items);
+    const customContainer = document.createElement("div");
+    document.body.append(customContainer);
+    const customRoot = createRoot(customContainer);
+    roots.push(customRoot);
+    await act(async () => customRoot.render(<custom.Table />));
+    custom.counters.bindings = 0;
+    custom.counters.descriptors = 0;
+    await act(async () => {
+      custom.customMapThenFilter();
+      await flushCompilerUpdates();
+    });
+    expect(labels(customContainer)).toEqual(["Custom map before filter", "Beta"]);
+    expect(custom.counters.bindings).toBeGreaterThan(0);
+
+    const changedKey = createHarness(items);
+    const changedKeyContainer = document.createElement("div");
+    document.body.append(changedKeyContainer);
+    const changedKeyRoot = createRoot(changedKeyContainer);
+    roots.push(changedKeyRoot);
+    await act(async () => changedKeyRoot.render(<changedKey.Table />));
+    changedKey.counters.bindings = 0;
+    changedKey.counters.descriptors = 0;
+    await act(async () => {
+      changedKey.invalidMappedStructuralIdentity();
+      await flushCompilerUpdates();
+    });
+    expect(labels(changedKeyContainer)).toEqual(["Alpha", "Replacement"]);
+    expect(changedKey.counters.bindings).toBeGreaterThan(0);
+    expect(changedKey.counters.descriptors).toBeGreaterThan(0);
+  });
+
   it("preserves a surviving controlled input, focus, and selection", async () => {
     const items: Item[] = [
       { id: "a", label: "Alpha", rank: 3, visible: true },
@@ -673,13 +810,17 @@ describe("compiled keyed-array structural reorder hints", () => {
         const rows = () => state[0].get() as Item[];
         update = () =>
           state[0].set((previous) =>
-            hintedMap(
+            hintedMappedStructural(
               hintedSlice(
-                hintedFilter(previous as Item[], (item) => item.id !== "a"),
+                hintedFilter(
+                  hintedMap(previous as Item[], (item) =>
+                    item.id === "b" ? { ...item, label: "Beta newest" } : item,
+                  ),
+                  (item) => item.id !== "a",
+                ),
                 0,
                 1,
               ),
-              (item) => (item.id === "b" ? { ...item, label: "Beta newest" } : item),
             ),
           );
         return (
@@ -1037,6 +1178,80 @@ describe("compiled keyed-array structural reorder hints", () => {
     expect(harness.counters.executions).toBe(1);
   }, 20_000);
 
+  it("matches React across 2,000 randomized mapped terminal-structural row transitions", async () => {
+    const initialItems = Array.from(
+      { length: 2_001 },
+      (_, index): Item => ({
+        id: `row-${index}`,
+        label: `Row ${index}`,
+        rank: (index * 1_229) % 2_003,
+        visible: true,
+      }),
+    );
+    const harness = createHarness(initialItems);
+    let updateReact: (
+      editedId: string,
+      nextLabel: string,
+      removed: ReadonlySet<string>,
+      limit: number,
+    ) => void = () => undefined;
+    function Normal() {
+      const [items, setItems] = useState(initialItems);
+      updateReact = (editedId, nextLabel, removed, limit) =>
+        setItems((previous) =>
+          previous
+            .map((item) => (item.id === editedId ? { ...item, label: nextLabel } : item))
+            .filter((item) => !removed.has(item.id))
+            .slice(0, limit),
+        );
+      return (
+        <ol>
+          {items.map((item) => (
+            <li data-key={item.id} key={item.id}>
+              {item.label}
+            </li>
+          ))}
+        </ol>
+      );
+    }
+    const compiledContainer = document.createElement("div");
+    const reactContainer = document.createElement("div");
+    document.body.append(compiledContainer, reactContainer);
+    const compiledRoot = createRoot(compiledContainer);
+    const reactRoot = createRoot(reactContainer);
+    roots.push(compiledRoot, reactRoot);
+    await act(async () => {
+      compiledRoot.render(<harness.Table />);
+      reactRoot.render(<Normal />);
+    });
+
+    let seed = 0x1b873593;
+    let active = initialItems.map((item) => item.id);
+    for (let batch = 0; batch < 100; batch += 1) {
+      const removed = new Set<string>();
+      for (let update = 0; update < 15; update += 1) {
+        seed = (Math.imul(seed, 1_664_525) + 1_013_904_223) >>> 0;
+        const available = active.filter((id) => !removed.has(id));
+        removed.add(available[seed % available.length]);
+      }
+      const survivors = active.filter((id) => !removed.has(id));
+      const limit = survivors.length - 5;
+      seed = (Math.imul(seed, 1_664_525) + 1_013_904_223) >>> 0;
+      const editedId = survivors[seed % limit];
+      const nextLabel = `Mapped structural ${batch}`;
+      await act(async () => {
+        harness.mapFilterSlice(editedId, nextLabel, removed, limit);
+        updateReact(editedId, nextLabel, removed, limit);
+        await flushCompilerUpdates();
+      });
+      expect(labels(compiledContainer)).toEqual(labels(reactContainer));
+      active = [...reactContainer.querySelectorAll<HTMLElement>("li")].map(
+        (row) => row.dataset.key!,
+      );
+    }
+    expect(harness.counters.executions).toBe(1);
+  }, 20_000);
+
   it("hydrates in StrictMode and drops a queued pipeline after unmount", async () => {
     const items: Item[] = [
       { id: "a", label: "Alpha", rank: 3, visible: true },
@@ -1060,7 +1275,7 @@ describe("compiled keyed-array structural reorder hints", () => {
     });
     roots.push(root);
     await act(async () => {
-      hydration.filterMapSliceMap("b", "Beta hydrated", 2, new Set(), 2);
+      hydration.mapFilterSlice("b", "Beta hydrated", new Set(), 2);
       await flushCompilerUpdates();
     });
     expect(labels(container)).toEqual(["Alpha", "Beta hydrated"]);
@@ -1072,7 +1287,7 @@ describe("compiled keyed-array structural reorder hints", () => {
     const unmountRoot = createRoot(unmountContainer);
     await act(async () => unmountRoot.render(<unmounted.Table />));
     act(() => {
-      unmounted.filterMapSliceMap("c", "Gamma queued", 2, new Set(["a"]), 2);
+      unmounted.mapFilterSlice("c", "Gamma queued", new Set(["a"]), 2);
       unmountRoot.unmount();
     });
     await flushCompilerUpdates();

--- a/packages/farm-react/src/compiler-runtime.tsx
+++ b/packages/farm-react/src/compiler-runtime.tsx
@@ -1132,6 +1132,31 @@ export function createCompilerKeyedArraySlice(
   return value;
 }
 
+/** @internal Retains mapped lineage through a compiler-proven terminal filter or slice. */
+export function finalizeCompilerKeyedArrayMappedStructuralUpdate(value: unknown): unknown {
+  try {
+    const valueTarget = compilerObject(value);
+    const structuralUpdate = valueTarget
+      ? COMPILER_KEYED_ARRAY_FILTERS.get(valueTarget)
+      : undefined;
+    const mappedItemSources = structuralUpdate?.mappedItemSources;
+    if (!valueTarget || !structuralUpdate || !mappedItemSources) return value;
+    const source = compilerKeyedArrayFilterSource(structuralUpdate, structuralUpdate.resultLength);
+    if (!source) return value;
+    COMPILER_KEYED_ARRAY_REORDERS.set(valueTarget, {
+      sourceToken: source.sourceToken,
+      sourceLength: source.sourceLength,
+      resultLength: structuralUpdate.resultLength,
+      mapped: true,
+      mappedItemSources,
+      structuralUpdate,
+    });
+  } catch {
+    // Metadata must never change the result of a successful native pipeline.
+  }
+  return value;
+}
+
 /** @internal Records a compiler-proven retained tail followed by incoming keyed rows. */
 export function createCompilerKeyedArrayRollingWindow(
   previous: unknown,

--- a/packages/farm-react/src/compiler.ts
+++ b/packages/farm-react/src/compiler.ts
@@ -2020,8 +2020,7 @@ function keyedArrayReorderPipeline(
     }
   }
   if (reorderSteps < 1) {
-    const finalStep = steps[steps.length - 1];
-    return structuralSteps > 0 && finalStep?.kind === "map" ? steps : undefined;
+    return structuralSteps > 0 && mapSteps > 0 ? steps : undefined;
   }
   if (mapSteps > 0 && reorderSteps >= 1) return steps;
   if (structuralSteps < 1 && reorderSteps < 2) return undefined;
@@ -2035,6 +2034,7 @@ function rewriteKeyedArrayReorderPipelineHints(
   filterHelperIdentifier: t.Identifier,
   mapHelperIdentifier: t.Identifier,
   mapReorderHelperIdentifier: t.Identifier,
+  mappedStructuralHelperIdentifier: t.Identifier,
   reorderHelperIdentifier: t.Identifier,
   structuralReorderHelperIdentifier: t.Identifier,
   sliceHelperIdentifier: t.Identifier,
@@ -2052,7 +2052,7 @@ function rewriteKeyedArrayReorderPipelineHints(
   sliceCount: number;
   sortCount: number;
   structuralReorderCount: number;
-  terminalStructuralMapCount: number;
+  terminalStructuralPipelineCount: number;
   structuralSortCount: number;
   stateIndices: ReadonlySet<number>;
 } {
@@ -2067,7 +2067,7 @@ function rewriteKeyedArrayReorderPipelineHints(
       sliceCount: 0,
       sortCount: 0,
       structuralReorderCount: 0,
-      terminalStructuralMapCount: 0,
+      terminalStructuralPipelineCount: 0,
       structuralSortCount: 0,
       stateIndices: new Set(),
     };
@@ -2082,7 +2082,7 @@ function rewriteKeyedArrayReorderPipelineHints(
   let sliceCount = 0;
   let sortCount = 0;
   let structuralReorderCount = 0;
-  let terminalStructuralMapCount = 0;
+  let terminalStructuralPipelineCount = 0;
   let structuralSortCount = 0;
   traverse(file, {
     CallExpression(path) {
@@ -2110,7 +2110,8 @@ function rewriteKeyedArrayReorderPipelineHints(
       );
       const mapPipeline = steps.some((step) => step.kind === "map");
       if (mapPipeline && !allowMapPipelines) return;
-      const terminalStructuralMap =
+      const terminalStructuralPipeline =
+        mapPipeline &&
         structuralPipeline &&
         steps.every((step) => step.kind !== "reverse" && step.kind !== "sort");
 
@@ -2262,8 +2263,14 @@ function rewriteKeyedArrayReorderPipelineHints(
           if (structuralPipeline) structuralSortCount += 1;
         }
       }
-      statements.push(t.returnStatement(t.cloneNode(value)));
-      if (terminalStructuralMap) terminalStructuralMapCount += 1;
+      statements.push(
+        t.returnStatement(
+          terminalStructuralPipeline
+            ? t.callExpression(t.cloneNode(mappedStructuralHelperIdentifier), [t.cloneNode(value)])
+            : t.cloneNode(value),
+        ),
+      );
+      if (terminalStructuralPipeline) terminalStructuralPipelineCount += 1;
       path.node.arguments[0] = t.arrowFunctionExpression(
         [t.cloneNode(previous)],
         t.blockStatement(statements),
@@ -2282,7 +2289,7 @@ function rewriteKeyedArrayReorderPipelineHints(
     sliceCount,
     sortCount,
     structuralReorderCount,
-    terminalStructuralMapCount,
+    terminalStructuralPipelineCount,
     structuralSortCount,
     stateIndices,
   };
@@ -7559,6 +7566,7 @@ function compileCandidate(
   keyedArrayMapPipelineIdentifier: t.Identifier,
   keyedArrayQueuedMapPipelineIdentifier: t.Identifier,
   keyedArrayMapReorderIdentifier: t.Identifier,
+  keyedArrayMappedStructuralIdentifier: t.Identifier,
   keyedArrayPrependIdentifier: t.Identifier,
   keyedArrayPositionIdentifier: t.Identifier,
   keyedArrayBatchInsertIdentifier: t.Identifier,
@@ -7593,6 +7601,7 @@ function compileCandidate(
     keyedArrayMapReorderHints: number;
     keyedArrayMapSortHints: number;
     keyedArrayMapUpdateHints: number;
+    keyedArrayMappedStructuralHints: number;
     keyedArrayQueuedMapUpdateHints: number;
     keyedArrayStructuralReorderHints: number;
     keyedArrayStructuralSortHints: number;
@@ -8074,6 +8083,7 @@ function compileCandidate(
     keyedArrayFilterIdentifier,
     keyedArrayMapPipelineIdentifier,
     keyedArrayMapReorderIdentifier,
+    keyedArrayMappedStructuralIdentifier,
     keyedArrayReorderIdentifier,
     keyedArrayStructuralReorderIdentifier,
     keyedArraySliceIdentifier,
@@ -8119,7 +8129,7 @@ function compileCandidate(
       appliedKeyedMapUpdateHints += reorderPipelineHintedRoot.mapCount;
       appliedPipelineReorderHints =
         reorderPipelineHintedRoot.reorderCount +
-        reorderPipelineHintedRoot.terminalStructuralMapCount;
+        reorderPipelineHintedRoot.terminalStructuralPipelineCount;
       appliedPipelineSliceHints = reorderPipelineHintedRoot.sliceCount;
       appliedPipelineSortHints = reorderPipelineHintedRoot.sortCount;
       appliedPipelineHintedStateIndices = reorderPipelineHintedRoot.stateIndices;
@@ -8134,6 +8144,8 @@ function compileCandidate(
       compilerUsage.keyedArrayMapUpdateHints += reorderPipelineHintedRoot.mapCount;
       compilerUsage.keyedArrayMapReorderHints += reorderPipelineHintedRoot.mapReorderCount;
       compilerUsage.keyedArrayMapSortHints += reorderPipelineHintedRoot.mapSortCount;
+      compilerUsage.keyedArrayMappedStructuralHints +=
+        reorderPipelineHintedRoot.terminalStructuralPipelineCount;
     }
   }
   const reorderHintedRoot = rewriteKeyedArrayReorderHints(
@@ -8660,6 +8672,7 @@ export async function compileReactModule(
     keyedArrayMapReorderHints: 0,
     keyedArrayMapSortHints: 0,
     keyedArrayMapUpdateHints: 0,
+    keyedArrayMappedStructuralHints: 0,
     keyedArrayQueuedMapUpdateHints: 0,
     keyedArrayStructuralReorderHints: 0,
     keyedArrayStructuralSortHints: 0,
@@ -8719,6 +8732,9 @@ export async function compileReactModule(
         );
         const keyedArrayMapReorderIdentifier = programPath.scope.generateUidIdentifier(
           "createCompilerKeyedArrayMapReorder",
+        );
+        const keyedArrayMappedStructuralIdentifier = programPath.scope.generateUidIdentifier(
+          "finalizeCompilerKeyedArrayMappedStructuralUpdate",
         );
         const keyedArrayPrependIdentifier = programPath.scope.generateUidIdentifier(
           "createCompilerKeyedArrayPrepend",
@@ -8783,6 +8799,7 @@ export async function compileReactModule(
             keyedArrayMapPipelineIdentifier,
             keyedArrayQueuedMapPipelineIdentifier,
             keyedArrayMapReorderIdentifier,
+            keyedArrayMappedStructuralIdentifier,
             keyedArrayPrependIdentifier,
             keyedArrayPositionIdentifier,
             keyedArrayBatchInsertIdentifier,
@@ -8850,6 +8867,14 @@ export async function compileReactModule(
                       t.importSpecifier(
                         keyedArrayMapReorderIdentifier,
                         t.identifier("createCompilerKeyedArrayMapReorder"),
+                      ),
+                    ]
+                  : []),
+                ...(compilerUsage.keyedArrayMappedStructuralHints > 0
+                  ? [
+                      t.importSpecifier(
+                        keyedArrayMappedStructuralIdentifier,
+                        t.identifier("finalizeCompilerKeyedArrayMappedStructuralUpdate"),
                       ),
                     ]
                   : []),

--- a/packages/farm-react/vitest.stress.config.ts
+++ b/packages/farm-react/vitest.stress.config.ts
@@ -21,7 +21,7 @@ export default defineConfig({
     ],
     setupFiles: ["src/__tests__/stress.setup.ts"],
     testNamePattern:
-      /2,000 deterministic mapped reorder updates|2,000 deterministic mapped reversal parity updates|2,000 queued reverse, map, and reverse updates|2,000 reverse-or-sort then map updates|2,000 queued reorder then standalone map updates|2,000 queued map then reorder updates|2,000 queued map and consecutive reorder updates|2,000 mapped structural removals|2,000 randomized interleaved map and structural removals|2,000 randomized terminal structural-map row transitions|3,000 deterministic recursive updates|4,096 rows/,
+      /2,000 deterministic mapped reorder updates|2,000 deterministic mapped reversal parity updates|2,000 queued reverse, map, and reverse updates|2,000 reverse-or-sort then map updates|2,000 queued reorder then standalone map updates|2,000 queued map then reorder updates|2,000 queued map and consecutive reorder updates|2,000 mapped structural removals|2,000 randomized interleaved map and structural removals|2,000 randomized terminal structural-map row transitions|2,000 randomized mapped terminal-structural row transitions|3,000 deterministic recursive updates|4,096 rows/,
     testTimeout: 30_000,
   },
 });


### PR DESCRIPTION
## Problem

The experimental React compiler already retained keyed-row replacement lineage when a safe same-key `map()` ended a `filter()` or `slice()` pipeline. The equivalent and common `map().filter()` or `map().slice()` order still discarded that proof solely because a structural step came last, so the final commit used complete keyed reconciliation.

## Root cause

The compiler accepted no-reorder map/structural pipelines only when their final AST step was `map`. At runtime, filter and slice helpers retained mapped-item sources internally but published only structural metadata for their result arrays. The combined mapped structural reconciler therefore could not discover the complete proof from a terminal filter or slice.

## Change

- Accept concise no-reorder keyed pipelines containing at least one safe map and one index-independent filter or slice, regardless of which accepted step is last.
- Emit a combined-hint finalizer only for eligible complete pipelines and publish the hint only when the structural source chain and mapped lineage are valid.
- Reuse the existing atomic mapped structural reconciler to remove rejected rows and patch only changed surviving bindings.
- Exercise map-before-filter in the maintained 10,000-row production dashboard benchmark and document the public behavior.

## Safety and compatibility

- Every native map, filter, and slice still executes in JavaScript order.
- The runtime validates the committed source token, dense native arrays/methods, survivor identity, unique keys, mapped source identity, and changed bindings before the first compiler-owned DOM write.
- Custom methods, unsupported callbacks, changed keys, failed proof, structural work split across setters, and maps after a structural reorder retain complete React reconciliation.
- Targeted tests preserve exact keyed DOM identity, controlled-input focus and selection, Strict Mode hydration, and unmount-before-flush cleanup.
- Custom-map and changed-key tests prove atomic fallback, and 2,000 randomized mapped terminal-structural transitions match normal React.
- React 18.3.1 and 19.2.8 compatibility pass.
- The new finalizer is imported only by eligible pipelines and is tree-shaken from filter- and slice-only builds. The exact Node 22.13 size gate passes with the keyed-filter fixture at 12,464 bytes premium gzip against its persisted 12,465-byte maximum; all other isolated fixtures remain within their existing ceilings.

## Verification

- `pnpm --filter @farm.js/react test` — 72 files, 741 passed, 10 skipped on the behavior-complete head; after the size-only finalizer isolation, the 60 affected compiler/runtime tests, 20 isolated contention-sensitive tests, and all 14 stress selections passed. Exact-head CI passed the complete Ubuntu Node 22/24, Windows Node 24, and React 18/19 matrices.
- `pnpm --filter @farm.js/react type-check`
- `pnpm --filter @farm.js/react test:compat`
- `pnpm --filter @farm.js/react test:runtime-size`
- `npx -y node@22.13.1 scripts/benchmark-runtime-size.mjs --check` from `packages/farm-react`
- `pnpm --dir packages/farm-react exec vitest run src/__tests__/compiler-keyed-array-sort-hints.test.ts src/__tests__/compiler-runtime-keyed-array-structural-reorder-hints.test.tsx` after rebasing — 60 passed.
- `NODE_OPTIONS=--max-old-space-size=6144 pnpm --filter @farm.js/core build`
- `pnpm --dir examples/react-compiler-dashboard type-check`
- `pnpm --dir examples/react-compiler-dashboard build`
- `pnpm docs:check-navigation`
- `pnpm --dir docs exec farm generate --check`
- `pnpm docs:build` — Vercel/Nitro output completed for 79 routes before the clean rebase; generated routes/navigation rechecked after the rebase.
- `pnpm exec oxfmt <changed files>`
- `pnpm exec oxlint <changed JS/TS files>`
- `FARM_EXPERIMENT_BROWSER_PATH='/Applications/Google Chrome.app/Contents/MacOS/Google Chrome' FARM_DASHBOARD_REPORT='/tmp/farm-react-terminal-mapped-structural-2.json' pnpm --dir examples/react-compiler-dashboard benchmark`

The complete Chrome 153 bracketed benchmark passed correctness, the broad 10% regression gate, optimization persistence, every feature-specific gate, and zero compiled owner executions. For the 10,000-row map-then-filter workload:

| Mode | Compiled path | Compiled control | vs React | vs control |
| --- | ---: | ---: | ---: | ---: |
| Static | 4.50 ms | 10.50 ms | 12.60x | 2.33x |
| Hybrid | 6.70 ms | 11.20 ms | 8.46x | 1.67x |

Environment: Apple M1 macOS arm64, Node.js 23.11.0, Chrome 153.0.8010.36. Timing varies by machine; deterministic parity, fallback, identity, compatibility, and size checks are the primary controls.

## Documentation and release

Updated the React renderer guide, package README, maintained dashboard README, executable benchmark UI/oracle, and benchmark results. No version or release metadata changes.
