### PR TITLE
fix(analyzer): preserve quoted angle brackets in tags

### DIFF
--- a/packages/farm-analyzer/src/analyze.test.ts
+++ b/packages/farm-analyzer/src/analyze.test.ts
@@ -67,7 +67,7 @@ async function createBuildFixture(): Promise<string> {
   await Promise.all([
     writeFile(
       path.join(publicDirectory, "index.html"),
-      '<script type="module" src="/assets/entry.js"></script><link rel="stylesheet" href="/assets/styles.css">',
+      '<script data-example="a > b" type="module" src="/assets/entry.js"></script><link rel="stylesheet" href="/assets/styles.css">',
     ),
     writeFile(
       path.join(publicDirectory, "about/index.html"),

--- a/packages/farm-analyzer/src/analyze.ts
+++ b/packages/farm-analyzer/src/analyze.ts
@@ -221,7 +221,7 @@ function extractHtmlReferences(
   files: Map<string, ReadAsset>,
 ): Set<string> {
   const references = new Set<string>();
-  for (const match of html.matchAll(/<(script|link)\b([^>]*)>/gi)) {
+  for (const match of html.matchAll(/<(script|link)\b((?:"[^"]*"|'[^']*'|[^'">])*)>/gi)) {
     const tag = match[1].toLowerCase();
     const attributes = parseAttributes(match[2]);
     const value = tag === "script" ? attributes.src : attributes.href;


### PR DESCRIPTION
## Problem

An HTML attribute containing `>` inside quotes could terminate the analyzer's tag match early. If `src`, `href`, or `rel` followed that attribute, the page's script or stylesheet was omitted from attribution.

## Root cause

The opening-tag matcher used `[^>]*`, which treated every angle bracket as markup even while inside a quoted attribute value.

## Change

Make the script/link opening-tag scan quote-aware so angle brackets inside single- or double-quoted values stay part of the attribute source. The production-output fixture places `data-example="a > b"` before the script source and verifies normal page attribution.

## Safety and compatibility

Unquoted attributes and ordinary quoted attributes keep their existing parsing behavior. The change remains limited to emitted `script` and `link` opening tags and does not alter report structure.

## Verification

- `pnpm --filter @farm.js/analyzer test`
- `pnpm --filter @farm.js/analyzer type-check`
- `pnpm --filter @farm.js/analyzer build`
- `pnpm exec oxlint packages/farm-analyzer/src/analyze.ts packages/farm-analyzer/src/analyze.test.ts`
- `git diff --check`

## Documentation and release

None. This is a correctness fix for the documented emitted-HTML attribution behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the analyzer's HTML tag matching so that quoted angle brackets (e.g., `data-example="a > b"`) no longer prematurely end a `script` or `link` tag, which previously caused scripts or stylesheets after such attributes to be missing from attribution. Unquoted attributes and ordinary quoted attributes keep the same parsing behavior.

<sup>Written for commit b025f8f7ecea71985e710ca0bb42e5d63549da67. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/880?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

