### PR TITLE
fix(pwa): reject unstable configured routes

### DIFF
--- a/docs/src/app/docs/plugins/pwa/page.md
+++ b/docs/src/app/docs/plugins/pwa/page.md
@@ -206,6 +206,10 @@ array when the app should not ship a service worker.
 | `staticRoutes` | `true`               | Every emitted static page, a route list, or `false`. |
 | `images`       | `"swr"`              | SWR options, `true`, `"swr"`, or `false`.            |
 
+`offline` and explicit `staticRoutes` entries must be stable root-relative application paths.
+URLs, query strings, fragments, dot segments, backslashes, control characters, and encoded path
+separators are rejected.
+
 ## Production lifecycle
 
 During `farm build`, generated-worker mode:

--- a/packages/farm-pwa/src/config.test.ts
+++ b/packages/farm-pwa/src/config.test.ts
@@ -86,6 +86,20 @@ describe("resolvePwaOptions", () => {
     );
   });
 
+  it("rejects routes that URL parsing could reinterpret", () => {
+    for (const route of [
+      "//example.com/offline",
+      "/safe/../offline",
+      "/safe/%2e%2e/offline",
+      "/safe%2foffline",
+      "/safe\\offline",
+      "/safe\u0000offline",
+    ]) {
+      expect(() => resolvePwaOptions({ offline: route })).toThrow();
+      expect(() => resolvePwaOptions({ cache: { staticRoutes: [route] } })).toThrow();
+    }
+  });
+
   it("rejects invalid top-level options instead of changing behavior silently", () => {
     expect(() => resolvePwaOptions(null as never)).toThrow("options must be an object");
     expect(() => resolvePwaOptions({ enabled: false } as never)).toThrow(

--- a/packages/farm-pwa/src/config.ts
+++ b/packages/farm-pwa/src/config.ts
@@ -205,8 +205,38 @@ function normalizeRoute(value: string | false, label: string): string | false {
   if (!route.startsWith("/")) {
     throw new TypeError(`PWA ${label} must start with "/"`);
   }
+  if (route.startsWith("//")) {
+    throw new TypeError(`PWA ${label} must be an application pathname, not a URL`);
+  }
   if (route.includes("?") || route.includes("#")) {
     throw new TypeError(`PWA ${label} cannot contain a query string or fragment`);
   }
+  if (hasUnstablePathCharacters(route)) {
+    throw new TypeError(`PWA ${label} cannot contain backslashes or control characters`);
+  }
+  for (const segment of route.split("/")) {
+    let decoded = segment;
+    try {
+      decoded = decodeURIComponent(segment);
+    } catch {
+      // Malformed escapes remain literal URL pathname segments.
+    }
+    if (hasUnstablePathCharacters(decoded) || decoded.includes("/")) {
+      throw new TypeError(`PWA ${label} cannot contain encoded path separators`);
+    }
+    if (decoded === "." || decoded === "..") {
+      throw new TypeError(`PWA ${label} cannot contain "." or ".." path segments`);
+    }
+  }
   return route === "/" ? route : route.replace(/\/+$/, "");
+}
+
+function hasUnstablePathCharacters(value: string): boolean {
+  return (
+    value.includes("\\") ||
+    Array.from(value).some((character) => {
+      const code = character.charCodeAt(0);
+      return code <= 31 || (code >= 127 && code <= 159);
+    })
+  );
 }


### PR DESCRIPTION
## Problem

PWA `offline` and explicit `staticRoutes` values accepted path forms that browsers or URL parsers can reinterpret, including protocol-relative URLs, dot segments, backslashes, control characters, and encoded path separators. The configured route could therefore differ from the route Farm validated and cached.

## Root cause

Route normalization only required a leading slash and rejected query strings and fragments. It did not validate URL authority forms or path segments before the service worker used them.

## Change

Require stable root-relative application pathnames for both route options. Reject protocol-relative URLs, literal and encoded dot segments, backslashes, control characters, and percent-encoded separators. Document the constraint and cover both option surfaces with regression tests.

## Safety and compatibility

Ordinary root-relative routes, trailing-slash normalization, `/`, automatic static-route discovery, and `false` remain unchanged. Only ambiguous route forms that do not have stable application-path semantics are rejected.

## Verification

- `pnpm --filter @farm.js/pwa test`
- `pnpm --filter @farm.js/pwa type-check`
- `pnpm --filter @farm.js/pwa build`
- `pnpm exec oxlint packages/farm-pwa/src/config.ts packages/farm-pwa/src/config.test.ts`
- `pnpm docs:check-navigation`
- `pnpm docs:build`
- `git diff --check`

## Documentation and release

Updated the PWA option reference with the accepted route contract. No generated artifacts changed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects PWA `offline` and explicit `staticRoutes` values that URL parsers could reinterpret, so the configured route always matches what Farm validates and caches.

- `offline` and explicit `staticRoutes` entries must now be stable root-relative application pathnames.
- Protocol-relative URLs, dot segments, backslashes, control characters, and percent-encoded path separators are rejected.
- Trailing-slash normalization, `/`, `false`, and automatic static-route discovery behave as before.
- Updated the PWA option reference to document the accepted route contract.

<sup>Written for commit 6f8b5893dd265cd50bd09b799458272d1e7edd6c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/876?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

