### PR TITLE
perf(react): retain structural lineage through queued reorders

### DIFF
--- a/docs/src/app/docs/renderers/react/page.md
+++ b/docs/src/app/docs/renderers/react/page.md
@@ -1334,6 +1334,24 @@ map/structural/map sequences compose. Every result and key is validated before t
 touches the DOM. An intervening statement, another setter, an unsupported callback, a changed key,
 or any failed runtime proof keeps complete reconciliation.
 
+That survivor proof may continue through adjacent native reorder setters too:
+
+```tsx
+setItems((current) => current.filter((item) => item.visible));
+setItems((current) =>
+  current.map((item) => (item.id === editedId ? { ...item, rank: nextRank } : item)),
+);
+setItems((current) => current.toSorted((left, right) => left.rank - right.rank));
+setItems((current) => current.toReversed());
+```
+
+Farm keeps the retained-row positions and same-key replacements attached to the same committed
+collection. The final update removes rejected rows, patches changed survivors, and applies the
+resulting order in one validated DOM transaction. Exact reverse chains use the minimum-move reverse
+path; an arbitrary sort uses one source lookup and LIS. The native setters still run in order. If
+the calls are not adjacent, target another state value, use an unsupported callback or method, or
+fail a runtime shape/key check, Farm discards the proof and performs complete reconciliation.
+
 A safe map may also be the final pipeline step:
 
 ```tsx
@@ -1365,10 +1383,11 @@ setItems((current) =>
 
 Farm links only consecutive concise calls to the same setter. Each accepted standalone map keeps
 the earlier reorder token, so an exact reverse still takes the direct minimum-move path and a sort
-still performs one validated lookup and LIS. An intervening statement, a different setter, a
-structural filter/slice reorder, an unsupported map, or host-backed/nested row structure ends this
-specialized chain and preserves the existing complete fallback. Map-only components do not retain
-the optional map-and-reorder runtime.
+still performs one validated lookup and LIS. Adjacent compiler-safe filter or slice work switches
+the chain to the structural proof described above. An intervening statement, a different setter,
+an unsupported map, or host-backed/nested row structure ends the specialized chain and preserves
+the existing complete fallback. Map-only components do not retain the optional map-and-reorder
+runtime.
 
 The maps may come first as separate queued setters too:
 
@@ -1401,7 +1420,8 @@ setItems((current) => current.toReversed());
 Farm still executes every updater and native method in order. Each accepted reverse or sort carries
 the same committed-row proof forward, so the final value needs one validated keyed reconciliation
 rather than losing map lineage after the first reorder. A `map().toReversed()` pipeline can start
-the same adjacent chain. An intervening statement, another setter, a structural update, or an
+the same adjacent chain. Adjacent compiler-safe filter or slice work changes this into a structural
+chain while retaining the committed source. An intervening statement, another setter, or an
 unsupported method ends the chain before later setters are considered.
 
 Exact reverse proof can also cross a setter boundary in the same batch:

--- a/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
+++ b/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
@@ -1,6 +1,42 @@
 # Complex dashboard and 21,000-row peak result
 
-Latest run: 2026-09-09
+Latest run: 2026-09-10
+
+## Queued structural maps through reorder setters — 2026-09-10
+
+Adjacent keyed-row setters may now keep one committed-row proof across compiler-safe `filter()`,
+same-key `map()`, and native reorder work. The focused 10,000-row workload removes one row, updates
+another, and queues two reverses that restore survivor order. Before this change, the reorder setter
+discarded the shorter structural result and the final value used complete keyed reconciliation.
+The new compiler linking selects the existing structural-reorder runtime, so the final commit
+removes the rejected row and patches the changed survivor without rescanning or moving the other
+9,998 rows.
+
+| Mode   | Parent compiler | This change | Lower median | vs React | vs compiled fallback |
+| ------ | --------------: | ----------: | -----------: | -------: | -------------------: |
+| Static |        21.35 ms |     8.50 ms |        60.2% |   10.41x |                2.40x |
+| Hybrid |        21.40 ms |     8.40 ms |        60.7% |   10.54x |                2.48x |
+
+The parent-compiler medians average matching 10-sample runs immediately before and after the
+candidate (18.10/24.60 ms static and 19.30/23.50 ms hybrid). The candidate run measured 88.50 ms
+for React and 20.40/20.80 ms for equivalent block-bodied compiled fallback controls. Every sample
+checked the final values, complete survivor order, rejected-row disconnection, and every surviving
+DOM identity.
+
+Compiler tests cover filter/map/reverse, maps on both sides of structural work, a map-and-reorder
+pipeline after a structural setter, multiple later reorders, and adjacency, setter, unsupported-map,
+and host-row fallback boundaries. Runtime tests cover zero owner reruns, exact DOM identity, focused
+input behavior inherited from the structural runtime, Strict Mode hydration, unmount-before-flush
+cleanup, and 2,001-row randomized queued transitions matched with normal React.
+
+Numbers are browser medians from focused production builds using 3 warmups and 10 measured samples
+per action in Chrome 153.0.8010.36 and Node.js 23.11.0 on macOS arm64. Timing varies by machine;
+deterministic parity, fallback, DOM-identity, compatibility, runtime-size, and the complete dashboard
+gate remain the primary safety controls.
+
+A reduced complete-dashboard run passed every correctness check and the new action's static and
+hybrid performance gates. Its intentionally small sample count made several unrelated timing gates
+miss narrow thresholds, so it is not recorded as a full default all-gates pass.
 
 ## Queued structural setters before maps — 2026-09-09
 

--- a/examples/react-compiler-dashboard/README.md
+++ b/examples/react-compiler-dashboard/README.md
@@ -269,18 +269,17 @@ same four native updates through complete reconciliation. Both compiler modes mu
 final committed order, every original DOM identity and connection, and both changed values. Package tests
 also cover mixed reverse/sort chains, chain boundaries, and 2,000 randomized differential updates.
 
-Queued structural-then-map updates have a separate 10,000-row comparison. One concise setter filters
-out a row and an immediately adjacent safe map changes a surviving row, with no synthetic reorder
-needed to retain the compiler proof. The block-bodied control performs the same two queued native
+Queued structural, map, and reorder updates have a separate 10,000-row comparison. One concise
+setter filters out a row, an immediately adjacent safe map changes a survivor, and two adjacent
+native reverses restore survivor order. The block-bodied control performs the same four queued
 updates through complete keyed reconciliation. Both compiler modes must remain at least 2x faster
 than React and 1.25x faster than the compiled control. The assertion checks the changed values,
 rejected-row cleanup, full survivor order, and every surviving DOM identity. Package tests cover
-maps before, between, and after filter/slice steps; structural and map work in either order across
-adjacent setters; multiple terminal maps; mapped structural reorders; controlled-input focus and
-selection; changed-key and custom-method fallback; Strict Mode hydration; cleanup; and separate
-2,000-row differential runs. The benchmark lifecycle rebuilds `@farm.js/react` first and then
-verifies the emitted hint counts, so local source changes cannot be silently measured through stale
-package output.
+maps before, between, and after filter/slice steps; structural, map, and reorder work across adjacent
+setters; multiple reorder steps; controlled-input focus and selection; changed-key and
+custom-method fallback; Strict Mode hydration; cleanup; and separate 2,000-row differential runs.
+The benchmark lifecycle rebuilds `@farm.js/react` first and then verifies the emitted hint counts,
+so local source changes cannot be silently measured through stale package output.
 
 Mapped reverse parity has an independent 10,000-row comparison. Two safe native maps update one
 row, then two native reversals restore committed order. Farm must patch the changed row without

--- a/examples/react-compiler-dashboard/scripts/benchmark.mjs
+++ b/examples/react-compiler-dashboard/scripts/benchmark.mjs
@@ -2972,9 +2972,10 @@ const keyedStructuralReorderRegressions = keyedStructuralReorderResults.filter(
     !Number.isFinite(snapshotSpeedup) ||
     snapshotSpeedup < keyedStructuralReorderMinimumSnapshotSpeedup,
 );
-// A safe filter followed by a terminal map in an adjacent setter changes membership and row data in
-// one queued commit. The combined path must remove the rejected row and patch the changed survivor
-// instead of dropping to complete keyed reconciliation at the setter boundary.
+// A safe filter, terminal map, and two native reverses in adjacent setters change membership and
+// row data while restoring the survivor order in one queued commit. The combined path must remove
+// the rejected row, patch the changed survivor, and retain structural lineage through both reorder
+// boundaries instead of dropping to complete keyed reconciliation.
 const keyedMappedStructuralReorderMinimumSpeedup = 2;
 const keyedMappedStructuralReorderMinimumSnapshotSpeedup = 1.25;
 const keyedMappedStructuralReorderResults = ["static", "hybrid"].map((mode) => {

--- a/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
+++ b/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
@@ -882,11 +882,13 @@ export function StandardTableBenchmark() {
                   : row,
               ),
             );
-            setOperation("filter one row, then review another in a queued setter");
+            setRows((current) => current.toReversed());
+            setRows((current) => current.toReversed());
+            setOperation("filter, review, and reorder rows across queued setters");
             setRevision((value) => value + 1);
           }}
         >
-          Queued filter + map
+          Queued filter + map + reorder
         </button>
         <button
           data-action="table-map-structural-reorder-pipeline-snapshot"
@@ -902,11 +904,17 @@ export function StandardTableBenchmark() {
                   : row,
               );
             });
-            setOperation("filter and review rows in queued setters (snapshot control)");
+            setRows((current) => {
+              return current.toReversed();
+            });
+            setRows((current) => {
+              return current.toReversed();
+            });
+            setOperation("filter, review, and reorder rows (snapshot control)");
             setRevision((value) => value + 1);
           }}
         >
-          Queued filter + map (snapshot control)
+          Queued filter + map + reorder (snapshot control)
         </button>
         <button
           data-action="table-map-reorder-pipeline"

--- a/packages/farm-react/README.md
+++ b/packages/farm-react/README.md
@@ -522,6 +522,23 @@ map/structural/map sequences compose. Every result and key is validated before t
 touches the DOM. An intervening statement, another setter, an unsafe callback, a changed key, or
 failed runtime validation keeps complete keyed reconciliation.
 
+The survivor proof may continue through adjacent native reorder setters:
+
+```tsx
+setItems((current) => current.filter((item) => item.visible));
+setItems((current) =>
+  current.map((item) => (item.id === editedId ? { ...item, rank: nextRank } : item)),
+);
+setItems((current) => current.toSorted((left, right) => left.rank - right.rank));
+setItems((current) => current.toReversed());
+```
+
+Farm retains the committed survivor positions and same-key replacements until the final queued
+value. The commit removes rejected rows, patches changed survivors, and applies the final order in
+one validated DOM transaction. Exact reverses use the minimum-move reverse path; an arbitrary sort
+uses one source lookup and LIS. Non-adjacent calls, another setter, unsupported syntax, or a failed
+shape/key check keep complete reconciliation.
+
 The reorder and safe maps may also be adjacent setter calls in the same synchronous block:
 
 ```tsx
@@ -536,9 +553,10 @@ setItems((current) =>
 
 The compiler links only consecutive calls to the same setter. It keeps the reorder token through
 each accepted native map, then validates row keys before applying the same exact-reverse or
-sort-permutation path at commit. An intervening statement, another setter, a structural
-filter/slice reorder, an unsupported map, or a changed key keeps the ordinary complete fallback.
-Standalone map-only components do not retain the map-and-reorder runtime.
+sort-permutation path at commit. Adjacent compiler-safe filter or slice work switches to the
+structural proof above. An intervening statement, another setter, an unsupported map, or a changed
+key keeps the ordinary complete fallback. Standalone map-only components do not retain the
+map-and-reorder runtime.
 
 The mirror order is supported as well: two or more adjacent concise same-key map setters may be
 followed by a concise native reverse or sort setter. Farm records their replacement lineage from
@@ -548,8 +566,9 @@ setter are linked; intervening work and unsupported updates retain complete reco
 Mapped lineage also continues through multiple adjacent native reorder setters. For example,
 `map -> reverse -> sort -> reverse` keeps the same committed-row proof until the final value, then
 performs one validated keyed reconciliation. A concise `map().toReversed()` pipeline may start the
-same chain. Every updater and native method still executes in order; another setter, intervening
-work, a structural update, or an unsupported method ends the chain and preserves the complete
+same chain. Adjacent compiler-safe filter or slice work changes it into a structural chain while
+retaining the committed source. Every updater and native method still executes in order; another
+setter, intervening work, or an unsupported method ends the chain and preserves the complete
 fallback.
 
 A reverse before the safe map pipeline may be queued in a separate setter:

--- a/packages/farm-react/src/__tests__/compiler-keyed-array-queued-map-reorder-hints.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-keyed-array-queued-map-reorder-hints.test.ts
@@ -191,10 +191,6 @@ describe("React AOT queued map then reorder hints", () => {
       name: "a different state setter",
       between: "setOther((current) => current + 1);",
     },
-    {
-      name: "a structural update",
-      between: "setRows((current) => current.filter((row) => row.visible));",
-    },
   ])("ends consecutive reorder lineage at $name", async ({ between }) => {
     const result = await compile(`
       import { useState } from "react";

--- a/packages/farm-react/src/__tests__/compiler-keyed-array-queued-structural-reorder-hints.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-keyed-array-queued-structural-reorder-hints.test.ts
@@ -1,0 +1,244 @@
+// @vitest-environment node
+
+import { describe, expect, it } from "vitest";
+import { transformWithEsbuild } from "vite";
+import { compileReactModule } from "../compiler";
+import { normalizeReactCompilerOptions } from "../index";
+
+const infer = normalizeReactCompilerOptions(true, "/app");
+
+async function compile(source: string) {
+  return compileReactModule(source, "/app/QueuedStructuralReorderHints.tsx", infer);
+}
+
+describe("React AOT queued structural reorder hints", () => {
+  it("retains structural and mapped lineage through a following reverse", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Table({ editedId, nextLabel, hiddenId }) {
+        const [rows, setRows] = useState([
+          { id: "a", label: "Alpha" },
+          { id: "b", label: "Beta" },
+          { id: "c", label: "Gamma" },
+        ]);
+        return <section>
+          <button onClick={() => {
+            setRows((current) => current.filter((row) => row.id !== hiddenId));
+            setRows((current) => current.map((row) =>
+              row.id === editedId ? { ...row, label: nextLabel } : row
+            ));
+            setRows((current) => current.toReversed());
+          }}>Trim, edit, and reverse</button>
+          <ul>{rows.map((row) => <li key={row.id}>{row.label}</li>)}</ul>
+        </section>;
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Table"]);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.code).toContain("createCompilerKeyedArrayFilter");
+    expect(result.code).toContain("createCompilerKeyedArrayMapPipeline");
+    expect(result.code).toContain("createCompilerKeyedArrayStructuralReorder");
+    expect(result.code).not.toContain("createCompilerKeyedArrayQueuedMapPipeline");
+    expect(result.code).not.toContain("createCompilerKeyedArrayMapReorder");
+    await expect(
+      transformWithEsbuild(result.code, "/app/QueuedStructuralReorderHints.tsx", {
+        loader: "tsx",
+        jsx: "automatic",
+      }),
+    ).resolves.toMatchObject({
+      code: expect.stringContaining("createCompilerKeyedArrayStructuralReorder"),
+    });
+  });
+
+  it("composes maps on both sides of structural work before a sort", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Table({ editedId, nextLabel, nextRank, hiddenId }) {
+        const [rows, setRows] = useState([
+          { id: "a", label: "Alpha", rank: 1 },
+          { id: "b", label: "Beta", rank: 2 },
+          { id: "c", label: "Gamma", rank: 3 },
+        ]);
+        return <section>
+          <button onClick={() => {
+            setRows((current) => current.map((row) =>
+              row.id === editedId ? { ...row, label: nextLabel } : row
+            ));
+            setRows((current) => current.filter((row) => row.id !== hiddenId));
+            setRows((current) => current.map((row) =>
+              row.id === editedId ? { ...row, rank: nextRank } : row
+            ));
+            setRows((current) => current.toSorted((left, right) => left.rank - right.rank));
+          }}>Edit, trim, edit, and sort</button>
+          <ul>{rows.map((row) => <li key={row.id}>{row.label}: {row.rank}</li>)}</ul>
+        </section>;
+      }
+    `);
+
+    expect(result.code).toContain("createCompilerKeyedArrayQueuedMapPipeline");
+    expect(result.code).toContain("finalizeCompilerKeyedArrayMappedStructuralUpdate");
+    expect(result.code).toContain("createCompilerKeyedArrayMapPipeline");
+    expect(result.code).toContain("createCompilerKeyedArrayStructuralSort");
+    expect(result.code).not.toContain("createCompilerKeyedArrayMapReorder");
+    expect(result.code).not.toContain("createCompilerKeyedArraySort");
+  });
+
+  it("keeps structural lineage through reorders and later maps", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Table({ editedId, nextLabel, hiddenId }) {
+        const [rows, setRows] = useState([
+          { id: "a", label: "Alpha" },
+          { id: "b", label: "Beta" },
+          { id: "c", label: "Gamma" },
+        ]);
+        return <section>
+          <button onClick={() => {
+            setRows((current) => current.filter((row) => row.id !== hiddenId));
+            setRows((current) => current.toReversed());
+            setRows((current) => current.map((row) =>
+              row.id === editedId ? { ...row, label: nextLabel } : row
+            ));
+            setRows((current) => current.toSorted());
+          }}>Trim, reverse, edit, and sort</button>
+          <ul>{rows.map((row) => <li key={row.id}>{row.label}</li>)}</ul>
+        </section>;
+      }
+    `);
+
+    expect(result.code).toContain("createCompilerKeyedArrayStructuralReorder");
+    expect(result.code).toContain("createCompilerKeyedArrayMapPipeline");
+    expect(result.code).toContain("createCompilerKeyedArrayStructuralSort");
+    expect(result.code).not.toContain("createCompilerKeyedArrayQueuedMapPipeline");
+    expect(result.code).not.toContain("createCompilerKeyedArrayMapReorder");
+  });
+
+  it("switches an existing mapped reorder to structural lineage after a filter", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Table({ editedId, nextRank }) {
+        const [rows, setRows] = useState([
+          { id: "a", rank: 1, visible: true },
+          { id: "b", rank: 2, visible: false },
+          { id: "c", rank: 3, visible: true },
+        ]);
+        return <section>
+          <button onClick={() => {
+            setRows((current) => current.map((row) =>
+              row.id === editedId ? { ...row, rank: nextRank } : row
+            ));
+            setRows((current) => current.toReversed());
+            setRows((current) => current.filter((row) => row.visible));
+            setRows((current) => current.toReversed());
+          }}>Edit and reorder</button>
+          <ul>{rows.map((row) => <li key={row.id}>{row.rank}</li>)}</ul>
+        </section>;
+      }
+    `);
+
+    expect(result.code.match(/createCompilerKeyedArrayMapReorder\(/g)).toHaveLength(1);
+    expect(result.code.match(/createCompilerKeyedArrayStructuralReorder\(/g)).toHaveLength(1);
+    expect(result.code).not.toContain("createCompilerKeyedArrayReorder");
+  });
+
+  it("rewrites a map and reorder pipeline after an adjacent structural setter", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Table({ editedId, nextLabel, hiddenId }) {
+        const [rows, setRows] = useState([
+          { id: "a", label: "Alpha" },
+          { id: "b", label: "Beta" },
+        ]);
+        return <section>
+          <button onClick={() => {
+            setRows((current) => current.filter((row) => row.id !== hiddenId));
+            setRows((current) => current
+              .map((row) => row.id === editedId ? { ...row, label: nextLabel } : row)
+              .toReversed()
+            );
+          }}>Update</button>
+          <ul>{rows.map((row) => <li key={row.id}>{row.label}</li>)}</ul>
+        </section>;
+      }
+    `);
+
+    expect(result.code).toContain("createCompilerKeyedArrayMapPipeline");
+    expect(result.code).toContain("createCompilerKeyedArrayStructuralReorder");
+    expect(result.code).not.toContain("createCompilerKeyedArrayMapReorder");
+  });
+
+  it.each([
+    {
+      name: "an intervening statement",
+      updates: `
+        setRows((current) => current.filter((row) => row.id !== hiddenId));
+        onFiltered();
+        setRows((current) => current.toReversed());
+      `,
+    },
+    {
+      name: "another state setter",
+      updates: `
+        setRows((current) => current.filter((row) => row.id !== hiddenId));
+        setSelected(editedId);
+        setRows((current) => current.toReversed());
+      `,
+    },
+    {
+      name: "an unsupported map",
+      updates: `
+        setRows((current) => current.filter((row) => row.id !== hiddenId));
+        setRows((current) => current.map((row) => ({ ...row, label: nextLabel })));
+        setRows((current) => current.toReversed());
+      `,
+    },
+  ])("keeps the complete fallback across $name", async ({ updates }) => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Table({ editedId, nextLabel, hiddenId, onFiltered }) {
+        const [rows, setRows] = useState([
+          { id: "a", label: "Alpha" },
+          { id: "b", label: "Beta" },
+        ]);
+        const [selected, setSelected] = useState(null);
+        return <section data-selected={selected ?? "none"}>
+          <button onClick={() => { ${updates} }}>Update</button>
+          <ul>{rows.map((row) => <li key={row.id}>{row.label}</li>)}</ul>
+        </section>;
+      }
+    `);
+
+    expect(result.code).toContain("createCompilerKeyedArrayReorder");
+    expect(result.code).not.toContain("createCompilerKeyedArrayStructuralReorder");
+  });
+
+  it("keeps host-backed keyed rows on complete reconciliation", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Table({ editedId, nextLabel }) {
+        const [rows, setRows] = useState([
+          { id: "a", label: "Alpha", visible: true },
+          { id: "b", label: "Beta", visible: false },
+        ]);
+        return <section>
+          <button onClick={() => {
+            setRows((current) => current.filter((row) => row.visible));
+            setRows((current) => current.map((row) =>
+              row.id === editedId ? { ...row, label: nextLabel } : row
+            ));
+            setRows((current) => current.toReversed());
+          }}>Update</button>
+          <ul>{rows.map((row) => <li key={row.id}>
+            <span>{row.label}</span>
+            <div>{row.visible && <strong>Visible</strong>}</div>
+          </li>)}</ul>
+        </section>;
+      }
+    `);
+
+    expect(result.code).toContain("keyedRowsHostEveryHintedRuntimeFeature");
+    expect(result.code).not.toContain("createCompilerKeyedArrayMapPipeline");
+    expect(result.code).not.toContain("createCompilerKeyedArrayStructuralReorder");
+  });
+});

--- a/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-structural-reorder-hints.test.tsx
+++ b/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-structural-reorder-hints.test.tsx
@@ -155,6 +155,12 @@ function createHarness(initialItems: Item[]) {
     removed: ReadonlySet<string>,
     limit: number,
   ) => void = () => undefined;
+  let queuedFilterMapSortReverse: (
+    editedId: string,
+    nextLabel: string,
+    nextRank: number,
+    removed: ReadonlySet<string>,
+  ) => void = () => undefined;
   let invalidQueuedMappedStructuralIdentity: () => void = () => undefined;
   let invalidQueuedStructuralMappedIdentity: () => void = () => undefined;
   let customQueuedMapThenFilter: () => void = () => undefined;
@@ -303,6 +309,20 @@ function createHarness(initialItems: Item[]) {
             item.id === editedId ? { ...item, rank: nextRank } : item,
           ),
         );
+      };
+      queuedFilterMapSortReverse = (editedId, nextLabel, nextRank, removed) => {
+        state[0].set((previous) =>
+          hintedFilter(previous as Item[], (item) => !removed.has(item.id)),
+        );
+        state[0].set((previous) =>
+          hintedMap(previous as Item[], (item) =>
+            item.id === editedId ? { ...item, label: nextLabel, rank: nextRank } : item,
+          ),
+        );
+        state[0].set((previous) =>
+          hintedSort(previous as Item[], (left, right) => left.rank - right.rank),
+        );
+        state[0].set((previous) => hintedReverse(previous as Item[]));
       };
       invalidQueuedMappedStructuralIdentity = () => {
         state[0].set((previous) =>
@@ -546,6 +566,12 @@ function createHarness(initialItems: Item[]) {
       removed: ReadonlySet<string>,
       limit: number,
     ) => queuedFilterSliceMap(editedId, nextLabel, nextRank, removed, limit),
+    queuedFilterMapSortReverse: (
+      editedId: string,
+      nextLabel: string,
+      nextRank: number,
+      removed: ReadonlySet<string>,
+    ) => queuedFilterMapSortReverse(editedId, nextLabel, nextRank, removed),
     mapFilterDoubleReverse: (editedId: string, nextLabel: string, removed: ReadonlySet<string>) =>
       mapFilterDoubleReverse(editedId, nextLabel, removed),
     mapFilterSortReverse: (
@@ -859,6 +885,43 @@ describe("compiled keyed-array structural reorder hints", () => {
     expect(harness.counters.executions).toBe(1);
     expect(harness.counters.renders).toBe(1);
     expect(harness.counters.keys).toBe(2);
+    expect(harness.counters.descriptors).toBe(0);
+    expect(harness.counters.bindings).toBe(1);
+  });
+
+  it("removes, maps, sorts, and reverses across queued setters without rerendering", async () => {
+    const items: Item[] = [
+      { id: "a", label: "Alpha", rank: 4, visible: true },
+      { id: "b", label: "Beta", rank: 1, visible: false },
+      { id: "c", label: "Gamma", rank: 3, visible: true },
+      { id: "d", label: "Delta", rank: 2, visible: true },
+    ];
+    const harness = createHarness(items);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Table />));
+    const alpha = container.querySelector('[data-key="a"]');
+    const gamma = container.querySelector('[data-key="c"]');
+    const delta = container.querySelector('[data-key="d"]');
+    harness.counters.bindings = 0;
+    harness.counters.descriptors = 0;
+    harness.counters.keys = 0;
+
+    await act(async () => {
+      harness.queuedFilterMapSortReverse("c", "Gamma queued reorder", 5, new Set(["b"]));
+      await flushCompilerUpdates();
+    });
+
+    expect(labels(container)).toEqual(["Gamma queued reorder", "Alpha", "Delta"]);
+    expect(container.querySelector('[data-key="a"]')).toBe(alpha);
+    expect(container.querySelector('[data-key="c"]')).toBe(gamma);
+    expect(container.querySelector('[data-key="d"]')).toBe(delta);
+    expect(container.querySelector('[data-key="b"]')).toBeNull();
+    expect(harness.counters.executions).toBe(1);
+    expect(harness.counters.renders).toBe(1);
+    expect(harness.counters.keys).toBe(3);
     expect(harness.counters.descriptors).toBe(0);
     expect(harness.counters.bindings).toBe(1);
   });
@@ -1683,6 +1746,83 @@ describe("compiled keyed-array structural reorder hints", () => {
     expect(harness.counters.executions).toBe(1);
   }, 20_000);
 
+  it("matches React across 2,000 randomized queued structural mapped reorders", async () => {
+    const initialItems = Array.from(
+      { length: 2_001 },
+      (_, index): Item => ({
+        id: `row-${index}`,
+        label: `Row ${index}`,
+        rank: (index * 1_229) % 2_003,
+        visible: true,
+      }),
+    );
+    const harness = createHarness(initialItems);
+    let updateReact: (
+      editedId: string,
+      nextLabel: string,
+      nextRank: number,
+      removed: ReadonlySet<string>,
+    ) => void = () => undefined;
+    function Normal() {
+      const [items, setItems] = useState(initialItems);
+      updateReact = (editedId, nextLabel, nextRank, removed) => {
+        setItems((previous) => previous.filter((item) => !removed.has(item.id)));
+        setItems((previous) =>
+          previous.map((item) =>
+            item.id === editedId ? { ...item, label: nextLabel, rank: nextRank } : item,
+          ),
+        );
+        setItems((previous) => previous.toSorted((left, right) => left.rank - right.rank));
+        setItems((previous) => previous.toReversed());
+      };
+      return (
+        <ol>
+          {items.map((item) => (
+            <li data-key={item.id} key={item.id}>
+              {item.label}
+            </li>
+          ))}
+        </ol>
+      );
+    }
+    const compiledContainer = document.createElement("div");
+    const reactContainer = document.createElement("div");
+    document.body.append(compiledContainer, reactContainer);
+    const compiledRoot = createRoot(compiledContainer);
+    const reactRoot = createRoot(reactContainer);
+    roots.push(compiledRoot, reactRoot);
+    await act(async () => {
+      compiledRoot.render(<harness.Table />);
+      reactRoot.render(<Normal />);
+    });
+
+    let seed = 0xb7e15162;
+    let active = initialItems.map((item) => item.id);
+    for (let batch = 0; batch < 100; batch += 1) {
+      const removed = new Set<string>();
+      for (let update = 0; update < 15; update += 1) {
+        seed = (Math.imul(seed, 1_664_525) + 1_013_904_223) >>> 0;
+        const available = active.filter((id) => !removed.has(id));
+        removed.add(available[seed % available.length]);
+      }
+      const survivors = active.filter((id) => !removed.has(id));
+      seed = (Math.imul(seed, 1_664_525) + 1_013_904_223) >>> 0;
+      const editedId = survivors[seed % survivors.length];
+      const nextLabel = `Queued structural reorder ${batch}`;
+      const nextRank = seed % 2_003;
+      await act(async () => {
+        harness.queuedFilterMapSortReverse(editedId, nextLabel, nextRank, removed);
+        updateReact(editedId, nextLabel, nextRank, removed);
+        await flushCompilerUpdates();
+      });
+      expect(labels(compiledContainer)).toEqual(labels(reactContainer));
+      active = [...reactContainer.querySelectorAll<HTMLElement>("li")].map(
+        (row) => row.dataset.key!,
+      );
+    }
+    expect(harness.counters.executions).toBe(1);
+  }, 20_000);
+
   it("hydrates in StrictMode and drops a queued pipeline after unmount", async () => {
     const items: Item[] = [
       { id: "a", label: "Alpha", rank: 3, visible: true },
@@ -1720,6 +1860,11 @@ describe("compiled keyed-array structural reorder hints", () => {
       await flushCompilerUpdates();
     });
     expect(labels(container)).toEqual(["Alpha queued", "Beta queued terminal"]);
+    await act(async () => {
+      hydration.queuedFilterMapSortReverse("b", "Beta queued reorder", 8, new Set());
+      await flushCompilerUpdates();
+    });
+    expect(labels(container)).toEqual(["Beta queued reorder", "Alpha queued"]);
     expect(recoverable).toEqual([]);
 
     const unmounted = createHarness(items);
@@ -1728,7 +1873,7 @@ describe("compiled keyed-array structural reorder hints", () => {
     const unmountRoot = createRoot(unmountContainer);
     await act(async () => unmountRoot.render(<unmounted.Table />));
     act(() => {
-      unmounted.queuedFilterSliceMap("c", "Gamma queued", 7, new Set(["a"]), 2);
+      unmounted.queuedFilterMapSortReverse("c", "Gamma queued", 7, new Set(["a"]));
       unmountRoot.unmount();
     });
     await flushCompilerUpdates();

--- a/packages/farm-react/src/compiler.ts
+++ b/packages/farm-react/src/compiler.ts
@@ -2684,6 +2684,191 @@ function rewriteQueuedKeyedArrayStructuralMapHints(
   };
 }
 
+function rewriteQueuedKeyedArrayStructuralReorderHints(
+  root: t.JSXElement,
+  statesBySetter: ReadonlyMap<string, StateBinding>,
+  filterIdentifier: t.Identifier,
+  sliceIdentifier: t.Identifier,
+  mapPipelineIdentifier: t.Identifier,
+  queuedMapPipelineIdentifier: t.Identifier,
+  mappedStructuralIdentifier: t.Identifier,
+  mapReorderIdentifier: t.Identifier,
+  reorderIdentifier: t.Identifier,
+  sortIdentifier: t.Identifier,
+  structuralReorderIdentifier: t.Identifier,
+  structuralSortIdentifier: t.Identifier,
+  allowed: boolean,
+): {
+  root: t.JSXElement;
+  reorderCount: number;
+  sortCount: number;
+  replacedMapReorderCount: number;
+  replacedMapSortCount: number;
+  replacedQueuedMapCount: number;
+} {
+  if (!allowed) {
+    return {
+      root: t.cloneNode(root, true),
+      reorderCount: 0,
+      sortCount: 0,
+      replacedMapReorderCount: 0,
+      replacedMapSortCount: 0,
+      replacedQueuedMapCount: 0,
+    };
+  }
+  const file = expressionFile(t.cloneNode(root, true));
+  let reorderCount = 0;
+  let sortCount = 0;
+  let replacedMapReorderCount = 0;
+  let replacedMapSortCount = 0;
+  let replacedQueuedMapCount = 0;
+
+  traverse(file, {
+    BlockStatement(path) {
+      let structuralState: number | undefined;
+      const statements = path.get("body") as NodePath<t.Statement>[];
+      for (const statementPath of statements) {
+        const statement = statementPath.node;
+        if (!t.isExpressionStatement(statement) || !t.isCallExpression(statement.expression)) {
+          structuralState = undefined;
+          continue;
+        }
+        const setterCall = statement.expression;
+        if (
+          !t.isIdentifier(setterCall.callee) ||
+          statementPath.scope.hasBinding(setterCall.callee.name) ||
+          setterCall.arguments.length !== 1
+        ) {
+          structuralState = undefined;
+          continue;
+        }
+        const state = statesBySetter.get(setterCall.callee.name);
+        const updater = setterCall.arguments[0];
+        if (
+          !state ||
+          !t.isArrowFunctionExpression(updater) ||
+          updater.async ||
+          updater.generator ||
+          updater.params.length !== 1 ||
+          !t.isIdentifier(updater.params[0])
+        ) {
+          structuralState = undefined;
+          continue;
+        }
+
+        const methodKinds = new Map<string, "reverse" | "sort">();
+        t.traverseFast(updater.body, (node) => {
+          if (
+            !t.isVariableDeclarator(node) ||
+            !t.isIdentifier(node.id) ||
+            !t.isMemberExpression(node.init) ||
+            node.init.computed ||
+            !t.isIdentifier(node.init.property)
+          ) {
+            return;
+          }
+          if (node.init.property.name === "toReversed") methodKinds.set(node.id.name, "reverse");
+          if (node.init.property.name === "toSorted") methodKinds.set(node.id.name, "sort");
+        });
+
+        let startsStructuralLineage = false;
+        let continuesStructuralLineage = false;
+        let unsupported = false;
+        const queuedMaps: t.CallExpression[] = [];
+        const reorderCalls: Array<{
+          call: t.CallExpression;
+          kind: "reverse" | "sort";
+          mapped: boolean;
+        }> = [];
+        t.traverseFast(updater.body, (node) => {
+          if (!t.isCallExpression(node) || !t.isIdentifier(node.callee)) return;
+          const helperName = node.callee.name;
+          if (
+            helperName === filterIdentifier.name ||
+            helperName === sliceIdentifier.name ||
+            helperName === mappedStructuralIdentifier.name
+          ) {
+            startsStructuralLineage = true;
+            return;
+          }
+          if (
+            helperName === structuralReorderIdentifier.name ||
+            helperName === structuralSortIdentifier.name
+          ) {
+            startsStructuralLineage = true;
+            return;
+          }
+          if (helperName === mapPipelineIdentifier.name) {
+            continuesStructuralLineage = true;
+            return;
+          }
+          if (helperName === queuedMapPipelineIdentifier.name) {
+            continuesStructuralLineage = true;
+            queuedMaps.push(node);
+            return;
+          }
+          if (helperName === reorderIdentifier.name) {
+            continuesStructuralLineage = true;
+            reorderCalls.push({ call: node, kind: "reverse", mapped: false });
+            return;
+          }
+          if (helperName === sortIdentifier.name) {
+            continuesStructuralLineage = true;
+            reorderCalls.push({ call: node, kind: "sort", mapped: false });
+            return;
+          }
+          if (helperName === mapReorderIdentifier.name) {
+            const method = node.arguments[1];
+            const kind = t.isIdentifier(method) ? methodKinds.get(method.name) : undefined;
+            if (!kind) {
+              unsupported = true;
+              return;
+            }
+            continuesStructuralLineage = true;
+            reorderCalls.push({ call: node, kind, mapped: true });
+          }
+        });
+
+        const hasStructuralLineage = startsStructuralLineage || structuralState === state.index;
+        if (unsupported || (!startsStructuralLineage && !continuesStructuralLineage)) {
+          structuralState = undefined;
+          continue;
+        }
+        if (!hasStructuralLineage) {
+          structuralState = undefined;
+          continue;
+        }
+
+        for (const call of queuedMaps) {
+          call.callee = t.cloneNode(mapPipelineIdentifier);
+          replacedQueuedMapCount += 1;
+        }
+        for (const { call, kind, mapped } of reorderCalls) {
+          call.callee = t.cloneNode(
+            kind === "reverse" ? structuralReorderIdentifier : structuralSortIdentifier,
+          );
+          if (kind === "reverse") {
+            reorderCount += 1;
+            if (mapped) replacedMapReorderCount += 1;
+          } else {
+            sortCount += 1;
+            if (mapped) replacedMapSortCount += 1;
+          }
+        }
+        structuralState = state.index;
+      }
+    },
+  });
+  return {
+    root: (file.program.body[0] as t.ExpressionStatement).expression as t.JSXElement,
+    reorderCount,
+    sortCount,
+    replacedMapReorderCount,
+    replacedMapSortCount,
+    replacedQueuedMapCount,
+  };
+}
+
 function rewriteQueuedKeyedArrayMapReorderHints(
   root: t.JSXElement,
   statesBySetter: ReadonlyMap<string, StateBinding>,
@@ -8708,6 +8893,57 @@ function compileCandidate(
       compilerUsage.keyedArrayQueuedMapUpdateHints += queuedMapCount;
       compilerUsage.keyedArrayMapReorderHints += queuedMapReorderHintedRoot.mapReorderCount;
       compilerUsage.keyedArrayMapSortHints += queuedMapReorderHintedRoot.mapSortCount;
+    }
+  }
+  const queuedStructuralReorderHintedRoot = rewriteQueuedKeyedArrayStructuralReorderHints(
+    expandedReactiveRoot,
+    statesBySetter,
+    keyedArrayFilterIdentifier,
+    keyedArraySliceIdentifier,
+    keyedArrayMapPipelineIdentifier,
+    keyedArrayQueuedMapPipelineIdentifier,
+    keyedArrayMappedStructuralIdentifier,
+    keyedArrayMapReorderIdentifier,
+    keyedArrayReorderIdentifier,
+    keyedArraySortIdentifier,
+    keyedArrayStructuralReorderIdentifier,
+    keyedArrayStructuralSortIdentifier,
+    allowKeyedArrayMapPipelines,
+  );
+  if (
+    queuedStructuralReorderHintedRoot.reorderCount > 0 ||
+    queuedStructuralReorderHintedRoot.sortCount > 0 ||
+    queuedStructuralReorderHintedRoot.replacedQueuedMapCount > 0
+  ) {
+    const hintedBlockAnalysis = analyzeComposableBlocks(
+      queuedStructuralReorderHintedRoot.root,
+      reactiveByValue,
+      safeGlobals,
+      listNames,
+      allowedComponentNames,
+    );
+    const hintedAnalysis = analyzeHostTree(
+      queuedStructuralReorderHintedRoot.root,
+      reactiveByValue,
+      safeGlobals,
+      hintedBlockAnalysis.conditionalExpressions || new Set<t.Expression>(),
+      hintedBlockAnalysis.keyedExpressions || new Set<t.Expression>(),
+      hintedBlockAnalysis.ownedElements || new Set<t.JSXElement>(),
+      hintedBlockAnalysis.componentElements || new Set<t.JSXElement>(),
+    );
+    if (!hintedBlockAnalysis.reason && !hintedAnalysis.reason) {
+      expandedReactiveRoot = queuedStructuralReorderHintedRoot.root;
+      blockAnalysis = hintedBlockAnalysis;
+      analysis = hintedAnalysis;
+      compilerUsage.keyedArrayQueuedMapUpdateHints -=
+        queuedStructuralReorderHintedRoot.replacedQueuedMapCount;
+      compilerUsage.keyedArrayMapReorderHints -=
+        queuedStructuralReorderHintedRoot.replacedMapReorderCount;
+      compilerUsage.keyedArrayMapSortHints -=
+        queuedStructuralReorderHintedRoot.replacedMapSortCount;
+      compilerUsage.keyedArrayStructuralReorderHints +=
+        queuedStructuralReorderHintedRoot.reorderCount;
+      compilerUsage.keyedArrayStructuralSortHints += queuedStructuralReorderHintedRoot.sortCount;
     }
   }
   const keyedCollectionTargetKinds = new Map<number, KeyedCollectionTargetKind>();

--- a/packages/farm-react/vitest.stress.config.ts
+++ b/packages/farm-react/vitest.stress.config.ts
@@ -21,7 +21,7 @@ export default defineConfig({
     ],
     setupFiles: ["src/__tests__/stress.setup.ts"],
     testNamePattern:
-      /2,000 deterministic mapped reorder updates|2,000 deterministic mapped reversal parity updates|2,000 queued reverse, map, and reverse updates|2,000 reverse-or-sort then map updates|2,000 queued reorder then standalone map updates|2,000 queued map then reorder updates|2,000 queued map and consecutive reorder updates|2,000 mapped structural removals|2,000 randomized interleaved map and structural removals|2,000 randomized terminal structural-map row transitions|2,000 randomized mapped terminal-structural row transitions|2,000 randomized queued mapped structural transitions|2,000 randomized queued structural mapped transitions|3,000 deterministic recursive updates|4,096 rows/,
+      /2,000 deterministic mapped reorder updates|2,000 deterministic mapped reversal parity updates|2,000 queued reverse, map, and reverse updates|2,000 reverse-or-sort then map updates|2,000 queued reorder then standalone map updates|2,000 queued map then reorder updates|2,000 queued map and consecutive reorder updates|2,000 mapped structural removals|2,000 randomized interleaved map and structural removals|2,000 randomized terminal structural-map row transitions|2,000 randomized mapped terminal-structural row transitions|2,000 randomized queued mapped structural transitions|2,000 randomized queued structural mapped transitions|2,000 randomized queued structural mapped reorders|3,000 deterministic recursive updates|4,096 rows/,
     testTimeout: 30_000,
   },
 });


### PR DESCRIPTION
## Problem

PR #859 preserves a committed keyed-row proof across adjacent structural and safe-map setters. A following native reverse or sort still selected the ordinary reorder helper, however. Because that helper expects the original source length, a preceding filter made its validation reject the shorter value and use complete keyed reconciliation.

## Root cause

The compiler tracked structural-to-map and map-to-reorder sequences independently. It did not carry structural lineage through later reorder setters or promote an already generated map-and-reorder helper to the structural reorder runtime.

## Change

- Track compiler-generated structural, safe-map, reverse, and sort helpers across adjacent concise calls to the same state setter.
- Promote reverse and sort work to the existing structural reorder helpers after filter or slice lineage.
- Keep later safe maps attached to the same structural proof, including map-and-reorder pipelines and multiple following reorders.
- Extend the dashboard workload with queued filter, safe map, and two native reorder setters.
- Document the supported sequence and fallback boundaries in the React renderer docs and package README.

This PR is intentionally stacked on #859 and contains one additional compiler optimization.

## Safety and compatibility

The pass recognizes only helpers already generated by the compiler and requires adjacent concise updater calls to the same setter. Intervening work, another setter, unsupported callbacks or methods, host-backed or nested row ownership, changed keys, and failed runtime shape checks retain complete React reconciliation. Native updater and method evaluation order is unchanged.

The implementation reuses the existing structural reverse and structural sort runtimes. It adds no compiler-runtime source and the runtime-size budget remains green. Tests cover DOM identity, removed-node cleanup, zero owner reruns, Strict Mode hydration, unmount-before-flush cleanup, randomized parity with React, and fallback boundaries.

## Verification

- `pnpm --filter @farm.js/react exec vitest run src/__tests__/compiler-keyed-array-queued-map-reorder-hints.test.ts src/__tests__/compiler-keyed-array-queued-structural-reorder-hints.test.ts` — 20 passed
- `pnpm --filter @farm.js/react exec vitest run src/__tests__/compiler-runtime-keyed-array-structural-reorder-hints.test.tsx` — 26 passed, including the 2,001-row randomized differential case
- `pnpm --filter @farm.js/react test:stress` — 17 passed, 69 skipped by the stress selector
- `pnpm --filter @farm.js/react type-check`
- `pnpm --filter @farm.js/react build`
- `pnpm --filter @farm.js/react test:compat` — React 18.3.1 and 19.2.8
- `pnpm --filter @farm.js/react test:runtime-size`
- `pnpm --dir examples/react-compiler-dashboard build`
- `pnpm docs:check-navigation`
- `pnpm --dir docs exec farm generate --check`
- `pnpm docs:build` — Vercel/Nitro production output
- `pnpm exec oxfmt <changed files>` and focused `pnpm exec oxlint` — clean

The full React package run completed 763 tests with 10 skipped; four existing 20-second randomized differential cases timed out only under the 75-file parallel run, and each passed when rerun individually. The new randomized test passed in both the full parallel run and the stress run.

Focused production browser benchmark, Chrome 153.0.8010.36, Node.js 23.11.0, macOS arm64, 3 warmups and 10 measured samples per action:

| Mode | Parent compiler | This PR | Lower median | vs React | vs compiled fallback |
| --- | ---: | ---: | ---: | ---: | ---: |
| Static | 21.35 ms | 8.50 ms | 60.2% | 10.41x | 2.40x |
| Hybrid | 21.40 ms | 8.40 ms | 60.7% | 10.54x | 2.48x |

Every benchmark sample checked values, complete survivor order, removed-row disconnection, and all surviving DOM identities. A reduced complete-dashboard run passed all correctness checks and the new action gates. Several unrelated performance gates missed narrow thresholds with the intentionally reduced samples, so this is not reported as a full default all-gates pass.

## Documentation and release

Updated the React renderer docs, `@farm.js/react` README, dashboard README, benchmark methodology, and reproducible results. No version or release change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retains the compiler's committed-row proof through queued native reverse and sort setters after filter or slice work. Previously a filter or slice followed by reverse/sort dropped the structural proof and used complete keyed reconciliation; now the final update removes rejected rows, patches changed survivors, and applies the final order in one DOM transaction.

**Behavior**
- The compiler links structural, safe-map, reverse, and sort helpers across adjacent concise setters to the same state value.
- Later safe maps and multiple following reorders keep the same structural proof.
- Non-adjacent calls, other setters, unsupported callbacks or methods, host-backed rows, changed keys, or failed shape checks keep complete reconciliation.
- Reuses the existing structural reverse and sort runtimes; no new runtime code, runtime-size budget stays green.
- Docs, `@farm.js/react` README, and the dashboard benchmark cover the new sequence.

<sup>Written for commit 8a3d24d1928467068a3b780e14313e7a45da3176. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/868?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

