### PR TITLE
fix(preview): cancel work after visitor disconnects

### DIFF
--- a/docs/src/app/docs/preview/page.md
+++ b/docs/src/app/docs/preview/page.md
@@ -66,6 +66,8 @@ The preview lifecycle is tied to the local app. When `farm dev` stops or the con
 
 The public URL is invalidated as soon as the session closes, so later requests return `404`. You do not need to run a separate command to stop or clean up the tunnel.
 
+Cancellation also applies to individual requests. If a visitor closes the connection while a slow or streaming local response is still running, the gateway tells the preview agent to abort that localhost request.
+
 ## Commands
 
 ```bash

--- a/examples/preview-gateway/lib/redis-coordinator.ts
+++ b/examples/preview-gateway/lib/redis-coordinator.ts
@@ -3,6 +3,7 @@ import {
   isRelayToAgentMessage,
   type PersistentPreviewRelayCoordinator,
   type PersistentPreviewRelayCoordinatorSession,
+  type TunnelCancelMessage,
   type TunnelRequestMessage,
   type TunnelResponseMessage,
 } from "@farm.js/preview-tunnel";
@@ -64,7 +65,10 @@ export class RedisPreviewRelayCoordinator implements PersistentPreviewRelayCoord
     await this.redis.eval(RELEASE_SESSION_SCRIPT, 1, this.nameKey(session.name), session.id);
   }
 
-  async publishRequest(sessionId: string, request: TunnelRequestMessage) {
+  async publishRequest(
+    sessionId: string,
+    request: TunnelRequestMessage | TunnelCancelMessage,
+  ) {
     await this.push(this.requestKey(sessionId), request);
   }
 
@@ -72,7 +76,10 @@ export class RedisPreviewRelayCoordinator implements PersistentPreviewRelayCoord
     const value = await this.take(this.requestKey(sessionId), timeoutMs);
     if (!value) return undefined;
     const message: unknown = JSON.parse(value);
-    return isRelayToAgentMessage(message) && message.type === "request" ? message : undefined;
+    return isRelayToAgentMessage(message) &&
+      (message.type === "request" || message.type === "cancel")
+      ? message
+      : undefined;
   }
 
   async publishResponse(sessionId: string, response: TunnelResponseMessage) {

--- a/packages/farm-cli/src/preview-gateway.ts
+++ b/packages/farm-cli/src/preview-gateway.ts
@@ -27,6 +27,7 @@ export interface PreviewGatewayRequest {
   headers?: Record<string, string>;
   body?: string | null;
   encoding?: "base64";
+  cancelled?: true;
 }
 
 export interface PreviewGatewayResponse {
@@ -104,6 +105,7 @@ export async function runPreviewGateway(
   const controller = new AbortController();
   let handledRequests = 0;
   const inFlightRequests = new Set<Promise<void>>();
+  const requestControllers = new Map<string, AbortController>();
   const maxConcurrentRequests = Math.max(
     1,
     options.maxConcurrentRequests ?? DEFAULT_MAX_CONCURRENT_REQUESTS,
@@ -127,7 +129,10 @@ export async function runPreviewGateway(
     }
   };
 
-  const handleRequest = async (request: PreviewGatewayRequest) => {
+  const handleRequest = async (
+    request: PreviewGatewayRequest,
+    requestController: AbortController,
+  ) => {
     const startedAt = Date.now();
     let response: PreviewGatewayResponse;
 
@@ -135,12 +140,13 @@ export async function runPreviewGateway(
       response = await forwardGatewayRequest(plan.target, request, {
         signal: AbortSignal.any([
           controller.signal,
+          requestController.signal,
           AbortSignal.timeout(options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS),
         ]),
         maxResponseBodyBytes: options.maxResponseBodyBytes ?? DEFAULT_MAX_RESPONSE_BODY_BYTES,
       });
     } catch (error) {
-      if (controller.signal.aborted) return;
+      if (controller.signal.aborted || requestController.signal.aborted) return;
       response = createGatewayErrorResponse(error);
     }
 
@@ -169,12 +175,24 @@ export async function runPreviewGateway(
       });
 
       for (const request of requests) {
+        if (request.cancelled) {
+          requestControllers.get(request.id)?.abort();
+          continue;
+        }
         await waitForAvailableRequestSlot();
         if (controller.signal.aborted) break;
 
-        const promise = handleRequest(request);
+        const requestController = new AbortController();
+        requestControllers.get(request.id)?.abort();
+        requestControllers.set(request.id, requestController);
+        const promise = handleRequest(request, requestController);
         inFlightRequests.add(promise);
-        promise.finally(() => inFlightRequests.delete(promise));
+        promise.finally(() => {
+          inFlightRequests.delete(promise);
+          if (requestControllers.get(request.id) === requestController) {
+            requestControllers.delete(request.id);
+          }
+        });
       }
 
       if (options.maxRequests && handledRequests >= options.maxRequests) {
@@ -185,6 +203,8 @@ export async function runPreviewGateway(
     process.removeListener("SIGINT", cleanup);
     process.removeListener("SIGTERM", cleanup);
     controller.abort();
+    for (const requestController of requestControllers.values()) requestController.abort();
+    requestControllers.clear();
     await Promise.allSettled(inFlightRequests);
     await localTargetWatch.catch(() => undefined);
     await closeGatewaySession(plan, session).catch(() => undefined);

--- a/packages/farm-cli/test/preview.test.mjs
+++ b/packages/farm-cli/test/preview.test.mjs
@@ -438,6 +438,58 @@ test("keeps the gateway session alive after one local request fails", async () =
   }
 });
 
+test("aborts local gateway work after a public cancellation", async () => {
+  let markSlowClosed;
+  const slowClosed = new Promise((resolve) => {
+    markSlowClosed = resolve;
+  });
+  const app = await createTestServer((req, res) => {
+    if (req.url === "/slow") {
+      res.once("close", markSlowClosed);
+      return;
+    }
+    res.end("ok");
+  });
+  const gateway = await createQueuedPreviewGatewayTestServer(
+    [
+      { id: "req_cancel", method: "GET", path: "/slow" },
+      { id: "req_cancel", method: "GET", path: "/slow", cancelled: true },
+      { id: "req_ok", method: "GET", path: "/ok" },
+    ],
+    { pollDelayMs: 20 },
+  );
+  const plan = createPreviewGatewayPlan(
+    {
+      localUrl: `http://localhost:${app.port}`,
+      host: "localhost",
+      port: app.port,
+      source: "port",
+    },
+    { gatewayUrl: gateway.url, name: "request-cancellation" },
+  );
+
+  try {
+    await runPreviewGateway(plan, {
+      maxRequests: 1,
+      pollTimeoutMs: 10,
+      localProbeIntervalMs: 1_000,
+    });
+    await Promise.race([
+      slowClosed,
+      new Promise((_, reject) =>
+        setTimeout(() => reject(new Error("cancelled local request remained active")), 500),
+      ),
+    ]);
+    assert.deepEqual(
+      gateway.responses.map(({ requestId, response }) => [requestId, response.status]),
+      [["req_ok", 200]],
+    );
+  } finally {
+    await app.close();
+    await gateway.close();
+  }
+});
+
 test("cancels streaming local health probe responses", async () => {
   const app = await createStreamingTestServer();
   const gateway = await createPreviewGatewayTestServer();
@@ -684,7 +736,7 @@ async function createPreviewGatewayTestServer() {
   };
 }
 
-async function createQueuedPreviewGatewayTestServer(requests) {
+async function createQueuedPreviewGatewayTestServer(requests, options = {}) {
   const queued = [...requests];
   const responses = [];
   const server = await createTestServer(async (req, res) => {
@@ -705,6 +757,8 @@ async function createQueuedPreviewGatewayTestServer(requests) {
     }
 
     if (req.method === "GET" && url.pathname === "/api/sessions/sess_queue/requests") {
+      if (options.pollDelayMs)
+        await new Promise((resolve) => setTimeout(resolve, options.pollDelayMs));
       res.setHeader("content-type", "application/json");
       res.end(JSON.stringify({ requests: queued.length ? [queued.shift()] : [] }));
       return;

--- a/packages/farm-preview-gateway/README.md
+++ b/packages/farm-preview-gateway/README.md
@@ -11,3 +11,5 @@ npm install @farm.js/preview-gateway@beta
 See the [Farm.js repository](https://github.com/farming-labs/farm.js) for documentation, examples, and support.
 
 The gateway limits public request bodies and local preview response bodies to 5 MiB by default. Use `maxBodyBytes` and `maxResponseBodyBytes` when creating the handler to set lower or higher limits. Oversized local responses are rejected at upload and the waiting public request receives a `502` response instead of being left pending.
+
+Public disconnects are propagated through the request queue. The polling agent aborts the matching localhost fetch instead of leaving abandoned app work running until its timeout.

--- a/packages/farm-preview-gateway/src/index.ts
+++ b/packages/farm-preview-gateway/src/index.ts
@@ -34,6 +34,7 @@ export interface PreviewGatewayRequest {
   body?: string | null;
   encoding?: "base64";
   createdAt: number;
+  cancelled?: true;
 }
 
 export interface PreviewGatewayResponse {
@@ -164,20 +165,36 @@ export function createNodePreviewGatewayHandler(options: PreviewGatewayOptions =
   const handler = createPreviewGatewayHandler(options);
 
   return async function nodePreviewGatewayHandler(req: IncomingMessage, res: ServerResponse) {
-    const response = await handler(nodeRequestToWebRequest(req));
-    res.statusCode = response.status;
-    // Headers.forEach folds repeated headers into one comma-joined value, which
-    // corrupts multiple Set-Cookie. Emit those separately as an array so each
-    // cookie becomes its own header line.
-    const setCookies = response.headers.getSetCookie?.() ?? [];
-    response.headers.forEach((value, key) => {
-      if (key.toLowerCase() === "set-cookie") return;
-      res.setHeader(key, value);
-    });
-    if (setCookies.length > 0) {
-      res.setHeader("set-cookie", setCookies);
+    const controller = new AbortController();
+    const abort = () => controller.abort();
+    const abortOnClose = () => {
+      if (!res.writableEnded) abort();
+    };
+    req.once("aborted", abort);
+    res.once("close", abortOnClose);
+    try {
+      const response = await handler(nodeRequestToWebRequest(req, controller.signal));
+      if (controller.signal.aborted || res.destroyed) {
+        await response.body?.cancel();
+        return;
+      }
+      res.statusCode = response.status;
+      // Headers.forEach folds repeated headers into one comma-joined value, which
+      // corrupts multiple Set-Cookie. Emit those separately as an array so each
+      // cookie becomes its own header line.
+      const setCookies = response.headers.getSetCookie?.() ?? [];
+      response.headers.forEach((value, key) => {
+        if (key.toLowerCase() === "set-cookie") return;
+        res.setHeader(key, value);
+      });
+      if (setCookies.length > 0) {
+        res.setHeader("set-cookie", setCookies);
+      }
+      res.end(Buffer.from(await response.arrayBuffer()));
+    } finally {
+      req.off("aborted", abort);
+      res.off("close", abortOnClose);
     }
-    res.end(Buffer.from(await response.arrayBuffer()));
   };
 }
 
@@ -615,7 +632,27 @@ async function proxyPublicRequest(
   await store.enqueueRequest(session.id, previewRequest, config.sessionTtlMs);
   await store.touchSession(session, config.sessionTtlMs);
 
-  const response = await waitForPreviewResponse(store, config, session, previewRequest.id);
+  const response = await waitForPreviewResponse(
+    store,
+    config,
+    session,
+    previewRequest.id,
+    request.signal,
+  );
+  if (response === "cancelled") {
+    await store.enqueueRequest(
+      session.id,
+      {
+        ...previewRequest,
+        body: undefined,
+        encoding: undefined,
+        cancelled: true,
+        createdAt: Date.now(),
+      },
+      config.sessionTtlMs,
+    );
+    return new Response(null, { status: 499 });
+  }
   if (response === "stale") {
     return text(`No active Farm preview is running for "${route.name}".`, 404);
   }
@@ -654,11 +691,13 @@ async function waitForPreviewResponse(
   config: PreviewGatewayRuntimeConfig,
   session: PreviewGatewaySession,
   requestId: string,
+  signal: AbortSignal,
 ) {
   const deadline = Date.now() + config.requestTimeoutMs;
   let nextLivenessCheckAt = 0;
 
   while (Date.now() < deadline) {
+    if (signal.aborted) return "cancelled";
     if (Date.now() >= nextLivenessCheckAt) {
       const latestSession = await store.getSessionById(session.id);
       if (!latestSession || !isPreviewClientOnline(latestSession, config)) {
@@ -673,7 +712,12 @@ async function waitForPreviewResponse(
       await store.deleteResponse(session.id, requestId);
       return response;
     }
-    await delay(config.pollIntervalMs);
+    try {
+      await delay(config.pollIntervalMs, undefined, { signal });
+    } catch {
+      if (signal.aborted) return "cancelled";
+      throw new Error("Preview response polling was interrupted.");
+    }
   }
 
   return undefined;
@@ -807,7 +851,7 @@ function matchSessionRoute(pathname: string) {
   };
 }
 
-function nodeRequestToWebRequest(req: IncomingMessage) {
+function nodeRequestToWebRequest(req: IncomingMessage, signal?: AbortSignal) {
   const host = headerValue(req.headers, "host") || "localhost";
   // This adapter is the public trust boundary. A visitor-controlled forwarded
   // protocol must not influence the authority serialized to the local app.
@@ -818,6 +862,7 @@ function nodeRequestToWebRequest(req: IncomingMessage) {
   const init: RequestInit & { duplex?: "half" } = {
     method,
     headers,
+    signal,
   };
 
   if (method !== "GET" && method !== "HEAD") {

--- a/packages/farm-preview-gateway/test/gateway.test.mjs
+++ b/packages/farm-preview-gateway/test/gateway.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { createServer } from "node:http";
+import { createServer, request as createRequest } from "node:http";
 import { setTimeout as delay } from "node:timers/promises";
 import test from "node:test";
 import { createNodePreviewGatewayHandler, MemoryPreviewGatewayStore } from "../dist/index.js";
@@ -206,6 +206,37 @@ test("expires stale preview clients before queueing public requests", async () =
     assert.equal(response.status, 404);
     assert.match(await response.text(), /No active Farm preview/);
     assert.ok(elapsedMs < 1000, `expected stale request to fail quickly, got ${elapsedMs}ms`);
+  } finally {
+    await gateway.close();
+  }
+});
+
+test("queues cancellation when a public visitor disconnects", async () => {
+  const store = new MemoryPreviewGatewayStore();
+  const gateway = await createGatewayServer(store);
+
+  try {
+    const session = await fetch(`${gateway.url}/api/sessions`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name: "cancel-check", localUrl: "http://localhost:4321" }),
+    }).then((response) => response.json());
+
+    const publicRequest = createRequest(`${gateway.url}/__preview/cancel-check/slow`);
+    publicRequest.on("error", () => undefined);
+    publicRequest.end();
+
+    const firstPoll = await fetch(
+      `${gateway.url}/api/sessions/${session.id}/requests?token=${session.token}&wait=1000`,
+    ).then((response) => response.json());
+    assert.equal(firstPoll.requests[0].cancelled, undefined);
+    publicRequest.destroy();
+
+    const secondPoll = await fetch(
+      `${gateway.url}/api/sessions/${session.id}/requests?token=${session.token}&wait=1000`,
+    ).then((response) => response.json());
+    assert.equal(secondPoll.requests[0].id, firstPoll.requests[0].id);
+    assert.equal(secondPoll.requests[0].cancelled, true);
   } finally {
     await gateway.close();
   }

--- a/packages/farm-preview-tunnel/README.md
+++ b/packages/farm-preview-tunnel/README.md
@@ -38,6 +38,8 @@ The agent closes automatically when the local target becomes unreachable. The re
 
 Local response bodies are limited to 5 MiB by default because the current protocol buffers and base64-encodes them. Configure `maxResponseBodyBytes` on the relay to change the limit; the relay advertises that limit to compatible agents and also enforces it when accepting responses. The TypeScript agent can set a smaller `maxResponseBodyBytes`, but cannot exceed the relay's limit.
 
+The relay sends a per-request cancellation message when a public visitor disconnects or the relay deadline expires. Compatible agents abort the matching localhost request, so abandoned streaming and slow responses do not continue running in the app.
+
 ## Rust agent
 
 The independent `@farm.js/tunnel` N-API package implements the same protocol and is the native agent used by `farm preview`. The TypeScript agent remains the portable protocol reference and fallback.

--- a/packages/farm-preview-tunnel/src/agent.ts
+++ b/packages/farm-preview-tunnel/src/agent.ts
@@ -82,6 +82,9 @@ export async function startTypeScriptPreviewAgent(
           if (inFlight.get(message.id) === controller) inFlight.delete(message.id);
         },
       );
+    } else if (message.type === "cancel") {
+      inFlight.get(message.id)?.abort();
+      inFlight.delete(message.id);
     }
   });
   socket.once("close", () => {
@@ -240,6 +243,7 @@ async function forwardRequest(
       body: responseBody.toString("base64"),
     };
   } catch (error) {
+    if (controller.signal.aborted && !timedOut) return;
     const unsafePath = error instanceof UnsafePreviewPathError;
     response = {
       type: "response",

--- a/packages/farm-preview-tunnel/src/protocol.ts
+++ b/packages/farm-preview-tunnel/src/protocol.ts
@@ -19,6 +19,11 @@ export interface TunnelRequestMessage {
   body?: string;
 }
 
+export interface TunnelCancelMessage {
+  type: "cancel";
+  id: string;
+}
+
 export interface TunnelResponseMessage {
   type: "response";
   id: string;
@@ -34,7 +39,11 @@ export interface TunnelErrorMessage {
 }
 
 export type AgentToRelayMessage = RegisterMessage | TunnelResponseMessage;
-export type RelayToAgentMessage = ReadyMessage | TunnelRequestMessage | TunnelErrorMessage;
+export type RelayToAgentMessage =
+  | ReadyMessage
+  | TunnelRequestMessage
+  | TunnelCancelMessage
+  | TunnelErrorMessage;
 
 export function isAgentToRelayMessage(value: unknown): value is AgentToRelayMessage {
   if (!isRecord(value)) return false;
@@ -59,6 +68,7 @@ export function isRelayToAgentMessage(value: unknown): value is RelayToAgentMess
       (value.id === undefined || typeof value.id === "string") && typeof value.message === "string"
     );
   }
+  if (value.type === "cancel") return typeof value.id === "string";
   return value.type === "request" && isTunnelRequestMessage(value);
 }
 

--- a/packages/farm-preview-tunnel/src/relay.ts
+++ b/packages/farm-preview-tunnel/src/relay.ts
@@ -6,6 +6,7 @@ import {
   isAgentToRelayMessage,
   normalizePreviewName,
   type ReadyMessage,
+  type TunnelCancelMessage,
   type TunnelRequestMessage,
   type TunnelResponseMessage,
 } from "./protocol.js";
@@ -52,8 +53,14 @@ export interface PersistentPreviewRelayCoordinator {
   findSession(name: string): Promise<PersistentPreviewRelayCoordinatorSession | undefined>;
   touchSession(session: PersistentPreviewRelayCoordinatorSession, ttlMs: number): Promise<boolean>;
   releaseSession(session: PersistentPreviewRelayCoordinatorSession): Promise<void>;
-  publishRequest(sessionId: string, request: TunnelRequestMessage): Promise<void>;
-  takeRequest(sessionId: string, timeoutMs: number): Promise<TunnelRequestMessage | undefined>;
+  publishRequest(
+    sessionId: string,
+    request: TunnelRequestMessage | TunnelCancelMessage,
+  ): Promise<void>;
+  takeRequest(
+    sessionId: string,
+    timeoutMs: number,
+  ): Promise<TunnelRequestMessage | TunnelCancelMessage | undefined>;
   publishResponse(sessionId: string, response: TunnelResponseMessage): Promise<void>;
   takeResponse(
     sessionId: string,
@@ -79,6 +86,7 @@ interface PendingRequest {
   response: ServerResponse;
   sessionId: string;
   timeout: NodeJS.Timeout;
+  cleanup: () => void;
 }
 
 export function createPersistentPreviewRelay(options: PersistentPreviewRelayOptions = {}) {
@@ -286,8 +294,9 @@ export function createPersistentPreviewRelay(options: PersistentPreviewRelayOpti
     },
     async close() {
       for (const session of agents.values()) session.socket.close(1001, "Relay shutting down");
-      for (const { response, timeout } of pending.values()) {
+      for (const { response, timeout, cleanup } of pending.values()) {
         clearTimeout(timeout);
+        cleanup();
         if (!response.headersSent)
           sendText(response, 503, "Persistent preview relay is shutting down.");
       }
@@ -318,13 +327,53 @@ async function forwardPublicRequest(options: ForwardPublicRequestOptions) {
   const id = randomUUID();
   const uploadController = new AbortController();
   const deadline = Date.now() + options.requestTimeoutMs;
+  let delivered = false;
+  let resolveDisconnected: (() => void) | undefined;
+  const disconnected = new Promise<"disconnected">((resolve) => {
+    resolveDisconnected = () => resolve("disconnected");
+  });
+  const sendCancel = () => {
+    if (!delivered) return;
+    const message: TunnelCancelMessage = { type: "cancel", id };
+    const localSession = options.localSession;
+    if (localSession && localSession.socket.readyState === localSession.socket.OPEN) {
+      localSession.socket.send(JSON.stringify(message));
+    } else if (options.coordinator && options.coordinatedSession) {
+      void options.coordinator
+        .publishRequest(options.coordinatedSession.id, message)
+        .catch(() => undefined);
+    }
+  };
+  const cleanup = () => {
+    options.request.off("aborted", onDisconnect);
+    options.response.off("close", onResponseClose);
+  };
+  const onDisconnect = () => {
+    uploadController.abort();
+    clearTimeout(timeout);
+    const entry = options.pending.get(id);
+    if (entry) {
+      options.pending.delete(id);
+      clearTimeout(entry.timeout);
+    }
+    sendCancel();
+    cleanup();
+    resolveDisconnected?.();
+  };
+  const onResponseClose = () => {
+    if (!options.response.writableEnded) onDisconnect();
+  };
   const timeout = setTimeout(() => {
     uploadController.abort();
     options.pending.delete(id);
+    sendCancel();
+    cleanup();
     if (!options.response.headersSent) {
       sendText(options.response, 504, "The persistent preview agent did not respond in time.");
     }
   }, options.requestTimeoutMs);
+  options.request.once("aborted", onDisconnect);
+  options.response.once("close", onResponseClose);
 
   let body: Buffer;
   try {
@@ -332,10 +381,14 @@ async function forwardPublicRequest(options: ForwardPublicRequestOptions) {
   } catch (error) {
     if (uploadController.signal.aborted) return;
     clearTimeout(timeout);
+    cleanup();
     throw error;
   }
 
-  if (uploadController.signal.aborted || options.response.writableEnded) return;
+  if (uploadController.signal.aborted || options.response.writableEnded) {
+    cleanup();
+    return;
+  }
   const message: TunnelRequestMessage = {
     type: "request",
     id,
@@ -347,10 +400,12 @@ async function forwardPublicRequest(options: ForwardPublicRequestOptions) {
 
   const localSession = options.localSession;
   if (localSession) {
+    delivered = true;
     options.pending.set(id, {
       response: options.response,
       sessionId: localSession.id,
       timeout,
+      cleanup,
     });
     try {
       localSession.socket.send(JSON.stringify(message), (error) => {
@@ -359,6 +414,7 @@ async function forwardPublicRequest(options: ForwardPublicRequestOptions) {
     } catch (error) {
       options.pending.delete(id);
       clearTimeout(timeout);
+      cleanup();
       throw error;
     }
     return;
@@ -366,17 +422,20 @@ async function forwardPublicRequest(options: ForwardPublicRequestOptions) {
 
   if (!options.coordinator || !options.coordinatedSession) {
     clearTimeout(timeout);
+    cleanup();
     throw new Error("Persistent preview relay coordination is unavailable.");
   }
 
   await options.coordinator.publishRequest(options.coordinatedSession.id, message);
+  delivered = true;
   const remainingMs = Math.max(1, deadline - Date.now());
-  const coordinatedResponse = await options.coordinator.takeResponse(
-    options.coordinatedSession.id,
-    id,
-    remainingMs,
-  );
+  const coordinatedResponse = await Promise.race([
+    options.coordinator.takeResponse(options.coordinatedSession.id, id, remainingMs),
+    disconnected,
+  ]);
   clearTimeout(timeout);
+  cleanup();
+  if (coordinatedResponse === "disconnected") return;
   if (options.response.writableEnded) return;
   if (!coordinatedResponse) {
     sendText(options.response, 504, "The persistent preview agent did not respond in time.");
@@ -483,6 +542,7 @@ function completePendingRequest(
   if (!entry || entry.sessionId !== sessionId) return false;
   pending.delete(message.id);
   clearTimeout(entry.timeout);
+  entry.cleanup();
 
   writeTunnelResponse(entry.response, message);
   return true;
@@ -526,6 +586,7 @@ function failPendingRequestsForSession(sessionId: string, pending: Map<string, P
     if (entry.sessionId !== sessionId) continue;
     pending.delete(id);
     clearTimeout(entry.timeout);
+    entry.cleanup();
     sendText(entry.response, 502, "The persistent preview agent disconnected.");
   }
 }
@@ -535,6 +596,7 @@ function failPendingRequest(id: string, sessionId: string, pending: Map<string, 
   if (!entry || entry.sessionId !== sessionId) return;
   pending.delete(id);
   clearTimeout(entry.timeout);
+  entry.cleanup();
   sendText(entry.response, 502, "The persistent preview agent disconnected.");
 }
 

--- a/packages/farm-preview-tunnel/test/tunnel.test.mjs
+++ b/packages/farm-preview-tunnel/test/tunnel.test.mjs
@@ -312,6 +312,51 @@ test("routes wildcard preview hosts and advertises the matching public URL", asy
   }
 });
 
+test("aborts the local request when the public visitor disconnects", async () => {
+  let markLocalStarted;
+  const localStarted = new Promise((resolve) => {
+    markLocalStarted = resolve;
+  });
+  let markLocalClosed;
+  const localClosed = new Promise((resolve) => {
+    markLocalClosed = resolve;
+  });
+  const target = createServer((_request, response) => {
+    markLocalStarted();
+    response.once("close", markLocalClosed);
+  });
+  await listen(target);
+  const targetAddress = target.address();
+  const relay = createPersistentPreviewRelay({ requestTimeoutMs: 2_000 });
+  const relayAddress = await relay.listen();
+  const agent = await startTypeScriptPreviewAgent({
+    relayUrl: relayAddress.websocketUrl,
+    name: "visitor-disconnect",
+    targetUrl: `http://127.0.0.1:${targetAddress.port}`,
+    requestTimeoutMs: 2_000,
+  });
+
+  const publicRequest = createRequest(agent.publicUrl);
+  publicRequest.on("error", () => undefined);
+  publicRequest.end();
+
+  try {
+    await localStarted;
+    publicRequest.destroy();
+    await Promise.race([
+      localClosed,
+      new Promise((_, reject) =>
+        setTimeout(() => reject(new Error("local request remained active")), 500),
+      ),
+    ]);
+  } finally {
+    publicRequest.destroy();
+    await agent.close();
+    await relay.close();
+    await close(target);
+  }
+});
+
 test("falls through to an existing HTTP gateway when no native session matches", async () => {
   const fallbackRequests = [];
   const relay = createPersistentPreviewRelay({


### PR DESCRIPTION
## Problem

When a public preview visitor disconnects, Farm continues forwarding and processing the abandoned request until completion or timeout.

## Root cause

The preview protocol had no cancellation message linking visitor disconnects to relay, gateway, CLI, and agent work.

## Change

Add request cancellation across direct relay and coordinated gateway paths, abort local forwarding, and clean queued request state.

## Safety and compatibility

Agents that do not yet understand cancellation safely ignore the additive protocol message. Completed responses retain existing behavior.

## Verification

- Tunnel tests: 14 passed
- Preview gateway tests: 7 passed
- CLI suite: 102 passed
- Type-check and focused lint checks passed
- Native end-to-end cancellation verified against a built local agent

## Documentation and release

Updated preview protocol and gateway documentation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cancels abandoned preview work when a public visitor disconnects, so the local app no longer keeps processing requests after the client is gone.

- Adds a `cancel` message to the preview tunnel protocol that is propagated over direct relay and coordinated gateway paths.
- The relay sets a per-request deadline and aborts local forwarding when the visitor disconnects or times out.
- The gateway enqueues cancellation and aborts polling when the public request is destroyed; agents that don't understand the new message safely ignore it.
- Updates preview protocol and gateway docs, and adds tests covering disconnect and cancellation behavior.

<sup>Written for commit 09bfc2a913f2de5ead3880cc53de2dc2c976896e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/856?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

