### PR TITLE
fix(analyzer): ignore import text outside module syntax

### DIFF
--- a/packages/farm-analyzer/package.json
+++ b/packages/farm-analyzer/package.json
@@ -37,7 +37,8 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@farm.js/core": "workspace:*"
+    "@farm.js/core": "workspace:*",
+    "es-module-lexer": "2.0.0"
   },
   "devDependencies": {
     "@types/node": "^20.10.5",

--- a/packages/farm-analyzer/src/analyze.test.ts
+++ b/packages/farm-analyzer/src/analyze.test.ts
@@ -55,6 +55,18 @@ describe("extractStaticImports", () => {
       ),
     ).toEqual(["./side-effect.js", "./shared.js", "./other.js"]);
   });
+
+  it("ignores import-shaped text in comments and strings", () => {
+    expect(
+      extractStaticImports(`
+        // import "./comment.js";
+        /* export { value } from "./block-comment.js"; */
+        const example = 'import value from "./string.js"';
+        import "./real.js";
+        export { value } from "./shared.js";
+      `),
+    ).toEqual(["./real.js", "./shared.js"]);
+  });
 });
 
 async function createBuildFixture(): Promise<string> {

--- a/packages/farm-analyzer/src/analyze.ts
+++ b/packages/farm-analyzer/src/analyze.ts
@@ -1,6 +1,7 @@
 import { constants as zlibConstants, brotliCompressSync, gzipSync } from "node:zlib";
 import { readdir, readFile, stat } from "node:fs/promises";
 import path from "node:path";
+import { initSync, parse } from "es-module-lexer";
 import type { AnalyzerMetric, ResolvedAnalyzerLimits } from "./config.js";
 
 export interface AnalyzerSizes {
@@ -70,6 +71,7 @@ interface ReadAsset extends AnalyzerAsset {
 
 const ZERO_SIZES: AnalyzerSizes = { raw: 0, gzip: 0, brotli: 0 };
 const CLIENT_KINDS = new Set<AnalyzerAssetKind>(["script", "style"]);
+let moduleLexerInitialized = false;
 
 export async function analyzeBuild(options: AnalyzeBuildOptions): Promise<AnalyzerBuildReport> {
   const publicDirectory = await firstDirectory([
@@ -278,13 +280,18 @@ function collectInitialAssets(entries: Set<string>, files: Map<string, ReadAsset
 }
 
 export function extractStaticImports(source: string): string[] {
-  const imports = new Set<string>();
-  const importPattern = /\bimport\s*(?:["']([^"']+)["']|[^"'();]+?\bfrom\s*["']([^"']+)["'])/g;
-  const exportPattern = /\bexport\s*[^"';]+?\bfrom\s*["']([^"']+)["']/g;
-
-  for (const match of source.matchAll(importPattern)) imports.add(match[1] ?? match[2]);
-  for (const match of source.matchAll(exportPattern)) imports.add(match[1]);
-  return [...imports];
+  if (!moduleLexerInitialized) {
+    initSync();
+    moduleLexerInitialized = true;
+  }
+  const [imports] = parse(source);
+  return [
+    ...new Set(
+      imports
+        .filter((specifier) => specifier.d === -1 && specifier.n !== undefined)
+        .map((specifier) => specifier.n as string),
+    ),
+  ];
 }
 
 function extractCssImports(source: string): string[] {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1819,6 +1819,9 @@ importers:
       '@farm.js/core':
         specifier: workspace:*
         version: link:../farm
+      es-module-lexer:
+        specifier: 2.0.0
+        version: 2.0.0
     devDependencies:
       '@types/node':
         specifier: ^20.10.5


### PR DESCRIPTION
## Problem

The analyzer's static-import regex interpreted import-like text inside JavaScript comments and string literals as real dependencies. Those false assets could be charged to a page's initial bundle.

## Root cause

Regular expressions cannot distinguish module syntax from comments, strings, templates, and other JavaScript grammar contexts.

## Change

Use the already-adopted `es-module-lexer` parser to read emitted module imports, retain only static imports and re-exports, and continue excluding dynamic imports. Add coverage for line comments, block comments, strings, real imports, and re-exports.

## Safety and compatibility

Side-effect imports, imports with bindings, static re-exports, decoded module specifiers, and de-duplication are preserved. Dynamic imports and `import.meta` remain outside initial page attribution. The parser is a direct runtime dependency and matches the version already used by core and the framework plugin.

## Verification

- `pnpm install --offline --frozen-lockfile`
- `pnpm --filter @farm.js/analyzer test`
- `pnpm --filter @farm.js/analyzer type-check`
- `pnpm --filter @farm.js/analyzer build`
- `pnpm exec oxlint packages/farm-analyzer/src/analyze.ts packages/farm-analyzer/src/analyze.test.ts`
- `git diff --check`

The workspace core declaration prerequisite was built with `NODE_OPTIONS=--max-old-space-size=6144` before the analyzer type-check.

## Documentation and release

No public option or report schema changes. Added `es-module-lexer@2.0.0` to `@farm.js/analyzer` and updated only its lockfile importer entry.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the analyzer's static-import parsing so import-like text inside comments and strings no longer counts as real dependencies.

Switches the analyzer's import extraction to `es-module-lexer`, preserving static imports and re-exports while excluding dynamic imports and `import.meta`. Adds `es-module-lexer@2.0.0` as a dependency of `@farm.js/analyzer`.

<sup>Written for commit e5a35c28d011338dc7cf62e234e22bf3c1903a13. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/878?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

