### PR TITLE
fix(doctor): detect renderer route extensions

### DIFF
--- a/packages/farm-cli/src/doctor.ts
+++ b/packages/farm-cli/src/doctor.ts
@@ -455,11 +455,19 @@ function collectPackageCheck(root: string, checks: FarmDoctorCheck[]): void {
 function collectRouterChecks(config: ResolvedFarmConfig, checks: FarmDoctorCheck[]): void {
   const sources = getFarmSourceRoots(config);
   const appDirectories = sources.map((source) => path.join(source.root, source.srcDir, "app"));
-  const hasPages = appDirectories.some((directory) =>
-    containsFile(directory, /^page\.(?:ts|tsx|js|jsx|vue|md|mdx)$/),
-  );
+  const routeExtensions = [
+    ...new Set([
+      ...ROUTE_EXTENSIONS,
+      ...(config.renderer.componentExtensions ?? []).map((extension) =>
+        extension.replace(/^\./, ""),
+      ),
+    ]),
+  ];
+  const pageFilePattern = new RegExp(`^page\\.(?:${routeExtensions.map(escapeRegExp).join("|")})$`);
+  const suggestedRouteExtension = config.renderer.componentExtensions?.[0] || ".tsx";
+  const hasPages = appDirectories.some((directory) => containsFile(directory, pageFilePattern));
   const hasProgrammaticRoutes = sources.some((source) =>
-    ROUTE_EXTENSIONS.some((extension) =>
+    routeExtensions.some((extension) =>
       existsSync(path.join(source.root, source.srcDir, `farm.routes.${extension}`)),
     ),
   );
@@ -476,14 +484,13 @@ function collectRouterChecks(config: ResolvedFarmConfig, checks: FarmDoctorCheck
           code: "NO_PAGE_ROUTES",
           title: "No page routes were found",
           message: `Farm found no page modules under ${config.srcDir}/app.`,
-          action: `Add ${config.srcDir}/app/page.tsx or ${config.srcDir}/farm.routes.tsx.`,
+          action: `Add ${config.srcDir}/app/page${suggestedRouteExtension} or ${config.srcDir}/farm.routes${suggestedRouteExtension}.`,
         },
   );
 
   const hasRootLayout = appDirectories.some((directory) =>
-    ROUTE_EXTENSIONS.some((extension) => existsSync(path.join(directory, `layout.${extension}`))),
+    routeExtensions.some((extension) => existsSync(path.join(directory, `layout.${extension}`))),
   );
-  const suggestedLayoutExtension = config.renderer.componentExtensions?.[0] || ".tsx";
   checks.push(
     hasRootLayout
       ? {
@@ -497,9 +504,13 @@ function collectRouterChecks(config: ResolvedFarmConfig, checks: FarmDoctorCheck
           code: "ROOT_LAYOUT_MISSING",
           title: "Root layout is missing",
           message: "The application has no shared root layout.",
-          action: `Add ${config.srcDir}/app/layout${suggestedLayoutExtension}.`,
+          action: `Add ${config.srcDir}/app/layout${suggestedRouteExtension}.`,
         },
   );
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 function collectDeploymentChecks(

--- a/packages/farm-cli/test/doctor.test.mjs
+++ b/packages/farm-cli/test/doctor.test.mjs
@@ -217,6 +217,42 @@ test("recognizes Vue pages and creates a Vue root layout", async () => {
   }
 });
 
+test("recognizes routes using the configured renderer extension", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "farm-cli-doctor-svelte-"));
+
+  try {
+    await mkdir(path.join(root, "src/app"), { recursive: true });
+    await writeFile(
+      path.join(root, "package.json"),
+      JSON.stringify({ name: "svelte-doctor", dependencies: { "@farm.js/core": "workspace:*" } }),
+    );
+    await writeFile(
+      path.join(root, "farm.config.mjs"),
+      `export default {
+  renderer: {
+    name: "svelte",
+    vite: "@farm.js/svelte/vite",
+    server: "@farm.js/svelte/server",
+    client: "@farm.js/svelte/client",
+    componentExtensions: [".svelte"],
+  },
+};
+`,
+    );
+    await writeFile(path.join(root, "src/app/page.svelte"), "<main>Svelte</main>\n");
+    await writeFile(path.join(root, "src/app/layout.svelte"), "<slot />\n");
+
+    const report = await runFarmDoctor({ root, offline: true });
+
+    assert.ok(report.checks.some((check) => check.code === "APP_ROUTER_READY"));
+    assert.ok(report.checks.some((check) => check.code === "ROOT_LAYOUT_READY"));
+    assert.ok(!report.checks.some((check) => check.code === "NO_PAGE_ROUTES"));
+    assert.ok(!report.checks.some((check) => check.code === "ROOT_LAYOUT_MISSING"));
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test("applies safe fixes inside a configured project root", async () => {
   const root = await mkdtemp(path.join(os.tmpdir(), "farm-cli-doctor-root-"));
   const projectRoot = path.join(root, "application");


### PR DESCRIPTION
## Problem

`farm doctor --offline` reports `NO_PAGE_ROUTES` and `ROOT_LAYOUT_MISSING` for valid Svelte applications because route discovery uses a hard-coded extension list that omits `.svelte`.

## Root cause

Doctor duplicated renderer support instead of consuming the configured renderer component extensions.

## Change

Merge the renderer component extensions into Doctor route discovery and use the renderer extension in suggested page and layout paths.

## Safety and compatibility

Existing TypeScript, JavaScript, Vue, Markdown, and MDX discovery remains available. Custom renderers now participate through the same public renderer contract used by Farm routing.

## Verification

- `node --test packages/farm-cli/test/doctor.test.mjs` (9 passed)
- `pnpm --filter @farm.js/cli type-check`
- `pnpm exec oxlint packages/farm-cli/src/doctor.ts`
- `git diff --check`

The regression test creates valid `.svelte` page and layout modules and fails with both false diagnostics on the previous implementation.

## Documentation and release

None.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `farm doctor --offline` reporting `NO_PAGE_ROUTES` and `ROOT_LAYOUT_MISSING` for valid Svelte applications because route discovery used a hard-coded extension list that omitted `.svelte`. Route discovery now merges the configured renderer component extensions into the accepted route extensions and suggests page and layout paths using the renderer's extension; existing TypeScript, JavaScript, Vue, Markdown, and MDX discovery remains unchanged.

<sup>Written for commit 6c5bc57e52564d34c77c305b24f147b9c3ad1f9b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/862?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

