### PR TITLE
fix(preview): bound relayed response bodies

### DIFF
--- a/docs/src/app/docs/preview/page.md
+++ b/docs/src/app/docs/preview/page.md
@@ -223,6 +223,8 @@ The local CLI owns:
 - Request and response logging.
 - Closing the preview when the local app exits.
 
+Preview transports currently buffer bodies while carrying them through the relay. Public request and local response bodies are limited to 5 MiB by default; an oversized request receives `413`, while an oversized local response receives `502`. Self-hosted gateway and relay operators can configure those limits.
+
 ## Self-Hosting a Gateway
 
 Most app developers should use the hosted gateway. Self-host only when you are operating a private preview domain or maintaining Farming Labs infrastructure.

--- a/packages/farm-cli/src/preview-gateway.ts
+++ b/packages/farm-cli/src/preview-gateway.ts
@@ -44,10 +44,12 @@ export interface RunPreviewGatewayOptions {
   maxRequests?: number;
   maxConcurrentRequests?: number;
   requestTimeoutMs?: number;
+  maxResponseBodyBytes?: number;
 }
 
 export interface ForwardGatewayRequestOptions {
   signal?: AbortSignal;
+  maxResponseBodyBytes?: number;
 }
 
 const DEFAULT_GATEWAY_URL = "https://preview.farming-labs.dev";
@@ -57,6 +59,7 @@ const DEFAULT_LOCAL_PROBE_INTERVAL_MS = 2000;
 const DEFAULT_LOCAL_PROBE_TIMEOUT_MS = 1000;
 const DEFAULT_MAX_CONCURRENT_REQUESTS = 25;
 const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
+const DEFAULT_MAX_RESPONSE_BODY_BYTES = 5 * 1024 * 1024;
 const HOP_BY_HOP_HEADERS = new Set([
   "connection",
   "content-length",
@@ -134,6 +137,7 @@ export async function runPreviewGateway(
           controller.signal,
           AbortSignal.timeout(options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS),
         ]),
+        maxResponseBodyBytes: options.maxResponseBodyBytes ?? DEFAULT_MAX_RESPONSE_BODY_BYTES,
       });
     } catch (error) {
       if (controller.signal.aborted) return;
@@ -311,12 +315,49 @@ export async function forwardGatewayRequest(
     responseHeaders["set-cookie"] = setCookies;
   }
 
+  const responseBody = await readResponseBody(
+    response,
+    options.maxResponseBodyBytes ?? DEFAULT_MAX_RESPONSE_BODY_BYTES,
+  );
   return {
     status: response.status,
     headers: responseHeaders,
-    body: Buffer.from(await response.arrayBuffer()).toString("base64"),
+    body: responseBody.toString("base64"),
     encoding: "base64",
   };
+}
+
+async function readResponseBody(response: Response, maxBytes: number) {
+  const contentLength = Number(response.headers.get("content-length") || 0);
+  if (
+    !response.headers.has("content-encoding") &&
+    Number.isFinite(contentLength) &&
+    contentLength > maxBytes
+  ) {
+    await response.body?.cancel();
+    throw new Error(`The local preview response exceeded the ${maxBytes} byte limit.`);
+  }
+  if (!response.body) return Buffer.alloc(0);
+
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let size = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      size += value.byteLength;
+      if (size > maxBytes) {
+        await reader.cancel();
+        throw new Error(`The local preview response exceeded the ${maxBytes} byte limit.`);
+      }
+      chunks.push(value);
+    }
+  } catch (error) {
+    await reader.cancel().catch(() => undefined);
+    throw error;
+  }
+  return Buffer.concat(chunks, size);
 }
 
 async function pollGatewayRequests(

--- a/packages/farm-cli/test/preview.test.mjs
+++ b/packages/farm-cli/test/preview.test.mjs
@@ -300,6 +300,35 @@ test("removes content encoding after fetch decodes a local response", async () =
   }
 });
 
+test("stops buffering gateway responses above the configured limit", async () => {
+  const server = await createTestServer((_req, res) => {
+    res.write("12345678");
+    res.end("9");
+  });
+
+  try {
+    await assert.rejects(
+      forwardGatewayRequest(
+        {
+          localUrl: `http://localhost:${server.port}`,
+          host: "localhost",
+          port: server.port,
+          source: "port",
+        },
+        {
+          id: "req_large",
+          method: "GET",
+          path: "/large",
+        },
+        { maxResponseBodyBytes: 8 },
+      ),
+      /exceeded the 8 byte limit/,
+    );
+  } finally {
+    await server.close();
+  }
+});
+
 test("cancels a forwarded local request at its deadline", async () => {
   const server = await createTestServer(() => undefined);
 

--- a/packages/farm-preview-gateway/README.md
+++ b/packages/farm-preview-gateway/README.md
@@ -9,3 +9,5 @@ npm install @farm.js/preview-gateway@beta
 ```
 
 See the [Farm.js repository](https://github.com/farming-labs/farm.js) for documentation, examples, and support.
+
+The gateway limits public request bodies and local preview response bodies to 5 MiB by default. Use `maxBodyBytes` and `maxResponseBodyBytes` when creating the handler to set lower or higher limits. Oversized local responses are rejected at upload and the waiting public request receives a `502` response instead of being left pending.

--- a/packages/farm-preview-gateway/src/index.ts
+++ b/packages/farm-preview-gateway/src/index.ts
@@ -11,6 +11,7 @@ export interface PreviewGatewayOptions {
   pollTimeoutMs?: number;
   pollIntervalMs?: number;
   maxBodyBytes?: number;
+  maxResponseBodyBytes?: number;
 }
 
 export interface PreviewGatewaySession {
@@ -72,6 +73,7 @@ interface PreviewGatewayRuntimeConfig {
   pollTimeoutMs: number;
   pollIntervalMs: number;
   maxBodyBytes: number;
+  maxResponseBodyBytes: number;
 }
 
 const DEFAULT_DOMAIN = "preview.farming-labs.dev";
@@ -81,6 +83,7 @@ const DEFAULT_REQUEST_TIMEOUT_MS = 25000;
 const DEFAULT_POLL_TIMEOUT_MS = 15000;
 const DEFAULT_POLL_INTERVAL_MS = 100;
 const DEFAULT_MAX_BODY_BYTES = 1024 * 1024 * 5;
+const DEFAULT_MAX_RESPONSE_BODY_BYTES = 1024 * 1024 * 5;
 const DEFAULT_POLL_REQUEST_LIMIT = 50;
 const HOP_BY_HOP_HEADERS = new Set([
   "connection",
@@ -107,6 +110,7 @@ export function createPreviewGatewayHandler(options: PreviewGatewayOptions = {})
     pollTimeoutMs: options.pollTimeoutMs ?? DEFAULT_POLL_TIMEOUT_MS,
     pollIntervalMs: options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS,
     maxBodyBytes: options.maxBodyBytes ?? DEFAULT_MAX_BODY_BYTES,
+    maxResponseBodyBytes: options.maxResponseBodyBytes ?? DEFAULT_MAX_RESPONSE_BODY_BYTES,
   };
 
   return async function handlePreviewGatewayRequest(request: Request): Promise<Response> {
@@ -488,7 +492,20 @@ async function handleSessionRoute(
   }
 
   if (request.method === "POST" && route.action === "responses" && route.requestId) {
-    const response = (await request.json()) as PreviewGatewayResponse;
+    let response: PreviewGatewayResponse;
+    try {
+      response = await parsePreviewResponse(request, config.maxResponseBodyBytes);
+    } catch (error) {
+      if (error instanceof GatewayHttpError && error.status === 413) {
+        await store.saveResponse(
+          session.id,
+          route.requestId,
+          createOversizedPreviewResponse(config.maxResponseBodyBytes),
+          config.sessionTtlMs,
+        );
+      }
+      throw error;
+    }
     await store.saveResponse(session.id, route.requestId, response, config.sessionTtlMs);
     await markSessionOnline(store, config, session);
     return json({ ok: true });
@@ -505,6 +522,48 @@ async function handleSessionRoute(
   }
 
   return text("Preview gateway route not found.", 404);
+}
+
+async function parsePreviewResponse(request: Request, maxBodyBytes: number) {
+  const maxEncodedBytes = Math.ceil(maxBodyBytes / 3) * 4 + 64 * 1024;
+  const contentLength = Number(request.headers.get("content-length") || 0);
+  if (Number.isFinite(contentLength) && contentLength > maxEncodedBytes) {
+    await request.body?.cancel();
+    throw new GatewayHttpError(413, "Preview response body is too large.");
+  }
+
+  const bytes = await readBodyWithLimit(
+    request,
+    maxEncodedBytes,
+    "Preview response body is too large.",
+  );
+  let response: PreviewGatewayResponse;
+  try {
+    response = JSON.parse(bytes.toString("utf8")) as PreviewGatewayResponse;
+  } catch {
+    throw new GatewayHttpError(400, "Preview response body must be valid JSON.");
+  }
+
+  if (getPreviewResponseBodySize(response) > maxBodyBytes) {
+    throw new GatewayHttpError(413, "Preview response body is too large.");
+  }
+  return response;
+}
+
+function getPreviewResponseBodySize(response: PreviewGatewayResponse) {
+  if (!response.body) return 0;
+  return Buffer.byteLength(response.body, response.encoding === "base64" ? "base64" : "utf8");
+}
+
+function createOversizedPreviewResponse(maxBodyBytes: number): PreviewGatewayResponse {
+  return {
+    status: 502,
+    headers: { "content-type": "text/plain; charset=utf-8" },
+    body: Buffer.from(
+      `The local preview response exceeded the ${maxBodyBytes} byte limit.`,
+    ).toString("base64"),
+    encoding: "base64",
+  };
 }
 
 async function pollSessionRequests(
@@ -662,10 +721,11 @@ async function serializePreviewRequest(
       throw new GatewayHttpError(413, "Preview request body is too large.");
     }
 
-    const buffer = Buffer.from(await request.arrayBuffer());
-    if (buffer.byteLength > maxBodyBytes) {
-      throw new GatewayHttpError(413, "Preview request body is too large.");
-    }
+    const buffer = await readBodyWithLimit(
+      request,
+      maxBodyBytes,
+      "Preview request body is too large.",
+    );
     body = buffer.toString("base64");
   }
 
@@ -678,6 +738,29 @@ async function serializePreviewRequest(
     encoding: body ? "base64" : undefined,
     createdAt: Date.now(),
   };
+}
+
+async function readBodyWithLimit(request: Request, maxBytes: number, message: string) {
+  if (!request.body) return Buffer.alloc(0);
+  const reader = request.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let size = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      size += value.byteLength;
+      if (size > maxBytes) {
+        await reader.cancel();
+        throw new GatewayHttpError(413, message);
+      }
+      chunks.push(value);
+    }
+  } catch (error) {
+    await reader.cancel().catch(() => undefined);
+    throw error;
+  }
+  return Buffer.concat(chunks, size);
 }
 
 async function requireSession(store: PreviewGatewayStore, sessionId: string, token: string | null) {

--- a/packages/farm-preview-gateway/test/gateway.test.mjs
+++ b/packages/farm-preview-gateway/test/gateway.test.mjs
@@ -59,6 +59,44 @@ test("proxies a public preview request through the gateway queue", async () => {
   }
 });
 
+test("rejects oversized agent responses and completes the public request safely", async () => {
+  const store = new MemoryPreviewGatewayStore();
+  const gateway = await createGatewayServer(store, { maxResponseBodyBytes: 8 });
+
+  try {
+    const session = await fetch(`${gateway.url}/api/sessions`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name: "response-limit", localUrl: "http://localhost:4321" }),
+    }).then((response) => response.json());
+
+    const publicRequest = fetch(`${gateway.url}/__preview/response-limit/large`);
+    const poll = await fetch(
+      `${gateway.url}/api/sessions/${session.id}/requests?token=${session.token}&wait=1000`,
+    ).then((response) => response.json());
+    const upload = await fetch(
+      `${gateway.url}/api/sessions/${session.id}/responses/${poll.requests[0].id}?token=${session.token}`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          status: 200,
+          headers: { "content-type": "text/plain" },
+          body: Buffer.from("123456789").toString("base64"),
+          encoding: "base64",
+        }),
+      },
+    );
+
+    assert.equal(upload.status, 413);
+    const response = await publicRequest;
+    assert.equal(response.status, 502);
+    assert.match(await response.text(), /exceeded the 8 byte limit/);
+  } finally {
+    await gateway.close();
+  }
+});
+
 test("does not resurrect a deleted session when a stale touch lands late", async () => {
   const store = new MemoryPreviewGatewayStore();
   const session = {

--- a/packages/farm-preview-tunnel/README.md
+++ b/packages/farm-preview-tunnel/README.md
@@ -36,13 +36,15 @@ When the relay can run on multiple server instances, provide a shared `Persisten
 
 The agent closes automatically when the local target becomes unreachable. The relay then removes its public route.
 
+Local response bodies are limited to 5 MiB by default because the current protocol buffers and base64-encodes them. Configure `maxResponseBodyBytes` on the relay to change the limit; the relay advertises that limit to compatible agents and also enforces it when accepting responses. The TypeScript agent can set a smaller `maxResponseBodyBytes`, but cannot exceed the relay's limit.
+
 ## Rust agent
 
 The independent `@farm.js/tunnel` N-API package implements the same protocol and is the native agent used by `farm preview`. The TypeScript agent remains the portable protocol reference and fallback.
 
 ## Prototype limitations
 
-- Request and response bodies are buffered and base64-encoded in JSON.
+- Request and response bodies are buffered and base64-encoded in JSON within their configured size limits.
 - Authentication and reconnect/resume are not implemented yet.
 - WebSocket upgrade forwarding and Vite HMR are not implemented yet.
 - The relay must run on infrastructure that supports long-lived WebSockets. Clients do not reconnect when the infrastructure's maximum connection duration is reached yet.

--- a/packages/farm-preview-tunnel/src/agent.ts
+++ b/packages/farm-preview-tunnel/src/agent.ts
@@ -29,6 +29,7 @@ export interface TypeScriptPreviewAgentOptions {
   localProbeIntervalMs?: number;
   localProbeTimeoutMs?: number;
   requestTimeoutMs?: number;
+  maxResponseBodyBytes?: number;
 }
 
 export interface TypeScriptPreviewAgent {
@@ -56,6 +57,10 @@ export async function startTypeScriptPreviewAgent(
   }
 
   const inFlight = new Map<string, AbortController>();
+  const maxResponseBodyBytes = Math.min(
+    options.maxResponseBodyBytes ?? Number.POSITIVE_INFINITY,
+    ready.maxResponseBodyBytes ?? 5 * 1024 * 1024,
+  );
   const stopWatchingTarget = watchLocalTarget(socket, options);
   const abortInFlight = () => {
     for (const controller of inFlight.values()) controller.abort();
@@ -72,9 +77,11 @@ export async function startTypeScriptPreviewAgent(
       const controller = new AbortController();
       inFlight.get(message.id)?.abort();
       inFlight.set(message.id, controller);
-      void forwardRequest(socket, options, message, controller).finally(() => {
-        if (inFlight.get(message.id) === controller) inFlight.delete(message.id);
-      });
+      void forwardRequest(socket, options, message, controller, maxResponseBodyBytes).finally(
+        () => {
+          if (inFlight.get(message.id) === controller) inFlight.delete(message.id);
+        },
+      );
     }
   });
   socket.once("close", () => {
@@ -186,6 +193,7 @@ async function forwardRequest(
   options: TypeScriptPreviewAgentOptions,
   request: TunnelRequestMessage,
   controller: AbortController,
+  maxResponseBodyBytes: number,
 ) {
   let response: TunnelResponseMessage;
   let timedOut = false;
@@ -223,12 +231,13 @@ async function forwardRequest(
     }
     const setCookies = getSetCookies(result.headers);
     if (setCookies.length) responseHeaders["set-cookie"] = setCookies;
+    const responseBody = await readResponseBody(result, maxResponseBodyBytes);
     response = {
       type: "response",
       id: request.id,
       status: result.status,
       headers: responseHeaders,
-      body: Buffer.from(await result.arrayBuffer()).toString("base64"),
+      body: responseBody.toString("base64"),
     };
   } catch (error) {
     const unsafePath = error instanceof UnsafePreviewPathError;
@@ -244,6 +253,39 @@ async function forwardRequest(
   }
 
   if (socket.readyState === socket.OPEN) socket.send(JSON.stringify(response));
+}
+
+async function readResponseBody(response: Response, maxBytes: number) {
+  const contentLength = Number(response.headers.get("content-length") || 0);
+  if (
+    !response.headers.has("content-encoding") &&
+    Number.isFinite(contentLength) &&
+    contentLength > maxBytes
+  ) {
+    await response.body?.cancel();
+    throw new PreviewResponseLimitError(maxBytes);
+  }
+  if (!response.body) return Buffer.alloc(0);
+
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let size = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      size += value.byteLength;
+      if (size > maxBytes) {
+        await reader.cancel();
+        throw new PreviewResponseLimitError(maxBytes);
+      }
+      chunks.push(value);
+    }
+  } catch (error) {
+    await reader.cancel().catch(() => undefined);
+    throw error;
+  }
+  return Buffer.concat(chunks, size);
 }
 
 function parseRelayMessage(data: WebSocket.RawData): RelayToAgentMessage | undefined {
@@ -281,6 +323,13 @@ function getSetCookies(headers: Headers) {
 
 function ensureTrailingSlash(value: string) {
   return value.endsWith("/") ? value : `${value}/`;
+}
+
+class PreviewResponseLimitError extends Error {
+  constructor(maxBytes: number) {
+    super(`The local preview response exceeded the ${maxBytes} byte limit.`);
+    this.name = "PreviewResponseLimitError";
+  }
 }
 
 function closeSocket(socket: WebSocket) {

--- a/packages/farm-preview-tunnel/src/protocol.ts
+++ b/packages/farm-preview-tunnel/src/protocol.ts
@@ -7,6 +7,7 @@ export interface ReadyMessage {
   type: "ready";
   sessionId: string;
   publicUrl: string;
+  maxResponseBodyBytes?: number;
 }
 
 export interface TunnelRequestMessage {
@@ -44,7 +45,14 @@ export function isAgentToRelayMessage(value: unknown): value is AgentToRelayMess
 export function isRelayToAgentMessage(value: unknown): value is RelayToAgentMessage {
   if (!isRecord(value)) return false;
   if (value.type === "ready") {
-    return typeof value.sessionId === "string" && typeof value.publicUrl === "string";
+    return (
+      typeof value.sessionId === "string" &&
+      typeof value.publicUrl === "string" &&
+      (value.maxResponseBodyBytes === undefined ||
+        (typeof value.maxResponseBodyBytes === "number" &&
+          Number.isSafeInteger(value.maxResponseBodyBytes) &&
+          value.maxResponseBodyBytes > 0))
+    );
   }
   if (value.type === "error") {
     return (

--- a/packages/farm-preview-tunnel/src/relay.ts
+++ b/packages/farm-preview-tunnel/src/relay.ts
@@ -34,6 +34,7 @@ export interface PersistentPreviewRelayOptions {
   coordinatorSessionTtlMs?: number;
   requestTimeoutMs?: number;
   maxBodyBytes?: number;
+  maxResponseBodyBytes?: number;
 }
 
 export type PersistentPreviewRelayFallbackHandler = (
@@ -83,7 +84,11 @@ interface PendingRequest {
 export function createPersistentPreviewRelay(options: PersistentPreviewRelayOptions = {}) {
   const agents = new Map<string, AgentSession>();
   const pending = new Map<string, PendingRequest>();
-  const websocketServer = new WebSocketServer({ noServer: true });
+  const maxResponseBodyBytes = options.maxResponseBodyBytes ?? 5 * 1024 * 1024;
+  const websocketServer = new WebSocketServer({
+    noServer: true,
+    maxPayload: Math.ceil(maxResponseBodyBytes / 3) * 4 + 256 * 1024,
+  });
   const host = options.host || "127.0.0.1";
   const publicDomain = normalizeDomain(options.publicDomain);
   const healthPath = options.healthPath || "/api/health";
@@ -131,6 +136,7 @@ export function createPersistentPreviewRelay(options: PersistentPreviewRelayOpti
         pending,
         requestTimeoutMs,
         maxBodyBytes,
+        maxResponseBodyBytes,
       });
     } catch (error) {
       const status = error instanceof BodyLimitError ? 413 : 500;
@@ -214,6 +220,7 @@ export function createPersistentPreviewRelay(options: PersistentPreviewRelayOpti
               type: "ready",
               sessionId: session.id,
               publicUrl: createPublicUrl(baseUrl, publicDomain, name),
+              maxResponseBodyBytes,
             };
             socket.send(JSON.stringify(ready));
             if (options.coordinator) {
@@ -233,6 +240,10 @@ export function createPersistentPreviewRelay(options: PersistentPreviewRelayOpti
         if (message.type === "response") {
           if (!session) {
             rejectSocketMessage(socket, "Register the preview agent before sending responses.");
+            return;
+          }
+          if (getEncodedBodySize(message.body) > maxResponseBodyBytes) {
+            rejectOversizedResponse(message.id, session.id, pending, maxResponseBodyBytes);
             return;
           }
           if (!completePendingRequest(message, session.id, pending)) {
@@ -296,6 +307,7 @@ interface ForwardPublicRequestOptions {
   pending: Map<string, PendingRequest>;
   requestTimeoutMs: number;
   maxBodyBytes: number;
+  maxResponseBodyBytes: number;
 }
 
 async function forwardPublicRequest(options: ForwardPublicRequestOptions) {
@@ -364,6 +376,14 @@ async function forwardPublicRequest(options: ForwardPublicRequestOptions) {
   if (options.response.writableEnded) return;
   if (!coordinatedResponse) {
     sendText(options.response, 504, "The persistent preview agent did not respond in time.");
+    return;
+  }
+  if (getEncodedBodySize(coordinatedResponse.body) > options.maxResponseBodyBytes) {
+    sendText(
+      options.response,
+      502,
+      `The local preview response exceeded the ${options.maxResponseBodyBytes} byte limit.`,
+    );
     return;
   }
   writeTunnelResponse(options.response, coordinatedResponse);
@@ -462,6 +482,27 @@ function completePendingRequest(
 
   writeTunnelResponse(entry.response, message);
   return true;
+}
+
+function rejectOversizedResponse(
+  requestId: string,
+  sessionId: string,
+  pending: Map<string, PendingRequest>,
+  maxResponseBodyBytes: number,
+) {
+  const entry = pending.get(requestId);
+  if (!entry || entry.sessionId !== sessionId) return;
+  pending.delete(requestId);
+  clearTimeout(entry.timeout);
+  sendText(
+    entry.response,
+    502,
+    `The local preview response exceeded the ${maxResponseBodyBytes} byte limit.`,
+  );
+}
+
+function getEncodedBodySize(body: string | undefined) {
+  return body ? Buffer.byteLength(body, "base64") : 0;
 }
 
 function writeTunnelResponse(response: ServerResponse, message: TunnelResponseMessage) {

--- a/packages/farm-preview-tunnel/test/tunnel.test.mjs
+++ b/packages/farm-preview-tunnel/test/tunnel.test.mjs
@@ -117,6 +117,32 @@ test("preserves repeated cookies and removes encoding after decoding a response"
   }
 });
 
+test("stops buffering local responses that exceed the relay limit", async () => {
+  const target = createServer((_request, response) => {
+    response.write("12345678");
+    response.end("9");
+  });
+  await listen(target);
+  const targetAddress = target.address();
+  const relay = createPersistentPreviewRelay({ maxResponseBodyBytes: 8 });
+  const relayAddress = await relay.listen();
+  const agent = await startTypeScriptPreviewAgent({
+    relayUrl: relayAddress.websocketUrl,
+    name: "bounded-response",
+    targetUrl: `http://127.0.0.1:${targetAddress.port}`,
+  });
+
+  try {
+    const response = await fetch(agent.publicUrl);
+    assert.equal(response.status, 502);
+    assert.match(await response.text(), /exceeded the 8 byte limit/);
+  } finally {
+    await agent.close();
+    await relay.close();
+    await close(target);
+  }
+});
+
 test("rejects malformed and unauthenticated agent messages without crashing", async () => {
   const relay = createPersistentPreviewRelay();
   const address = await relay.listen();


### PR DESCRIPTION
## Problem

A preview target can return an unbounded response body, allowing one request to exhaust relay, gateway, CLI, or agent memory.

## Root cause

The preview protocol bounded incoming requests but did not define or enforce a response-body limit end to end.

## Change

Add a 5 MiB default response limit to the relay protocol, TypeScript agent, compatibility gateway, and CLI forwarder. Oversized responses fail explicitly.

## Safety and compatibility

Normal responses are unchanged. The protocol communicates the selected limit to compatible agents and retains the documented default.

## Verification

- Tunnel tests: 14 passed
- Preview gateway tests: 7 passed
- CLI suite: 102 passed
- Type-check and focused lint checks passed

## Documentation and release

Updated preview gateway and tunnel documentation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Limits preview response bodies to 5 MiB by default so a single oversized local response can no longer exhaust relay, gateway, CLI, or agent memory. Oversized responses now fail explicitly instead of being buffered unboundedly.

- Enforces the limit in the tunnel relay, TypeScript agent, compatibility gateway, and CLI forwarder.
- The relay advertises its limit to compatible agents in the protocol ready message; agents cannot exceed it.
- Returns `502` for oversized local responses and `413` when the gateway rejects an oversized upload, so the waiting public request completes instead of hanging.
- `maxResponseBodyBytes` is available on the relay, gateway handler, gateway options, and CLI to change the default.
- Normal responses are unchanged when they stay within the limit.

<sup>Written for commit 107fa6ae5f01399a5ef40f44241a629e488c2be8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/851?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

