### PR TITLE
fix(api): release malformed NDJSON streams

### DIFF
--- a/packages/farm/src/__tests__/api-transport.test.ts
+++ b/packages/farm/src/__tests__/api-transport.test.ts
@@ -86,4 +86,24 @@ describe("API transports", () => {
 
     expect(released).toBe(true);
   });
+
+  it("cancels and unlocks the response body when NDJSON decoding fails", async () => {
+    let cancelReason: unknown;
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode('{"progress":}\n'));
+      },
+      cancel(reason) {
+        cancelReason = reason;
+      },
+    });
+    const response = new Response(body, {
+      headers: { "content-type": "application/x-ndjson" },
+    });
+    const iterator = readJSONStream(response)[Symbol.asyncIterator]();
+
+    await expect(iterator.next()).rejects.toBeInstanceOf(SyntaxError);
+    expect(cancelReason).toBeInstanceOf(SyntaxError);
+    expect(response.body?.locked).toBe(false);
+  });
 });

--- a/packages/farm/src/api/transport.ts
+++ b/packages/farm/src/api/transport.ts
@@ -150,6 +150,29 @@ export function readJSONStream<TItem>(response: Response): FarmAPIStream<TItem> 
   let buffer = "";
   let completed = false;
   let claimed = false;
+  let released = false;
+
+  const releaseReader = () => {
+    if (released) return;
+    released = true;
+    reader.releaseLock();
+  };
+  const parseLine = async (line: string) => {
+    try {
+      return JSON.parse(line) as TItem;
+    } catch (error) {
+      completed = true;
+      buffer = "";
+      try {
+        await reader.cancel(error);
+      } catch {
+        // Preserve the decode error even if the underlying stream also fails cleanup.
+      } finally {
+        releaseReader();
+      }
+      throw error;
+    }
+  };
 
   const iterator: AsyncIterator<TItem> = {
     async next() {
@@ -159,17 +182,28 @@ export function readJSONStream<TItem>(response: Response): FarmAPIStream<TItem> 
           const line = buffer.slice(0, lineEnd).trim();
           buffer = buffer.slice(lineEnd + 1);
           if (!line) continue;
-          return { done: false, value: JSON.parse(line) as TItem };
+          return { done: false, value: await parseLine(line) };
         }
 
         if (completed) {
           const line = buffer.trim();
           buffer = "";
-          if (!line) return { done: true, value: undefined };
-          return { done: false, value: JSON.parse(line) as TItem };
+          if (!line) {
+            releaseReader();
+            return { done: true, value: undefined };
+          }
+          return { done: false, value: await parseLine(line) };
         }
 
-        const chunk = await reader.read();
+        let chunk: ReadableStreamReadResult<Uint8Array>;
+        try {
+          chunk = await reader.read();
+        } catch (error) {
+          completed = true;
+          buffer = "";
+          releaseReader();
+          throw error;
+        }
         completed = chunk.done;
         buffer += decoder.decode(chunk.value, { stream: !chunk.done });
       }
@@ -177,7 +211,13 @@ export function readJSONStream<TItem>(response: Response): FarmAPIStream<TItem> 
     async return() {
       completed = true;
       buffer = "";
-      await reader.cancel();
+      if (!released) {
+        try {
+          await reader.cancel();
+        } finally {
+          releaseReader();
+        }
+      }
       return { done: true, value: undefined };
     },
   };
@@ -187,7 +227,13 @@ export function readJSONStream<TItem>(response: Response): FarmAPIStream<TItem> 
     async cancel(reason) {
       completed = true;
       buffer = "";
-      await reader.cancel(reason);
+      if (!released) {
+        try {
+          await reader.cancel(reason);
+        } finally {
+          releaseReader();
+        }
+      }
     },
     [Symbol.asyncIterator]() {
       if (claimed) {


### PR DESCRIPTION
## Problem

A malformed NDJSON record rejects parsing while leaving its source stream and reader allocated.

## Root cause

The parsing failure escaped before canceling the source and releasing the reader lock.

## Change

Cancel malformed streams and release the reader in the failure path while preserving the original syntax error.

## Safety and compatibility

Valid NDJSON parsing is unchanged. Cleanup failures do not replace the parse error exposed to callers.

## Verification

- API transport tests: 5 passed
- Core type-check passed
- Focused format and lint checks passed

## Documentation and release

None.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Previously, a malformed NDJSON record failed parsing without canceling the source stream or releasing the reader lock. Now the stream is canceled and the reader released on failure, while preserving the original syntax error. Valid NDJSON parsing is unchanged.

<sup>Written for commit 5b0b2df9c445fcc88d8cacf6fac8bf68b577fde9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/849?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

