### PR TITLE
fix(doctor): resolve cron routes from API base path

### DIFF
--- a/packages/farm-cli/src/doctor.ts
+++ b/packages/farm-cli/src/doctor.ts
@@ -572,13 +572,25 @@ function collectCronChecks(
 }
 
 function hasCronRoute(config: ResolvedFarmConfig, job: FarmCronJob): boolean {
-  const relative = job.path.replace(/^\/+/, "").replace(/^api\//, "");
+  const relative = resolveCronSourceRelativePath(config, job.path);
+  if (relative === undefined) return false;
   return getFarmSourceRoots(config).some((source) => {
     const directory = path.join(source.root, source.srcDir, "app", "api", relative);
     return ROUTE_EXTENSIONS.some((extension) =>
       existsSync(path.join(directory, `route.${extension}`)),
     );
   });
+}
+
+function resolveCronSourceRelativePath(
+  config: ResolvedFarmConfig,
+  cronPath: string,
+): string | undefined {
+  const serverBasePath = config.api.baseURL.startsWith("/") ? config.api.basePath : "/api";
+  if (serverBasePath === "/") return cronPath.replace(/^\/+/, "");
+  if (cronPath === serverBasePath) return "";
+  if (!cronPath.startsWith(`${serverBasePath}/`)) return undefined;
+  return cronPath.slice(serverBasePath.length + 1);
 }
 
 function containsFile(directory: string, pattern: RegExp): boolean {

--- a/packages/farm-cli/test/doctor.test.mjs
+++ b/packages/farm-cli/test/doctor.test.mjs
@@ -134,6 +134,25 @@ test("reports missing cron routes and ephemeral serverless storage", async () =>
   }
 });
 
+test("finds cron routes mounted under a custom API base path", async () => {
+  const root = await createTempProject({
+    apiBasePath: "/v2/api",
+    cronPath: "/v2/api/maintenance/cleanup",
+  });
+
+  try {
+    const report = await runFarmDoctor({
+      root,
+      offline: true,
+      env: { CRON_SECRET: "configured" },
+    });
+
+    assert.ok(!report.checks.some((check) => check.code === "CRON_ROUTE_MISSING"));
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test("prints a machine-readable report through the CLI", async () => {
   const root = await createTempProject();
 
@@ -269,6 +288,7 @@ async function createTempProject(options = {}) {
     [
       "export default {",
       `  deploy: { target: '${target}' },`,
+      ...(options.apiBasePath ? [`  api: { basePath: '${options.apiBasePath}' },`] : []),
       `  storage: ${storage},`,
       "  cron: {",
       `    cleanup: { schedule: '0 2 * * *', path: '${cronPath}' },`,


### PR DESCRIPTION
## Problem

Doctor reports `CRON_ROUTE_MISSING` when a valid file-based API route is mounted under a custom `api.basePath`, such as `/v2/api/maintenance/cleanup`.

## Root cause

The project inspection check always stripped a literal `/api` prefix instead of translating the configured public API mount back to the canonical `app/api` source directory.

## Change

Resolve the source-relative cron path from the effective local API base path before checking route files. Absolute external API URLs retain Farms local `/api` mount behavior.

## Safety and compatibility

The default `/api` behavior is unchanged. Cron paths outside the configured local API mount still produce the missing-route warning.

## Verification

- `node --test packages/farm-cli/test/doctor.test.mjs` (9 passed)
- `pnpm --filter @farm.js/cli type-check`
- `pnpm exec oxlint packages/farm-cli/src/doctor.ts`
- `git diff --check`

The regression test creates `app/api/maintenance/cleanup/route.ts`, mounts APIs at `/v2/api`, and fails with a false warning before this fix.

## Documentation and release

None.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes doctor falsely reporting `CRON_ROUTE_MISSING` for cron routes mounted under a custom `api.basePath`, like `/v2/api/maintenance/cleanup`. The check now resolves the source-relative cron path from the configured local API base path instead of always stripping a literal `/api` prefix.

- Absolute external API URLs still use the local `/api` mount behavior.
- Default `/api` behavior is unchanged; routes outside the local API mount still produce the warning.
- Adds a regression test covering a custom API base path.

<sup>Written for commit 1d65b7ba7badb415e41512073b4b3367c885f0ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/864?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

