### PR TITLE
fix(scripts): reject cross-origin path lookalikes

### DIFF
--- a/docs/src/app/docs/plugins/scripts/page.md
+++ b/docs/src/app/docs/plugins/scripts/page.md
@@ -235,7 +235,7 @@ defineScript<VendorSDK>({
 | Option           | Default           | Purpose                                                                  |
 | ---------------- | ----------------- | ------------------------------------------------------------------------ |
 | `name`           | Required          | Unique application registry name.                                        |
-| `src`            | Required          | Root-relative or absolute HTTP(S) URL.                                   |
+| `src`            | Required          | Root-relative path without backslashes, or an absolute HTTP(S) URL.      |
 | `global`         | None              | Safe dotted browser global returned by `load()` and `use()`.             |
 | `load`           | `after-hydration` | One of the built-in loading strategies.                                  |
 | `consent`        | None              | App-owned category that must be granted first.                           |

--- a/packages/farm-scripts/src/config.test.ts
+++ b/packages/farm-scripts/src/config.test.ts
@@ -59,6 +59,12 @@ describe("resolveScriptsOptions", () => {
 
   it("rejects ambiguous or unsafe definitions", () => {
     expect(() => defineScript({ name: "x", src: "./vendor.js" })).toThrow("root-relative");
+    expect(() => defineScript({ name: "x", src: "/\\evil.example/vendor.js" })).toThrow(
+      "backslashes",
+    );
+    expect(() => defineScript({ name: "x", src: "/vendor/unsafe\nscript.js" })).toThrow(
+      "control characters",
+    );
     expect(() =>
       defineScript({ name: "x", src: "/vendor.js", global: "window.__proto__.x" }),
     ).toThrow("relative to window");

--- a/packages/farm-scripts/src/shared.ts
+++ b/packages/farm-scripts/src/shared.ts
@@ -255,7 +255,18 @@ function normalizeDependencies(value: readonly ScriptDependency[] | undefined): 
 function normalizeScriptSource(value: unknown): string {
   const src = normalizeText(value, "src");
   const rootRelative = src.startsWith("/") && !src.startsWith("//");
-  if (rootRelative) return src;
+  if (rootRelative) {
+    const hasControlCharacter = Array.from(src).some((character) => {
+      const code = character.charCodeAt(0);
+      return code <= 31 || code === 127;
+    });
+    if (src.includes("\\") || hasControlCharacter) {
+      throw new TypeError(
+        "script root-relative src cannot contain backslashes or control characters",
+      );
+    }
+    return src;
+  }
   if (!/^https?:\/\//i.test(src)) {
     throw new TypeError("script src must be root-relative or use an absolute HTTP(S) URL");
   }


### PR DESCRIPTION
## Problem

A script source beginning with `/\\` passes the root-relative check, but the browser URL parser treats the backslash as a slash and loads the script from another origin.

## Root cause

Source validation rejected `//` but did not reject browser-normalized backslashes or control characters in local paths.

## Change

Reject backslashes and control characters in root-relative script sources, with regression coverage for both forms.

## Safety and compatibility

Normal public-directory paths and absolute HTTP(S) vendor URLs are unchanged. The rejected forms cannot reliably identify a local application asset.

## Verification

- `pnpm --filter @farm.js/scripts test` — 22 tests passed
- `pnpm --filter @farm.js/scripts type-check`
- `pnpm --filter @farm.js/scripts build`
- `pnpm exec oxlint packages/farm-scripts/src/shared.ts packages/farm-scripts/src/config.test.ts`

## Documentation and release

Clarified the `src` contract in the Scripts guide.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a validation gap in script source checking so root-relative `src` values like `/\\evil.example/vendor.js` no longer pass validation and then load from a different origin when the browser normalizes the backslash.

**Details**
- Rejects backslashes and control characters in root-relative script sources.
- Updates the Scripts guide to state that root-relative paths must not contain backslashes.
- Normal public-directory paths and absolute HTTP(S) URLs are unaffected.

<sup>Written for commit 580e6fc8ca7865576cfcd3d5493a272699bea6ab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/873?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

