### PR TITLE
fix(hints): report invalid image dimensions

### DIFF
--- a/packages/farm-hints/src/scan.test.ts
+++ b/packages/farm-hints/src/scan.test.ts
@@ -53,6 +53,28 @@ describe("document hint scanners", () => {
     expect(issues).toEqual([]);
   });
 
+  it("reports image dimensions that cannot reserve a stable aspect ratio", async () => {
+    document.body.innerHTML = `
+      <img id="empty" src="/empty.png" width="" height="100">
+      <img id="zero" src="/zero.png" width="100" height="0">
+      <img id="decimal" src="/decimal.png" width="100.5" height="80">
+      <img id="unit" src="/unit.png" width="100px" height="80">
+      <img id="valid" src="/valid.png" width="100" height="80">
+    `;
+
+    const issues = await collectDocumentHints(
+      document,
+      window,
+      resolveHintsOptions({
+        accessibility: false,
+        html: false,
+        thirdParty: false,
+      }),
+    );
+
+    expect(issues.map((issue) => issue.selector)).toEqual(["#empty", "#zero", "#decimal", "#unit"]);
+  });
+
   it("does not repeat a nested-control finding already reported by axe", async () => {
     document.body.innerHTML = `<button class="outer-control"><a href="/details">Details</a></button>`;
 

--- a/packages/farm-hints/src/scan.ts
+++ b/packages/farm-hints/src/scan.ts
@@ -83,7 +83,12 @@ async function scanAccessibility(
 function scanPerformance(document: Document): HintIssue[] {
   return Array.from(document.images).flatMap((image, index): HintIssue[] => {
     if (image.closest("farm-hints")) return [];
-    if (image.hasAttribute("width") && image.hasAttribute("height")) return [];
+    if (
+      hasPositiveIntegerAttribute(image, "width") &&
+      hasPositiveIntegerAttribute(image, "height")
+    ) {
+      return [];
+    }
     const selector = createSelector(image);
     return [
       {
@@ -98,6 +103,11 @@ function scanPerformance(document: Document): HintIssue[] {
       },
     ];
   });
+}
+
+function hasPositiveIntegerAttribute(element: Element, name: string): boolean {
+  const value = element.getAttribute(name)?.trim();
+  return value !== undefined && /^[1-9]\d*$/.test(value);
 }
 
 function scanHtml(document: Document): HintIssue[] {


### PR DESCRIPTION
## Problem

The image-size performance hint considered the mere presence of `width` and `height` attributes sufficient. Empty, zero, decimal, and unit-suffixed values suppressed the warning even though they do not provide a usable positive intrinsic aspect ratio.

## Root cause

The scanner checked `hasAttribute` rather than validating the HTML attribute values.

## Change

Suppress the hint only when both dimensions are positive integer attributes. Regression coverage verifies empty, zero, decimal, and CSS-unit forms are reported while a valid `100` by `80` image is not.

## Safety and compatibility

Valid intrinsic dimensions retain existing behavior. Missing dimensions continue to be reported. CSS layout sizing remains outside this focused heuristic, as explained by the existing hint detail.

## Verification

- `pnpm --filter @farm.js/hints test`
- `pnpm --filter @farm.js/hints type-check`
- `pnpm --filter @farm.js/hints build`
- `pnpm exec oxlint packages/farm-hints/src/scan.ts packages/farm-hints/src/scan.test.ts`
- `git diff --check`

## Documentation and release

None. The docs already describe this category as detecting images that can cause layout shift.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the image-size performance hint to report images whose `width` or `height` attributes are present but invalid (empty, zero, decimal, or unit-suffixed). Previously the hint only checked that both attributes existed, so these values wrongly suppressed the warning. Valid positive integer dimensions still suppress it, and missing dimensions are still reported.

<sup>Written for commit f8ae96e8132dcb8099c7a46f8a21bbef99054a65. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/881?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

