### PR TITLE
perf(react): compose queued structural map setters

### DIFF
--- a/docs/src/app/docs/renderers/react/page.md
+++ b/docs/src/app/docs/renderers/react/page.md
@@ -1306,21 +1306,33 @@ validates every survivor and key before the first DOM write, removes rejected ro
 moves only when a reorder needs them, and patches bindings only for changed survivors. A changed
 item that a later structural step removes needs no row patch.
 
-Leading maps may also be split from following filter or slice work across adjacent setter calls:
+Structural and map work may also be split across adjacent setter calls in either order:
 
 ```tsx
+// Map, then structural work.
 setItems((current) =>
   current.map((item) => (item.id === editedId ? { ...item, label: nextLabel } : item)),
 );
 setItems((current) => current.filter((item) => item.visible));
 setItems((current) => current.slice(0, limit));
+
+// Structural work, then maps.
+setItems((current) => current.filter((item) => item.visible));
+setItems((current) => current.slice(0, limit));
+setItems((current) =>
+  current.map((item) => (item.id === editedId ? { ...item, label: nextLabel } : item)),
+);
+setItems((current) =>
+  current.map((item) => (item.id === editedId ? { ...item, rank: nextRank } : item)),
+);
 ```
 
-Farm links only consecutive calls to the same setter. It retains the first committed map source and
-validates each structural result before the queued commit touches the DOM. Multiple leading map
-setters and multiple following filter/slice setters may share the proof. A map after structural
-work, an intervening statement, another setter, an unsupported callback, a changed key, or any
-failed runtime proof keeps complete reconciliation.
+Farm links only consecutive calls to the same setter. A leading map retains its first committed
+source through later structural work; a terminal map consumes the saved survivor lineage from the
+preceding filter or slice. Multiple safe steps in either segment may share the proof, and mixed
+map/structural/map sequences compose. Every result and key is validated before the queued commit
+touches the DOM. An intervening statement, another setter, an unsupported callback, a changed key,
+or any failed runtime proof keeps complete reconciliation.
 
 A safe map may also be the final pipeline step:
 
@@ -2294,10 +2306,10 @@ The package and example test suites verify more than generated code:
 - 2,000 deterministic mapped structural removals, another 2,000 randomized updates with maps
   interleaved between filter/slice steps and a final reorder, 2,000 randomized terminal
   structural-map transitions, 2,000 randomized map-before-terminal-filter/slice transitions, and
-  2,000 randomized adjacent queued map/filter/slice transitions match normal React; targeted tests
-  preserve surviving DOM identity and controlled-input focus/selection, patch only changed
-  survivors, and cover adjacency boundaries, changed-key and custom-method fallback, Strict Mode
-  hydration, and unmount-before-flush cleanup;
+  separate 2,000-transition adjacent-setter runs with map/structural work in both orders match normal
+  React; targeted tests preserve surviving DOM identity and controlled-input focus/selection, patch
+  only changed survivors, and cover multiple terminal maps, adjacency boundaries, changed-key and
+  custom-method fallback, Strict Mode hydration, and unmount-before-flush cleanup;
 - 2,000 deterministic native reversals or sorts followed by consecutive same-key edits match normal
   React; targeted tests require exact reversal to use `n - 1` direct DOM moves without a generic
   source-item map, require ambiguous sorting to use one validated keyed reconciliation, and cover

--- a/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
+++ b/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
@@ -2,6 +2,36 @@
 
 Latest run: 2026-09-09
 
+## Queued structural setters before maps — 2026-09-09
+
+Adjacent keyed-row setters may now retain one safe lineage when native `filter()` or `slice()`
+work runs before one or more same-key `map()` setters. The maintained workload removes one row and
+then updates another. Farm carries the structural survivor proof into the terminal map, validates
+the complete result before the first DOM write, removes the rejected row, and patches only the
+changed survivor. The block-bodied control performs the same two native operations through
+complete keyed reconciliation.
+
+| Mode   | Queued filter + map | Compiled control | vs React | vs control |
+| ------ | ------------------: | ---------------: | -------: | ---------: |
+| Static |             4.70 ms |         12.90 ms |   14.97x |      2.74x |
+| Hybrid |             4.60 ms |         12.70 ms |   15.29x |      2.76x |
+
+Both modes passed the unchanged 2x React and 1.25x compiled-control floors. The complete bracketed
+run passed its correctness oracle, broad 10% regression gate, optimization-persistence gate, every
+existing feature-specific performance gate, and zero compiled owner executions.
+
+Compiler and runtime tests cover multiple filter/slice and terminal-map setters, mixed
+map/structural/map sequences, exact survivor DOM identity, one changed-row binding read,
+controlled-input focus and selection, atomic fallback when adjacency or runtime proof fails,
+Strict Mode hydration, unmount-before-flush cleanup, and 2,000 randomized queued transitions
+matched with normal React. React 18.3.1 and 19.2.8 compatibility passes, and all isolated optional
+runtime gzip fixtures remain within their unchanged budgets.
+
+Numbers are medians from one complete bracketed run: 10 samples per compiler mode and 20 surrounding
+React samples using Chrome 153.0.8010.36, Node.js 23.11.0, and Apple M1 macOS arm64. Timing varies by
+machine; deterministic parity, fallback, DOM-identity, compatibility, and runtime-size checks remain
+the primary safety controls.
+
 ## Queued maps before structural setters — 2026-09-09
 
 Adjacent keyed-row setters may now keep one safe lineage across the queued update boundary. The

--- a/examples/react-compiler-dashboard/README.md
+++ b/examples/react-compiler-dashboard/README.md
@@ -269,18 +269,18 @@ same four native updates through complete reconciliation. Both compiler modes mu
 final committed order, every original DOM identity and connection, and both changed values. Package tests
 also cover mixed reverse/sort chains, chain boundaries, and 2,000 randomized differential updates.
 
-Mapped terminal-structural updates have a separate 10,000-row comparison. One concise setter changes
-a surviving row through a safe map and an immediately adjacent setter filters out another row, with
-no synthetic reorder needed to retain the compiler proof. The block-bodied control performs the
-same two queued native updates through complete keyed reconciliation. Both compiler modes must
-remain at least 2x faster than React and 1.25x faster than the compiled control. The assertion checks
-the changed values, rejected-row cleanup, full survivor order, and every surviving DOM identity.
-Package tests also cover maps before, between, and after filter/slice steps; adjacent queued map,
-filter, and slice setters; mapped structural reorders; controlled-input focus and selection;
-changed-key and custom-method fallback; Strict Mode hydration; cleanup; and separate 2,000-row
-differential runs. The benchmark lifecycle rebuilds `@farm.js/react` first and then verifies the
-emitted hint counts, so local source changes cannot be silently measured through stale package
-output.
+Queued structural-then-map updates have a separate 10,000-row comparison. One concise setter filters
+out a row and an immediately adjacent safe map changes a surviving row, with no synthetic reorder
+needed to retain the compiler proof. The block-bodied control performs the same two queued native
+updates through complete keyed reconciliation. Both compiler modes must remain at least 2x faster
+than React and 1.25x faster than the compiled control. The assertion checks the changed values,
+rejected-row cleanup, full survivor order, and every surviving DOM identity. Package tests cover
+maps before, between, and after filter/slice steps; structural and map work in either order across
+adjacent setters; multiple terminal maps; mapped structural reorders; controlled-input focus and
+selection; changed-key and custom-method fallback; Strict Mode hydration; cleanup; and separate
+2,000-row differential runs. The benchmark lifecycle rebuilds `@farm.js/react` first and then
+verifies the emitted hint counts, so local source changes cannot be silently measured through stale
+package output.
 
 Mapped reverse parity has an independent 10,000-row comparison. Two safe native maps update one
 row, then two native reversals restore committed order. Farm must patch the changed row without

--- a/examples/react-compiler-dashboard/scripts/benchmark.mjs
+++ b/examples/react-compiler-dashboard/scripts/benchmark.mjs
@@ -2972,8 +2972,8 @@ const keyedStructuralReorderRegressions = keyedStructuralReorderResults.filter(
     !Number.isFinite(snapshotSpeedup) ||
     snapshotSpeedup < keyedStructuralReorderMinimumSnapshotSpeedup,
 );
-// A safe map followed by a terminal filter in an adjacent setter changes row data and membership in
-// one queued commit. The combined path must patch the changed survivor and remove the rejected row
+// A safe filter followed by a terminal map in an adjacent setter changes membership and row data in
+// one queued commit. The combined path must remove the rejected row and patch the changed survivor
 // instead of dropping to complete keyed reconciliation at the setter boundary.
 const keyedMappedStructuralReorderMinimumSpeedup = 2;
 const keyedMappedStructuralReorderMinimumSnapshotSpeedup = 1.25;

--- a/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
+++ b/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
@@ -874,6 +874,7 @@ export function StandardTableBenchmark() {
           data-action="table-map-structural-reorder-pipeline"
           type="button"
           onClick={() => {
+            setRows((current) => current.filter((row) => row.id % 10_000 !== 7_001));
             setRows((current) =>
               current.map((row) =>
                 row.id % 10_000 === 5_001
@@ -881,17 +882,19 @@ export function StandardTableBenchmark() {
                   : row,
               ),
             );
-            setRows((current) => current.filter((row) => row.id % 10_000 !== 7_001));
-            setOperation("review one row, then filter another in a queued setter");
+            setOperation("filter one row, then review another in a queued setter");
             setRevision((value) => value + 1);
           }}
         >
-          Queued map + filter
+          Queued filter + map
         </button>
         <button
           data-action="table-map-structural-reorder-pipeline-snapshot"
           type="button"
           onClick={() => {
+            setRows((current) => {
+              return current.filter((row) => row.id % 10_000 !== 7_001);
+            });
             setRows((current) => {
               return current.map((row) =>
                 row.id % 10_000 === 5_001
@@ -899,14 +902,11 @@ export function StandardTableBenchmark() {
                   : row,
               );
             });
-            setRows((current) => {
-              return current.filter((row) => row.id % 10_000 !== 7_001);
-            });
-            setOperation("review and filter rows in queued setters (snapshot control)");
+            setOperation("filter and review rows in queued setters (snapshot control)");
             setRevision((value) => value + 1);
           }}
         >
-          Queued map + filter (snapshot control)
+          Queued filter + map (snapshot control)
         </button>
         <button
           data-action="table-map-reorder-pipeline"

--- a/packages/farm-react/README.md
+++ b/packages/farm-react/README.md
@@ -493,21 +493,34 @@ each accepted step. The final commit removes rejected rows, performs LIS moves o
 needs them, and patches bindings only for changed survivors. Every native callback and method still
 runs in JavaScript order.
 
-The maps may also be followed by filter or slice work in immediately adjacent setter calls:
+The structural and map steps may also be split across immediately adjacent setter calls in either
+order:
 
 ```tsx
+// Map, then structural work.
 setItems((current) =>
   current.map((item) => (item.id === editedId ? { ...item, label: nextLabel } : item)),
 );
 setItems((current) => current.filter((item) => item.visible));
 setItems((current) => current.slice(0, limit));
+
+// Structural work, then maps.
+setItems((current) => current.filter((item) => item.visible));
+setItems((current) => current.slice(0, limit));
+setItems((current) =>
+  current.map((item) => (item.id === editedId ? { ...item, label: nextLabel } : item)),
+);
+setItems((current) =>
+  current.map((item) => (item.id === editedId ? { ...item, rank: nextRank } : item)),
+);
 ```
 
-Farm links only consecutive calls to the same setter, retains the first committed map source, and
-validates each structural result before the queued commit touches the DOM. Multiple leading map
-setters and multiple following filter/slice setters may share this proof. A map after structural
-work, an intervening statement, another setter, an unsafe callback, a changed key, or failed runtime
-validation keeps complete keyed reconciliation.
+Farm links only consecutive calls to the same setter. A leading map retains its first committed
+source through later structural work; a terminal map consumes the saved survivor lineage from the
+preceding filter or slice. Multiple safe steps in either segment may share the proof, and mixed
+map/structural/map sequences compose. Every result and key is validated before the queued commit
+touches the DOM. An intervening statement, another setter, an unsafe callback, a changed key, or
+failed runtime validation keeps complete keyed reconciliation.
 
 The reorder and safe maps may also be adjacent setter calls in the same synchronous block:
 

--- a/packages/farm-react/src/__tests__/compiler-keyed-array-queued-structural-map-hints.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-keyed-array-queued-structural-map-hints.test.ts
@@ -8,11 +8,11 @@ import { normalizeReactCompilerOptions } from "../index";
 const infer = normalizeReactCompilerOptions(true, "/app");
 
 async function compile(source: string) {
-  return compileReactModule(source, "/app/QueuedMappedStructuralHints.tsx", infer);
+  return compileReactModule(source, "/app/QueuedStructuralMapHints.tsx", infer);
 }
 
-describe("React AOT queued mapped structural hints", () => {
-  it("retains adjacent maps through following filter and slice setters", async () => {
+describe("React AOT queued structural then map hints", () => {
+  it("retains adjacent filter and slice setters through following maps", async () => {
     const result = await compile(`
       import { useState } from "react";
       export function Table({ editedId, nextLabel, nextRank, hiddenId, limit }) {
@@ -23,15 +23,15 @@ describe("React AOT queued mapped structural hints", () => {
         ]);
         return <section>
           <button onClick={() => {
+            setRows((current) => current.filter((row) => row.id !== hiddenId));
+            setRows((current) => current.slice(0, limit));
             setRows((current) => current.map((row) =>
               row.id === editedId ? { ...row, label: nextLabel } : row
             ));
             setRows((current) => current.map((row) =>
               row.id === editedId ? { ...row, rank: nextRank } : row
             ));
-            setRows((current) => current.filter((row) => row.id !== hiddenId));
-            setRows((current) => current.slice(0, limit));
-          }}>Edit and trim</button>
+          }}>Trim and edit</button>
           <ul>{rows.map((row) => <li key={row.id}>{row.label}: {row.rank}</li>)}</ul>
         </section>;
       }
@@ -42,49 +42,69 @@ describe("React AOT queued mapped structural hints", () => {
     expect(result.optimizations.keyedMapUpdateHints).toBe(2);
     expect(result.optimizations.keyedArrayFilterHints).toBe(1);
     expect(result.optimizations.keyedArraySliceHints).toBe(1);
-    expect(result.code.match(/createCompilerKeyedArrayQueuedMapPipeline\(/g)).toHaveLength(2);
-    expect(result.code.match(/finalizeCompilerKeyedArrayMappedStructuralUpdate\(/g)).toHaveLength(
-      2,
-    );
+    expect(result.code.match(/createCompilerKeyedArrayMapPipeline\(/g)).toHaveLength(2);
     expect(result.code).not.toContain("createCompilerKeyedMapUpdate");
-    expect(result.code).not.toContain("createCompilerKeyedArrayMapPipeline");
+    expect(result.code).not.toContain("createCompilerKeyedArrayQueuedMapPipeline");
+    expect(result.code).not.toContain("finalizeCompilerKeyedArrayMappedStructuralUpdate");
     expect(result.code).toContain("keyedRowsEveryHintedRuntimeFeature");
     expect(result.code).toContain("reorderIndexIndependent={true}");
     await expect(
-      transformWithEsbuild(result.code, "/app/QueuedMappedStructuralHints.tsx", {
+      transformWithEsbuild(result.code, "/app/QueuedStructuralMapHints.tsx", {
         loader: "tsx",
         jsx: "automatic",
       }),
     ).resolves.toMatchObject({
-      code: expect.stringContaining("finalizeCompilerKeyedArrayMappedStructuralUpdate"),
+      code: expect.stringContaining("createCompilerKeyedArrayMapPipeline"),
     });
+  });
+
+  it("composes a queued map on both sides of a structural setter", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Table({ editedId, nextLabel, nextRank, hiddenId }) {
+        const [rows, setRows] = useState([
+          { id: "a", label: "Alpha", rank: 1 },
+          { id: "b", label: "Beta", rank: 2 },
+        ]);
+        return <section>
+          <button onClick={() => {
+            setRows((current) => current.map((row) =>
+              row.id === editedId ? { ...row, label: nextLabel } : row
+            ));
+            setRows((current) => current.filter((row) => row.id !== hiddenId));
+            setRows((current) => current.map((row) =>
+              row.id === editedId ? { ...row, rank: nextRank } : row
+            ));
+          }}>Edit, trim, and edit</button>
+          <ul>{rows.map((row) => <li key={row.id}>{row.label}: {row.rank}</li>)}</ul>
+        </section>;
+      }
+    `);
+
+    expect(result.code.match(/createCompilerKeyedArrayQueuedMapPipeline\(/g)).toHaveLength(1);
+    expect(result.code.match(/createCompilerKeyedArrayMapPipeline\(/g)).toHaveLength(1);
+    expect(result.code.match(/finalizeCompilerKeyedArrayMappedStructuralUpdate\(/g)).toHaveLength(
+      1,
+    );
+    expect(result.code).not.toContain("createCompilerKeyedMapUpdate");
   });
 
   it.each([
     {
       name: "an intervening statement",
       updates: `
+        setRows((current) => current.filter((row) => row.id !== hiddenId));
+        onFiltered();
         setRows((current) => current.map((row) =>
           row.id === editedId ? { ...row, label: nextLabel } : row
         ));
-        onMapped();
-        setRows((current) => current.filter((row) => row.id !== hiddenId));
       `,
     },
     {
       name: "another state setter",
       updates: `
-        setRows((current) => current.map((row) =>
-          row.id === editedId ? { ...row, label: nextLabel } : row
-        ));
+        setRows((current) => current.filter((row) => row.id !== hiddenId));
         setSelected(editedId);
-        setRows((current) => current.filter((row) => row.id !== hiddenId));
-      `,
-    },
-    {
-      name: "structural work before the map",
-      updates: `
-        setRows((current) => current.filter((row) => row.id !== hiddenId));
         setRows((current) => current.map((row) =>
           row.id === editedId ? { ...row, label: nextLabel } : row
         ));
@@ -93,14 +113,14 @@ describe("React AOT queued mapped structural hints", () => {
     {
       name: "an unsupported map callback",
       updates: `
-        setRows((current) => current.map((row) => ({ ...row, label: nextLabel })));
         setRows((current) => current.filter((row) => row.id !== hiddenId));
+        setRows((current) => current.map((row) => ({ ...row, label: nextLabel })));
       `,
     },
   ])("keeps complete fallback across $name", async ({ updates }) => {
     const result = await compile(`
       import { useState } from "react";
-      export function Table({ editedId, nextLabel, hiddenId, onMapped }) {
+      export function Table({ editedId, nextLabel, hiddenId, onFiltered }) {
         const [rows, setRows] = useState([
           { id: "a", label: "Alpha" },
           { id: "b", label: "Beta" },
@@ -116,7 +136,6 @@ describe("React AOT queued mapped structural hints", () => {
     `);
 
     expect(result.compiled).toEqual(["Table"]);
-    expect(result.code).not.toContain("createCompilerKeyedArrayQueuedMapPipeline");
-    expect(result.code).not.toContain("finalizeCompilerKeyedArrayMappedStructuralUpdate");
+    expect(result.code).not.toContain("createCompilerKeyedArrayMapPipeline");
   });
 });

--- a/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-structural-reorder-hints.test.tsx
+++ b/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-structural-reorder-hints.test.tsx
@@ -48,8 +48,12 @@ function hintedFilter(items: Item[], predicate: (item: Item) => boolean): Item[]
   return createCompilerKeyedArrayFilter(items, items.filter, predicate) as Item[];
 }
 
-function hintedMap(items: Item[], mapper: (item: Item) => Item): Item[] {
-  return createCompilerKeyedArrayMapPipeline(items, items.map, mapper) as Item[];
+function hintedMap(
+  items: Item[],
+  mapper: (item: Item) => Item,
+  method: unknown = items.map,
+): Item[] {
+  return createCompilerKeyedArrayMapPipeline(items, method, mapper) as Item[];
 }
 
 function queuedHintedMap(
@@ -144,8 +148,17 @@ function createHarness(initialItems: Item[]) {
     removed: ReadonlySet<string>,
     limit: number,
   ) => void = () => undefined;
+  let queuedFilterSliceMap: (
+    editedId: string,
+    nextLabel: string,
+    nextRank: number,
+    removed: ReadonlySet<string>,
+    limit: number,
+  ) => void = () => undefined;
   let invalidQueuedMappedStructuralIdentity: () => void = () => undefined;
+  let invalidQueuedStructuralMappedIdentity: () => void = () => undefined;
   let customQueuedMapThenFilter: () => void = () => undefined;
+  let customQueuedFilterThenMap: () => void = () => undefined;
   let invalidIdentity: () => void = () => undefined;
   let invalidMappedIdentity: () => void = () => undefined;
   let invalidTerminalMappedIdentity: () => void = () => undefined;
@@ -275,6 +288,22 @@ function createHarness(initialItems: Item[]) {
           hintedMappedStructural(hintedSlice(previous as Item[], 0, limit)),
         );
       };
+      queuedFilterSliceMap = (editedId, nextLabel, nextRank, removed, limit) => {
+        state[0].set((previous) =>
+          hintedFilter(previous as Item[], (item) => !removed.has(item.id)),
+        );
+        state[0].set((previous) => hintedSlice(previous as Item[], 0, limit));
+        state[0].set((previous) =>
+          hintedMap(previous as Item[], (item) =>
+            item.id === editedId ? { ...item, label: nextLabel } : item,
+          ),
+        );
+        state[0].set((previous) =>
+          hintedMap(previous as Item[], (item) =>
+            item.id === editedId ? { ...item, rank: nextRank } : item,
+          ),
+        );
+      };
       invalidQueuedMappedStructuralIdentity = () => {
         state[0].set((previous) =>
           queuedHintedMap(previous as Item[], (item) =>
@@ -283,6 +312,14 @@ function createHarness(initialItems: Item[]) {
         );
         state[0].set((previous) =>
           hintedMappedStructural(hintedFilter(previous as Item[], (item) => item.id !== "c")),
+        );
+      };
+      invalidQueuedStructuralMappedIdentity = () => {
+        state[0].set((previous) => hintedFilter(previous as Item[], (item) => item.id !== "c"));
+        state[0].set((previous) =>
+          hintedMap(previous as Item[], (item) =>
+            item.id === "b" ? { ...item, id: "replacement", label: "Replacement" } : item,
+          ),
         );
       };
       customQueuedMapThenFilter = () => {
@@ -303,6 +340,23 @@ function createHarness(initialItems: Item[]) {
         state[0].set((previous) =>
           hintedMappedStructural(hintedFilter(previous as Item[], (item) => item.id !== "c")),
         );
+      };
+      customQueuedFilterThenMap = () => {
+        state[0].set((previous) => hintedFilter(previous as Item[], (item) => item.id !== "c"));
+        state[0].set((previous) => {
+          const items = previous as Item[];
+          const customMap = function (
+            this: Item[],
+            callback: (item: Item, index: number, items: Item[]) => Item,
+          ) {
+            return Array.prototype.map.call(this, callback);
+          };
+          return hintedMap(
+            items,
+            (item) => (item.id === "a" ? { ...item, label: "Custom queued terminal map" } : item),
+            customMap,
+          );
+        });
       };
       invalidIdentity = () =>
         state[0].set((previous) => {
@@ -447,6 +501,7 @@ function createHarness(initialItems: Item[]) {
     customMapStructural: () => customMapStructural(),
     customMapTerminal: () => customMapTerminal(),
     customMapThenFilter: () => customMapThenFilter(),
+    customQueuedFilterThenMap: () => customQueuedFilterThenMap(),
     customQueuedMapThenFilter: () => customQueuedMapThenFilter(),
     filterMapSliceMap: (
       editedId: string,
@@ -470,6 +525,7 @@ function createHarness(initialItems: Item[]) {
     invalidMappedIdentity: () => invalidMappedIdentity(),
     invalidMappedStructuralIdentity: () => invalidMappedStructuralIdentity(),
     invalidQueuedMappedStructuralIdentity: () => invalidQueuedMappedStructuralIdentity(),
+    invalidQueuedStructuralMappedIdentity: () => invalidQueuedStructuralMappedIdentity(),
     invalidTerminalMappedIdentity: () => invalidTerminalMappedIdentity(),
     mapFilterSlice: (
       editedId: string,
@@ -483,6 +539,13 @@ function createHarness(initialItems: Item[]) {
       removed: ReadonlySet<string>,
       limit: number,
     ) => queuedMapFilterSlice(editedId, nextLabel, removed, limit),
+    queuedFilterSliceMap: (
+      editedId: string,
+      nextLabel: string,
+      nextRank: number,
+      removed: ReadonlySet<string>,
+      limit: number,
+    ) => queuedFilterSliceMap(editedId, nextLabel, nextRank, removed, limit),
     mapFilterDoubleReverse: (editedId: string, nextLabel: string, removed: ReadonlySet<string>) =>
       mapFilterDoubleReverse(editedId, nextLabel, removed),
     mapFilterSortReverse: (
@@ -764,6 +827,42 @@ describe("compiled keyed-array structural reorder hints", () => {
     expect(harness.counters.bindings).toBe(1);
   });
 
+  it("patches a mapped survivor across queued filter, slice, and map setters", async () => {
+    const items: Item[] = [
+      { id: "a", label: "Alpha", rank: 4, visible: true },
+      { id: "b", label: "Beta", rank: 1, visible: false },
+      { id: "c", label: "Gamma", rank: 3, visible: true },
+      { id: "d", label: "Delta", rank: 2, visible: true },
+    ];
+    const harness = createHarness(items);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Table />));
+    const alpha = container.querySelector('[data-key="a"]');
+    const gamma = container.querySelector('[data-key="c"]');
+    harness.counters.bindings = 0;
+    harness.counters.descriptors = 0;
+    harness.counters.keys = 0;
+
+    await act(async () => {
+      harness.queuedFilterSliceMap("c", "Gamma queued terminal", 7, new Set(["b"]), 2);
+      await flushCompilerUpdates();
+    });
+
+    expect(labels(container)).toEqual(["Alpha", "Gamma queued terminal"]);
+    expect(container.querySelector('[data-key="a"]')).toBe(alpha);
+    expect(container.querySelector('[data-key="c"]')).toBe(gamma);
+    expect(container.querySelector('[data-key="b"]')).toBeNull();
+    expect(container.querySelector('[data-key="d"]')).toBeNull();
+    expect(harness.counters.executions).toBe(1);
+    expect(harness.counters.renders).toBe(1);
+    expect(harness.counters.keys).toBe(2);
+    expect(harness.counters.descriptors).toBe(0);
+    expect(harness.counters.bindings).toBe(1);
+  });
+
   it("falls back safely for custom methods and identity mismatches", async () => {
     const items: Item[] = [
       { id: "a", label: "Alpha", rank: 2, visible: true },
@@ -943,6 +1042,44 @@ describe("compiled keyed-array structural reorder hints", () => {
     expect(changedKey.counters.descriptors).toBeGreaterThan(0);
   });
 
+  it("falls back atomically when queued structural work precedes an invalid map", async () => {
+    const items: Item[] = [
+      { id: "a", label: "Alpha", rank: 2, visible: true },
+      { id: "b", label: "Beta", rank: 1, visible: true },
+      { id: "c", label: "Gamma", rank: 3, visible: true },
+    ];
+    const custom = createHarness(items);
+    const customContainer = document.createElement("div");
+    document.body.append(customContainer);
+    const customRoot = createRoot(customContainer);
+    roots.push(customRoot);
+    await act(async () => customRoot.render(<custom.Table />));
+    custom.counters.bindings = 0;
+    custom.counters.descriptors = 0;
+    await act(async () => {
+      custom.customQueuedFilterThenMap();
+      await flushCompilerUpdates();
+    });
+    expect(labels(customContainer)).toEqual(["Custom queued terminal map", "Beta"]);
+    expect(custom.counters.bindings).toBeGreaterThan(0);
+
+    const changedKey = createHarness(items);
+    const changedKeyContainer = document.createElement("div");
+    document.body.append(changedKeyContainer);
+    const changedKeyRoot = createRoot(changedKeyContainer);
+    roots.push(changedKeyRoot);
+    await act(async () => changedKeyRoot.render(<changedKey.Table />));
+    changedKey.counters.bindings = 0;
+    changedKey.counters.descriptors = 0;
+    await act(async () => {
+      changedKey.invalidQueuedStructuralMappedIdentity();
+      await flushCompilerUpdates();
+    });
+    expect(labels(changedKeyContainer)).toEqual(["Alpha", "Replacement"]);
+    expect(changedKey.counters.bindings).toBeGreaterThan(0);
+    expect(changedKey.counters.descriptors).toBeGreaterThan(0);
+  });
+
   it("preserves a surviving controlled input, focus, and selection", async () => {
     const items: Item[] = [
       { id: "a", label: "Alpha", rank: 3, visible: true },
@@ -956,15 +1093,13 @@ describe("compiled keyed-array structural reorder hints", () => {
       render(_props: Record<string, never>, state, blocks) {
         const rows = () => state[0].get() as Item[];
         update = () => {
+          state[0].set((previous) => hintedFilter(previous as Item[], (item) => item.id !== "a"));
+          state[0].set((previous) => hintedSlice(previous as Item[], 0, 1));
           state[0].set((previous) =>
-            queuedHintedMap(previous as Item[], (item) =>
+            hintedMap(previous as Item[], (item) =>
               item.id === "b" ? { ...item, label: "Beta newest" } : item,
             ),
           );
-          state[0].set((previous) =>
-            hintedMappedStructural(hintedFilter(previous as Item[], (item) => item.id !== "a")),
-          );
-          state[0].set((previous) => hintedMappedStructural(hintedSlice(previous as Item[], 0, 1)));
         };
         return (
           <section>
@@ -1469,6 +1604,85 @@ describe("compiled keyed-array structural reorder hints", () => {
     expect(harness.counters.executions).toBe(1);
   }, 20_000);
 
+  it("matches React across 2,000 randomized queued structural mapped transitions", async () => {
+    const initialItems = Array.from(
+      { length: 2_001 },
+      (_, index): Item => ({
+        id: `row-${index}`,
+        label: `Row ${index}`,
+        rank: (index * 1_229) % 2_003,
+        visible: true,
+      }),
+    );
+    const harness = createHarness(initialItems);
+    let updateReact: (
+      editedId: string,
+      nextLabel: string,
+      nextRank: number,
+      removed: ReadonlySet<string>,
+      limit: number,
+    ) => void = () => undefined;
+    function Normal() {
+      const [items, setItems] = useState(initialItems);
+      updateReact = (editedId, nextLabel, nextRank, removed, limit) => {
+        setItems((previous) => previous.filter((item) => !removed.has(item.id)));
+        setItems((previous) => previous.slice(0, limit));
+        setItems((previous) =>
+          previous.map((item) => (item.id === editedId ? { ...item, label: nextLabel } : item)),
+        );
+        setItems((previous) =>
+          previous.map((item) => (item.id === editedId ? { ...item, rank: nextRank } : item)),
+        );
+      };
+      return (
+        <ol>
+          {items.map((item) => (
+            <li data-key={item.id} key={item.id}>
+              {item.label}
+            </li>
+          ))}
+        </ol>
+      );
+    }
+    const compiledContainer = document.createElement("div");
+    const reactContainer = document.createElement("div");
+    document.body.append(compiledContainer, reactContainer);
+    const compiledRoot = createRoot(compiledContainer);
+    const reactRoot = createRoot(reactContainer);
+    roots.push(compiledRoot, reactRoot);
+    await act(async () => {
+      compiledRoot.render(<harness.Table />);
+      reactRoot.render(<Normal />);
+    });
+
+    let seed = 0x243f6a88;
+    let active = initialItems.map((item) => item.id);
+    for (let batch = 0; batch < 100; batch += 1) {
+      const removed = new Set<string>();
+      for (let update = 0; update < 15; update += 1) {
+        seed = (Math.imul(seed, 1_664_525) + 1_013_904_223) >>> 0;
+        const available = active.filter((id) => !removed.has(id));
+        removed.add(available[seed % available.length]);
+      }
+      const survivors = active.filter((id) => !removed.has(id));
+      const limit = survivors.length - 5;
+      seed = (Math.imul(seed, 1_664_525) + 1_013_904_223) >>> 0;
+      const editedId = survivors[seed % limit];
+      const nextLabel = `Queued structural mapped ${batch}`;
+      const nextRank = seed % 2_003;
+      await act(async () => {
+        harness.queuedFilterSliceMap(editedId, nextLabel, nextRank, removed, limit);
+        updateReact(editedId, nextLabel, nextRank, removed, limit);
+        await flushCompilerUpdates();
+      });
+      expect(labels(compiledContainer)).toEqual(labels(reactContainer));
+      active = [...reactContainer.querySelectorAll<HTMLElement>("li")].map(
+        (row) => row.dataset.key!,
+      );
+    }
+    expect(harness.counters.executions).toBe(1);
+  }, 20_000);
+
   it("hydrates in StrictMode and drops a queued pipeline after unmount", async () => {
     const items: Item[] = [
       { id: "a", label: "Alpha", rank: 3, visible: true },
@@ -1501,6 +1715,11 @@ describe("compiled keyed-array structural reorder hints", () => {
       await flushCompilerUpdates();
     });
     expect(labels(container)).toEqual(["Alpha queued", "Beta hydrated"]);
+    await act(async () => {
+      hydration.queuedFilterSliceMap("b", "Beta queued terminal", 7, new Set(), 2);
+      await flushCompilerUpdates();
+    });
+    expect(labels(container)).toEqual(["Alpha queued", "Beta queued terminal"]);
     expect(recoverable).toEqual([]);
 
     const unmounted = createHarness(items);
@@ -1509,7 +1728,7 @@ describe("compiled keyed-array structural reorder hints", () => {
     const unmountRoot = createRoot(unmountContainer);
     await act(async () => unmountRoot.render(<unmounted.Table />));
     act(() => {
-      unmounted.queuedMapFilterSlice("c", "Gamma queued", new Set(["a"]), 2);
+      unmounted.queuedFilterSliceMap("c", "Gamma queued", 7, new Set(["a"]), 2);
       unmountRoot.unmount();
     });
     await flushCompilerUpdates();

--- a/packages/farm-react/src/compiler.ts
+++ b/packages/farm-react/src/compiler.ts
@@ -2420,6 +2420,35 @@ function rewriteQueuedKeyedArrayReorderMapHints(
   };
 }
 
+function countKeyedArrayMapPipeline(
+  updater: t.ArrowFunctionExpression,
+  mapUpdateIdentifier: t.Identifier,
+): number {
+  if (
+    !t.isCallExpression(updater.body) ||
+    !t.isIdentifier(updater.body.callee, { name: mapUpdateIdentifier.name }) ||
+    updater.body.arguments.length !== 2
+  ) {
+    return 0;
+  }
+  const pipeline = updater.body.arguments[1];
+  if (
+    !t.isArrowFunctionExpression(pipeline) ||
+    pipeline.params.length !== 2 ||
+    !t.isIdentifier(pipeline.params[1])
+  ) {
+    return 0;
+  }
+  const applyMapName = pipeline.params[1].name;
+  let count = 0;
+  t.traverseFast(pipeline.body, (node) => {
+    if (t.isCallExpression(node) && t.isIdentifier(node.callee, { name: applyMapName })) {
+      count += 1;
+    }
+  });
+  return count;
+}
+
 function rewriteQueuedKeyedArrayMappedStructuralHints(
   root: t.JSXElement,
   statesBySetter: ReadonlyMap<string, StateBinding>,
@@ -2429,39 +2458,24 @@ function rewriteQueuedKeyedArrayMappedStructuralHints(
   filterIdentifier: t.Identifier,
   sliceIdentifier: t.Identifier,
   allowed: boolean,
-): { root: t.JSXElement; mapCount: number; structuralCount: number } {
+): {
+  root: t.JSXElement;
+  mapCount: number;
+  structuralCount: number;
+  stateIndices: ReadonlySet<number>;
+} {
   if (!allowed) {
-    return { root: t.cloneNode(root, true), mapCount: 0, structuralCount: 0 };
+    return {
+      root: t.cloneNode(root, true),
+      mapCount: 0,
+      structuralCount: 0,
+      stateIndices: new Set(),
+    };
   }
   const file = expressionFile(t.cloneNode(root, true));
   let mapCount = 0;
   let structuralCount = 0;
-
-  const mapPipelineCount = (updater: t.ArrowFunctionExpression): number => {
-    if (
-      !t.isCallExpression(updater.body) ||
-      !t.isIdentifier(updater.body.callee, { name: mapUpdateIdentifier.name }) ||
-      updater.body.arguments.length !== 2
-    ) {
-      return 0;
-    }
-    const pipeline = updater.body.arguments[1];
-    if (
-      !t.isArrowFunctionExpression(pipeline) ||
-      pipeline.params.length !== 2 ||
-      !t.isIdentifier(pipeline.params[1])
-    ) {
-      return 0;
-    }
-    const applyMapName = pipeline.params[1].name;
-    let count = 0;
-    t.traverseFast(pipeline.body, (node) => {
-      if (t.isCallExpression(node) && t.isIdentifier(node.callee, { name: applyMapName })) {
-        count += 1;
-      }
-    });
-    return count;
-  };
+  const stateIndices = new Set<number>();
 
   const terminalStructuralReturn = (
     updater: t.ArrowFunctionExpression,
@@ -2522,10 +2536,10 @@ function rewriteQueuedKeyedArrayMappedStructuralHints(
           continue;
         }
 
-        const pipelineMapCount = mapPipelineCount(updater);
+        const pipelineMapCount = countKeyedArrayMapPipeline(updater, mapUpdateIdentifier);
         if (pipelineMapCount > 0) {
-          // A map after an already structural result needs a different queued proof. Keep that
-          // direction on the complete fallback until it is supported deliberately.
+          // A later pass handles maps after an already structural result. End this pass's
+          // map-before-structural segment without rewriting that map here.
           if (mappedStructuralState !== undefined) {
             mappedStructuralState = undefined;
             pendingMaps = [];
@@ -2565,6 +2579,7 @@ function rewriteQueuedKeyedArrayMappedStructuralHints(
           t.cloneNode(structuralValue),
         ]);
         structuralCount += 1;
+        stateIndices.add(state.index);
         mappedStructuralState = state.index;
         pendingMaps = [];
       }
@@ -2574,6 +2589,98 @@ function rewriteQueuedKeyedArrayMappedStructuralHints(
     root: (file.program.body[0] as t.ExpressionStatement).expression as t.JSXElement,
     mapCount,
     structuralCount,
+    stateIndices,
+  };
+}
+
+function rewriteQueuedKeyedArrayStructuralMapHints(
+  root: t.JSXElement,
+  statesBySetter: ReadonlyMap<string, StateBinding>,
+  mapUpdateIdentifier: t.Identifier,
+  mapPipelineIdentifier: t.Identifier,
+  filterIdentifier: t.Identifier,
+  sliceIdentifier: t.Identifier,
+  allowed: boolean,
+): { root: t.JSXElement; mapCount: number; stateIndices: ReadonlySet<number> } {
+  if (!allowed) {
+    return { root: t.cloneNode(root, true), mapCount: 0, stateIndices: new Set() };
+  }
+  const file = expressionFile(t.cloneNode(root, true));
+  let mapCount = 0;
+  const stateIndices = new Set<number>();
+
+  const returnsStructuralValue = (updater: t.ArrowFunctionExpression): boolean => {
+    if (!t.isBlockStatement(updater.body)) return false;
+    const statement = updater.body.body.at(-1);
+    if (!t.isReturnStatement(statement) || !statement.argument) return false;
+    let found = false;
+    t.traverseFast(statement.argument, (node) => {
+      if (
+        !found &&
+        t.isCallExpression(node) &&
+        t.isIdentifier(node.callee) &&
+        (node.callee.name === filterIdentifier.name || node.callee.name === sliceIdentifier.name)
+      ) {
+        found = true;
+      }
+    });
+    return found;
+  };
+
+  traverse(file, {
+    BlockStatement(path) {
+      let structuralState: number | undefined;
+      const statements = path.get("body") as NodePath<t.Statement>[];
+      for (const statementPath of statements) {
+        const statement = statementPath.node;
+        if (!t.isExpressionStatement(statement) || !t.isCallExpression(statement.expression)) {
+          structuralState = undefined;
+          continue;
+        }
+        const setterCall = statement.expression;
+        if (
+          !t.isIdentifier(setterCall.callee) ||
+          statementPath.scope.hasBinding(setterCall.callee.name) ||
+          setterCall.arguments.length !== 1
+        ) {
+          structuralState = undefined;
+          continue;
+        }
+        const state = statesBySetter.get(setterCall.callee.name);
+        const updater = setterCall.arguments[0];
+        if (
+          !state ||
+          !t.isArrowFunctionExpression(updater) ||
+          updater.async ||
+          updater.generator ||
+          updater.params.length !== 1 ||
+          !t.isIdentifier(updater.params[0])
+        ) {
+          structuralState = undefined;
+          continue;
+        }
+
+        if (returnsStructuralValue(updater)) {
+          structuralState = state.index;
+          continue;
+        }
+
+        const pipelineMapCount = countKeyedArrayMapPipeline(updater, mapUpdateIdentifier);
+        if (structuralState !== state.index || pipelineMapCount === 0) {
+          structuralState = undefined;
+          continue;
+        }
+        (updater as t.ArrowFunctionExpression & { body: t.CallExpression }).body.callee =
+          t.cloneNode(mapPipelineIdentifier);
+        mapCount += pipelineMapCount;
+        stateIndices.add(state.index);
+      }
+    },
+  });
+  return {
+    root: (file.program.body[0] as t.ExpressionStatement).expression as t.JSXElement,
+    mapCount,
+    stateIndices,
   };
 }
 
@@ -8497,10 +8604,54 @@ function compileCandidate(
         queuedMappedStructuralHintedRoot.mapCount +
         queuedMappedStructuralHintedRoot.structuralCount;
       appliedKeyedArrayReorderHints += queuedMappedStructuralHintedRoot.structuralCount;
+      appliedReorderHintedStateIndices = new Set([
+        ...appliedReorderHintedStateIndices,
+        ...queuedMappedStructuralHintedRoot.stateIndices,
+      ]);
       compilerUsage.keyedArrayMapUpdateHints += queuedMappedStructuralHintedRoot.mapCount;
       compilerUsage.keyedArrayQueuedMapUpdateHints += queuedMappedStructuralHintedRoot.mapCount;
       compilerUsage.keyedArrayMappedStructuralHints +=
         queuedMappedStructuralHintedRoot.structuralCount;
+    }
+  }
+  const queuedStructuralMapHintedRoot = rewriteQueuedKeyedArrayStructuralMapHints(
+    expandedReactiveRoot,
+    statesBySetter,
+    keyedMapUpdateIdentifier,
+    keyedArrayMapPipelineIdentifier,
+    keyedArrayFilterIdentifier,
+    keyedArraySliceIdentifier,
+    allowKeyedArrayMapPipelines,
+  );
+  let appliedQueuedStructuralMapHints = 0;
+  if (queuedStructuralMapHintedRoot.mapCount > 0) {
+    const hintedBlockAnalysis = analyzeComposableBlocks(
+      queuedStructuralMapHintedRoot.root,
+      reactiveByValue,
+      safeGlobals,
+      listNames,
+      allowedComponentNames,
+    );
+    const hintedAnalysis = analyzeHostTree(
+      queuedStructuralMapHintedRoot.root,
+      reactiveByValue,
+      safeGlobals,
+      hintedBlockAnalysis.conditionalExpressions || new Set<t.Expression>(),
+      hintedBlockAnalysis.keyedExpressions || new Set<t.Expression>(),
+      hintedBlockAnalysis.ownedElements || new Set<t.JSXElement>(),
+      hintedBlockAnalysis.componentElements || new Set<t.JSXElement>(),
+    );
+    if (!hintedBlockAnalysis.reason && !hintedAnalysis.reason) {
+      expandedReactiveRoot = queuedStructuralMapHintedRoot.root;
+      blockAnalysis = hintedBlockAnalysis;
+      analysis = hintedAnalysis;
+      appliedQueuedStructuralMapHints = queuedStructuralMapHintedRoot.mapCount;
+      appliedKeyedArrayReorderHints += queuedStructuralMapHintedRoot.mapCount;
+      appliedReorderHintedStateIndices = new Set([
+        ...appliedReorderHintedStateIndices,
+        ...queuedStructuralMapHintedRoot.stateIndices,
+      ]);
+      compilerUsage.keyedArrayMapUpdateHints += queuedStructuralMapHintedRoot.mapCount;
     }
   }
   const queuedMapReorderHintedRoot = rewriteQueuedKeyedArrayMapReorderHints(
@@ -8661,7 +8812,8 @@ function compileCandidate(
     appliedKeyedArrayReorderHints > 0 || appliedKeyedArraySortHints > 0,
     appliedPipelineMapHints > 0 ||
       appliedQueuedReorderMapHints > 0 ||
-      appliedQueuedMappedStructuralHints > 0,
+      appliedQueuedMappedStructuralHints > 0 ||
+      appliedQueuedStructuralMapHints > 0,
     appliedKeyedArrayRollingWindowHints > 0,
   );
   markShortCircuitBindings(analysis.bindings || []);

--- a/packages/farm-react/vitest.stress.config.ts
+++ b/packages/farm-react/vitest.stress.config.ts
@@ -21,7 +21,7 @@ export default defineConfig({
     ],
     setupFiles: ["src/__tests__/stress.setup.ts"],
     testNamePattern:
-      /2,000 deterministic mapped reorder updates|2,000 deterministic mapped reversal parity updates|2,000 queued reverse, map, and reverse updates|2,000 reverse-or-sort then map updates|2,000 queued reorder then standalone map updates|2,000 queued map then reorder updates|2,000 queued map and consecutive reorder updates|2,000 mapped structural removals|2,000 randomized interleaved map and structural removals|2,000 randomized terminal structural-map row transitions|2,000 randomized mapped terminal-structural row transitions|2,000 randomized queued mapped structural transitions|3,000 deterministic recursive updates|4,096 rows/,
+      /2,000 deterministic mapped reorder updates|2,000 deterministic mapped reversal parity updates|2,000 queued reverse, map, and reverse updates|2,000 reverse-or-sort then map updates|2,000 queued reorder then standalone map updates|2,000 queued map then reorder updates|2,000 queued map and consecutive reorder updates|2,000 mapped structural removals|2,000 randomized interleaved map and structural removals|2,000 randomized terminal structural-map row transitions|2,000 randomized mapped terminal-structural row transitions|2,000 randomized queued mapped structural transitions|2,000 randomized queued structural mapped transitions|3,000 deterministic recursive updates|4,096 rows/,
     testTimeout: 30_000,
   },
 });


### PR DESCRIPTION
## Problem

Adjacent concise keyed-row updates already retained map lineage when map setters came before filter or slice setters. The mirror order still lost that proof: a safe filter or slice setter followed by a same-key map setter fell back to complete keyed reconciliation.

That made ordinary flows such as filtering a table and then updating one surviving row pay for full key, descriptor, and binding work even though the compiler could prove both steps.

## Root cause

The compiler finalized standalone filter and slice hints without linking a following map setter to their survivor lineage. The existing mapped-structural runtime already carried the required structural metadata, but generated keyed blocks also needed explicit reorder-independence proof for the runtime to accept the combined update. A larger dashboard happened to contain other reorder operations, so generated-code coverage was needed to catch that minimal-component boundary.

## Change

- Detect consecutive concise calls to the same state setter where one or more compiler-safe filter or slice updates are followed by one or more safe same-key maps.
- Reuse the existing keyed-array map pipeline so the structural survivor proof flows into terminal maps without adding runtime code.
- Compose map/structural/map setter sequences.
- Propagate the complete reorder-independence state proof for both queued directions.
- Keep compiler reports on the existing filter, slice, and map counters.
- Update the React package guide, renderer documentation, maintained dashboard workload, and recorded benchmark evidence.

No public API, configuration flag, syntax, or renderer-neutral behavior changes.

## Safety and compatibility

The compiler links only immediately adjacent calls to the same unshadowed setter. Intervening statements, another setter, unsupported callbacks, changed keys, custom methods, sparse or subclassed arrays, ambiguous ownership, and failed runtime validation keep complete keyed reconciliation.

Runtime validation completes before the first compiler-owned DOM write. Tests cover DOM identity, controlled-input focus and selection, Strict Mode hydration, unmount-before-flush cleanup, multiple structural and terminal-map setters, mixed map/structural/map sequences, and atomic fallback.

The optimization remains React-specific and opt-in through the existing experimental compiler. Disabled compiler behavior and other renderers are unchanged. No runtime source was added; the isolated keyed map/reorder fixture remains 13,470 bytes gzip against its unchanged 13,471-byte ceiling.

## Verification

- `pnpm --filter @farm.js/react test` — 757 passed, 10 skipped
- `pnpm --filter @farm.js/react test:stress` — 16 passed, 68 skipped
- Focused compiler/runtime suite after rebasing onto current `origin/main` — 34 passed
- `pnpm --filter @farm.js/react type-check`
- `pnpm --filter @farm.js/react build`
- `pnpm --filter @farm.js/react test:compat` — React 18.3.1 and React 19.2.8
- `npx -y node@22.13.1 scripts/benchmark-runtime-size.mjs --check`
- Dashboard type-check and production build
- `pnpm docs:check-navigation`
- `pnpm --dir docs exec farm generate --check`
- `pnpm docs:build`
- Focused `oxfmt`, `oxlint`, and `git diff --check`
- Full bracketed Chrome benchmark — result PASS, correctness PASS, broad regression PASS, optimization persistence PASS, every feature-specific gate PASS, zero compiled owner executions

Maintained 10,000-row queued filter then map result:

| Mode | Pipeline | Compiled control | vs React | vs control |
| --- | ---: | ---: | ---: | ---: |
| Static | 4.70 ms | 12.90 ms | 14.97x | 2.74x |
| Hybrid | 4.60 ms | 12.70 ms | 15.29x | 2.76x |

Environment: Chrome 153.0.8010.36, Node.js 23.11.0, Apple M1 macOS arm64. Timings are local medians; deterministic parity and fallback checks remain the primary safety controls.

## Documentation and release

Updated:

- `packages/farm-react/README.md`
- `docs/src/app/docs/renderers/react/page.md`
- `examples/react-compiler-dashboard/README.md`
- `examples/react-compiler-dashboard/BENCHMARK_RESULTS.md`
- Maintained dashboard action and benchmark explanation

Release/version changes: None.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Composes queued structural setters followed by same-key map setters so filtering or slicing a table and then updating a surviving row no longer falls back to complete keyed reconciliation.

**Compiler behavior**
- Rewrites adjacent safe filter/slice setters followed by same-key map setters to reuse the existing keyed-array map pipeline; no runtime code was added.
- Mixed map/structural/map sequences compose as well, and compiler reports stay on the existing filter, slice, and map counters.

**Safety and compatibility**
- Only immediately adjacent calls to the same unshadowed setter are linked; intervening statements, another setter, unsupported callbacks, changed keys, custom methods, and failed runtime validation keep complete reconciliation.
- Runtime validation still completes before the first compiler-owned DOM write.
- No public API, configuration, syntax, or renderer-neutral behavior changes; the optimization stays React-specific and opt-in through the existing experimental compiler.

<sup>Written for commit df78f99f8ac1a71830406200e9d63f7293e3c868. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/859?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

