### PR TITLE
fix(i18n): preserve basePath around locale routes

### DIFF
--- a/docs/src/app/docs/internationalization/page.md
+++ b/docs/src/app/docs/internationalization/page.md
@@ -150,6 +150,11 @@ The same app route serves every locale. A file such as `src/app/products/page.ts
 
 Farm canonicalizes locale paths. With `prefix-except-default`, a request for `/en/products` redirects to `/products`.
 
+When the application has a `basePath`, the locale prefix stays inside that mount path. For example,
+`basePath: "/store"` produces `/store/products` for the default locale and
+`/store/fr/products` for French. Server redirects, `Link`, locale switching, metadata alternates,
+static generation, and production routing all preserve the same order.
+
 `Link` preserves the active locale automatically:
 
 ```tsx

--- a/packages/farm/src/__tests__/i18n.test.ts
+++ b/packages/farm/src/__tests__/i18n.test.ts
@@ -35,6 +35,7 @@ describe("Farm i18n configuration", () => {
 
     expect(config).toMatchObject({
       enabled: true,
+      basePath: "/",
       locales: ["en-US", "am"],
       defaultLocale: "en-US",
       fallbackLocale: "en-US",
@@ -118,6 +119,27 @@ describe("Farm locale routing", () => {
     expect(localizeFarmPathname("/", "en", always)).toBe("/en");
     expect(localizeFarmPathname("/am/account", "en", always)).toBe("/en/account");
   });
+
+  it("preserves the application base path around locale prefixes", () => {
+    const based = resolveFarmI18nConfig(
+      {
+        locales: ["en", "fr"],
+        defaultLocale: "en",
+      },
+      { basePath: "/app" },
+    );
+
+    expect(resolveFarmLocalePath("/app/fr/account", based)).toEqual({
+      locale: "fr",
+      pathname: "/account",
+      explicit: true,
+    });
+    expect(localizeFarmPathname("/account", "en", based)).toBe("/app/account");
+    expect(localizeFarmPathname("/app/fr/account", "en", based)).toBe("/app/account");
+    expect(localizeFarmHref("/app/account?tab=profile#name", "fr", based)).toBe(
+      "/app/fr/account?tab=profile#name",
+    );
+  });
 });
 
 describe("Farm locale request signals", () => {
@@ -161,6 +183,37 @@ describe("Farm locale request signals", () => {
       locale: "fr",
       source: "cookie",
       redirect: "/fr/dashboard",
+    });
+  });
+
+  it("keeps locale redirects beneath the application base path", () => {
+    const based = resolveFarmI18nConfig(
+      {
+        locales: ["en", "fr"],
+        defaultLocale: "en",
+      },
+      { basePath: "/app" },
+    );
+
+    expect(
+      resolveFarmLocaleRequest(
+        new Request("https://farm.test/app/products", {
+          headers: { "accept-language": "fr" },
+        }),
+        based,
+      ),
+    ).toMatchObject({
+      locale: "fr",
+      pathname: "/products",
+      redirect: "/app/fr/products",
+    });
+    expect(
+      resolveFarmLocaleRequest(new Request("https://farm.test/app/fr/products"), based),
+    ).toMatchObject({
+      locale: "fr",
+      source: "url",
+      pathname: "/products",
+      redirect: undefined,
     });
   });
 

--- a/packages/farm/src/__tests__/production-ssg.test.ts
+++ b/packages/farm/src/__tests__/production-ssg.test.ts
@@ -276,6 +276,7 @@ export default {
           ? `
 export default {
   srcDir: "src",
+  basePath: "/app",
   images: { provider: "none" },
   i18n: {
     locales: ["en", "fr"],
@@ -613,7 +614,7 @@ describe("production SSG output", () => {
         const publicDir = path.join(root, ".farm", ".output", "public");
         const artifactPaths =
           kind === "i18n"
-            ? ["en/sensitive/index.html", "fr/sensitive/index.html"]
+            ? ["app/en/sensitive/index.html", "app/fr/sensitive/index.html"]
             : ["sensitive/index.html"];
         for (const artifactPath of artifactPaths) {
           await expect(fs.access(path.join(publicDir, artifactPath))).rejects.toThrow();
@@ -621,7 +622,7 @@ describe("production SSG output", () => {
 
         production = await startProductionServer(
           path.join(root, ".farm", ".output", "server"),
-          kind === "i18n" ? "/en/sensitive" : "/sensitive",
+          kind === "i18n" ? "/app/en/sensitive" : "/sensitive",
         );
         if (kind === "context") {
           const tenantAHtml = await fetch(`${production.origin}/sensitive`, {
@@ -646,12 +647,16 @@ describe("production SSG output", () => {
           expect(secondHtml).toMatch(/plugin-page-\d+/);
           expect(secondHtml).not.toBe(firstHtml);
         } else {
-          const english = await fetch(`${production.origin}/en/sensitive`);
-          const french = await fetch(`${production.origin}/fr/sensitive`);
+          const english = await fetch(`${production.origin}/app/en/sensitive`);
+          const french = await fetch(`${production.origin}/app/fr/sensitive`);
           expect(english.status).toBe(200);
           expect(french.status).toBe(200);
-          await expect(english.text()).resolves.toContain("i18n-page");
-          await expect(french.text()).resolves.toContain("i18n-page");
+          const englishHtml = await english.text();
+          const frenchHtml = await french.text();
+          expect(englishHtml).toContain("i18n-page");
+          expect(frenchHtml).toContain("i18n-page");
+          expect(englishHtml).toContain('hreflang="fr" href="/app/fr/sensitive"');
+          expect(frenchHtml).toContain('hreflang="en" href="/app/en/sensitive"');
         }
       } finally {
         await production?.stop();

--- a/packages/farm/src/app.ts
+++ b/packages/farm/src/app.ts
@@ -182,6 +182,7 @@ export class FarmApp {
         : resolveFarmI18nConfig(config.i18n, {
             root,
             mode: process.env.NODE_ENV === "production" ? "production" : "development",
+            basePath,
           }),
       deploymentId: config.deploymentId || "development",
       notFound: config.notFound || {},

--- a/packages/farm/src/config.ts
+++ b/packages/farm/src/config.ts
@@ -1006,7 +1006,7 @@ export async function resolveConfig(
     performance: resolveFarmPerformanceConfig(userConfig.performance),
     theme: resolveFarmThemeConfig(userConfig.theme, basePath),
     publicDir: userConfig.publicDir || "public",
-    i18n: resolveFarmI18nConfig(userConfig.i18n, { root, mode }),
+    i18n: resolveFarmI18nConfig(userConfig.i18n, { root, mode, basePath }),
     openapi: {
       enabled: false,
       route: "/docs/reference",

--- a/packages/farm/src/i18n/config.ts
+++ b/packages/farm/src/i18n/config.ts
@@ -13,14 +13,16 @@ const DEFAULT_DETECTION: readonly FarmI18nDetectionSignal[] = ["url", "cookie", 
 
 export function resolveFarmI18nConfig(
   input: FarmI18nUserConfig | false | undefined,
-  options: { root?: string; mode?: "development" | "production" } = {},
+  options: { root?: string; mode?: "development" | "production"; basePath?: string } = {},
 ): ResolvedFarmI18nConfig {
   const root = options.root || process.cwd();
+  const basePath = options.basePath || "/";
   const strictByDefault = options.mode === "production";
 
   if (!input) {
     return {
       enabled: false,
+      basePath,
       locales: ["en"],
       defaultLocale: "en",
       messages: path.join(root, "src/messages"),
@@ -77,6 +79,7 @@ export function resolveFarmI18nConfig(
 
   return {
     enabled: true,
+    basePath,
     locales,
     defaultLocale,
     messages: path.resolve(root, input.messages || "src/messages"),

--- a/packages/farm/src/i18n/resolver.ts
+++ b/packages/farm/src/i18n/resolver.ts
@@ -1,4 +1,5 @@
 import { localizeFarmPathname, resolveFarmLocalePath } from "./routing";
+import { stripFarmBasePath } from "../base-path";
 import type { FarmI18nLocaleSource, ResolvedFarmI18nConfig } from "./types";
 
 export interface FarmLocaleResolution {
@@ -57,7 +58,7 @@ export function resolveFarmLocaleRequest(
   const detected = detectLocale(request, config);
   const shouldRedirect =
     options.redirect !== false &&
-    !isInternalOrApiPath(url.pathname) &&
+    !isInternalOrApiPath(stripFarmBasePath(url.pathname, config.basePath)) &&
     config.routing !== "none" &&
     (config.routing === "prefix-always" || detected.locale !== config.defaultLocale);
 

--- a/packages/farm/src/i18n/routing.ts
+++ b/packages/farm/src/i18n/routing.ts
@@ -1,9 +1,11 @@
+import { applyFarmBasePath, stripFarmBasePath } from "../base-path";
 import type { FarmI18nDirection, FarmI18nRouting, ResolvedFarmI18nConfig } from "./types";
 
 export interface FarmLocalePathConfig {
   locales: readonly string[];
   defaultLocale: string;
   routing: FarmI18nRouting;
+  basePath?: string;
 }
 
 export interface FarmLocalePathMatch {
@@ -33,7 +35,7 @@ export function resolveFarmLocalePath(
   pathname: string,
   config: FarmLocalePathConfig,
 ): FarmLocalePathMatch {
-  const normalized = normalizePathname(pathname);
+  const normalized = normalizePathname(stripFarmBasePath(pathname, config.basePath));
   if (config.routing === "none") {
     return { pathname: normalized, explicit: false };
   }
@@ -68,11 +70,15 @@ export function localizeFarmPathname(
   config: FarmLocalePathConfig,
 ): string {
   const internalPathname = resolveFarmLocalePath(pathname, config).pathname;
-  if (config.routing === "none") return internalPathname;
-  if (config.routing === "prefix-except-default" && locale === config.defaultLocale) {
-    return internalPathname;
+  let localizedPathname = internalPathname;
+  if (config.routing === "none") {
+    return applyFarmBasePath(localizedPathname, config.basePath);
   }
-  return internalPathname === "/" ? `/${locale}` : `/${locale}${internalPathname}`;
+  if (config.routing === "prefix-except-default" && locale === config.defaultLocale) {
+    return applyFarmBasePath(localizedPathname, config.basePath);
+  }
+  localizedPathname = internalPathname === "/" ? `/${locale}` : `/${locale}${internalPathname}`;
+  return applyFarmBasePath(localizedPathname, config.basePath);
 }
 
 export function localizeFarmHref(

--- a/packages/farm/src/i18n/runtime.ts
+++ b/packages/farm/src/i18n/runtime.ts
@@ -72,6 +72,7 @@ export class FarmI18nRuntime {
       locales: this.config.locales,
       defaultLocale: this.config.defaultLocale,
       routing: this.config.routing,
+      basePath: this.config.basePath,
       cookie: this.config.cookie,
       direction: getFarmLocaleDirection(resolution.locale, this.config.direction),
       messages: {

--- a/packages/farm/src/i18n/types.ts
+++ b/packages/farm/src/i18n/types.ts
@@ -37,6 +37,8 @@ export interface ResolvedFarmI18nCookieConfig {
 
 export interface ResolvedFarmI18nConfig {
   enabled: boolean;
+  /** Normalized public pathname where the application is mounted. */
+  basePath: string;
   locales: readonly string[];
   defaultLocale: string;
   messages: string;
@@ -57,6 +59,8 @@ export interface FarmI18nClientSnapshot {
   locales: readonly string[];
   defaultLocale: string;
   routing: FarmI18nRouting;
+  /** Public application mount path. Optional for compatibility with older snapshots. */
+  basePath?: string;
   cookie: ResolvedFarmI18nCookieConfig;
   direction: FarmI18nDirection;
   messages: FarmI18nCatalog;

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -2056,6 +2056,7 @@ function generateClientHydrationEntry(
   docsAdapterReact: string | undefined,
   i18nConfig: ResolvedFarmConfig["i18n"] = {
     enabled: false,
+    basePath: "/",
     locales: ["en"],
     defaultLocale: "en",
     messages: "",


### PR DESCRIPTION
## Problem

Production locale routing can drop the configured base path, so routes such as `/app/fr/products` do not resolve consistently with development.

## Root cause

Locale detection and rewriting operated on the full deployment pathname instead of isolating and restoring the configured base path.

## Change

Strip the base path before locale matching, then restore it after locale redirects and rewrites across the production adapters.

## Safety and compatibility

Apps without `basePath` keep their current behavior. Default-locale and explicit-locale routes retain existing semantics.

## Verification

- Core source tests: 108 passed
- Built Node production fixture verified `/app/en/...` and `/app/fr/...`
- Core build and focused lint checks passed

## Documentation and release

Updated i18n documentation for `basePath` composition.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes production locale routing so the configured `basePath` is preserved around locale prefixes, making routes like `/app/fr/products` work consistently with development.

- Strips the base path before locale detection and restores it after redirects and rewrites across production adapters.
- Apps without `basePath` keep their existing behavior.
- Updated i18n docs to describe `basePath` composition.

<sup>Written for commit de62f9cc514a622b5dd855f9a9e0707cfb4a2513. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/848?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

