### PR TITLE
fix(cron): abort active runs during scheduler shutdown

### DIFF
--- a/docs/src/app/docs/cron/page.md
+++ b/docs/src/app/docs/cron/page.md
@@ -121,7 +121,7 @@ Use the opt-in development scheduler to run every configured expression in memor
 farm dev --cron
 ```
 
-The development scheduler uses UTC, prints each next run, and skips a run when any previous local invocation of the same named job is still active, including one started by another expression in its schedule array. It stops with the dev server and does not persist state across restarts.
+The development scheduler uses UTC, prints each next run, and skips a run when any previous local invocation of the same named job is still active, including one started by another expression in its schedule array. It stops its timers and aborts active requests with the dev server, and it does not persist state across restarts.
 
 ## Schedule Syntax
 

--- a/packages/farm-cli/src/cron.ts
+++ b/packages/farm-cli/src/cron.ts
@@ -21,6 +21,7 @@ export interface RunFarmCronOptions extends FarmCronCLIOptions {
   secret?: string;
   timeoutMs?: number;
   fetch?: typeof globalThis.fetch;
+  signal?: AbortSignal;
   trigger?: "manual" | "development";
 }
 
@@ -108,7 +109,8 @@ export async function startFarmCronScheduler(
 ): Promise<FarmCronScheduler> {
   const cron = await loadFarmCronConfig(options);
   const entries: FarmCronSchedulerEntry[] = [];
-  const activeJobs = new Set<string>();
+  const activeRuns = new Map<string, AbortController>();
+  let stopped = false;
 
   for (const job of cron.jobs) {
     for (const schedule of job.schedule) {
@@ -125,21 +127,26 @@ export async function startFarmCronScheduler(
           },
         },
         async () => {
-          if (activeJobs.has(job.name)) {
+          if (stopped) return;
+          if (activeRuns.has(job.name)) {
             logger.warn(`Cron ${job.name} skipped an overlapping run.`);
             return;
           }
 
-          activeJobs.add(job.name);
+          const controller = new AbortController();
+          activeRuns.set(job.name, controller);
           try {
             logger.info(`Cron ${job.name} -> ${job.path}`);
             const result = await invokeFarmCronJob(job, cron, {
               ...options,
+              signal: controller.signal,
               trigger: "development",
             });
             logger.success(`Cron ${job.name} completed in ${result.durationMs}ms.`);
+          } catch (error) {
+            if (!controller.signal.aborted) throw error;
           } finally {
-            activeJobs.delete(job.name);
+            activeRuns.delete(job.name);
           }
         },
       );
@@ -164,7 +171,9 @@ export async function startFarmCronScheduler(
   return {
     entries,
     stop() {
+      stopped = true;
       for (const entry of entries) entry.timer.stop();
+      for (const controller of activeRuns.values()) controller.abort();
     },
   };
 }
@@ -184,7 +193,15 @@ async function invokeFarmCronJob(
   if (secret) headers.set("authorization", `Bearer ${secret}`);
 
   const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), options.timeoutMs ?? 10_000);
+  const abortFromCaller = () => controller.abort(options.signal?.reason);
+  if (options.signal?.aborted) abortFromCaller();
+  else options.signal?.addEventListener("abort", abortFromCaller, { once: true });
+
+  let timedOut = false;
+  const timeout = setTimeout(() => {
+    timedOut = true;
+    controller.abort();
+  }, options.timeoutMs ?? 10_000);
   timeout.unref?.();
   const startedAt = Date.now();
 
@@ -211,6 +228,9 @@ async function invokeFarmCronJob(
     };
   } catch (error) {
     if (error instanceof Error && error.name === "AbortError") {
+      if (!timedOut && options.signal?.aborted) {
+        throw new Error(`Cron ${job.name} was cancelled.`);
+      }
       throw new Error(`Cron ${job.name} timed out after ${options.timeoutMs ?? 10_000}ms.`);
     }
     if (error instanceof TypeError) {
@@ -221,6 +241,7 @@ async function invokeFarmCronJob(
     throw error;
   } finally {
     clearTimeout(timeout);
+    options.signal?.removeEventListener("abort", abortFromCaller);
   }
 }
 

--- a/packages/farm-cli/test/cron.test.mjs
+++ b/packages/farm-cli/test/cron.test.mjs
@@ -110,6 +110,42 @@ test("starts UTC development schedules and stops them cleanly", async () => {
   }
 });
 
+test("stopping the development scheduler aborts an active invocation", async () => {
+  const root = await createTempProject();
+  let requestSignal;
+  let markStarted;
+  const started = new Promise((resolve) => {
+    markStarted = resolve;
+  });
+
+  try {
+    const scheduler = await startFarmCronScheduler({
+      root,
+      url: "http://localhost:4319",
+      fetch: async (_input, init) => {
+        requestSignal = init.signal;
+        markStarted();
+        await new Promise((_resolve, reject) => {
+          requestSignal.addEventListener(
+            "abort",
+            () => reject(new DOMException("The operation was aborted", "AbortError")),
+            { once: true },
+          );
+        });
+      },
+    });
+
+    const activeRun = scheduler.entries[0].timer.trigger();
+    await started;
+    scheduler.stop();
+
+    await assert.doesNotReject(activeRun);
+    assert.equal(requestSignal.aborted, true);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test("prevents one cron job's schedules from overlapping", async () => {
   const root = await createTempProject({ schedule: ["0 2 * * *", "0 14 * * *"] });
   let finishFirstRun;


### PR DESCRIPTION
## Problem

Stopping the development cron scheduler stopped future timers but left an active HTTP invocation running until completion or timeout. Dev server shutdown could therefore retain work and sockets unexpectedly.

## Root cause

The scheduler tracked active job names only. It did not retain an AbortController for each invocation, so its stop lifecycle had nothing to cancel.

## Change

Each active scheduled run now owns an AbortController. Scheduler shutdown stops all timers, prevents late callbacks from starting, and aborts every active request. Manual invocation options also accept an optional caller signal.

## Safety and compatibility

Existing timeout behavior and overlap protection are preserved. Expected cancellation during scheduler shutdown is swallowed by the scheduled callback rather than logged as a failed job. A fetch implementation still needs to honor AbortSignal to settle promptly.

## Verification

- pnpm --filter @farm.js/cli build
- node --test packages/farm-cli/test/cron.test.mjs (7 passed)
- pnpm --filter @farm.js/cli type-check
- focused oxlint and oxfmt checks

The regression test hangs without cleanup unless its request is manually released before this change; with the fix, stop aborts the captured request signal and the run settles.

## Documentation and release

Updated the cron development scheduler lifecycle documentation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the cron dev scheduler so stopping it aborts active runs instead of leaving them running until timeout.

**Behavior**
- Each active scheduled run owns an `AbortController` that the scheduler aborts on stop.
- Manual invocation options accept an optional caller signal.
- Cancellation during shutdown is swallowed rather than logged as a failed job.
- Timeout and overlap protection behavior are preserved.
- Adds a regression test and updates the lifecycle docs.

<sup>Written for commit 72871dfcd73936cc124afb2e6781a233de8ed9b5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/867?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

