### PR TITLE
fix(cron): prevent overlap across job schedules

### DIFF
--- a/docs/src/app/docs/cron/page.md
+++ b/docs/src/app/docs/cron/page.md
@@ -121,7 +121,7 @@ Use the opt-in development scheduler to run every configured expression in memor
 farm dev --cron
 ```
 
-The development scheduler uses UTC, prints each next run, and skips a run when its previous local invocation is still active. It stops with the dev server and does not persist state across restarts.
+The development scheduler uses UTC, prints each next run, and skips a run when any previous local invocation of the same named job is still active, including one started by another expression in its schedule array. It stops with the dev server and does not persist state across restarts.
 
 ## Schedule Syntax
 

--- a/packages/farm-cli/src/cron.ts
+++ b/packages/farm-cli/src/cron.ts
@@ -108,6 +108,7 @@ export async function startFarmCronScheduler(
 ): Promise<FarmCronScheduler> {
   const cron = await loadFarmCronConfig(options);
   const entries: FarmCronSchedulerEntry[] = [];
+  const activeJobs = new Set<string>();
 
   for (const job of cron.jobs) {
     for (const schedule of job.schedule) {
@@ -124,12 +125,22 @@ export async function startFarmCronScheduler(
           },
         },
         async () => {
-          logger.info(`Cron ${job.name} -> ${job.path}`);
-          const result = await invokeFarmCronJob(job, cron, {
-            ...options,
-            trigger: "development",
-          });
-          logger.success(`Cron ${job.name} completed in ${result.durationMs}ms.`);
+          if (activeJobs.has(job.name)) {
+            logger.warn(`Cron ${job.name} skipped an overlapping run.`);
+            return;
+          }
+
+          activeJobs.add(job.name);
+          try {
+            logger.info(`Cron ${job.name} -> ${job.path}`);
+            const result = await invokeFarmCronJob(job, cron, {
+              ...options,
+              trigger: "development",
+            });
+            logger.success(`Cron ${job.name} completed in ${result.durationMs}ms.`);
+          } finally {
+            activeJobs.delete(job.name);
+          }
         },
       );
       entries.push({ job, schedule, timer });

--- a/packages/farm-cli/test/cron.test.mjs
+++ b/packages/farm-cli/test/cron.test.mjs
@@ -110,6 +110,46 @@ test("starts UTC development schedules and stops them cleanly", async () => {
   }
 });
 
+test("prevents one cron job's schedules from overlapping", async () => {
+  const root = await createTempProject({ schedule: ["0 2 * * *", "0 14 * * *"] });
+  let finishFirstRun;
+  let firstRunStarted;
+  const started = new Promise((resolve) => {
+    firstRunStarted = resolve;
+  });
+  let calls = 0;
+
+  try {
+    const scheduler = await startFarmCronScheduler({
+      root,
+      url: "http://localhost:4319",
+      fetch: async () => {
+        calls += 1;
+        if (calls === 1) {
+          firstRunStarted();
+          await new Promise((resolve) => {
+            finishFirstRun = resolve;
+          });
+        }
+        return Response.json({ ok: true });
+      },
+    });
+
+    const firstRun = scheduler.entries[0].timer.trigger();
+    await started;
+    await scheduler.entries[1].timer.trigger();
+    assert.equal(calls, 1);
+
+    finishFirstRun();
+    await firstRun;
+    await scheduler.entries[1].timer.trigger();
+    assert.equal(calls, 2);
+    scheduler.stop();
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test("runs cron list and cron run through the CLI", async () => {
   const root = await createTempProject();
   const server = await createTestServer();
@@ -139,15 +179,16 @@ test("runs cron list and cron run through the CLI", async () => {
   }
 });
 
-async function createTempProject() {
+async function createTempProject(options = {}) {
   const root = await mkdtemp(path.join(os.tmpdir(), "farm-cli-cron-"));
+  const schedule = JSON.stringify(options.schedule || "0 2 * * *");
   await writeFile(
     path.join(root, "farm.config.mjs"),
     [
       "export default {",
       "  cron: {",
       "    dailyCleanup: {",
-      "      schedule: '0 2 * * *',",
+      `      schedule: ${schedule},`,
       "      path: '/api/maintenance/cleanup',",
       "      description: 'Delete expired sessions.',",
       "    },",


### PR DESCRIPTION
## Problem

A named cron job with multiple schedule expressions can run concurrently with itself in the development scheduler.

## Root cause

Crorner overlap protection is scoped to one timer, while Farm creates a separate timer for every expression.

## Change

Share one in-flight guard across all timers belonging to the same named job and release it on success or failure.

## Safety and compatibility

Different named jobs can still run concurrently. Single-expression jobs retain existing overlap protection.

## Verification

- CLI suite: 102 passed
- CLI type-check passed
- Focused lint and format checks passed

## Documentation and release

Clarified multi-expression overlap behavior in cron documentation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents a named cron job with multiple schedule expressions from running concurrently with itself in the development scheduler. Previously overlap protection was scoped per timer, so timers for different expressions of the same job could overlap; now one in-flight guard is shared across all timers for a job and released on success or failure.

**Bug Fixes**
- Different named jobs can still run concurrently, and single-expression jobs keep their existing overlap protection.
- Documented the new overlap behavior in the cron docs and added a regression test for multi-expression schedules.

<sup>Written for commit a8726fb651de4f2eac0735f7ea8164c9ee713ff4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/852?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

