### PR TITLE
fix(analyzer): follow unquoted CSS imports

### DIFF
--- a/packages/farm-analyzer/src/analyze.test.ts
+++ b/packages/farm-analyzer/src/analyze.test.ts
@@ -18,7 +18,12 @@ describe("analyzeBuild", () => {
     expect(report.summary.pages).toBe(2);
     expect(report.pages.map((page) => page.route).sort()).toEqual(["/", "/about"]);
     const home = report.pages.find((page) => page.route === "/");
-    expect(home?.assets).toEqual(["assets/entry.js", "assets/shared.js", "assets/styles.css"]);
+    expect(home?.assets).toEqual([
+      "assets/entry.js",
+      "assets/shared.js",
+      "assets/styles.css",
+      "assets/theme.css",
+    ]);
     expect(home?.assets).not.toContain("assets/lazy.js");
     expect(report.clientAssets.find((asset) => asset.path === "assets/entry.js")?.usedByPages).toBe(
       2,
@@ -79,7 +84,11 @@ async function createBuildFixture(): Promise<string> {
     ),
     writeFile(path.join(publicDirectory, "assets/shared.js"), "export const x = 1;"),
     writeFile(path.join(publicDirectory, "assets/lazy.js"), "export const lazy = true;"),
-    writeFile(path.join(publicDirectory, "assets/styles.css"), "body{color:#123}"),
+    writeFile(
+      path.join(publicDirectory, "assets/styles.css"),
+      "@import url(./theme.css);body{color:#123}",
+    ),
+    writeFile(path.join(publicDirectory, "assets/theme.css"), ":root{color-scheme:dark}"),
     writeFile(path.join(publicDirectory, "logo.svg"), "<svg></svg>"),
     writeFile(path.join(serverDirectory, "index.mjs"), "export default {}"),
     writeFile(path.join(serverDirectory, "index.mjs.map"), "{}"),

--- a/packages/farm-analyzer/src/analyze.ts
+++ b/packages/farm-analyzer/src/analyze.ts
@@ -288,7 +288,11 @@ export function extractStaticImports(source: string): string[] {
 }
 
 function extractCssImports(source: string): string[] {
-  return [...source.matchAll(/@import\s+(?:url\(\s*)?["']([^"']+)["']/g)].map((match) => match[1]);
+  return [
+    ...source.matchAll(
+      /@import\s+(?:url\(\s*(?:"([^"]+)"|'([^']+)'|([^"')\s]+))\s*\)|"([^"]+)"|'([^']+)')/gi,
+    ),
+  ].map((match) => match.slice(1).find((value) => value !== undefined) as string);
 }
 
 function resolveAssetReference(


### PR DESCRIPTION
## Problem

The analyzer did not follow valid unquoted CSS imports such as `@import url(./theme.css)`. The imported stylesheet was omitted from page assets and initial-size totals.

## Root cause

CSS dependency extraction required every import target to begin with a quote, including targets inside `url(...)`.

## Change

Accept direct quoted imports, quoted `url(...)` imports, and unquoted `url(...)` imports. The end-to-end build fixture now verifies that an unquoted imported stylesheet is attributed to the page.

## Safety and compatibility

Existing quoted forms remain supported. External and missing references still pass through the existing asset resolver and are excluded. This changes only static CSS dependency attribution in analyzer reports.

## Verification

- `pnpm --filter @farm.js/analyzer test`
- `pnpm --filter @farm.js/analyzer type-check`
- `pnpm --filter @farm.js/analyzer build`
- `pnpm exec oxlint packages/farm-analyzer/src/analyze.ts packages/farm-analyzer/src/analyze.test.ts`
- `git diff --check`

## Documentation and release

None. The analyzer already documents that it follows static CSS imports; this makes the implementation satisfy that contract.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the analyzer so it follows unquoted CSS imports like `@import url(./theme.css)`, which were previously omitted from page assets and initial-size totals. Existing quoted import forms remain unchanged.

<sup>Written for commit 1ffd000c35b04680954f2ad90ae21e4fd2cd1562. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/879?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

