### PR TITLE
fix(deploy): reject unsupported Vercel output paths

### DIFF
--- a/docs/src/app/docs/deployment/page.md
+++ b/docs/src/app/docs/deployment/page.md
@@ -252,6 +252,10 @@ export default defineConfig({
 
 When `target` is `vercel`, Farm uses the Vercel Nitro preset and writes Build Output API output to `.vercel/output`. Other targets default to `.farm/.output` unless you override `output` or `outputDir`. When `preset` is set directly, Farm passes that value through to Nitro.
 
+`farm deploy --vercel` requires `.vercel/output` because the Vercel CLI reads that fixed directory
+for `--prebuilt` uploads. Keep the default output for Farm-managed Vercel deploys. A custom Vercel
+output directory is only suitable when another deployment workflow uploads the build itself.
+
 ## Override output
 
 Use `output` for the compact form or `outputDir` when you want the explicit option name.

--- a/packages/farm-cli/src/deploy.ts
+++ b/packages/farm-cli/src/deploy.ts
@@ -178,6 +178,16 @@ async function resolveFarmDeployContext(options: DeployFarmOptions) {
   });
   const preset = deployConfig.preset || getPresetForDeployTarget(platform) || "node-server";
   const nitroOutput = resolveDeployOutputPath(root, deployConfig.outputDir);
+  if (
+    platform === "vercel" &&
+    path.resolve(nitroOutput) !== path.resolve(root, ".vercel", "output")
+  ) {
+    throw new FarmDeployError(
+      "INVALID_BUILD_OUTPUT",
+      "vercel",
+      `Vercel prebuilt deploys require output at ${path.resolve(root, ".vercel", "output")}. Remove the custom deploy outputDir or deploy that output with your own upload workflow.`,
+    );
+  }
   const cloudflareAgent =
     platform === "cloudflare"
       ? resolveCloudflareAgentDeployPlan(root) ||

--- a/packages/farm-cli/test/deploy.test.mjs
+++ b/packages/farm-cli/test/deploy.test.mjs
@@ -34,6 +34,25 @@ test("resolves a deployment plan without building or invoking a platform CLI", a
   }
 });
 
+test("rejects a custom Vercel output that --prebuilt cannot upload", async () => {
+  let root;
+
+  try {
+    root = await mkdtemp(path.join(tmpdir(), "farm-cli-vercel-custom-output-"));
+    await writeFile(
+      path.join(root, "farm.config.mjs"),
+      "export default { deploy: { target: 'vercel', outputDir: 'custom-output' } };\n",
+    );
+
+    await assert.rejects(
+      () => createFarmDeployPlan({ root }),
+      /Vercel prebuilt deploys require output at .*\.vercel.*output/,
+    );
+  } finally {
+    if (root) await rm(root, { recursive: true, force: true });
+  }
+});
+
 test("reads a Cloudflare Agents Worker deployment handoff", async () => {
   let root;
 


### PR DESCRIPTION
## Problem

Farm can build Vercel output into a custom directory and verify that directory, but `vercel deploy --prebuilt` always reads `.vercel/output` from the project root. `farm deploy` could therefore upload stale output or fail after successfully validating a different build.

## Root cause

The deploy plan passed the resolved output directory to Farm validation but invoked Vercel from the application root without checking that the output matched the Build Output API directory used by `--prebuilt`.

## Change

Reject custom Vercel output directories in the Farm-managed deploy command with an actionable error. Document that custom output remains available for external upload workflows.

## Safety and compatibility

Default Vercel deploys are unchanged. Cloudflare and Netlify custom output directories are unchanged. The failure happens during planning, before Farm builds or uploads anything.

## Verification

- `node --test packages/farm-cli/test/deploy.test.mjs` (11 passed)
- `pnpm --filter @farm.js/cli type-check`
- `pnpm exec oxlint packages/farm-cli/src/deploy.ts`
- `git diff --check`

The regression test fails on the previous behavior because the unsupported plan was accepted.

## Documentation and release

Updated the deployment guide with the fixed `.vercel/output` requirement for Farm-managed Vercel uploads.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Farm deploys to Vercel previously validated a custom output directory but then uploaded from `.vercel/output`, so a successfully validated build could deploy stale or wrong output. `farm deploy --vercel` now rejects custom Vercel output directories with an actionable error before any build or upload.

- Default Vercel deploys and Cloudflare/Netlify custom output directories are unchanged.
- The deployment guide now documents the fixed `.vercel/output` requirement for Farm-managed Vercel deploys.
- A regression test covers the rejected custom output plan.

<sup>Written for commit 39ad54f4a5768e8cdf24a393d9b646cc698f1225. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/861?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

