### PR TITLE
fix(content): reject circular transform values

### DIFF
--- a/packages/farm-content/src/loader.test.ts
+++ b/packages/farm-content/src/loader.test.ts
@@ -149,6 +149,22 @@ describe("content collection loading", () => {
     expect(() => encodeContentValue(sparse)).toThrow("sparse arrays");
   });
 
+  it("reports circular transformed values without overflowing the stack", async () => {
+    const root = await fixtureRoot();
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+
+    await expect(
+      loadContentCollections(root, {
+        posts: collection({
+          source: files("content/posts/hello.md"),
+          schema: postSchema,
+          transform: () => circular,
+        }),
+      }),
+    ).rejects.toThrow("[farm:content] Content data cannot contain circular references");
+  });
+
   it("writes a normal generated server module only when content changes", async () => {
     const root = await fixtureRoot();
     const output = path.join(root, ".farm", "content", "server.mjs");

--- a/packages/farm-content/src/loader.ts
+++ b/packages/farm-content/src/loader.ts
@@ -347,18 +347,26 @@ function isArrayIndex(key: string, length: number): boolean {
   return Number.isInteger(index) && index >= 0 && index < length && String(index) === key;
 }
 
-function freezeContentValue<T>(value: T): T {
+function freezeContentValue<T>(value: T, ancestors = new Set<object>()): T {
   if (!value || typeof value !== "object" || Object.isFrozen(value)) return value;
-  if (Array.isArray(value)) {
-    for (const descriptor of Object.values(Object.getOwnPropertyDescriptors(value))) {
-      if ("value" in descriptor) freezeContentValue(descriptor.value);
-    }
-  } else if (!(value instanceof Date)) {
-    for (const descriptor of Object.values(Object.getOwnPropertyDescriptors(value))) {
-      if ("value" in descriptor) freezeContentValue(descriptor.value);
-    }
+  if (ancestors.has(value)) {
+    throw new TypeError("[farm:content] Content data cannot contain circular references");
   }
-  return Object.freeze(value);
+  ancestors.add(value);
+  try {
+    if (Array.isArray(value)) {
+      for (const descriptor of Object.values(Object.getOwnPropertyDescriptors(value))) {
+        if ("value" in descriptor) freezeContentValue(descriptor.value, ancestors);
+      }
+    } else if (!(value instanceof Date)) {
+      for (const descriptor of Object.values(Object.getOwnPropertyDescriptors(value))) {
+        if ("value" in descriptor) freezeContentValue(descriptor.value, ancestors);
+      }
+    }
+    return Object.freeze(value);
+  } finally {
+    ancestors.delete(value);
+  }
 }
 
 async function writeFileIfChanged(filePath: string, source: string): Promise<void> {


### PR DESCRIPTION
## Problem

A content schema or transform that returns a circular object crashes collection loading with a `RangeError: Maximum call stack size exceeded` instead of the serializer contract error.

## Root cause

Content data is recursively frozen before serialization. The serializer tracks ancestor objects and rejects cycles, but the preceding freeze traversal did not.

## Change

Track ancestor objects while recursively freezing content values and reject a cycle with the same actionable error used by content serialization.

## Safety and compatibility

Shared non-circular references remain valid because entries are removed from the ancestor set after each branch. Primitive values, dates, arrays, plain objects, and already frozen values retain their existing behavior.

## Verification

- `pnpm --filter @farm.js/content test` (16 passed)
- `pnpm --filter @farm.js/content type-check`
- `pnpm --filter @farm.js/content build`
- `pnpm exec oxlint packages/farm-content/src/loader.ts packages/farm-content/src/loader.test.ts`
- `git diff --check`

The regression test returns a self-referencing value from a content transform and overflows on the previous implementation.

## Documentation and release

None.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes content loading crashing with a stack overflow when a schema or transform returns a circular object; it now throws the same actionable circular reference error used by content serialization.

**Bug Fixes**
- Tracks ancestor objects during recursive freezing and rejects cycles before the serializer runs.
- Shared non-circular references still work because ancestors are removed after each branch is processed.

<sup>Written for commit 34d80dbf46ee4fb66259499e85eb2c18583247a9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/865?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

