### PR TITLE
fix(auth): reject unstable endpoint base paths

### DIFF
--- a/docs/src/app/docs/auth/page.md
+++ b/docs/src/app/docs/auth/page.md
@@ -139,6 +139,10 @@ export default defineConfig({
 
 This interface stays at application-policy level. It does not expose a Better Auth instance or require Better Auth imports in application code.
 
+`basePath` accepts a stable application pathname, with or without its leading slash. URLs, query
+strings, fragments, dot segments, backslashes, control characters, and encoded path separators are
+rejected.
+
 If `basePath` is customized, create matching client helpers once:
 
 ```ts

--- a/packages/farm-auth/src/config.ts
+++ b/packages/farm-auth/src/config.ts
@@ -57,10 +57,48 @@ export function resolveFarmAuthConfig(
 }
 
 function normalizeBasePath(value: string | undefined): string {
-  const path = (value || "/api/auth").trim();
-  const withLeadingSlash = path.startsWith("/") ? path : `/${path}`;
+  const route = (value || "/api/auth").trim();
+  if (!route) return "/api/auth";
+  assertStableBasePath(route);
+  const withLeadingSlash = route.startsWith("/") ? route : `/${route}`;
   const normalized = withLeadingSlash.replace(/\/+/g, "/").replace(/\/+$/, "");
   return normalized || "/api/auth";
+}
+
+function assertStableBasePath(route: string): void {
+  if (route.includes("?") || route.includes("#")) {
+    throw new Error("auth.basePath cannot contain a query string or fragment.");
+  }
+  if (route.startsWith("//") || /^[a-z][a-z\d+.-]*:\/\//i.test(route)) {
+    throw new Error('auth.basePath must be an application pathname such as "/api/auth".');
+  }
+  if (hasUnstablePathCharacters(route)) {
+    throw new Error("auth.basePath cannot contain backslashes or control characters.");
+  }
+  for (const segment of route.split("/")) {
+    let decoded = segment;
+    try {
+      decoded = decodeURIComponent(segment);
+    } catch {
+      // Malformed escapes remain literal URL pathname segments.
+    }
+    if (hasUnstablePathCharacters(decoded) || decoded.includes("/")) {
+      throw new Error("auth.basePath cannot contain encoded path separators.");
+    }
+    if (decoded === "." || decoded === "..") {
+      throw new Error('auth.basePath cannot contain "." or ".." path segments.');
+    }
+  }
+}
+
+function hasUnstablePathCharacters(value: string): boolean {
+  return (
+    value.includes("\\") ||
+    Array.from(value).some((character) => {
+      const code = character.charCodeAt(0);
+      return code <= 31 || (code >= 127 && code <= 159);
+    })
+  );
 }
 
 function validateFarmAuthConfig(config: ResolvedFarmAuthConfig): void {

--- a/packages/farm-auth/test/config.test.ts
+++ b/packages/farm-auth/test/config.test.ts
@@ -53,4 +53,20 @@ describe("resolveFarmAuthConfig", () => {
       }),
     ).toThrow(/maxPasswordLength/);
   });
+
+  it("rejects base paths that URL parsing could reinterpret", () => {
+    for (const basePath of [
+      "//example.com/auth",
+      "https://example.com/auth",
+      "/api/../auth",
+      "/api/%2e%2e/auth",
+      "/api%2fauth",
+      "/api\\auth",
+      "/api\u0000auth",
+      "/api/auth?tenant=farm",
+      "/api/auth#sign-in",
+    ]) {
+      expect(() => resolveFarmAuthConfig({ basePath })).toThrow();
+    }
+  });
 });

--- a/packages/farm/src/__tests__/auth-config.test.ts
+++ b/packages/farm/src/__tests__/auth-config.test.ts
@@ -18,4 +18,20 @@ describe("Farm auth config", () => {
   it("supports auth: { enabled: true }", () => {
     expect(resolveFarmAuthConfig({ enabled: true }).enabled).toBe(true);
   });
+
+  it("rejects base paths that URL parsing could reinterpret", () => {
+    for (const basePath of [
+      "//example.com/auth",
+      "https://example.com/auth",
+      "/api/../auth",
+      "/api/%2e%2e/auth",
+      "/api%2fauth",
+      "/api\\auth",
+      "/api\u0000auth",
+      "/api/auth?tenant=farm",
+      "/api/auth#sign-in",
+    ]) {
+      expect(() => resolveFarmAuthConfig({ basePath })).toThrow();
+    }
+  });
 });

--- a/packages/farm/src/auth-config.ts
+++ b/packages/farm/src/auth-config.ts
@@ -148,9 +148,47 @@ export async function resolveFarmAuthIntegration(
 
 function normalizeBasePath(value: string | undefined): string {
   const route = (value || "/api/auth").trim();
+  if (!route) return "/api/auth";
+  assertStableBasePath(route);
   const withLeadingSlash = route.startsWith("/") ? route : `/${route}`;
   const normalized = withLeadingSlash.replace(/\/+/g, "/").replace(/\/+$/, "");
   return normalized || "/api/auth";
+}
+
+function assertStableBasePath(route: string): void {
+  if (route.includes("?") || route.includes("#")) {
+    throw new Error("auth.basePath cannot contain a query string or fragment.");
+  }
+  if (route.startsWith("//") || /^[a-z][a-z\d+.-]*:\/\//i.test(route)) {
+    throw new Error('auth.basePath must be an application pathname such as "/api/auth".');
+  }
+  if (hasUnstablePathCharacters(route)) {
+    throw new Error("auth.basePath cannot contain backslashes or control characters.");
+  }
+  for (const segment of route.split("/")) {
+    let decoded = segment;
+    try {
+      decoded = decodeURIComponent(segment);
+    } catch {
+      // Malformed escapes remain literal URL pathname segments.
+    }
+    if (hasUnstablePathCharacters(decoded) || decoded.includes("/")) {
+      throw new Error("auth.basePath cannot contain encoded path separators.");
+    }
+    if (decoded === "." || decoded === "..") {
+      throw new Error('auth.basePath cannot contain "." or ".." path segments.');
+    }
+  }
+}
+
+function hasUnstablePathCharacters(value: string): boolean {
+  return (
+    value.includes("\\") ||
+    Array.from(value).some((character) => {
+      const code = character.charCodeAt(0);
+      return code <= 31 || (code >= 127 && code <= 159);
+    })
+  );
 }
 
 function validateFarmAuthConfig(config: ResolvedFarmAuthConfig): void {


### PR DESCRIPTION
## Problem

The built-in auth `basePath` accepted URL-like and unstable path forms. Browser or server URL normalization could reinterpret protocol-relative URLs, dot segments, backslashes, control characters, or encoded separators differently from the configured endpoint prefix.

## Root cause

Both the core config resolver and the independently published auth resolver only added a leading slash, collapsed repeated slashes, and removed the trailing slash.

## Change

Validate the route before normalization in both authoritative runtime copies. Reject URLs, query strings, fragments, dot segments, backslashes, control characters, and encoded path separators. Add matching regression coverage to core and `@farm.js/auth`, and document the accepted pathname contract.

## Safety and compatibility

The default `/api/auth`, optional leading slashes, internal repeated-slash normalization, trailing-slash normalization, and existing custom application paths remain supported. Core and package resolution retain identical behavior.

## Verification

- `pnpm --filter @farm.js/core exec vitest run src/__tests__/auth-config.test.ts`
- `pnpm --filter @farm.js/core type-check`
- `pnpm --filter @farm.js/auth test`
- `pnpm --filter @farm.js/auth type-check`
- `pnpm --filter @farm.js/auth build`
- `pnpm exec oxlint packages/farm/src/auth-config.ts packages/farm-auth/src/config.ts packages/farm/src/__tests__/auth-config.test.ts packages/farm-auth/test/config.test.ts`
- `pnpm docs:check-navigation`
- `pnpm docs:build`
- `git diff --check`

## Documentation and release

Updated the auth configuration page. No generated artifacts changed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects unstable `basePath` values in auth config so browser or server URL normalization can no longer reinterpret the endpoint differently than configured. The default `/api/auth` and existing custom paths remain supported.

**Bug Fixes**
- Rejects URLs, query strings, fragments, dot segments, backslashes, control characters, and encoded path separators.
- Applies the same validation to `@farm.js/core` and `@farm.js/auth` config resolvers.
- Adds regression tests and documents the accepted pathname contract.

<sup>Written for commit 7a0dcae4a1fa910f41a0a83abae87c660ce71498. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/882?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

