### PR TITLE
fix(compression): propagate stream lifecycle

### DIFF
--- a/packages/farm/src/__tests__/compression.test.ts
+++ b/packages/farm/src/__tests__/compression.test.ts
@@ -1,5 +1,5 @@
 import { brotliDecompressSync, gunzipSync } from "node:zlib";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { PluginManager } from "../plugin";
 import { createCompressionPlugin } from "../plugins/compression";
 
@@ -132,5 +132,43 @@ describe("compression plugin", () => {
     expect(await eventStream.text()).toBe("data: ready\n\n");
     expect(parameterizedEventStream.headers.get("content-encoding")).toBeNull();
     expect(await parameterizedEventStream.text()).toBe("data: still-ready\n\n");
+  });
+
+  it("propagates source stream failures to the compressed response", async () => {
+    const manager = createManager();
+    const source = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode("partial response"));
+        queueMicrotask(() => controller.error(new Error("source stream failed")));
+      },
+    });
+    const response = await manager.runRuntimeRequest(
+      new Request("https://farm.test/", { headers: { "accept-encoding": "gzip" } }),
+      () => new Response(source, { headers: { "content-type": "text/plain" } }),
+    );
+
+    await expect(response.arrayBuffer()).rejects.toThrow("source stream failed");
+  });
+
+  it("cancels the source when the compressed response consumer disconnects", async () => {
+    const manager = createManager();
+    const cancel = vi.fn();
+    const chunk = new TextEncoder().encode("streamed response".repeat(256));
+    const source = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        controller.enqueue(chunk);
+      },
+      cancel,
+    });
+    const response = await manager.runRuntimeRequest(
+      new Request("https://farm.test/", { headers: { "accept-encoding": "gzip" } }),
+      () => new Response(source, { headers: { "content-type": "text/plain" } }),
+    );
+
+    const reader = response.body!.getReader();
+    await reader.read();
+    await reader.cancel("client disconnected");
+
+    await vi.waitFor(() => expect(cancel).toHaveBeenCalledOnce());
   });
 });

--- a/packages/farm/src/plugins/compression.ts
+++ b/packages/farm/src/plugins/compression.ts
@@ -1,6 +1,6 @@
 import type { FarmPlugin, FarmPluginContext } from "../plugin";
 import type { FarmRequest, FarmResponse } from "../types";
-import { Readable } from "node:stream";
+import { pipeline, Readable } from "node:stream";
 import { constants, createBrotliCompress, createGzip } from "node:zlib";
 
 type SupportedEncoding = "br" | "gzip";
@@ -78,7 +78,11 @@ function compressResponse(response: Response, encoding: SupportedEncoding): Resp
   const compressor =
     encoding === "br" ? createBrotliCompress() : createGzip({ flush: constants.Z_SYNC_FLUSH });
   const input = Readable.fromWeb(response.body as any);
-  const output = input.pipe(compressor);
+  const output = pipeline(input, compressor, () => {
+    // pipeline forwards source failures to the compressed body and destroys
+    // the source when the response consumer cancels it. The web stream owns
+    // observing the resulting destination error.
+  });
   const headers = new Headers(response.headers);
 
   headers.set("content-encoding", encoding);


### PR DESCRIPTION
## Problem

Canceling or failing a compressed response can leave the source stream active.

## Root cause

The compression transform forwarded chunks but did not consistently propagate cancellation and terminal errors through the stream pipeline.

## Change

Connect cancel, close, and failure behavior across the compressed response pipeline.

## Safety and compatibility

Successful compressed responses keep their existing encoding and headers. The change only adds missing lifecycle propagation.

## Verification

- Compression pipeline tests: 8 passed
- Core type-check passed
- Focused format and lint checks passed

## Documentation and release

None.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Propagates source stream failures and cancellation through the compressed response pipeline so downstream consumers see terminal errors and disconnects instead of hanging streams. Previously, canceling or failing a compressed response left the source stream active; now errors from the source reject the compressed body and consumer cancellation destroys the source. Successful responses keep their existing encoding and headers.

<sup>Written for commit 1b3f4ad28a931cd11b5b9e89636cbbd3fa7a3130. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/850?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

