### PR TITLE
fix(upgrade): update repeated dependency sections

### DIFF
--- a/docs/src/app/docs/cli/page.md
+++ b/docs/src/app/docs/cli/page.md
@@ -73,7 +73,7 @@ the newest prerelease published under the `beta` tag. Exactly one release channe
 
 Farm reads the app's dependencies and upgrades every published `@farm.js/*` package together. It
 detects npm, pnpm, Yarn, or Bun from `packageManager` and lockfiles, preserves whether each package
-is a regular, development, optional, or peer dependency, and skips local `workspace:`, `file:`,
+is a regular, development, optional, or peer dependency (including packages repeated across sections), and skips local `workspace:`, `file:`,
 `link:`, `portal:`, and `catalog:` references. Use `--dry-run` to inspect the commands without
 changing the project.
 

--- a/packages/farm-cli/README.md
+++ b/packages/farm-cli/README.md
@@ -17,7 +17,7 @@ farm upgrade --latest --dry-run
 ```
 
 `--latest` selects the newest stable release. `--beta` selects the newest beta release. The CLI
-detects npm, pnpm, Yarn, or Bun from the project and leaves `workspace:`, `file:`, and other local
-package references unchanged.
+detects npm, pnpm, Yarn, or Bun from the project, updates repeated Farm packages in every dependency
+section, and leaves `workspace:`, `file:`, and other local package references unchanged.
 
 See the [Farm.js repository](https://github.com/farming-labs/farm.js) for documentation, examples, and support.

--- a/packages/farm-cli/src/upgrade.ts
+++ b/packages/farm-cli/src/upgrade.ts
@@ -92,15 +92,13 @@ export async function createFarmUpgradePlan(options: FarmUpgradeOptions): Promis
     options.packageManager || detectFarmPackageManager(root, packageJson.packageManager);
   const packages: FarmUpgradePackage[] = [];
   const skipped: FarmSkippedUpgradePackage[] = [];
-  const seen = new Set<string>();
 
   for (const section of DEPENDENCY_SECTIONS) {
     const dependencies = packageJson[section];
     if (!dependencies || typeof dependencies !== "object") continue;
 
     for (const [name, rawSpecifier] of Object.entries(dependencies)) {
-      if (!name.startsWith("@farm.js/") || seen.has(name)) continue;
-      seen.add(name);
+      if (!name.startsWith("@farm.js/")) continue;
 
       const current = typeof rawSpecifier === "string" ? rawSpecifier : String(rawSpecifier);
       if (isLocalSpecifier(current)) {

--- a/packages/farm-cli/test/upgrade.test.mjs
+++ b/packages/farm-cli/test/upgrade.test.mjs
@@ -123,6 +123,53 @@ test("executes beta upgrades and skips local Farm packages", async () => {
   }
 });
 
+test("upgrades every manifest section when a Farm package is repeated", async () => {
+  const root = await createTempProject({
+    packageManager: "pnpm@8.12.1",
+    devDependencies: {
+      "@farm.js/core": "^0.1.0-beta.3",
+    },
+    peerDependencies: {
+      "@farm.js/core": "^0.1.0-beta.2",
+    },
+  });
+
+  try {
+    const plan = await createFarmUpgradePlan({ root, channel: "beta" });
+
+    assert.deepEqual(
+      plan.packages.map(({ name, current, section }) => ({ name, current, section })),
+      [
+        {
+          name: "@farm.js/core",
+          current: "^0.1.0-beta.3",
+          section: "devDependencies",
+        },
+        {
+          name: "@farm.js/core",
+          current: "^0.1.0-beta.2",
+          section: "peerDependencies",
+        },
+      ],
+    );
+    assert.deepEqual(
+      plan.commands.map(({ command, args }) => ({ command, args })),
+      [
+        {
+          command: "pnpm",
+          args: ["add", "--save-dev", "@farm.js/core@beta"],
+        },
+        {
+          command: "pnpm",
+          args: ["add", "--save-peer", "@farm.js/core@beta"],
+        },
+      ],
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test("detects Bun from its lockfile when packageManager is not declared", async () => {
   const root = await createTempProject({
     dependencies: {


### PR DESCRIPTION
## Problem

`farm upgrade` leaves stale versions when the same Farm package appears in more than one dependency section.

## Root cause

A global seen-name set discarded every occurrence after the first instead of planning upgrades per manifest section.

## Change

Plan each published package occurrence independently and retain the correct package-manager flag for each section.

## Safety and compatibility

Local workspace and file references remain skipped. Projects without repeated packages produce the same commands.

## Verification

- Upgrade tests: 6 passed
- CLI type-check passed
- Focused lint and format checks passed

## Documentation and release

Updated CLI reference and package README.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `farm upgrade` leaving stale versions when the same Farm package appears in more than one dependency section.

- Plans each published package occurrence independently, preserving the correct package-manager flag for each section.
- Skips local `workspace:`, `file:`, `link:`, `portal:`, and `catalog:` references as before.
- Projects without repeated packages produce identical commands.
- Updates CLI reference and package README to mention repeated package handling.

<sup>Written for commit a5b8156e3fb8f3b54a614c9440bfc1a5bc013ed4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/855?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

