### PR TITLE
fix(pwa): prefix precache assets with app base path

### DIFF
--- a/packages/farm-pwa/src/build.test.ts
+++ b/packages/farm-pwa/src/build.test.ts
@@ -81,7 +81,15 @@ describe("writePwaBuildArtifacts", () => {
 
     expect(result.workerUrl).toBe("/app/sw.js");
     expect(result.workerPath).toBe(path.join(publicDir, "app", "sw.js"));
+    expect(result.precacheUrls).toEqual([
+      "/app/assets/app.abc123.css",
+      "/app/assets/app.abc123.js",
+      "/app/offline/index.html",
+    ]);
     expect(result.staticRoutes).toEqual({ "/app/offline": "offline/index.html" });
+    expect(await readFile(result.workerPath, "utf8")).toContain(
+      'const OFFLINE_FILE = "/app/offline/index.html"',
+    );
   });
 
   it("copies a custom service worker verbatim under basePath", async () => {
@@ -119,6 +127,13 @@ describe("writePwaBuildArtifacts", () => {
       "/app/offline": "offline/index.html",
       "/app/pricing": "pricing/index.html",
     });
+    expect(result.precacheUrls).toEqual([
+      "/app/assets/app.abc123.css",
+      "/app/assets/app.abc123.js",
+      "/app/index.html",
+      "/app/offline/index.html",
+      "/app/pricing/index.html",
+    ]);
   });
 
   it("fails the build when the offline fallback is not an emitted static page", async () => {

--- a/packages/farm-pwa/src/build.ts
+++ b/packages/farm-pwa/src/build.ts
@@ -91,10 +91,11 @@ export async function writePwaBuildArtifacts(input: PwaBuildInput): Promise<PwaB
 
   const assetFiles = files.filter(
     (file) =>
-      file !== workerRelativePath && PRECACHE_EXTENSIONS.has(path.extname(file).toLowerCase()),
+      toPublicUrl(file, basePath) !== withBasePath("/sw.js", basePath) &&
+      PRECACHE_EXTENSIONS.has(path.extname(file).toLowerCase()),
   );
   const precacheFiles = [...new Set([...assetFiles, ...Object.values(selectedRoutes)])].sort();
-  const precacheUrls = precacheFiles.map(toPublicUrl);
+  const precacheUrls = precacheFiles.map((file) => toPublicUrl(file, basePath));
   const fileHashes = await Promise.all(
     precacheFiles.map(async (file) => {
       const content = await readFile(path.join(publicDir, file));
@@ -150,7 +151,10 @@ export interface GenerateServiceWorkerOptions {
 
 export function generateServiceWorker(options: GenerateServiceWorkerOptions): string {
   const routeFiles = Object.fromEntries(
-    Object.entries(options.staticRoutes).map(([route, file]) => [route, toPublicUrl(file)]),
+    Object.entries(options.staticRoutes).map(([route, file]) => [
+      route,
+      toPublicUrl(file, options.basePath),
+    ]),
   );
   const offlineFile = options.offlineRoute ? (routeFiles[options.offlineRoute] ?? null) : null;
   const cacheScope = createHash("sha256")
@@ -380,10 +384,11 @@ function selectStaticRoutes(
   return selected;
 }
 
-function toPublicUrl(file: string): string {
-  return `/${file
+function toPublicUrl(file: string, basePath: string): string {
+  const url = `/${file
     .replace(/\\/g, "/")
     .split("/")
     .map((segment) => encodeURIComponent(segment))
     .join("/")}`;
+  return withBasePath(url, basePath);
 }


### PR DESCRIPTION
## Problem

Generated PWA workers were emitted beneath an app base path such as `/app/sw.js`, but their precache entries and static-route file targets still pointed at root URLs such as `/assets/app.js`. Those requests miss a base-path deployment. An existing public `sw.js` could also be added back as the generated worker's own precache URL.

## Root cause

Build files were converted to public URLs without passing the configured base path. Worker exclusion compared physical file paths rather than the final public worker URL.

## Change

Prefix generated precache and static-route file URLs with the normalized app base path, and exclude the service worker by its final public URL. Regression coverage verifies assets, pages, the offline fallback, and service-worker exclusion under `/app`.

## Safety and compatibility

Root deployments retain their existing URLs. Route lookup keys remain logical base-path routes, cache names stay isolated by scope, and custom service workers are unchanged.

## Verification

- `pnpm --filter @farm.js/pwa test`
- `pnpm --filter @farm.js/pwa type-check`
- `pnpm --filter @farm.js/pwa build`
- `pnpm exec oxlint packages/farm-pwa/src/build.ts packages/farm-pwa/src/build.test.ts`
- `git diff --check`

## Documentation and release

None. This fixes generated output to match the existing documented `basePath` contract.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes generated PWA precache URLs and static-route targets to include the app base path, so requests under `/app` no longer miss root URLs. Also stops the generated worker from precaching an existing public `sw.js` by excluding it via its final public URL.

- Precache entries and offline-file URLs are now prefixed with the normalized base path.
- Static-route file mapping uses the base path for file targets while route keys stay logical routes.
- Root deployments keep the same URLs; custom service workers are untouched.
- Added regression tests covering assets, pages, offline fallback, and worker exclusion under `/app`.

<sup>Written for commit b39abba6db50ae0a5964e18f8852d2d59cc47004. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/875?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

