### PR TITLE
fix(preview): replace client forwarding headers at relay

### DIFF
--- a/packages/farm-preview-gateway/src/index.ts
+++ b/packages/farm-preview-gateway/src/index.ts
@@ -647,7 +647,11 @@ async function serializePreviewRequest(
   const headers: Record<string, string> = {};
   request.headers.forEach((value, key) => {
     const normalized = key.toLowerCase();
-    if (!HOP_BY_HOP_HEADERS.has(normalized)) {
+    if (
+      !HOP_BY_HOP_HEADERS.has(normalized) &&
+      normalized !== "forwarded" &&
+      !normalized.startsWith("x-forwarded-")
+    ) {
       headers[key] = value;
     }
   });
@@ -722,9 +726,9 @@ function matchSessionRoute(pathname: string) {
 
 function nodeRequestToWebRequest(req: IncomingMessage) {
   const host = headerValue(req.headers, "host") || "localhost";
-  const protocol =
-    headerValue(req.headers, "x-forwarded-proto") ||
-    (isLocalHost(host.split(":")[0]) ? "http" : "https");
+  // This adapter is the public trust boundary. A visitor-controlled forwarded
+  // protocol must not influence the authority serialized to the local app.
+  const protocol = isLocalHost(host.split(":")[0]) ? "http" : "https";
   const url = `${protocol}://${host}${req.url || "/"}`;
   const headers = nodeHeadersToWebHeaders(req.headers);
   const method = req.method || "GET";

--- a/packages/farm-preview-gateway/test/gateway.test.mjs
+++ b/packages/farm-preview-gateway/test/gateway.test.mjs
@@ -23,7 +23,14 @@ test("proxies a public preview request through the gateway queue", async () => {
 
     assert.equal(session.publicUrl, `${gateway.url}/__preview/docs-check`);
 
-    const publicRequest = fetch(`${gateway.url}/__preview/docs-check/docs?hello=world`);
+    const publicRequest = fetch(`${gateway.url}/__preview/docs-check/docs?hello=world`, {
+      headers: {
+        forwarded: "for=127.0.0.1;host=evil.example;proto=https",
+        "x-forwarded-for": "127.0.0.1",
+        "x-forwarded-host": "evil.example",
+        "x-forwarded-proto": "https",
+      },
+    });
     const pollResponse = await fetch(
       `${gateway.url}/api/sessions/${session.id}/requests?token=${session.token}&wait=1000`,
     );
@@ -32,6 +39,10 @@ test("proxies a public preview request through the gateway queue", async () => {
     assert.equal(poll.requests.length, 1);
     assert.equal(poll.requests[0].method, "GET");
     assert.equal(poll.requests[0].path, "/docs?hello=world");
+    assert.equal(poll.requests[0].headers.forwarded, undefined);
+    assert.equal(poll.requests[0].headers["x-forwarded-for"], undefined);
+    assert.equal(poll.requests[0].headers["x-forwarded-host"], new URL(gateway.url).host);
+    assert.equal(poll.requests[0].headers["x-forwarded-proto"], "http");
 
     await fetch(
       `${gateway.url}/api/sessions/${session.id}/responses/${poll.requests[0].id}?token=${session.token}`,

--- a/packages/farm-preview-tunnel/src/relay.ts
+++ b/packages/farm-preview-tunnel/src/relay.ts
@@ -125,6 +125,8 @@ export function createPersistentPreviewRelay(options: PersistentPreviewRelayOpti
         request,
         response,
         path: route.path,
+        publicBaseUrl: options.publicBaseUrl || address?.httpUrl || "",
+        publicDomain,
         localSession: activeLocalSession,
         coordinatedSession,
         coordinator: options.coordinator,
@@ -290,6 +292,8 @@ interface ForwardPublicRequestOptions {
   request: IncomingMessage;
   response: ServerResponse;
   path: string;
+  publicBaseUrl: string;
+  publicDomain?: string;
   localSession?: AgentSession;
   coordinatedSession?: PersistentPreviewRelayCoordinatorSession;
   coordinator?: PersistentPreviewRelayCoordinator;
@@ -325,7 +329,7 @@ async function forwardPublicRequest(options: ForwardPublicRequestOptions) {
     id,
     method: options.request.method || "GET",
     path: options.path,
-    headers: normalizeIncomingHeaders(options.request.headers),
+    headers: normalizeIncomingHeaders(options.request, options.publicBaseUrl, options.publicDomain),
     ...(body.length ? { body: body.toString("base64") } : {}),
   };
 
@@ -543,12 +547,32 @@ function readRequestBody(request: IncomingMessage, maxBodyBytes: number, signal:
   });
 }
 
-function normalizeIncomingHeaders(headers: IncomingMessage["headers"]) {
+function normalizeIncomingHeaders(
+  request: IncomingMessage,
+  publicBaseUrl: string,
+  publicDomain: string | undefined,
+) {
   const normalized: Record<string, string> = {};
-  for (const [name, value] of Object.entries(headers)) {
-    if (value === undefined || HOP_BY_HOP_HEADERS.has(name.toLowerCase())) continue;
+  for (const [name, value] of Object.entries(request.headers)) {
+    const lowerName = name.toLowerCase();
+    if (
+      value === undefined ||
+      HOP_BY_HOP_HEADERS.has(lowerName) ||
+      lowerName === "forwarded" ||
+      lowerName.startsWith("x-forwarded-")
+    ) {
+      continue;
+    }
     normalized[name] = Array.isArray(value) ? value.join(", ") : value;
   }
+
+  const publicUrl = new URL(publicBaseUrl);
+  normalized["x-forwarded-host"] = publicDomain
+    ? Array.isArray(request.headers.host)
+      ? request.headers.host[0] || publicUrl.host
+      : request.headers.host || publicUrl.host
+    : publicUrl.host;
+  normalized["x-forwarded-proto"] = publicUrl.protocol.replace(":", "");
   return normalized;
 }
 

--- a/packages/farm-preview-tunnel/test/tunnel.test.mjs
+++ b/packages/farm-preview-tunnel/test/tunnel.test.mjs
@@ -81,6 +81,49 @@ test("mounts public preview paths beneath the target URL pathname", async () => 
   }
 });
 
+test("replaces client-supplied forwarding headers at the relay boundary", async () => {
+  const target = createServer((request, response) => {
+    response.setHeader("content-type", "application/json");
+    response.end(
+      JSON.stringify({
+        forwarded: request.headers.forwarded,
+        forwardedFor: request.headers["x-forwarded-for"],
+        forwardedHost: request.headers["x-forwarded-host"],
+        forwardedProto: request.headers["x-forwarded-proto"],
+      }),
+    );
+  });
+  await listen(target);
+  const targetAddress = target.address();
+  const relay = createPersistentPreviewRelay();
+  const relayAddress = await relay.listen();
+  const agent = await startTypeScriptPreviewAgent({
+    relayUrl: relayAddress.websocketUrl,
+    name: "forwarded-headers",
+    targetUrl: `http://127.0.0.1:${targetAddress.port}`,
+  });
+
+  try {
+    const response = await fetch(agent.publicUrl, {
+      headers: {
+        forwarded: "for=127.0.0.1;host=evil.example;proto=https",
+        "x-forwarded-for": "127.0.0.1",
+        "x-forwarded-host": "evil.example",
+        "x-forwarded-proto": "https",
+      },
+    });
+
+    assert.deepEqual(await response.json(), {
+      forwardedHost: new URL(agent.publicUrl).host,
+      forwardedProto: "http",
+    });
+  } finally {
+    await agent.close();
+    await relay.close();
+    await close(target);
+  }
+});
+
 test("preserves repeated cookies and removes encoding after decoding a response", async () => {
   const target = createServer((_request, response) => {
     response.statusCode = 200;


### PR DESCRIPTION
## Problem

Preview visitors can supply forwarding headers that are relayed alongside Farm-generated values, creating duplicate and misleading client metadata.

## Root cause

The relay appended trusted forwarding values without first removing the visitor-provided variants.

## Change

Replace forwarded, real-IP, and forwarded-host/proto headers at the relay boundary while preserving unrelated repeated headers.

## Safety and compatibility

The change is limited to the preview relay. Ordinary request headers and repeated values remain unchanged.

## Verification

- Tunnel tests: 14 passed
- Preview gateway tests: 6 passed
- Focused format and lint checks passed

## Documentation and release

None.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the preview relay and gateway so forwarding headers from visitors are replaced with trusted values, preventing duplicate and misleading client metadata.

- The relay strips incoming `forwarded` and all `x-forwarded-*` headers, then sets `x-forwarded-host` and `x-forwarded-proto` from the public base URL and domain.
- The gateway ignores visitor-supplied `x-forwarded-proto` when determining the protocol between the gateway and local app.
- Unrelated repeated and ordinary request headers are preserved.
- Added tests covering both the relay and gateway behavior.

<sup>Written for commit 4783aff1e501c42f1b82d3cb755066f41c9655f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/847?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

