### PR TITLE
fix(integrations): reject external checkout return paths

### DIFF
--- a/docs/src/app/docs/integrations/autumn/page.md
+++ b/docs/src/app/docs/integrations/autumn/page.md
@@ -128,6 +128,8 @@ if (checkout.data?.redirectTo) {
 }
 ```
 
+Checkout and portal return paths must be same-origin, root-relative application paths. Protocol-relative paths such as `//example.com` are rejected.
+
 ## Owner and entitlements
 
 Autumn needs a billing owner when it checks or attaches customer state. Use the owner resolver to connect Farm auth/session data with Autumn customers.

--- a/docs/src/app/docs/integrations/polar/page.md
+++ b/docs/src/app/docs/integrations/polar/page.md
@@ -130,6 +130,8 @@ if (portal.data?.redirectTo) {
 }
 ```
 
+Checkout and portal return paths must be same-origin, root-relative application paths. Protocol-relative paths such as `//example.com` are rejected.
+
 ## When Polar is a good fit
 
 Polar works especially well when the product is developer-facing, open-source, sponsor-backed, or selling digital access. The Farm integration keeps the same caller shape as other billing providers, so moving between Stripe, Autumn, and Polar does not force your app UI to learn a new local API style.

--- a/docs/src/app/docs/integrations/stripe/page.md
+++ b/docs/src/app/docs/integrations/stripe/page.md
@@ -138,6 +138,8 @@ if (portal.data?.redirectTo) {
 }
 ```
 
+Checkout and portal return paths must be same-origin, root-relative application paths. Protocol-relative paths such as `//example.com` are rejected.
+
 ## Billing owner
 
 Production billing usually needs an owner resolver. That resolver decides whether the billing account belongs to a user, organization, workspace, or team.

--- a/packages/farm-integration-utils/src/url.ts
+++ b/packages/farm-integration-utils/src/url.ts
@@ -56,11 +56,17 @@ export function resolveAppPath(path: string | undefined, label: string): string 
     return undefined;
   }
 
-  if (!path.startsWith("/")) {
-    throw new Error(`${label} must be a root-relative path.`);
+  if (!isSameOriginRootRelativePath(path)) {
+    throw new Error(`${label} must be a same-origin root-relative path.`);
   }
 
   return path;
+}
+
+function isSameOriginRootRelativePath(value: string): boolean {
+  if (!value.startsWith("/")) return false;
+  const second = value[1];
+  return second !== "/" && second !== "\\";
 }
 
 export function resolveCallbackSettings(

--- a/packages/farm/src/__tests__/integration-utils-auth-safety.test.ts
+++ b/packages/farm/src/__tests__/integration-utils-auth-safety.test.ts
@@ -1,7 +1,11 @@
 // @vitest-environment node
 import { describe, expect, it } from "vitest";
 import { getCookieValue, parseCookieHeaderMap } from "../../../farm-integration-utils/src/cookies";
-import { getReturnTo } from "../../../farm-integration-utils/src/url";
+import {
+  getReturnTo,
+  resolveAppPath,
+  toAbsoluteUrl,
+} from "../../../farm-integration-utils/src/url";
 
 describe("getReturnTo open-redirect hardening", () => {
   it("keeps ordinary root-relative paths", () => {
@@ -25,6 +29,24 @@ describe("getReturnTo open-redirect hardening", () => {
     expect(getReturnTo("", "/dashboard")).toBe("/dashboard");
     expect(getReturnTo(null, "/dashboard")).toBe("/dashboard");
     expect(getReturnTo(undefined)).toBe("/");
+  });
+});
+
+describe("resolveAppPath open-redirect hardening", () => {
+  it("keeps same-origin application paths", () => {
+    const request = new Request("https://app.example.com/account");
+    const path = resolveAppPath("/billing/success?plan=pro", "Checkout successPath");
+
+    expect(path).toBe("/billing/success?plan=pro");
+    expect(toAbsoluteUrl(path!, request).origin).toBe("https://app.example.com");
+  });
+
+  it("rejects path forms that browsers resolve to another origin", () => {
+    for (const value of ["//evil.example", "/\\evil.example", "/\\/evil.example"]) {
+      expect(() => resolveAppPath(value, "Checkout successPath")).toThrow(
+        "same-origin root-relative path",
+      );
+    }
   });
 });
 


### PR DESCRIPTION
## Problem

Checkout and portal request bodies accept path values such as `//evil.example` and `/\\evil.example`. Browsers resolve those forms to a foreign origin even though the integrations describe them as root-relative application paths.

## Root cause

The shared `resolveAppPath()` helper checked only the first slash. Unlike the hardened auth return-path helper, it did not reject protocol-relative or leading-backslash authority forms.

## Change

Require checkout and portal destinations to be same-origin root-relative paths. Stripe, Polar, and Autumn receive the fix through their existing shared helper, and their guides now state the constraint.

## Safety and compatibility

Ordinary paths, query strings, and fragments remain supported. Absolute and protocol-relative destinations were never part of the documented contract.

## Verification

- `pnpm --filter @farm.js/integration-utils build`
- `pnpm --filter @farm.js/integration-utils type-check`
- `pnpm --filter @farm.js/core test -- integration-utils-auth-safety.test.ts`
- `pnpm exec oxlint packages/farm-integration-utils/src/url.ts packages/farm/src/__tests__/integration-utils-auth-safety.test.ts`
- Focused regression confirms every accepted checkout path resolves to the application's origin.

## Documentation and release

Updated the Stripe, Polar, and Autumn integration guides.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes checkout and portal return path validation so browsers can no longer redirect to foreign origins through paths like `//evil.example` or `/\\evil.example`.

- `resolveAppPath()` now requires a same-origin root-relative path and rejects protocol-relative and leading-backslash authority forms.
- Stripe, Polar, and Autumn inherit the fix through the shared helper, and their docs now state the constraint.
- Ordinary paths, query strings, and fragments are still accepted.

<sup>Written for commit 69a4b135b53dfd6a82b4fde54a76ca62862e4802. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/872?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

