### PR TITLE
fix(doctor): create renderer-native root layouts

### DIFF
--- a/packages/farm-cli/src/doctor.ts
+++ b/packages/farm-cli/src/doctor.ts
@@ -363,16 +363,10 @@ function applySafeProjectFixes(
     const rendererExtension = config.renderer.componentExtensions?.[0] || ".tsx";
     const layoutPath = path.join(config.root, config.srcDir, "app", `layout${rendererExtension}`);
     if (!existsSync(layoutPath)) {
+      const source = createRootLayoutSource(config.renderer.name);
+      if (!source) return fixes;
       mkdirSync(path.dirname(layoutPath), { recursive: true });
-      writeFileSync(
-        layoutPath,
-        config.renderer.name === "vue"
-          ? `<script setup lang="ts">\ndefineOptions({ inheritAttrs: false });\n</script>\n\n<template>\n  <slot />\n</template>\n`
-          : config.renderer.name === "solid"
-            ? `import type { ParentProps } from "solid-js";\n\nexport default function RootLayout(props: ParentProps) {\n  return <>{props.children}</>;\n}\n`
-            : `import type { ReactNode } from "react";\n\nexport default function RootLayout({ children }: { children: ReactNode }) {\n  return (\n    <html lang="en">\n      <body>{children}</body>\n    </html>\n  );\n}\n`,
-        { encoding: "utf8", flag: "wx" },
-      );
+      writeFileSync(layoutPath, source, { encoding: "utf8", flag: "wx" });
       fixes.push({
         code: "ROOT_LAYOUT_CREATED",
         title: "Created the missing root layout",
@@ -381,6 +375,23 @@ function applySafeProjectFixes(
     }
   }
   return fixes;
+}
+
+function createRootLayoutSource(renderer: string): string | undefined {
+  if (renderer === "vue") {
+    return `<script setup lang="ts">\ndefineOptions({ inheritAttrs: false });\n</script>\n\n<template>\n  <slot />\n</template>\n`;
+  }
+  if (renderer === "solid") {
+    return `import type { ParentProps } from "solid-js";\n\nexport default function RootLayout(props: ParentProps) {\n  return <>{props.children}</>;\n}\n`;
+  }
+  if (renderer === "preact") {
+    return `import type { ComponentChildren } from "preact";\n\nexport default function RootLayout({ children }: { children?: ComponentChildren }) {\n  return <>{children}</>;\n}\n`;
+  }
+  if (renderer === "svelte") {
+    return `<script lang="ts">\n  import type { Snippet } from "svelte";\n\n  let { children }: { children?: Snippet } = $props();\n</script>\n\n{@render children?.()}\n`;
+  }
+  if (renderer !== "react") return undefined;
+  return `import type { ReactNode } from "react";\n\nexport default function RootLayout({ children }: { children: ReactNode }) {\n  return (\n    <html lang="en">\n      <body>{children}</body>\n    </html>\n  );\n}\n`;
 }
 
 function collectNodeCheck(checks: FarmDoctorCheck[]): void {

--- a/packages/farm-cli/test/doctor.test.mjs
+++ b/packages/farm-cli/test/doctor.test.mjs
@@ -272,6 +272,59 @@ test("recognizes routes using the configured renderer extension", async () => {
   }
 });
 
+for (const fixture of [
+  {
+    renderer: "preact",
+    extension: ".tsx",
+    expected: /ComponentChildren.*from "preact"/,
+    rejected: /from "react"/,
+  },
+  {
+    renderer: "svelte",
+    extension: ".svelte",
+    expected: /Snippet.*from "svelte"/,
+    rejected: /from "react"/,
+  },
+]) {
+  test(`creates a ${fixture.renderer} root layout with renderer-native source`, async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), `farm-cli-doctor-${fixture.renderer}-`));
+    const layoutPath = path.join(root, `src/app/layout${fixture.extension}`);
+
+    try {
+      await mkdir(path.join(root, "src/app"), { recursive: true });
+      await writeFile(
+        path.join(root, "package.json"),
+        JSON.stringify({
+          name: `${fixture.renderer}-doctor`,
+          dependencies: { "@farm.js/core": "workspace:*" },
+        }),
+      );
+      await writeFile(
+        path.join(root, "farm.config.mjs"),
+        `export default {
+  renderer: {
+    name: ${JSON.stringify(fixture.renderer)},
+    vite: "@farm.js/${fixture.renderer}/vite",
+    server: "@farm.js/${fixture.renderer}/server",
+    client: "@farm.js/${fixture.renderer}/client",
+    componentExtensions: [${JSON.stringify(fixture.extension)}],
+  },
+};
+`,
+      );
+
+      const report = await runFarmDoctor({ root, offline: true, fix: true });
+      const source = await readFile(layoutPath, "utf8");
+
+      assert.ok(report.fixes?.some((fix) => fix.filePath.endsWith(`layout${fixture.extension}`)));
+      assert.match(source, fixture.expected);
+      assert.doesNotMatch(source, fixture.rejected);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+}
+
 test("applies safe fixes inside a configured project root", async () => {
   const root = await mkdtemp(path.join(os.tmpdir(), "farm-cli-doctor-root-"));
   const projectRoot = path.join(root, "application");


### PR DESCRIPTION
## Problem

`farm doctor --fix` writes the React fallback into missing Preact and Svelte root-layout files. Preact projects receive an undeclared React type import, while Svelte projects receive TSX inside `layout.svelte`.

## Root cause

The safe fixer only had explicit templates for Vue and Solid and treated every other renderer as React.

## Change

Generate minimal renderer-native root layouts for React, Preact, Solid, Vue, and Svelte. Unknown custom renderers are left untouched because Doctor cannot safely invent their component syntax.

## Safety and compatibility

The fixer remains additive and uses `wx`, so existing application files are never overwritten. React, Vue, and Solid retain their established output. Unsupported custom renderers now receive guidance without an unsafe automatic write.

## Verification

- `node --test packages/farm-cli/test/doctor.test.mjs` (10 passed)
- `pnpm --filter @farm.js/cli type-check`
- `pnpm exec oxlint packages/farm-cli/src/doctor.ts`
- `git diff --check`

The new Preact and Svelte regression cases fail on the previous implementation because both generated files import React.

## Documentation and release

None.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
`farm doctor --fix` now generates renderer-native root layouts for Preact and Svelte projects instead of the React fallback. Unknown custom renderers are left untouched because Doctor cannot safely invent their component syntax.

- Preact layouts import `ComponentChildren` from `preact`; Svelte layouts use Svelte 5 snippets in `layout.svelte`.
- React, Vue, and Solid output is unchanged, and the fixer remains additive with `wx` so existing files are never overwritten.
- Regression tests for Preact and Svelte fail on the previous implementation because both generated files imported React.

<sup>Written for commit 09004deaeb48119a0d5736319912d4d7dcfbc5e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/863?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

