### PR TITLE
fix(api): finalize failed JSON streams

### DIFF
--- a/packages/farm/src/__tests__/api-transport.test.ts
+++ b/packages/farm/src/__tests__/api-transport.test.ts
@@ -106,4 +106,20 @@ describe("API transports", () => {
     expect(cancelReason).toBeInstanceOf(SyntaxError);
     expect(response.body?.locked).toBe(false);
   });
+
+  it("finalizes the source when a streamed value cannot be serialized", async () => {
+    let finalized = false;
+    async function* events() {
+      try {
+        yield 1n;
+      } finally {
+        finalized = true;
+      }
+    }
+
+    const response = jsonStream(events());
+    await expect(response.text()).rejects.toThrow(/BigInt/);
+
+    expect(finalized).toBe(true);
+  });
 });

--- a/packages/farm/src/api/transport.ts
+++ b/packages/farm/src/api/transport.ts
@@ -105,6 +105,11 @@ export function jsonStream<TItem>(
           controller.enqueue(encoder.encode(`${JSON.stringify(next.value)}\n`));
         } catch (error) {
           finished = true;
+          try {
+            await iterator.return?.(error);
+          } catch {
+            // Preserve the serialization/source error that failed the response stream.
+          }
           controller.error(error);
         }
       },


### PR DESCRIPTION
## Problem

Streaming JSON serialization failures can leave a generator or async iterator open.

## Root cause

The stream adapter did not call iterator return when reading or serialization failed.

## Change

Finalize the iterator on failure and preserve the original source or serialization error.

## Safety and compatibility

Successful JSON streaming is unchanged. Iterator cleanup is only added to failure paths.

## Verification

- API transport tests: 5 passed
- Core type-check passed
- Focused format and lint checks passed

## Documentation and release

None.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes JSON stream serialization failures to finalize the source iterator instead of leaving it open. The original serialization error is preserved, and successful streaming is unchanged.

<sup>Written for commit c7a6ebf06cbd9d3b56061cd39365c8efe1e2ac3c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/853?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

