### PR TITLE
fix(partytown): detect bootstrap markers on script tags

### DIFF
--- a/docs/src/app/docs/plugins/partytown/page.md
+++ b/docs/src/app/docs/plugins/partytown/page.md
@@ -166,6 +166,8 @@ code.
 - Production assets land in Nitro's public directory, including the separate Vercel static output.
 - Debug worker files are omitted from production unless `debug: true` is explicit.
 - The bootstrap is an external same-origin script rather than plugin-owned inline JavaScript.
+- Bootstrap injection is idempotent when an actual script carries `data-farm-partytown`; matching
+  text elsewhere in the document does not suppress it.
 
 Partytown's worker scope can coexist with a root PWA service worker because the browser selects the
 most specific matching scope.

--- a/packages/farm-partytown/src/build.test.ts
+++ b/packages/farm-partytown/src/build.test.ts
@@ -101,6 +101,17 @@ describe("Partytown document bootstrap", () => {
     expect(twice).toBe(once);
   });
 
+  it("does not mistake document text or another attribute value for the marker", () => {
+    const html =
+      '<!doctype html><html><head><title>data-farm-partytown</title><script title="x data-farm-partytown y"></script></head><body></body></html>';
+
+    const result = injectPartytownBootstrap(html, "/~partytown/farm-partytown.js");
+
+    expect(result).toContain(
+      '<script src="/~partytown/farm-partytown.js" data-farm-partytown></script></head>',
+    );
+  });
+
   it("leaves fragments unchanged and validates base paths", () => {
     expect(injectPartytownBootstrap("<main>Farm</main>", "/bootstrap.js")).toBe(
       "<main>Farm</main>",

--- a/packages/farm-partytown/src/build.ts
+++ b/packages/farm-partytown/src/build.ts
@@ -63,11 +63,23 @@ export function createPartytownBootstrap(
 }
 
 export function injectPartytownBootstrap(html: string, bootstrapUrl: string): string {
-  if (html.includes("data-farm-partytown")) return html;
+  if (hasPartytownBootstrap(html)) return html;
   const closingHead = html.search(/<\/head\s*>/i);
   if (closingHead < 0) return html;
   const tag = `<script src="${escapeHtmlAttribute(bootstrapUrl)}" data-farm-partytown></script>`;
   return `${html.slice(0, closingHead)}${tag}${html.slice(closingHead)}`;
+}
+
+function hasPartytownBootstrap(html: string): boolean {
+  const scriptTags = html.matchAll(/<script\b(?:[^>"']|"[^"]*"|'[^']*')*>/gi);
+  for (const tag of scriptTags) {
+    const attributes = tag[0].slice("<script".length, -1);
+    const parsed = attributes.matchAll(/([^\s"'<>=]+)(?:\s*=\s*(?:"[^"]*"|'[^']*'|[^\s"'=<>]+))?/g);
+    for (const attribute of parsed) {
+      if (attribute[1]?.toLowerCase() === "data-farm-partytown") return true;
+    }
+  }
+  return false;
 }
 
 export async function readPartytownDevAsset(


### PR DESCRIPTION
## Problem

Any occurrence of the text data-farm-partytown anywhere in a document prevented bootstrap injection. Documentation text, a title, or an unrelated attribute value could leave opted-in scripts without the Partytown runtime.

## Root cause

The idempotency guard searched the complete HTML string instead of verifying that the marker was an attribute on a script start tag.

## Change

The guard now scans script start tags and parses their attributes before treating the bootstrap as present.

## Safety and compatibility

A real data-farm-partytown script marker remains idempotent, including case-insensitive HTML tag and attribute names. Documents without a closing head remain unchanged as before. The generated tag and bootstrap URL handling are unchanged.

## Verification

- pnpm --filter @farm.js/partytown test (22 passed)
- pnpm --filter @farm.js/partytown type-check
- pnpm --filter @farm.js/partytown build
- focused oxlint and oxfmt checks

The new regression includes the marker text in a title and another script attribute value. It fails to inject before this fix and injects exactly where expected afterward.

## Documentation and release

Updated the Partytown ownership documentation to describe marker-based idempotency.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Partytown bootstrap idempotency so only a real `data-farm-partytown` attribute on a script start tag prevents injection. Previously, any occurrence of that text anywhere in the HTML (like in a title or another attribute value) suppressed the bootstrap, leaving opted-in scripts without the runtime.

**Changes**
- The guard now scans script start tags and parses their attributes instead of searching the entire HTML string.
- Added a regression test covering the false-positive case and updated the Partytown docs.

<sup>Written for commit 0248a4601a983de6fad6e65059e3fbe9c8be8da9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/870?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

