### PR TITLE
fix(preview): ship the updated native tunnel

### DIFF
--- a/packages/farm-cli/package.json
+++ b/packages/farm-cli/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@farm.js/core": "workspace:*",
-    "@farm.js/tunnel": "0.1.0",
+    "@farm.js/tunnel": "0.1.1",
     "commander": "^11.1.0",
     "croner": "9.1.0",
     "picocolors": "^1.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1904,8 +1904,8 @@ importers:
         specifier: workspace:*
         version: link:../farm
       '@farm.js/tunnel':
-        specifier: 0.1.0
-        version: 0.1.0
+        specifier: 0.1.1
+        version: 0.1.1
       commander:
         specifier: ^11.1.0
         version: 11.1.0
@@ -4942,8 +4942,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@farm.js/tunnel-darwin-arm64@0.1.0:
-    resolution: {integrity: sha512-QY2GqvBeGhJXnI+0M2E6cQQbTYgxT2t7qYZQZohB5AP1IzKivyl+AM8e3e3DWuevoS6qbehqxnyg+yqCBk94Rw==}
+  /@farm.js/tunnel-darwin-arm64@0.1.1:
+    resolution: {integrity: sha512-QFZGrH22vJbHa7DbwH61kraQzIFhmi8ipd4fIP9s5cHWQB+2W0uEodZoBVbrSLhxGwxcYHqG46VJwlCIQCjnvA==}
     engines: {node: '>=20.0.0'}
     cpu: [arm64]
     os: [darwin]
@@ -4951,8 +4951,8 @@ packages:
     dev: false
     optional: true
 
-  /@farm.js/tunnel-darwin-x64@0.1.0:
-    resolution: {integrity: sha512-iniAHaEQ0mP5fbBv9UD+uC6ZJKiy33OszOaGzS50fWDxgpUpfkf++TgU2ASW7h2B8G48mpKMSO8t0yxhKcjH8Q==}
+  /@farm.js/tunnel-darwin-x64@0.1.1:
+    resolution: {integrity: sha512-05IMDpkq81JGPHQLyFNPvZnxJ0WNYON7PYBlivAP9uyOg+0PVXuIA/H5hs0P7QQiDrP9cGExvUH7+IN/wX0sZQ==}
     engines: {node: '>=20.0.0'}
     cpu: [x64]
     os: [darwin]
@@ -4960,8 +4960,8 @@ packages:
     dev: false
     optional: true
 
-  /@farm.js/tunnel-linux-arm64-gnu@0.1.0:
-    resolution: {integrity: sha512-X9jwnZPv6xyY8+uS781qv7gmp7n0tAee/EN67piFSiUv3+BZdC7YXMc3NrT29hUEhIsG5vmYr+TDyr8j1ynqsA==}
+  /@farm.js/tunnel-linux-arm64-gnu@0.1.1:
+    resolution: {integrity: sha512-NnnUV4xH5mnlfliq3dDW+7FnwNvaDnuipCB05teSH5AHpwN9llntmoO9B84TER4BwRlZ5YO02Pcoij2svQDOpQ==}
     engines: {node: '>=20.0.0'}
     cpu: [arm64]
     os: [linux]
@@ -4969,8 +4969,8 @@ packages:
     dev: false
     optional: true
 
-  /@farm.js/tunnel-linux-arm64-musl@0.1.0:
-    resolution: {integrity: sha512-oAiHgXXj1GEVIe5YZKY0PBFEdFOssgWEF4gUuDKP8GIFqXEc/Jqe7udYInsVniuBxkMYM5zS5j862KNeUNFACw==}
+  /@farm.js/tunnel-linux-arm64-musl@0.1.1:
+    resolution: {integrity: sha512-WjdP+ke9zwjqgwxgfsdNvzXW6ucVNDjqZCBV+wEDv21rQbxeZ/crFd0hDFij58a5ZttEyE3vJeACvh1knUW6uw==}
     engines: {node: '>=20.0.0'}
     cpu: [arm64]
     os: [linux]
@@ -4978,8 +4978,8 @@ packages:
     dev: false
     optional: true
 
-  /@farm.js/tunnel-linux-x64-gnu@0.1.0:
-    resolution: {integrity: sha512-Btzqj2G7RPmGl7GWH0WXZWdwqovMsqTol0qkbMsqJILLXHi/wRjKbQ8cTL8dV3u1pVWlJGAvQyoB5esCnADnfQ==}
+  /@farm.js/tunnel-linux-x64-gnu@0.1.1:
+    resolution: {integrity: sha512-jPzR4YBztdu5s509yLtshWlX3Es4oHPdrNn2XV3MpivWvIAD51U3Z7H3/PJyB7ZJiY3jfzo9ixTQr0Jfofb8uA==}
     engines: {node: '>=20.0.0'}
     cpu: [x64]
     os: [linux]
@@ -4987,8 +4987,8 @@ packages:
     dev: false
     optional: true
 
-  /@farm.js/tunnel-linux-x64-musl@0.1.0:
-    resolution: {integrity: sha512-HeQJaPaPLXp5OpthCwHb9SvGXJPG01/DWk5Y0zxhxGo7+lxSkXFNyM5HQY2TqavkcbTKoHX7KcKaJqAfU4dh2g==}
+  /@farm.js/tunnel-linux-x64-musl@0.1.1:
+    resolution: {integrity: sha512-HCbzkQ0pADtHzkLPHEOTIlMnex1w8M1aq6K/IKgb4hhGokiZW0d4sdlAvS5FAso1NC7tl+877j0eNzjhGZJR6w==}
     engines: {node: '>=20.0.0'}
     cpu: [x64]
     os: [linux]
@@ -4996,8 +4996,8 @@ packages:
     dev: false
     optional: true
 
-  /@farm.js/tunnel-win32-arm64-msvc@0.1.0:
-    resolution: {integrity: sha512-VzIHitxt2oot9Ob3TD/EQxKFZoZnou2QyI5/Y3eOExP4JwrlWhN7dskpKU566IIoB5Yv1ubcXJN+KE255zWAlA==}
+  /@farm.js/tunnel-win32-arm64-msvc@0.1.1:
+    resolution: {integrity: sha512-JwGGq622xPUpizBb35PRMAMifACuAVre95Cnp9IjdhqE9aIOKLdKWLjAq+bb9+qa1JgE8999FoPOcQIria0Xtw==}
     engines: {node: '>=20.0.0'}
     cpu: [arm64]
     os: [win32]
@@ -5005,8 +5005,8 @@ packages:
     dev: false
     optional: true
 
-  /@farm.js/tunnel-win32-x64-msvc@0.1.0:
-    resolution: {integrity: sha512-pchzMhRSr6XJ6C5Hd5DfdR0dd4NIAy9FMoojrfuMaR+YovXAU/MbwHfleIqnlAU0SrM9XQMzEH0RkR8ZvclD+Q==}
+  /@farm.js/tunnel-win32-x64-msvc@0.1.1:
+    resolution: {integrity: sha512-wle5M4MB3Zv+nYg75i93O2o4IRVBDvYjdV+Vk6KVXZr6bTrb2ELW2CiLGB4gjhlWdOA4whN3s63rXthZXBrM2g==}
     engines: {node: '>=20.0.0'}
     cpu: [x64]
     os: [win32]
@@ -5014,18 +5014,18 @@ packages:
     dev: false
     optional: true
 
-  /@farm.js/tunnel@0.1.0:
-    resolution: {integrity: sha512-03KDpHY71+Z2FM2MVfrricXJP9y0uZfhdcDiT9eBi5v6wMjW2znaOoINoikGi82Gd4vCJMbeib6SD5GhD7rm3Q==}
+  /@farm.js/tunnel@0.1.1:
+    resolution: {integrity: sha512-kaGeTp1iJx85Me+NAW70k1u361/bba1Veosx2zV9TN1soxFCUGnb+YlZXyA+soswFKAhw0eul+Et9+DX0A3LvA==}
     engines: {node: '>=20.0.0'}
     optionalDependencies:
-      '@farm.js/tunnel-darwin-arm64': 0.1.0
-      '@farm.js/tunnel-darwin-x64': 0.1.0
-      '@farm.js/tunnel-linux-arm64-gnu': 0.1.0
-      '@farm.js/tunnel-linux-arm64-musl': 0.1.0
-      '@farm.js/tunnel-linux-x64-gnu': 0.1.0
-      '@farm.js/tunnel-linux-x64-musl': 0.1.0
-      '@farm.js/tunnel-win32-arm64-msvc': 0.1.0
-      '@farm.js/tunnel-win32-x64-msvc': 0.1.0
+      '@farm.js/tunnel-darwin-arm64': 0.1.1
+      '@farm.js/tunnel-darwin-x64': 0.1.1
+      '@farm.js/tunnel-linux-arm64-gnu': 0.1.1
+      '@farm.js/tunnel-linux-arm64-musl': 0.1.1
+      '@farm.js/tunnel-linux-x64-gnu': 0.1.1
+      '@farm.js/tunnel-linux-x64-musl': 0.1.1
+      '@farm.js/tunnel-win32-arm64-msvc': 0.1.1
+      '@farm.js/tunnel-win32-x64-msvc': 0.1.1
     dev: false
 
   /@farming-labs/docs@0.2.111(react@19.2.8)(supports-color@10.2.2):


### PR DESCRIPTION
## Problem

Farm CLI still installs `@farm.js/tunnel@0.1.0`, so the native preview path cannot use the newly released response limits and request cancellation.

## Root cause

The native package is released independently and the CLI pin had not yet been advanced.

## Change

Pin `@farm.js/tunnel` and all lockfile-resolved platform binaries to `0.1.1`.

## Safety and compatibility

The native package API is unchanged. The compatibility gateway fallback remains available when the native relay cannot connect. All supported platform packages are pinned exactly to the same release.

## Verification

- `pnpm install --frozen-lockfile --ignore-scripts`
- Loaded `@farm.js/tunnel` through the CLI workspace and confirmed version `0.1.1` plus the expected exports.
- `pnpm --filter @farm.js/cli test` (105 passed)
- `pnpm --filter @farm.js/cli type-check`

## Documentation and release

The behavior documentation shipped in the owning preview PRs. This dependency pin will be included in the next Farm beta.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins `@farm.js/tunnel` to `0.1.1` so the CLI's native preview path picks up the new response limits and request cancellation from the independently released tunnel package. The package API is unchanged, and the compatibility gateway fallback still works when the native relay can't connect.

<sup>Written for commit 12d36ba24a97e37f7b089b2cadac988a93daf943. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/858?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

