### PR TITLE
perf(react): optimize queued map and structural setters

### DIFF
--- a/docs/src/app/docs/renderers/react/page.md
+++ b/docs/src/app/docs/renderers/react/page.md
@@ -1304,10 +1304,23 @@ Each callback still evaluates in normal JavaScript order. Farm carries both proo
 pipeline: which committed rows survived and which surviving items replaced their source items. It
 validates every survivor and key before the first DOM write, removes rejected rows, performs LIS
 moves only when a reorder needs them, and patches bindings only for changed survivors. A changed
-item that a later structural step removes needs no row patch. This combined path is limited to one
-concise functional setter. A map after the structural pipeline has reordered, structural work split
-across setter calls, unsupported callbacks, changed keys, or any failed runtime proof keeps complete
-reconciliation.
+item that a later structural step removes needs no row patch.
+
+Leading maps may also be split from following filter or slice work across adjacent setter calls:
+
+```tsx
+setItems((current) =>
+  current.map((item) => (item.id === editedId ? { ...item, label: nextLabel } : item)),
+);
+setItems((current) => current.filter((item) => item.visible));
+setItems((current) => current.slice(0, limit));
+```
+
+Farm links only consecutive calls to the same setter. It retains the first committed map source and
+validates each structural result before the queued commit touches the DOM. Multiple leading map
+setters and multiple following filter/slice setters may share the proof. A map after structural
+work, an intervening statement, another setter, an unsupported callback, a changed key, or any
+failed runtime proof keeps complete reconciliation.
 
 A safe map may also be the final pipeline step:
 
@@ -2280,10 +2293,11 @@ The package and example test suites verify more than generated code:
   unmount-before-flush cleanup;
 - 2,000 deterministic mapped structural removals, another 2,000 randomized updates with maps
   interleaved between filter/slice steps and a final reorder, 2,000 randomized terminal
-  structural-map transitions, and 2,000 randomized map-before-terminal-filter/slice transitions
-  match normal React; targeted tests preserve surviving DOM identity and controlled-input
-  focus/selection, patch only changed survivors, and cover changed-key and custom-method fallback,
-  Strict Mode hydration, and unmount-before-flush cleanup;
+  structural-map transitions, 2,000 randomized map-before-terminal-filter/slice transitions, and
+  2,000 randomized adjacent queued map/filter/slice transitions match normal React; targeted tests
+  preserve surviving DOM identity and controlled-input focus/selection, patch only changed
+  survivors, and cover adjacency boundaries, changed-key and custom-method fallback, Strict Mode
+  hydration, and unmount-before-flush cleanup;
 - 2,000 deterministic native reversals or sorts followed by consecutive same-key edits match normal
   React; targeted tests require exact reversal to use `n - 1` direct DOM moves without a generic
   source-item map, require ambiguous sorting to use one validated keyed reconciliation, and cover

--- a/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
+++ b/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
@@ -2,6 +2,36 @@
 
 Latest run: 2026-09-09
 
+## Queued maps before structural setters — 2026-09-09
+
+Adjacent keyed-row setters may now keep one safe lineage across the queued update boundary. The
+maintained workload first updates one row with `map()`, then removes another row with `filter()`.
+Farm preserves the mapped sources until the structural setter finishes, validates the complete
+result before the first DOM write, removes the rejected row, and patches only the changed survivor.
+The block-bodied control performs the same two native operations through complete keyed
+reconciliation.
+
+| Mode   | Queued map + filter | Compiled control | vs React | vs control |
+| ------ | ------------------: | ---------------: | -------: | ---------: |
+| Static |             3.30 ms |         10.50 ms |   16.23x |      3.18x |
+| Hybrid |             3.50 ms |         10.60 ms |   15.30x |      3.03x |
+
+Both modes passed the unchanged 2x React and 1.25x compiled-control floors. The complete bracketed
+run passed its correctness oracle, broad 10% regression gate, optimization-persistence gate, every
+existing feature-specific performance gate, and zero compiled owner executions.
+
+Compiler and runtime tests cover multiple queued maps before filter and slice setters, exact
+survivor DOM identity, one changed-row binding read, controlled-input focus and selection, atomic
+fallback when adjacency or runtime proof fails, Strict Mode hydration, unmount-before-flush
+cleanup, and 2,000 randomized queued transitions matched with normal React. React 18.3.1 and 19.2.8
+compatibility passes, and all isolated optional-runtime gzip fixtures remain within their unchanged
+budgets.
+
+Numbers are medians from one complete bracketed run: 10 samples per compiler mode and 20 surrounding
+React samples using Chrome 153.0.8010.36, Node.js 23.11.0, and Apple M1 macOS arm64. Timing varies by
+machine; deterministic parity, fallback, DOM-identity, compatibility, and runtime-size checks remain
+the primary safety controls.
+
 ## Maps before terminal structural steps — 2026-09-09
 
 A concise keyed-row setter may now run a safe same-key `map()` before a terminal native `filter()`

--- a/examples/react-compiler-dashboard/README.md
+++ b/examples/react-compiler-dashboard/README.md
@@ -269,17 +269,18 @@ same four native updates through complete reconciliation. Both compiler modes mu
 final committed order, every original DOM identity and connection, and both changed values. Package tests
 also cover mixed reverse/sort chains, chain boundaries, and 2,000 randomized differential updates.
 
-Mapped terminal-structural pipelines have a separate 10,000-row comparison. One concise setter
-changes a surviving row through a safe map and then filters out another row, with no synthetic
-reorder needed to retain the compiler proof. The block-bodied control performs the same native work
-through complete keyed reconciliation. Both compiler modes must remain at least 2x faster than React
-and 1.25x faster than the compiled control. The assertion checks the changed values, rejected-row
-cleanup, full survivor order, and every surviving DOM identity. Package tests also cover maps
-before, between, and after filter/slice steps, mapped structural reorders, controlled-input focus and
-selection, changed-key and custom-method fallback, Strict Mode hydration, cleanup, and separate
-2,000-row differential runs for final-reorder and both no-reorder pipeline orders. The benchmark lifecycle rebuilds
-`@farm.js/react` first and then verifies the emitted hint counts, so local source changes cannot be
-silently measured through stale package output.
+Mapped terminal-structural updates have a separate 10,000-row comparison. One concise setter changes
+a surviving row through a safe map and an immediately adjacent setter filters out another row, with
+no synthetic reorder needed to retain the compiler proof. The block-bodied control performs the
+same two queued native updates through complete keyed reconciliation. Both compiler modes must
+remain at least 2x faster than React and 1.25x faster than the compiled control. The assertion checks
+the changed values, rejected-row cleanup, full survivor order, and every surviving DOM identity.
+Package tests also cover maps before, between, and after filter/slice steps; adjacent queued map,
+filter, and slice setters; mapped structural reorders; controlled-input focus and selection;
+changed-key and custom-method fallback; Strict Mode hydration; cleanup; and separate 2,000-row
+differential runs. The benchmark lifecycle rebuilds `@farm.js/react` first and then verifies the
+emitted hint counts, so local source changes cannot be silently measured through stale package
+output.
 
 Mapped reverse parity has an independent 10,000-row comparison. Two safe native maps update one
 row, then two native reversals restore committed order. Farm must patch the changed row without

--- a/examples/react-compiler-dashboard/scripts/benchmark.mjs
+++ b/examples/react-compiler-dashboard/scripts/benchmark.mjs
@@ -2972,9 +2972,9 @@ const keyedStructuralReorderRegressions = keyedStructuralReorderResults.filter(
     !Number.isFinite(snapshotSpeedup) ||
     snapshotSpeedup < keyedStructuralReorderMinimumSnapshotSpeedup,
 );
-// A safe map before a terminal filter changes row data and membership in one setter. The combined
-// path must patch the changed survivor and remove the rejected row instead of dropping to complete
-// keyed reconciliation merely because a structural step follows the map and no reorder follows.
+// A safe map followed by a terminal filter in an adjacent setter changes row data and membership in
+// one queued commit. The combined path must patch the changed survivor and remove the rejected row
+// instead of dropping to complete keyed reconciliation at the setter boundary.
 const keyedMappedStructuralReorderMinimumSpeedup = 2;
 const keyedMappedStructuralReorderMinimumSnapshotSpeedup = 1.25;
 const keyedMappedStructuralReorderResults = ["static", "hybrid"].map((mode) => {

--- a/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
+++ b/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
@@ -875,38 +875,38 @@ export function StandardTableBenchmark() {
           type="button"
           onClick={() => {
             setRows((current) =>
-              current
-                .map((row) =>
-                  row.id % 10_000 === 5_001
-                    ? { ...row, amount: row.amount + 1, label: `${row.label} reviewed` }
-                    : row,
-                )
-                .filter((row) => row.id % 10_000 !== 7_001),
+              current.map((row) =>
+                row.id % 10_000 === 5_001
+                  ? { ...row, amount: row.amount + 1, label: `${row.label} reviewed` }
+                  : row,
+              ),
             );
-            setOperation("review one row, then filter another");
+            setRows((current) => current.filter((row) => row.id % 10_000 !== 7_001));
+            setOperation("review one row, then filter another in a queued setter");
             setRevision((value) => value + 1);
           }}
         >
-          Map + terminal filter
+          Queued map + filter
         </button>
         <button
           data-action="table-map-structural-reorder-pipeline-snapshot"
           type="button"
           onClick={() => {
             setRows((current) => {
-              return current
-                .map((row) =>
-                  row.id % 10_000 === 5_001
-                    ? { ...row, amount: row.amount + 1, label: `${row.label} reviewed` }
-                    : row,
-                )
-                .filter((row) => row.id % 10_000 !== 7_001);
+              return current.map((row) =>
+                row.id % 10_000 === 5_001
+                  ? { ...row, amount: row.amount + 1, label: `${row.label} reviewed` }
+                  : row,
+              );
             });
-            setOperation("review and filter rows (snapshot control)");
+            setRows((current) => {
+              return current.filter((row) => row.id % 10_000 !== 7_001);
+            });
+            setOperation("review and filter rows in queued setters (snapshot control)");
             setRevision((value) => value + 1);
           }}
         >
-          Map + terminal filter (snapshot control)
+          Queued map + filter (snapshot control)
         </button>
         <button
           data-action="table-map-reorder-pipeline"

--- a/packages/farm-react/README.md
+++ b/packages/farm-react/README.md
@@ -491,9 +491,23 @@ setItems((current) =>
 The structural helpers retain both the committed survivor indices and mapped-item sources across
 each accepted step. The final commit removes rejected rows, performs LIS moves only when a reorder
 needs them, and patches bindings only for changed survivors. Every native callback and method still
-runs in JavaScript order. A map after the structural pipeline has already reordered, structural work
-split across setters, unsafe callbacks, changed keys, and failed runtime validation keep complete
-keyed reconciliation.
+runs in JavaScript order.
+
+The maps may also be followed by filter or slice work in immediately adjacent setter calls:
+
+```tsx
+setItems((current) =>
+  current.map((item) => (item.id === editedId ? { ...item, label: nextLabel } : item)),
+);
+setItems((current) => current.filter((item) => item.visible));
+setItems((current) => current.slice(0, limit));
+```
+
+Farm links only consecutive calls to the same setter, retains the first committed map source, and
+validates each structural result before the queued commit touches the DOM. Multiple leading map
+setters and multiple following filter/slice setters may share this proof. A map after structural
+work, an intervening statement, another setter, an unsafe callback, a changed key, or failed runtime
+validation keeps complete keyed reconciliation.
 
 The reorder and safe maps may also be adjacent setter calls in the same synchronous block:
 

--- a/packages/farm-react/src/__tests__/compiler-keyed-array-queued-mapped-structural-hints.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-keyed-array-queued-mapped-structural-hints.test.ts
@@ -1,0 +1,121 @@
+// @vitest-environment node
+
+import { describe, expect, it } from "vitest";
+import { transformWithEsbuild } from "vite";
+import { compileReactModule } from "../compiler";
+import { normalizeReactCompilerOptions } from "../index";
+
+const infer = normalizeReactCompilerOptions(true, "/app");
+
+async function compile(source: string) {
+  return compileReactModule(source, "/app/QueuedMappedStructuralHints.tsx", infer);
+}
+
+describe("React AOT queued mapped structural hints", () => {
+  it("retains adjacent maps through following filter and slice setters", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Table({ editedId, nextLabel, nextRank, hiddenId, limit }) {
+        const [rows, setRows] = useState([
+          { id: "a", label: "Alpha", rank: 1 },
+          { id: "b", label: "Beta", rank: 2 },
+          { id: "c", label: "Gamma", rank: 3 },
+        ]);
+        return <section>
+          <button onClick={() => {
+            setRows((current) => current.map((row) =>
+              row.id === editedId ? { ...row, label: nextLabel } : row
+            ));
+            setRows((current) => current.map((row) =>
+              row.id === editedId ? { ...row, rank: nextRank } : row
+            ));
+            setRows((current) => current.filter((row) => row.id !== hiddenId));
+            setRows((current) => current.slice(0, limit));
+          }}>Edit and trim</button>
+          <ul>{rows.map((row) => <li key={row.id}>{row.label}: {row.rank}</li>)}</ul>
+        </section>;
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Table"]);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.optimizations.keyedMapUpdateHints).toBe(2);
+    expect(result.optimizations.keyedArrayFilterHints).toBe(1);
+    expect(result.optimizations.keyedArraySliceHints).toBe(1);
+    expect(result.code.match(/createCompilerKeyedArrayQueuedMapPipeline\(/g)).toHaveLength(2);
+    expect(result.code.match(/finalizeCompilerKeyedArrayMappedStructuralUpdate\(/g)).toHaveLength(
+      2,
+    );
+    expect(result.code).not.toContain("createCompilerKeyedMapUpdate");
+    expect(result.code).not.toContain("createCompilerKeyedArrayMapPipeline");
+    expect(result.code).toContain("keyedRowsEveryHintedRuntimeFeature");
+    await expect(
+      transformWithEsbuild(result.code, "/app/QueuedMappedStructuralHints.tsx", {
+        loader: "tsx",
+        jsx: "automatic",
+      }),
+    ).resolves.toMatchObject({
+      code: expect.stringContaining("finalizeCompilerKeyedArrayMappedStructuralUpdate"),
+    });
+  });
+
+  it.each([
+    {
+      name: "an intervening statement",
+      updates: `
+        setRows((current) => current.map((row) =>
+          row.id === editedId ? { ...row, label: nextLabel } : row
+        ));
+        onMapped();
+        setRows((current) => current.filter((row) => row.id !== hiddenId));
+      `,
+    },
+    {
+      name: "another state setter",
+      updates: `
+        setRows((current) => current.map((row) =>
+          row.id === editedId ? { ...row, label: nextLabel } : row
+        ));
+        setSelected(editedId);
+        setRows((current) => current.filter((row) => row.id !== hiddenId));
+      `,
+    },
+    {
+      name: "structural work before the map",
+      updates: `
+        setRows((current) => current.filter((row) => row.id !== hiddenId));
+        setRows((current) => current.map((row) =>
+          row.id === editedId ? { ...row, label: nextLabel } : row
+        ));
+      `,
+    },
+    {
+      name: "an unsupported map callback",
+      updates: `
+        setRows((current) => current.map((row) => ({ ...row, label: nextLabel })));
+        setRows((current) => current.filter((row) => row.id !== hiddenId));
+      `,
+    },
+  ])("keeps complete fallback across $name", async ({ updates }) => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Table({ editedId, nextLabel, hiddenId, onMapped }) {
+        const [rows, setRows] = useState([
+          { id: "a", label: "Alpha" },
+          { id: "b", label: "Beta" },
+        ]);
+        const [selected, setSelected] = useState(null);
+        return <section data-selected={selected ?? "none"}>
+          <button onClick={() => {
+            ${updates}
+          }}>Update</button>
+          <ul>{rows.map((row) => <li key={row.id}>{row.label}</li>)}</ul>
+        </section>;
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Table"]);
+    expect(result.code).not.toContain("createCompilerKeyedArrayQueuedMapPipeline");
+    expect(result.code).not.toContain("finalizeCompilerKeyedArrayMappedStructuralUpdate");
+  });
+});

--- a/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-structural-reorder-hints.test.tsx
+++ b/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-structural-reorder-hints.test.tsx
@@ -7,6 +7,7 @@ import {
   createCompiledComponent,
   createCompilerKeyedArrayFilter,
   createCompilerKeyedArrayMapPipeline,
+  createCompilerKeyedArrayQueuedMapPipeline,
   createCompilerKeyedArraySlice,
   createCompilerKeyedArrayStructuralReorder,
   createCompilerKeyedArrayStructuralSort,
@@ -49,6 +50,20 @@ function hintedFilter(items: Item[], predicate: (item: Item) => boolean): Item[]
 
 function hintedMap(items: Item[], mapper: (item: Item) => Item): Item[] {
   return createCompilerKeyedArrayMapPipeline(items, items.map, mapper) as Item[];
+}
+
+function queuedHintedMap(
+  items: Item[],
+  mapper: (item: Item, index: number, items: Item[]) => Item,
+  method: unknown = items.map,
+): Item[] {
+  return createCompilerKeyedArrayQueuedMapPipeline(
+    items,
+    (
+      current: unknown,
+      applyMap: (collection: unknown, method: unknown, callback: unknown) => unknown,
+    ) => applyMap(current, method, mapper),
+  ) as Item[];
 }
 
 function hintedSlice(items: Item[], start: number, end?: number): Item[] {
@@ -123,6 +138,14 @@ function createHarness(initialItems: Item[]) {
     removed: ReadonlySet<string>,
     limit: number,
   ) => void = () => undefined;
+  let queuedMapFilterSlice: (
+    editedId: string,
+    nextLabel: string,
+    removed: ReadonlySet<string>,
+    limit: number,
+  ) => void = () => undefined;
+  let invalidQueuedMappedStructuralIdentity: () => void = () => undefined;
+  let customQueuedMapThenFilter: () => void = () => undefined;
   let invalidIdentity: () => void = () => undefined;
   let invalidMappedIdentity: () => void = () => undefined;
   let invalidTerminalMappedIdentity: () => void = () => undefined;
@@ -239,6 +262,48 @@ function createHarness(initialItems: Item[]) {
             ),
           ),
         );
+      queuedMapFilterSlice = (editedId, nextLabel, removed, limit) => {
+        state[0].set((previous) =>
+          queuedHintedMap(previous as Item[], (item) =>
+            item.id === editedId ? { ...item, label: nextLabel } : item,
+          ),
+        );
+        state[0].set((previous) =>
+          hintedMappedStructural(hintedFilter(previous as Item[], (item) => !removed.has(item.id))),
+        );
+        state[0].set((previous) =>
+          hintedMappedStructural(hintedSlice(previous as Item[], 0, limit)),
+        );
+      };
+      invalidQueuedMappedStructuralIdentity = () => {
+        state[0].set((previous) =>
+          queuedHintedMap(previous as Item[], (item) =>
+            item.id === "b" ? { ...item, id: "replacement", label: "Replacement" } : item,
+          ),
+        );
+        state[0].set((previous) =>
+          hintedMappedStructural(hintedFilter(previous as Item[], (item) => item.id !== "c")),
+        );
+      };
+      customQueuedMapThenFilter = () => {
+        state[0].set((previous) => {
+          const items = previous as Item[];
+          const customMap = function (
+            this: Item[],
+            callback: (item: Item, index: number, items: Item[]) => Item,
+          ) {
+            return Array.prototype.map.call(this, callback);
+          };
+          return queuedHintedMap(
+            items,
+            (item) => (item.id === "a" ? { ...item, label: "Custom queued map" } : item),
+            customMap,
+          );
+        });
+        state[0].set((previous) =>
+          hintedMappedStructural(hintedFilter(previous as Item[], (item) => item.id !== "c")),
+        );
+      };
       invalidIdentity = () =>
         state[0].set((previous) => {
           const next = hintedReverse(hintedFilter(previous as Item[], (item) => item.id !== "b"));
@@ -382,6 +447,7 @@ function createHarness(initialItems: Item[]) {
     customMapStructural: () => customMapStructural(),
     customMapTerminal: () => customMapTerminal(),
     customMapThenFilter: () => customMapThenFilter(),
+    customQueuedMapThenFilter: () => customQueuedMapThenFilter(),
     filterMapSliceMap: (
       editedId: string,
       nextLabel: string,
@@ -403,6 +469,7 @@ function createHarness(initialItems: Item[]) {
     invalidIdentity: () => invalidIdentity(),
     invalidMappedIdentity: () => invalidMappedIdentity(),
     invalidMappedStructuralIdentity: () => invalidMappedStructuralIdentity(),
+    invalidQueuedMappedStructuralIdentity: () => invalidQueuedMappedStructuralIdentity(),
     invalidTerminalMappedIdentity: () => invalidTerminalMappedIdentity(),
     mapFilterSlice: (
       editedId: string,
@@ -410,6 +477,12 @@ function createHarness(initialItems: Item[]) {
       removed: ReadonlySet<string>,
       limit: number,
     ) => mapFilterSlice(editedId, nextLabel, removed, limit),
+    queuedMapFilterSlice: (
+      editedId: string,
+      nextLabel: string,
+      removed: ReadonlySet<string>,
+      limit: number,
+    ) => queuedMapFilterSlice(editedId, nextLabel, removed, limit),
     mapFilterDoubleReverse: (editedId: string, nextLabel: string, removed: ReadonlySet<string>) =>
       mapFilterDoubleReverse(editedId, nextLabel, removed),
     mapFilterSortReverse: (
@@ -655,6 +728,42 @@ describe("compiled keyed-array structural reorder hints", () => {
     expect(harness.counters.bindings).toBe(1);
   });
 
+  it("patches a mapped survivor across queued map, filter, and slice setters", async () => {
+    const items: Item[] = [
+      { id: "a", label: "Alpha", rank: 4, visible: true },
+      { id: "b", label: "Beta", rank: 1, visible: false },
+      { id: "c", label: "Gamma", rank: 3, visible: true },
+      { id: "d", label: "Delta", rank: 2, visible: true },
+    ];
+    const harness = createHarness(items);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Table />));
+    const alpha = container.querySelector('[data-key="a"]');
+    const gamma = container.querySelector('[data-key="c"]');
+    harness.counters.bindings = 0;
+    harness.counters.descriptors = 0;
+    harness.counters.keys = 0;
+
+    await act(async () => {
+      harness.queuedMapFilterSlice("c", "Gamma queued", new Set(["b"]), 2);
+      await flushCompilerUpdates();
+    });
+
+    expect(labels(container)).toEqual(["Alpha", "Gamma queued"]);
+    expect(container.querySelector('[data-key="a"]')).toBe(alpha);
+    expect(container.querySelector('[data-key="c"]')).toBe(gamma);
+    expect(container.querySelector('[data-key="b"]')).toBeNull();
+    expect(container.querySelector('[data-key="d"]')).toBeNull();
+    expect(harness.counters.executions).toBe(1);
+    expect(harness.counters.renders).toBe(1);
+    expect(harness.counters.keys).toBe(2);
+    expect(harness.counters.descriptors).toBe(0);
+    expect(harness.counters.bindings).toBe(1);
+  });
+
   it("falls back safely for custom methods and identity mismatches", async () => {
     const items: Item[] = [
       { id: "a", label: "Alpha", rank: 2, visible: true },
@@ -796,6 +905,44 @@ describe("compiled keyed-array structural reorder hints", () => {
     expect(changedKey.counters.descriptors).toBeGreaterThan(0);
   });
 
+  it("falls back atomically for queued custom maps and changed keys", async () => {
+    const items: Item[] = [
+      { id: "a", label: "Alpha", rank: 2, visible: true },
+      { id: "b", label: "Beta", rank: 1, visible: true },
+      { id: "c", label: "Gamma", rank: 3, visible: true },
+    ];
+    const custom = createHarness(items);
+    const customContainer = document.createElement("div");
+    document.body.append(customContainer);
+    const customRoot = createRoot(customContainer);
+    roots.push(customRoot);
+    await act(async () => customRoot.render(<custom.Table />));
+    custom.counters.bindings = 0;
+    custom.counters.descriptors = 0;
+    await act(async () => {
+      custom.customQueuedMapThenFilter();
+      await flushCompilerUpdates();
+    });
+    expect(labels(customContainer)).toEqual(["Custom queued map", "Beta"]);
+    expect(custom.counters.bindings).toBeGreaterThan(0);
+
+    const changedKey = createHarness(items);
+    const changedKeyContainer = document.createElement("div");
+    document.body.append(changedKeyContainer);
+    const changedKeyRoot = createRoot(changedKeyContainer);
+    roots.push(changedKeyRoot);
+    await act(async () => changedKeyRoot.render(<changedKey.Table />));
+    changedKey.counters.bindings = 0;
+    changedKey.counters.descriptors = 0;
+    await act(async () => {
+      changedKey.invalidQueuedMappedStructuralIdentity();
+      await flushCompilerUpdates();
+    });
+    expect(labels(changedKeyContainer)).toEqual(["Alpha", "Replacement"]);
+    expect(changedKey.counters.bindings).toBeGreaterThan(0);
+    expect(changedKey.counters.descriptors).toBeGreaterThan(0);
+  });
+
   it("preserves a surviving controlled input, focus, and selection", async () => {
     const items: Item[] = [
       { id: "a", label: "Alpha", rank: 3, visible: true },
@@ -808,21 +955,17 @@ describe("compiled keyed-array structural reorder hints", () => {
       initialize: () => [items],
       render(_props: Record<string, never>, state, blocks) {
         const rows = () => state[0].get() as Item[];
-        update = () =>
+        update = () => {
           state[0].set((previous) =>
-            hintedMappedStructural(
-              hintedSlice(
-                hintedFilter(
-                  hintedMap(previous as Item[], (item) =>
-                    item.id === "b" ? { ...item, label: "Beta newest" } : item,
-                  ),
-                  (item) => item.id !== "a",
-                ),
-                0,
-                1,
-              ),
+            queuedHintedMap(previous as Item[], (item) =>
+              item.id === "b" ? { ...item, label: "Beta newest" } : item,
             ),
           );
+          state[0].set((previous) =>
+            hintedMappedStructural(hintedFilter(previous as Item[], (item) => item.id !== "a")),
+          );
+          state[0].set((previous) => hintedMappedStructural(hintedSlice(previous as Item[], 0, 1)));
+        };
         return (
           <section>
             <blocks.KeyedRows
@@ -1252,6 +1395,80 @@ describe("compiled keyed-array structural reorder hints", () => {
     expect(harness.counters.executions).toBe(1);
   }, 20_000);
 
+  it("matches React across 2,000 randomized queued mapped structural transitions", async () => {
+    const initialItems = Array.from(
+      { length: 2_001 },
+      (_, index): Item => ({
+        id: `row-${index}`,
+        label: `Row ${index}`,
+        rank: (index * 1_229) % 2_003,
+        visible: true,
+      }),
+    );
+    const harness = createHarness(initialItems);
+    let updateReact: (
+      editedId: string,
+      nextLabel: string,
+      removed: ReadonlySet<string>,
+      limit: number,
+    ) => void = () => undefined;
+    function Normal() {
+      const [items, setItems] = useState(initialItems);
+      updateReact = (editedId, nextLabel, removed, limit) => {
+        setItems((previous) =>
+          previous.map((item) => (item.id === editedId ? { ...item, label: nextLabel } : item)),
+        );
+        setItems((previous) => previous.filter((item) => !removed.has(item.id)));
+        setItems((previous) => previous.slice(0, limit));
+      };
+      return (
+        <ol>
+          {items.map((item) => (
+            <li data-key={item.id} key={item.id}>
+              {item.label}
+            </li>
+          ))}
+        </ol>
+      );
+    }
+    const compiledContainer = document.createElement("div");
+    const reactContainer = document.createElement("div");
+    document.body.append(compiledContainer, reactContainer);
+    const compiledRoot = createRoot(compiledContainer);
+    const reactRoot = createRoot(reactContainer);
+    roots.push(compiledRoot, reactRoot);
+    await act(async () => {
+      compiledRoot.render(<harness.Table />);
+      reactRoot.render(<Normal />);
+    });
+
+    let seed = 0x9e3779b9;
+    let active = initialItems.map((item) => item.id);
+    for (let batch = 0; batch < 100; batch += 1) {
+      const removed = new Set<string>();
+      for (let update = 0; update < 15; update += 1) {
+        seed = (Math.imul(seed, 1_664_525) + 1_013_904_223) >>> 0;
+        const available = active.filter((id) => !removed.has(id));
+        removed.add(available[seed % available.length]);
+      }
+      const survivors = active.filter((id) => !removed.has(id));
+      const limit = survivors.length - 5;
+      seed = (Math.imul(seed, 1_664_525) + 1_013_904_223) >>> 0;
+      const editedId = survivors[seed % limit];
+      const nextLabel = `Queued mapped structural ${batch}`;
+      await act(async () => {
+        harness.queuedMapFilterSlice(editedId, nextLabel, removed, limit);
+        updateReact(editedId, nextLabel, removed, limit);
+        await flushCompilerUpdates();
+      });
+      expect(labels(compiledContainer)).toEqual(labels(reactContainer));
+      active = [...reactContainer.querySelectorAll<HTMLElement>("li")].map(
+        (row) => row.dataset.key!,
+      );
+    }
+    expect(harness.counters.executions).toBe(1);
+  }, 20_000);
+
   it("hydrates in StrictMode and drops a queued pipeline after unmount", async () => {
     const items: Item[] = [
       { id: "a", label: "Alpha", rank: 3, visible: true },
@@ -1279,6 +1496,11 @@ describe("compiled keyed-array structural reorder hints", () => {
       await flushCompilerUpdates();
     });
     expect(labels(container)).toEqual(["Alpha", "Beta hydrated"]);
+    await act(async () => {
+      hydration.queuedMapFilterSlice("a", "Alpha queued", new Set(), 2);
+      await flushCompilerUpdates();
+    });
+    expect(labels(container)).toEqual(["Alpha queued", "Beta hydrated"]);
     expect(recoverable).toEqual([]);
 
     const unmounted = createHarness(items);
@@ -1287,7 +1509,7 @@ describe("compiled keyed-array structural reorder hints", () => {
     const unmountRoot = createRoot(unmountContainer);
     await act(async () => unmountRoot.render(<unmounted.Table />));
     act(() => {
-      unmounted.mapFilterSlice("c", "Gamma queued", new Set(["a"]), 2);
+      unmounted.queuedMapFilterSlice("c", "Gamma queued", new Set(["a"]), 2);
       unmountRoot.unmount();
     });
     await flushCompilerUpdates();

--- a/packages/farm-react/src/compiler.ts
+++ b/packages/farm-react/src/compiler.ts
@@ -2420,6 +2420,163 @@ function rewriteQueuedKeyedArrayReorderMapHints(
   };
 }
 
+function rewriteQueuedKeyedArrayMappedStructuralHints(
+  root: t.JSXElement,
+  statesBySetter: ReadonlyMap<string, StateBinding>,
+  mapUpdateIdentifier: t.Identifier,
+  queuedMapPipelineIdentifier: t.Identifier,
+  mappedStructuralIdentifier: t.Identifier,
+  filterIdentifier: t.Identifier,
+  sliceIdentifier: t.Identifier,
+  allowed: boolean,
+): { root: t.JSXElement; mapCount: number; structuralCount: number } {
+  if (!allowed) {
+    return { root: t.cloneNode(root, true), mapCount: 0, structuralCount: 0 };
+  }
+  const file = expressionFile(t.cloneNode(root, true));
+  let mapCount = 0;
+  let structuralCount = 0;
+
+  const mapPipelineCount = (updater: t.ArrowFunctionExpression): number => {
+    if (
+      !t.isCallExpression(updater.body) ||
+      !t.isIdentifier(updater.body.callee, { name: mapUpdateIdentifier.name }) ||
+      updater.body.arguments.length !== 2
+    ) {
+      return 0;
+    }
+    const pipeline = updater.body.arguments[1];
+    if (
+      !t.isArrowFunctionExpression(pipeline) ||
+      pipeline.params.length !== 2 ||
+      !t.isIdentifier(pipeline.params[1])
+    ) {
+      return 0;
+    }
+    const applyMapName = pipeline.params[1].name;
+    let count = 0;
+    t.traverseFast(pipeline.body, (node) => {
+      if (t.isCallExpression(node) && t.isIdentifier(node.callee, { name: applyMapName })) {
+        count += 1;
+      }
+    });
+    return count;
+  };
+
+  const terminalStructuralReturn = (
+    updater: t.ArrowFunctionExpression,
+  ): t.ReturnStatement | undefined => {
+    if (!t.isBlockStatement(updater.body)) return undefined;
+    const statement = updater.body.body.at(-1);
+    if (
+      !t.isReturnStatement(statement) ||
+      !statement.argument ||
+      !t.isCallExpression(statement.argument) ||
+      !t.isIdentifier(statement.argument.callee) ||
+      (statement.argument.callee.name !== filterIdentifier.name &&
+        statement.argument.callee.name !== sliceIdentifier.name)
+    ) {
+      return undefined;
+    }
+    return statement;
+  };
+
+  traverse(file, {
+    BlockStatement(path) {
+      let mappedStructuralState: number | undefined;
+      let pendingMaps: Array<{
+        count: number;
+        stateIndex: number;
+        updater: t.ArrowFunctionExpression & { body: t.CallExpression };
+      }> = [];
+      const statements = path.get("body") as NodePath<t.Statement>[];
+      for (const statementPath of statements) {
+        const statement = statementPath.node;
+        if (!t.isExpressionStatement(statement) || !t.isCallExpression(statement.expression)) {
+          mappedStructuralState = undefined;
+          pendingMaps = [];
+          continue;
+        }
+        const setterCall = statement.expression;
+        if (
+          !t.isIdentifier(setterCall.callee) ||
+          statementPath.scope.hasBinding(setterCall.callee.name) ||
+          setterCall.arguments.length !== 1
+        ) {
+          mappedStructuralState = undefined;
+          pendingMaps = [];
+          continue;
+        }
+        const state = statesBySetter.get(setterCall.callee.name);
+        const updater = setterCall.arguments[0];
+        if (
+          !state ||
+          !t.isArrowFunctionExpression(updater) ||
+          updater.async ||
+          updater.generator ||
+          updater.params.length !== 1 ||
+          !t.isIdentifier(updater.params[0])
+        ) {
+          mappedStructuralState = undefined;
+          pendingMaps = [];
+          continue;
+        }
+
+        const pipelineMapCount = mapPipelineCount(updater);
+        if (pipelineMapCount > 0) {
+          // A map after an already structural result needs a different queued proof. Keep that
+          // direction on the complete fallback until it is supported deliberately.
+          if (mappedStructuralState !== undefined) {
+            mappedStructuralState = undefined;
+            pendingMaps = [];
+            continue;
+          }
+          const candidate = {
+            count: pipelineMapCount,
+            stateIndex: state.index,
+            updater: updater as t.ArrowFunctionExpression & { body: t.CallExpression },
+          };
+          pendingMaps =
+            pendingMaps[0]?.stateIndex === state.index ? [...pendingMaps, candidate] : [candidate];
+          continue;
+        }
+
+        const structuralReturn = terminalStructuralReturn(updater);
+        const hasPendingMaps = pendingMaps.length > 0 && pendingMaps[0].stateIndex === state.index;
+        if (!structuralReturn || (!hasPendingMaps && mappedStructuralState !== state.index)) {
+          mappedStructuralState = undefined;
+          pendingMaps = [];
+          continue;
+        }
+
+        if (hasPendingMaps) {
+          for (const candidate of pendingMaps) {
+            candidate.updater.body.callee = t.cloneNode(queuedMapPipelineIdentifier);
+            mapCount += candidate.count;
+          }
+        }
+        const structuralValue = structuralReturn.argument;
+        if (!t.isExpression(structuralValue)) {
+          mappedStructuralState = undefined;
+          pendingMaps = [];
+          continue;
+        }
+        structuralReturn.argument = t.callExpression(t.cloneNode(mappedStructuralIdentifier), [
+          t.cloneNode(structuralValue),
+        ]);
+        structuralCount += 1;
+        mappedStructuralState = state.index;
+        pendingMaps = [];
+      }
+    },
+  });
+  return {
+    root: (file.program.body[0] as t.ExpressionStatement).expression as t.JSXElement,
+    mapCount,
+    structuralCount,
+  };
+}
+
 function rewriteQueuedKeyedArrayMapReorderHints(
   root: t.JSXElement,
   statesBySetter: ReadonlyMap<string, StateBinding>,
@@ -8301,6 +8458,51 @@ function compileCandidate(
       optimizationCounts.keyedArrayFilterHints += filterHintedRoot.count;
     }
   }
+  const queuedMappedStructuralHintedRoot = rewriteQueuedKeyedArrayMappedStructuralHints(
+    expandedReactiveRoot,
+    statesBySetter,
+    keyedMapUpdateIdentifier,
+    keyedArrayQueuedMapPipelineIdentifier,
+    keyedArrayMappedStructuralIdentifier,
+    keyedArrayFilterIdentifier,
+    keyedArraySliceIdentifier,
+    allowKeyedArrayMapPipelines,
+  );
+  let appliedQueuedMappedStructuralHints = 0;
+  if (
+    queuedMappedStructuralHintedRoot.mapCount > 0 &&
+    queuedMappedStructuralHintedRoot.structuralCount > 0
+  ) {
+    const hintedBlockAnalysis = analyzeComposableBlocks(
+      queuedMappedStructuralHintedRoot.root,
+      reactiveByValue,
+      safeGlobals,
+      listNames,
+      allowedComponentNames,
+    );
+    const hintedAnalysis = analyzeHostTree(
+      queuedMappedStructuralHintedRoot.root,
+      reactiveByValue,
+      safeGlobals,
+      hintedBlockAnalysis.conditionalExpressions || new Set<t.Expression>(),
+      hintedBlockAnalysis.keyedExpressions || new Set<t.Expression>(),
+      hintedBlockAnalysis.ownedElements || new Set<t.JSXElement>(),
+      hintedBlockAnalysis.componentElements || new Set<t.JSXElement>(),
+    );
+    if (!hintedBlockAnalysis.reason && !hintedAnalysis.reason) {
+      expandedReactiveRoot = queuedMappedStructuralHintedRoot.root;
+      blockAnalysis = hintedBlockAnalysis;
+      analysis = hintedAnalysis;
+      appliedQueuedMappedStructuralHints =
+        queuedMappedStructuralHintedRoot.mapCount +
+        queuedMappedStructuralHintedRoot.structuralCount;
+      appliedKeyedArrayReorderHints += queuedMappedStructuralHintedRoot.structuralCount;
+      compilerUsage.keyedArrayMapUpdateHints += queuedMappedStructuralHintedRoot.mapCount;
+      compilerUsage.keyedArrayQueuedMapUpdateHints += queuedMappedStructuralHintedRoot.mapCount;
+      compilerUsage.keyedArrayMappedStructuralHints +=
+        queuedMappedStructuralHintedRoot.structuralCount;
+    }
+  }
   const queuedMapReorderHintedRoot = rewriteQueuedKeyedArrayMapReorderHints(
     expandedReactiveRoot,
     statesBySetter,
@@ -8457,7 +8659,9 @@ function compileCandidate(
     appliedKeyedArrayBatchInsertHints > 0,
     appliedKeyedArrayWindowReplaceHints > 0,
     appliedKeyedArrayReorderHints > 0 || appliedKeyedArraySortHints > 0,
-    appliedPipelineMapHints > 0 || appliedQueuedReorderMapHints > 0,
+    appliedPipelineMapHints > 0 ||
+      appliedQueuedReorderMapHints > 0 ||
+      appliedQueuedMappedStructuralHints > 0,
     appliedKeyedArrayRollingWindowHints > 0,
   );
   markShortCircuitBindings(analysis.bindings || []);

--- a/packages/farm-react/vitest.stress.config.ts
+++ b/packages/farm-react/vitest.stress.config.ts
@@ -21,7 +21,7 @@ export default defineConfig({
     ],
     setupFiles: ["src/__tests__/stress.setup.ts"],
     testNamePattern:
-      /2,000 deterministic mapped reorder updates|2,000 deterministic mapped reversal parity updates|2,000 queued reverse, map, and reverse updates|2,000 reverse-or-sort then map updates|2,000 queued reorder then standalone map updates|2,000 queued map then reorder updates|2,000 queued map and consecutive reorder updates|2,000 mapped structural removals|2,000 randomized interleaved map and structural removals|2,000 randomized terminal structural-map row transitions|2,000 randomized mapped terminal-structural row transitions|3,000 deterministic recursive updates|4,096 rows/,
+      /2,000 deterministic mapped reorder updates|2,000 deterministic mapped reversal parity updates|2,000 queued reverse, map, and reverse updates|2,000 reverse-or-sort then map updates|2,000 queued reorder then standalone map updates|2,000 queued map then reorder updates|2,000 queued map and consecutive reorder updates|2,000 mapped structural removals|2,000 randomized interleaved map and structural removals|2,000 randomized terminal structural-map row transitions|2,000 randomized mapped terminal-structural row transitions|2,000 randomized queued mapped structural transitions|3,000 deterministic recursive updates|4,096 rows/,
     testTimeout: 30_000,
   },
 });


### PR DESCRIPTION
## Problem

The React compiler already retains safe same-key `map()` lineage through a following `filter()` or `slice()` when the operations are written in one setter. Writing those ordinary React updates as adjacent functional setters loses that proof, so the final queued commit falls back to complete keyed reconciliation even though the updater order and result are equally provable.

## Root cause

Standalone map, filter, and slice lowering handled each setter independently. The map result carried replacement lineage, but the compiler did not connect it to a structural result produced by the next queued updater. The runtime already has the conservative queued-map and mapped-structural metadata needed to validate this composition; the missing piece was compile-time adjacency analysis.

## Change

- recognize one or more safe same-key map setters immediately followed by one or more filter/slice setters for the same state cell;
- select the existing queued map pipeline and mapped-structural finalizer so source-item and survivor lineage reaches the final commit;
- keep native updater calls and callback evaluation in React order;
- extend compiler, runtime, interaction, hydration, cleanup, and randomized differential coverage;
- change the maintained 10,000-row browser workload to exercise the real queued-setter boundary and record the result.

## Safety and compatibility

The proof is limited to consecutive expression statements using the same unshadowed setter. A map after structural work, an intervening statement, another setter, an unsupported callback, a changed key, custom native-method behavior, ambiguous ownership, or failed runtime validation keeps complete React reconciliation before any compiler-owned DOM write.

No public API or runtime implementation changes. Compiler-disabled builds and non-React renderers are unchanged. Exact surviving DOM identity, controlled-input focus/selection, Strict Mode hydration, unmount-before-flush cleanup, and React 18/19 behavior are covered.

## Verification

- `pnpm --filter @farm.js/react type-check`
- `pnpm --filter @farm.js/react build`
- `pnpm --filter @farm.js/react test` — 73 files, 749 passed; stress suite 15 passed
- `pnpm --filter @farm.js/react test:compat` — React 18.3.1 and 19.2.8
- `npx -y node@22.13.1 scripts/benchmark-runtime-size.mjs --check` — every unchanged gzip budget passed
- `pnpm --dir examples/react-compiler-dashboard type-check`
- `pnpm --dir examples/react-compiler-dashboard build`
- `pnpm docs:check-navigation`
- `pnpm --dir docs exec farm generate --check`
- `pnpm docs:build` — Vercel/Nitro production output, 80 pages
- `pnpm exec oxlint <changed JS/TS files>` — 0 warnings and 0 errors
- complete bracketed production-browser benchmark — correctness, broad regression, optimization-persistence, and every feature gate passed; compiled owner executions remained zero

Queued 10,000-row map + filter medians on Chrome 153 / Node 23 / Apple M1:

| Mode | Queued path | Equal-work compiled control | vs React | vs control |
| --- | ---: | ---: | ---: | ---: |
| Static | 3.30 ms | 10.50 ms | 16.23x | 3.18x |
| Hybrid | 3.50 ms | 10.60 ms | 15.30x | 3.03x |

## Documentation and release

Updated the React renderer documentation, package README, dashboard guide, reproducible benchmark workload, and benchmark record. No version or release metadata changes.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Optimizes queued keyed-row updates so adjacent safe same-key `map()` setters followed by `filter()`/`slice()` setters share one lineage, replacing the previous fallback to complete keyed reconciliation.

- Previously, the map-through-structural proof only survived when written in a single functional setter.
- Links only consecutive expression statements using the same unshadowed setter; all other patterns keep complete React reconciliation.
- Adds compiler and runtime coverage including 2,000 randomized differential transitions, hydration, and cleanup.
- The updated 10,000-row benchmark runs 3.18x faster than the equal-work compiled control.
- No public API or runtime implementation changes.

<sup>Written for commit acf508471af5e1a978133b12da1a4aa0e550f45d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/846?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

