### PR TITLE
fix(analyzer): keep report output inside project

### DIFF
--- a/docs/src/app/docs/plugins/analyzer/page.md
+++ b/docs/src/app/docs/plugins/analyzer/page.md
@@ -119,8 +119,8 @@ needed.
 
 | Option    | Type                          | Default              | Purpose                                      |
 | --------- | ----------------------------- | -------------------- | -------------------------------------------- |
-| `output`  | `string \| false`             | `.farm/analyze.html` | HTML report path, or no HTML report.         |
-| `json`    | `boolean \| string`           | `false`              | Write companion JSON or use a custom path.   |
+| `output`  | `string \| false`             | `.farm/analyze.html` | Project-relative HTML report path, or none.  |
+| `json`    | `boolean \| string`           | `false`              | Write companion JSON or use a relative path. |
 | `open`    | `boolean`                     | `false`              | Open the HTML report after the build.        |
 | `metric`  | `"raw" \| "gzip" \| "brotli"` | `"gzip"`             | Compression metric used by limits.           |
 | `limits`  | `AnalyzerLimits`              | `{}`                 | Optional page, asset, client, server limits. |

--- a/packages/farm-analyzer/src/config.test.ts
+++ b/packages/farm-analyzer/src/config.test.ts
@@ -50,6 +50,20 @@ describe("resolveAnalyzerOptions", () => {
     expect(() => resolveAnalyzerOptions({ metric: "zip" as never })).toThrow("metric");
     expect(() => resolveAnalyzerOptions({ json: " " })).toThrow("non-empty path");
   });
+
+  it("keeps HTML and JSON reports inside the project root", () => {
+    for (const output of [
+      "/tmp/report.html",
+      "../report.html",
+      "reports/../../report.html",
+      "C:\\reports\\report.html",
+      "C:report.html",
+      "\\\\server\\share\\report.html",
+    ]) {
+      expect(() => resolveAnalyzerOptions({ output })).toThrow();
+      expect(() => resolveAnalyzerOptions({ json: output })).toThrow();
+    }
+  });
 });
 
 describe("parseAnalyzerSize", () => {

--- a/packages/farm-analyzer/src/config.ts
+++ b/packages/farm-analyzer/src/config.ts
@@ -1,3 +1,5 @@
+import path from "node:path";
+
 export type AnalyzerMetric = "raw" | "gzip" | "brotli";
 export type AnalyzerLimitAction = "error" | "warn";
 export type AnalyzerSize = number | `${number}${"b" | "kb" | "mb" | "gb"}`;
@@ -122,5 +124,15 @@ function normalizeOutput(value: string | false, label: string): string | false {
   if (value === false) return false;
   const normalized = value.trim();
   if (!normalized) throw new TypeError(`Analyzer ${label} must be a non-empty path`);
+  if (
+    path.posix.isAbsolute(normalized) ||
+    path.win32.isAbsolute(normalized) ||
+    /^[a-z]:/i.test(normalized)
+  ) {
+    throw new TypeError(`Analyzer ${label} must be relative to the project root`);
+  }
+  if (normalized.replace(/\\/g, "/").split("/").includes("..")) {
+    throw new TypeError(`Analyzer ${label} cannot contain parent path segments`);
+  }
   return normalized;
 }


### PR DESCRIPTION
## Problem

Analyzer `output` and custom `json` paths were documented as project-relative, but absolute paths and parent traversal were accepted. A build could therefore write reports outside the application root.

## Root cause

Option normalization only trimmed the value and checked that it was non-empty before `path.resolve(root, output)` wrote it.

## Change

Reject POSIX, Windows drive, drive-relative, and UNC absolute forms, plus parent path segments using either slash style. Cover both HTML and JSON options and clarify the project-relative contract in the docs.

## Safety and compatibility

Existing relative paths such as `.farm/analyze.html` and `reports/build.json` are unchanged. Companion JSON name derivation is unchanged. Only paths that can resolve outside or independently of the project root are rejected.

## Verification

- `pnpm --filter @farm.js/analyzer test`
- `pnpm --filter @farm.js/analyzer type-check`
- `pnpm --filter @farm.js/analyzer build`
- `pnpm exec oxlint packages/farm-analyzer/src/config.ts packages/farm-analyzer/src/config.test.ts`
- `pnpm docs:check-navigation`
- `pnpm docs:build`
- `git diff --check`

The first docs build reached Vercel packaging but encountered `ENOSPC`; after removing only that run's generated docs outputs, the clean rerun completed successfully.

## Documentation and release

Updated the analyzer option table. No generated artifacts changed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the analyzer so HTML and JSON reports stay inside the project root. Previously, the `output` and `json` options accepted absolute paths and parent traversal, so a build could write reports outside the application root; now those forms are rejected.

Validation now rejects POSIX, Windows drive, drive-relative, and UNC absolute paths, plus parent path segments using either slash style, for both HTML and JSON options. Existing relative paths like `.farm/analyze.html` and `reports/build.json` are unchanged, as is companion JSON name derivation. The analyzer option docs now describe the paths as project-relative.

<sup>Written for commit cd0aadc7cf210e93c857d946f42864c1fc06d6c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/877?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

