### PR TITLE
fix(jobs): reject malformed trigger bodies

### DIFF
--- a/packages/farm-jobs/src/index.ts
+++ b/packages/farm-jobs/src/index.ts
@@ -528,15 +528,10 @@ function toKebabCase(value: string) {
 }
 
 function readJsonBody(value: unknown) {
-  if (value == null) {
-    return undefined;
-  }
-
-  if (typeof value === "object") {
+  if (value && typeof value === "object" && !Array.isArray(value)) {
     return value as Record<string, unknown>;
   }
-
-  return undefined;
+  throw new JobsRuntimeError("Jobs request body must be a JSON object.", 400);
 }
 
 function hasOwn(value: Record<string, unknown>, key: string) {
@@ -588,12 +583,21 @@ function readInlinePayload(value: Record<string, unknown>, reservedKeys: readonl
 }
 
 async function parseRequestBody(request: Request) {
+  let source: string;
   try {
-    const body = await request.json();
-    return readJsonBody(body);
+    source = await request.text();
   } catch {
-    return undefined;
+    throw new JobsRuntimeError("Jobs request body could not be read.", 400);
   }
+  if (!source.trim()) return undefined;
+
+  let body: unknown;
+  try {
+    body = JSON.parse(source);
+  } catch {
+    throw new JobsRuntimeError("Jobs request body must contain valid JSON.", 400);
+  }
+  return readJsonBody(body);
 }
 
 function normalizeQueue(queue: JobsTaskDefaults<any>["queue"]) {

--- a/packages/farm/src/__tests__/jobs-integration.test.ts
+++ b/packages/farm/src/__tests__/jobs-integration.test.ts
@@ -26,6 +26,37 @@ describe("jobs integration", () => {
     vi.unstubAllGlobals();
   });
 
+  it("rejects malformed and non-object JSON before dispatching a job", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const integration = jobs({
+      runtime: trigger({ apiKey: "tr_dev_test" }),
+      tasks: defineTasks({
+        sendEmail: task({
+          async run(input: { recipient: string }) {
+            return input;
+          },
+        }),
+      }),
+    });
+    const routes = integration.routes as Array<{
+      path: string;
+      handler(request: Request): Promise<Response>;
+    }>;
+    const triggerRoute = routes.find((route) => route.path.endsWith("/trigger"));
+
+    for (const body of ["{", "null", "[]", '"recipient"']) {
+      const response = await triggerRoute!.handler(
+        new Request("https://farmjs.dev/api/jobs/send-email/trigger", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body,
+        }),
+      );
+      expect(response.status).toBe(400);
+    }
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
   it("infers task input/output types and exposes task metadata", async () => {
     const tasks = defineTasks({
       sendWelcomeEmail: task({


### PR DESCRIPTION
## Problem

Malformed JSON and valid non-object JSON bodies on a Jobs trigger route were treated as if no request body had been sent. The provider job could therefore be dispatched instead of returning a client error.

## Root cause

The request parser caught every JSON parsing failure and returned `undefined`, while the body reader silently accepted only object-shaped values. That made malformed, scalar, and array payloads indistinguishable from an intentionally empty body.

## Change

Read the request body explicitly, preserve an empty body for input-free tasks, reject malformed JSON, and require non-empty JSON payloads to be objects. A regression test verifies that invalid payloads return `400` before the Trigger.dev adapter is called.

## Safety and compatibility

Empty request bodies continue to work for tasks without input. Existing object payloads, including inline task fields and wrapped payloads, retain their current behavior. The change only rejects payloads that cannot satisfy the Jobs object-body contract.

## Verification

- `pnpm --filter @farm.js/core exec vitest run src/__tests__/jobs-integration.test.ts src/__tests__/jobs-trigger-payload.test.ts`
- `pnpm --filter @farm.js/jobs type-check`
- `pnpm --filter @farm.js/jobs build`
- `pnpm exec oxlint packages/farm-jobs/src/index.ts packages/farm/src/__tests__/jobs-integration.test.ts`
- `git diff --check`

Focused lint completes with two unrelated existing warnings in `packages/farm-jobs/src/index.ts`.

## Documentation and release

None. The endpoint already documents an object-shaped JSON body; this aligns runtime validation with that contract.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Jobs trigger route so malformed JSON and non-object JSON bodies now return a 400 instead of being treated as an empty request and dispatching the job.

- Empty request bodies still work for input-free tasks.
- Existing object payloads, including inline task fields and wrapped payloads, keep their current behavior.

<sup>Written for commit d0af78e9728ec437bdb0a0c52f72937bf251189b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/874?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

