### PR TITLE
fix(upgrade): preserve repeated dependency sections

### DIFF
--- a/packages/farm-cli/src/upgrade.ts
+++ b/packages/farm-cli/src/upgrade.ts
@@ -1,6 +1,6 @@
 import { spawn } from "node:child_process";
 import { existsSync } from "node:fs";
-import { readFile } from "node:fs/promises";
+import { readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 
 export type FarmUpgradeChannel = "latest" | "beta";
@@ -151,7 +151,11 @@ export async function upgradeFarm(options: FarmUpgradeOptions): Promise<FarmUpgr
   }
 
   const runCommand = options.runCommand || runFarmUpgradeCommand;
-  for (const command of plan.commands) {
+  const repeatedPackages = getRepeatedPackages(plan.packages);
+  for (const [index, command] of plan.commands.entries()) {
+    if (repeatedPackages.length > 0 && index === plan.commands.length - 1) {
+      await restoreRepeatedDependencySections(plan.packageJsonPath, repeatedPackages);
+    }
     await runCommand(command);
   }
 
@@ -218,7 +222,7 @@ function createUpgradeCommands(
 ): FarmUpgradeCommand[] {
   const command = packageManager === "npm" ? "install" : "add";
 
-  return DEPENDENCY_SECTIONS.flatMap((section) => {
+  const commands = DEPENDENCY_SECTIONS.flatMap((section) => {
     const targets = packages
       .filter((entry) => entry.section === section)
       .map((entry) => entry.target);
@@ -232,6 +236,48 @@ function createUpgradeCommands(
       },
     ];
   });
+
+  if (getRepeatedPackages(packages).length > 0) {
+    commands.push({ command: packageManager, args: ["install"], cwd: root });
+  }
+  return commands;
+}
+
+function getRepeatedPackages(packages: FarmUpgradePackage[]): FarmUpgradePackage[][] {
+  const byName = new Map<string, FarmUpgradePackage[]>();
+  for (const entry of packages) {
+    const entries = byName.get(entry.name) ?? [];
+    entries.push(entry);
+    byName.set(entry.name, entries);
+  }
+  return [...byName.values()].filter((entries) => entries.length > 1);
+}
+
+async function restoreRepeatedDependencySections(
+  packageJsonPath: string,
+  repeatedPackages: FarmUpgradePackage[][],
+): Promise<void> {
+  const source = await readFile(packageJsonPath, "utf8");
+  const packageJson = JSON.parse(source) as ProjectPackageJson;
+
+  for (const entries of repeatedPackages) {
+    const installedSpecifier = [...entries]
+      .reverse()
+      .map((entry) => packageJson[entry.section]?.[entry.name])
+      .find((value): value is string => typeof value === "string");
+    if (!installedSpecifier) {
+      throw new Error(
+        `Package manager removed ${entries[0].name} while upgrading repeated dependency sections.`,
+      );
+    }
+    for (const entry of entries) {
+      const section = (packageJson[entry.section] ??= {});
+      section[entry.name] = installedSpecifier;
+    }
+  }
+
+  const indentation = /^([\t ]+)"/m.exec(source)?.[1] ?? "  ";
+  await writeFile(packageJsonPath, `${JSON.stringify(packageJson, null, indentation)}\n`, "utf8");
 }
 
 function getDependencySectionFlags(

--- a/packages/farm-cli/test/upgrade.test.mjs
+++ b/packages/farm-cli/test/upgrade.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { execFile } from "node:child_process";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { createRequire } from "node:module";
@@ -163,8 +163,48 @@ test("upgrades every manifest section when a Farm package is repeated", async ()
           command: "pnpm",
           args: ["add", "--save-peer", "@farm.js/core@beta"],
         },
+        {
+          command: "pnpm",
+          args: ["install"],
+        },
       ],
     );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("restores repeated sections after the package manager relocates a package", async () => {
+  const root = await createTempProject({
+    devDependencies: { "@farm.js/core": "^0.1.0-beta.3" },
+    peerDependencies: { "@farm.js/core": "^0.1.0-beta.2" },
+  });
+
+  try {
+    const commands = [];
+    await upgradeFarm({
+      root,
+      channel: "beta",
+      packageManager: "pnpm",
+      runCommand: async (command) => {
+        commands.push(command.args);
+        if (command.args[0] !== "add") return;
+        const manifestPath = path.join(root, "package.json");
+        const manifest = JSON.parse(await readFile(manifestPath, "utf8"));
+        delete manifest.devDependencies?.["@farm.js/core"];
+        delete manifest.peerDependencies?.["@farm.js/core"];
+        const section = command.args.includes("--save-peer")
+          ? "peerDependencies"
+          : "devDependencies";
+        manifest[section] = { ...manifest[section], "@farm.js/core": "^0.1.0-beta.91" };
+        await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
+      },
+    });
+
+    const manifest = JSON.parse(await readFile(path.join(root, "package.json"), "utf8"));
+    assert.equal(manifest.devDependencies["@farm.js/core"], "^0.1.0-beta.91");
+    assert.equal(manifest.peerDependencies["@farm.js/core"], "^0.1.0-beta.91");
+    assert.deepEqual(commands.at(-1), ["install"]);
   } finally {
     await rm(root, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Problem

`farm upgrade` plans one package-manager command per dependency section. When the same Farm package is declared in more than one section, npm and pnpm relocate that package as each command runs, so the last section wins.

## Root cause

The existing regression test asserted the command plan but did not model the package managers mutation of `package.json`.

## Change

After the targeted upgrades finish, restore the resolved package specifier to every original dependency section and run one ordinary install to synchronize the lockfile. The final install is included in dry-run output.

## Safety and compatibility

Single-section upgrades keep their existing command sequence. Reconciliation only runs for package names that were present in multiple sections before the upgrade and uses the version written by the selected package manager.

## Verification

- `node --test packages/farm-cli/test/upgrade.test.mjs` (7 passed)
- `pnpm --filter @farm.js/cli type-check`
- `pnpm exec oxlint packages/farm-cli/src/upgrade.ts`
- `git diff --check`

The new regression test simulates package-manager relocation and fails without the reconciliation step.

## Documentation and release

None.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `farm upgrade` so repeated dependency sections are preserved instead of losing to the last section.

- Reconciles package specifiers across all original sections after targeted upgrades.
- Runs an ordinary install afterward to sync the lockfile.
- Adds regression test simulating package-manager relocation.

<sup>Written for commit 936a68e72e6a4b6270617b9ae115ef04a5def8e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/860?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

