### PR TITLE
fix(telemetry): fail closed for invalid custom endpoints

### DIFF
--- a/docs/src/app/docs/telemetry/page.md
+++ b/docs/src/app/docs/telemetry/page.md
@@ -145,7 +145,8 @@ with `FARM_TELEMETRY_RETENTION_DAYS`.
 
 For local endpoint development only, `FARM_TELEMETRY_ENDPOINT` and
 `FARM_TELEMETRY_SITE_ENDPOINT` can point at an HTTPS URL or an HTTP localhost address. Released
-clients use the Farm-owned endpoints by default.
+clients use the Farm-owned endpoints by default. An invalid or insecure explicit override is skipped
+instead of being redirected to a Farm-owned endpoint.
 
 ## Maintainer deployment setup
 

--- a/packages/farm-cli/src/telemetry.ts
+++ b/packages/farm-cli/src/telemetry.ts
@@ -225,16 +225,20 @@ function isInteractive(): boolean {
 }
 
 function getEndpoint(): string {
-  const candidate = process.env.FARM_TELEMETRY_ENDPOINT || DEFAULT_TELEMETRY_ENDPOINT;
+  return process.env.FARM_TELEMETRY_ENDPOINT || DEFAULT_TELEMETRY_ENDPOINT;
+}
+
+function resolveTelemetryEndpoint(candidate: string): URL | undefined {
   try {
     const url = new URL(candidate);
-    const isLocal = ["localhost", "127.0.0.1", "::1"].includes(url.hostname);
+    const hostname = url.hostname.toLowerCase().replace(/^\[|\]$/g, "");
+    const isLocal = ["localhost", "127.0.0.1", "::1"].includes(hostname);
     if (url.protocol !== "https:" && !(url.protocol === "http:" && isLocal)) {
-      return DEFAULT_TELEMETRY_ENDPOINT;
+      return undefined;
     }
-    return url.toString();
+    return url;
   } catch {
-    return DEFAULT_TELEMETRY_ENDPOINT;
+    return undefined;
   }
 }
 
@@ -434,19 +438,13 @@ async function send(payload: FarmTelemetryEvent): Promise<void> {
 }
 
 async function sendOnce(payload: FarmTelemetryEvent): Promise<"delivered" | "retry" | "rejected"> {
-  let endpoint: URL;
-  try {
-    endpoint = new URL(getEndpoint());
-  } catch {
-    debug("invalid endpoint URL");
+  const endpoint = resolveTelemetryEndpoint(getEndpoint());
+  if (!endpoint) {
+    debug("invalid or insecure telemetry endpoint; event skipped");
     return "rejected";
   }
 
   const requestTransport = endpoint.protocol === "http:" ? httpRequest : httpsRequest;
-  if (endpoint.protocol !== "http:" && endpoint.protocol !== "https:") {
-    debug(`unsupported endpoint protocol ${endpoint.protocol}`);
-    return "rejected";
-  }
 
   const body = JSON.stringify(payload);
   return new Promise((resolve) => {

--- a/packages/farm-cli/test/telemetry.test.mjs
+++ b/packages/farm-cli/test/telemetry.test.mjs
@@ -99,6 +99,26 @@ test("telemetry is enabled without creating an identity by default", async () =>
   });
 });
 
+test("status preserves an invalid custom endpoint instead of hiding a fallback", async () => {
+  await withTelemetryEnvironment(async () => {
+    process.env.FARM_TELEMETRY_ENDPOINT = "http://telemetry.example.com/events";
+
+    const status = await getFarmTelemetryStatus();
+
+    assert.equal(status.endpoint, "http://telemetry.example.com/events");
+  });
+});
+
+test("status accepts an HTTP IPv6 loopback endpoint", async () => {
+  await withTelemetryEnvironment(async () => {
+    process.env.FARM_TELEMETRY_ENDPOINT = "http://[::1]:4318/events";
+
+    const status = await getFarmTelemetryStatus();
+
+    assert.equal(status.endpoint, "http://[::1]:4318/events");
+  });
+});
+
 test("telemetry remains inactive in recognized CI environments", async () => {
   await withTelemetryEnvironment(async () => {
     for (const key of ["CI", "GITHUB_ACTIONS", "BUILDKITE", "CIRCLECI"]) {

--- a/packages/farm/src/__tests__/product-telemetry.test.ts
+++ b/packages/farm/src/__tests__/product-telemetry.test.ts
@@ -61,6 +61,36 @@ describe("production-site origin detection", () => {
 });
 
 describe("production-site telemetry reporting", () => {
+  it("does not redirect an invalid custom endpoint to the Farm-owned service", async () => {
+    const send = vi.fn<typeof fetch>().mockResolvedValue(new Response(null, { status: 202 }));
+    const deliveries: Promise<unknown>[] = [];
+    const reporter = createFarmProductionSiteReporter({
+      renderer: "react",
+      endpoint: "http://telemetry.example.com/sites",
+      fetch: send,
+    });
+
+    reporter.report("https://example.com", (promise) => deliveries.push(promise));
+    await Promise.all(deliveries);
+
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("accepts an HTTP IPv6 loopback endpoint for local development", async () => {
+    const send = vi.fn<typeof fetch>().mockResolvedValue(new Response(null, { status: 202 }));
+    const deliveries: Promise<unknown>[] = [];
+    const reporter = createFarmProductionSiteReporter({
+      renderer: "react",
+      endpoint: "http://[::1]:4318/sites",
+      fetch: send,
+    });
+
+    reporter.report("https://example.com", (promise) => deliveries.push(promise));
+    await Promise.all(deliveries);
+
+    expect(send).toHaveBeenCalledWith("http://[::1]:4318/sites", expect.any(Object));
+  });
+
   it("hands delivery to waitUntil without waiting for the network", async () => {
     let finishRequest: ((response: Response) => void) | undefined;
     const response = new Promise<Response>((resolve) => {

--- a/packages/farm/src/product-telemetry.ts
+++ b/packages/farm/src/product-telemetry.ts
@@ -155,9 +155,14 @@ export function createFarmProductionSiteReporter(
 
 async function deliver(
   send: typeof fetch,
-  endpoint: string,
+  endpoint: string | undefined,
   payload: FarmProductionSiteTelemetryPayload,
 ): Promise<boolean> {
+  if (!endpoint) {
+    debug("invalid or insecure production-site telemetry endpoint; check-in skipped");
+    return false;
+  }
+
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
   timeout.unref?.();
@@ -190,20 +195,21 @@ async function deliver(
   }
 }
 
-function resolveSiteTelemetryEndpoint(explicit?: string): string {
+function resolveSiteTelemetryEndpoint(explicit?: string): string | undefined {
   const candidate = explicit || process.env.FARM_TELEMETRY_SITE_ENDPOINT;
   if (!candidate) return DEFAULT_SITE_TELEMETRY_ENDPOINT;
 
   try {
     const url = new URL(candidate);
-    const isLocal = ["localhost", "127.0.0.1", "::1"].includes(url.hostname);
+    const hostname = url.hostname.toLowerCase().replace(/^\[|\]$/g, "");
+    const isLocal = ["localhost", "127.0.0.1", "::1"].includes(hostname);
     if (url.protocol === "https:" || (url.protocol === "http:" && isLocal)) {
       return url.toString();
     }
   } catch {
-    // Fall through to the Farm-owned endpoint.
+    // Invalid explicit overrides fail closed below.
   }
-  return DEFAULT_SITE_TELEMETRY_ENDPOINT;
+  return undefined;
 }
 
 function productionTelemetryDisabled(): boolean {


### PR DESCRIPTION
## Problem

An invalid or insecure custom telemetry endpoint silently fell back to the Farm-owned endpoint. This could send an event to a destination the operator did not select. HTTP IPv6 loopback endpoints were also rejected even though local HTTP is supported.

## Root cause

Endpoint validation returned the production default on every validation failure, and URL.hostname represents IPv6 literals with brackets.

## Change

Custom endpoint validation now fails closed while preserving the configured endpoint in CLI status output. Both telemetry clients normalize IPv6 brackets when checking loopback hosts.

## Safety and compatibility

The default Farm endpoint is unchanged when no override is configured. HTTPS overrides and localhost HTTP overrides remain supported. Telemetry stays best-effort and never blocks framework or CLI operation.

## Verification

- node --test packages/farm-cli/test/telemetry.test.mjs (14 passed)
- pnpm --filter @farm.js/cli type-check
- pnpm --filter @farm.js/core exec vitest run src/__tests__/product-telemetry.test.ts (27 passed)
- pnpm --filter @farm.js/core type-check
- focused oxlint and oxfmt checks

The new regression tests fail before this change because invalid overrides are hidden by the production fallback and IPv6 loopback is not recognized.

## Documentation and release

Updated the telemetry endpoint override documentation.