### PR TITLE
fix(server): cancel bodies discarded for HEAD

### DIFF
--- a/packages/farm/src/__tests__/api-route-manager.test.ts
+++ b/packages/farm/src/__tests__/api-route-manager.test.ts
@@ -336,11 +336,20 @@ describe("APIRouteManager", () => {
 
   it("uses GET for HEAD requests and strips the response body", async () => {
     const manager = new APIRouteManager("/tmp/farm-api-head-test");
+    let cancelled = false;
     const getHandler = async () =>
-      new Response("payload", {
-        status: 201,
-        headers: { "x-handler": "get" },
-      });
+      new Response(
+        new ReadableStream({
+          pull() {},
+          cancel() {
+            cancelled = true;
+          },
+        }),
+        {
+          status: 201,
+          headers: { "x-handler": "get" },
+        },
+      );
     manager.getRoutes().set("/api/status", {
       path: "/api/status",
       filePath: "/tmp/farm-api-head-test/status/route.ts",
@@ -355,6 +364,7 @@ describe("APIRouteManager", () => {
     expect(response.status).toBe(201);
     expect(response.headers.get("x-handler")).toBe("get");
     expect(await response.text()).toBe("");
+    expect(cancelled).toBe(true);
   });
 
   it("strips bodies returned by explicit HEAD handlers", async () => {

--- a/packages/farm/src/__tests__/metadata-image.test.tsx
+++ b/packages/farm/src/__tests__/metadata-image.test.tsx
@@ -87,4 +87,23 @@ describe("generated metadata images", () => {
     expect(response.headers.get("content-type")).toBe("image/custom");
     expect(await response.text()).toBe("custom");
   });
+
+  it("cancels a custom image response body that HEAD discards", async () => {
+    let cancelled = false;
+    const custom = new Response(
+      new ReadableStream({
+        pull() {},
+        cancel() {
+          cancelled = true;
+        },
+      }),
+      { headers: { "Content-Type": "image/custom" } },
+    );
+
+    const response = await createFarmMetadataImageResponse(custom, {}, { method: "HEAD" });
+
+    expect(response.body).toBeNull();
+    expect(response.headers.get("content-type")).toBe("image/custom");
+    expect(cancelled).toBe(true);
+  });
 });

--- a/packages/farm/src/__tests__/metadata-route.test.ts
+++ b/packages/farm/src/__tests__/metadata-route.test.ts
@@ -96,6 +96,26 @@ Host: https://farm.test
     expect(response.headers.get("allow")).toBe("GET, HEAD");
   });
 
+  it("cancels a custom response body that HEAD discards", async () => {
+    let cancelled = false;
+    const custom = new Response(
+      new ReadableStream({
+        pull() {},
+        cancel() {
+          cancelled = true;
+        },
+      }),
+      { headers: { "x-custom": "yes" } },
+    );
+
+    const response = createFarmMetadataRouteResponse("robots", custom, {}, { method: "HEAD" });
+    await Promise.resolve();
+
+    expect(response.body).toBeNull();
+    expect(response.headers.get("x-custom")).toBe("yes");
+    expect(cancelled).toBe(true);
+  });
+
   it("reports invalid convention values with focused errors", () => {
     expect(() => createFarmMetadataRouteResponse("sitemap", {})).toThrow(
       "sitemap.ts must return an array",

--- a/packages/farm/src/api/runtime.ts
+++ b/packages/farm/src/api/runtime.ts
@@ -13,6 +13,7 @@ import {
 import { DEFAULT_FARM_API_BASE_PATH, normalizeFarmAPIBasePath } from "./config";
 import { resolveFarmAPICanonicalPathname } from "./server-path";
 import { compareRouteSpecificity, type RouteSegmentSpecificity } from "../routing/specificity";
+import { omitFarmResponseBody } from "../response-body";
 
 export type APIRouteParamValue = string | string[];
 export type APIRouteParams = Record<string, APIRouteParamValue>;
@@ -125,11 +126,7 @@ export async function invokeAPIRouteEndpoint(
     return response;
   }
 
-  return new Response(null, {
-    status: response.status,
-    statusText: response.statusText,
-    headers: response.headers,
-  });
+  return omitFarmResponseBody(response);
 }
 
 async function invokeAPIRouteEndpointInContext(

--- a/packages/farm/src/metadata-image.ts
+++ b/packages/farm/src/metadata-image.ts
@@ -1,5 +1,6 @@
 import type { ImageResponseOptions } from "@vercel/og";
 import type { ReactElement } from "react";
+import { omitFarmResponseBody } from "./response-body";
 import { matchesFarmIfNoneMatch } from "./server-http";
 
 const REACT_ELEMENT_TYPE = Symbol.for("react.element");
@@ -187,9 +188,7 @@ export async function createFarmMetadataImageResponse(
   }
 
   if (isResponse(value)) {
-    return method === "HEAD"
-      ? new Response(null, { status: value.status, headers: value.headers })
-      : value;
+    return method === "HEAD" ? omitFarmResponseBody(value) : value;
   }
 
   const cacheControl = resolveCacheControl(imageModule.revalidate);

--- a/packages/farm/src/metadata-route.ts
+++ b/packages/farm/src/metadata-route.ts
@@ -1,3 +1,5 @@
+import { omitFarmResponseBody } from "./response-body";
+
 export type ApplicationMetadataRouteKind = "sitemap" | "robots" | "manifest";
 
 export namespace MetadataRoute {
@@ -218,13 +220,7 @@ export function createFarmMetadataRouteResponse(
   }
 
   if (isResponse(value)) {
-    return method === "HEAD"
-      ? new Response(null, {
-          status: value.status,
-          statusText: value.statusText,
-          headers: value.headers,
-        })
-      : value;
+    return method === "HEAD" ? omitFarmResponseBody(value) : value;
   }
 
   const body =

--- a/packages/farm/src/response-body.ts
+++ b/packages/farm/src/response-body.ts
@@ -1,0 +1,12 @@
+/** @internal */
+export function omitFarmResponseBody(response: Response): Response {
+  if (response.body) {
+    void response.body.cancel().catch(() => undefined);
+  }
+
+  return new Response(null, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: response.headers,
+  });
+}


### PR DESCRIPTION
## Problem

Farm discards bodies from custom HEAD responses without canceling their streams, leaving producers and resources active.

## Root cause

API and metadata handlers rebuilt HEAD responses with null bodies but did not dispose the original response body.

## Change

Use a shared internal helper that cancels discarded bodies across API routes, application metadata, and metadata-image responses.

## Safety and compatibility

HEAD status and headers remain unchanged. GET responses and responses without bodies are unaffected.

## Verification

- API and metadata route tests: 40 passed
- Core type-check passed
- Focused format and lint checks passed

## Documentation and release

None.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes HEAD responses leaking streams by cancelling bodies that are discarded for HEAD requests.

- Adds a shared `omitFarmResponseBody` helper that cancels the original body before rebuilding a null-body response.
- Applies it to API routes, application metadata routes, and metadata-image responses.
- HEAD status and headers are unchanged; GET responses and responses without bodies are unaffected.

<sup>Written for commit 98a3b94f65db99b657f77e76546cc77ce188ada0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/854?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

