### PR TITLE
perf(react): reuse rows across queued removal and append

### DIFF
--- a/docs/src/app/docs/renderers/react/page.md
+++ b/docs/src/app/docs/renderers/react/page.md
@@ -966,6 +966,33 @@ normal React behavior; the syntax does not opt the component into a different co
 The compiler report exposes emitted sites as `keyedArrayAppendHints`, and the hinted runtime is
 retained only when a module emits at least one append or same-order map hint.
 
+Adjacent removal and append setters can share the same committed-row proof:
+
+```tsx
+setItems((current) => current.filter((item) => item.id !== expiredId));
+setItems((current) => [...current, incoming]);
+
+setItems((current) => current.slice(start, end));
+setItems((current) => [...current, ...incoming]);
+```
+
+The setters still execute in order and still create their normal native arrays. Before changing the
+DOM, Farm validates the original committed token, every filter or slice survivor, the complete final
+length, and every incoming key. It prepares all incoming keys, descriptors, bindings, and detached
+host rows first; only then does it remove rejected rows, update survivor indexes, and append the new
+suffix in one fragment. Existing survivors are neither rebound nor recreated, and additional
+adjacent append setters are collapsed into the same final suffix. This keeps the unavoidable native
+filter or slice work while removing the keyed runtime's second full scan.
+
+Only concise updater results that form one direct chain for the same state array are linked. The row
+and key must be compiler-owned and index-independent. A map or reorder between the structural step
+and append, an unhinted update to that state, another dirty row dependency, collection-reading
+binding, custom, sparse, or subclassed array, nested or React-owned row, duplicate final key, or
+reuse of any committed key in the appended suffix keeps complete React reconciliation before a DOM
+write. No API or configuration is added. Compiler reports use the existing
+`keyedArrayFilterHints`, `keyedArraySliceHints`, and `keyedArrayAppendHints` counts, and modules
+without both accepted operations omit the composed runtime.
+
 #### Keyed array prepend hints
 
 A direct keyed `useState` array can avoid rescanning every existing row when new items are inserted
@@ -2294,6 +2321,10 @@ The package and example test suites verify more than generated code:
 - 2,000 deterministic keyed-array appends match normal React; targeted tests require key,
   descriptor, and binding reads to equal only the appended suffix and cover queued updates,
   multi-boundary sharing, StrictMode hydration/unmount, and conservative fallback;
+- 2,000 randomized queued filter-or-slice then append transitions match normal React; targeted
+  tests require survivor DOM identity, suffix-only descriptor and binding reads, controlled-input
+  focus and selection, multi-boundary sharing, Strict Mode hydration, nested unmount cleanup,
+  removed-key reuse fallback, and atomic validation before mutation;
 - 2,000 deterministic keyed-array prepends match normal React; targeted tests require key,
   descriptor, and binding reads to equal only the inserted prefix, preserve every existing DOM
   row, update delegated event indexes, and cover queued updates, StrictMode hydration, unmount,

--- a/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
+++ b/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
@@ -2,6 +2,37 @@
 
 Latest run: 2026-09-10
 
+## Queued removal followed by append — 2026-09-10
+
+Adjacent keyed-row setters may now keep one committed-row proof when an index-independent
+`filter()` or bounded `slice()` is followed by one or more immutable appends. Before this change,
+the append result lost the structural survivor lineage and the final commit used complete keyed
+reconciliation. The new path validates the complete chain before its first DOM write, removes only
+rejected rows, preserves every surviving node, and creates only the appended suffix.
+
+| Mode   | Remove + append | Compiled fallback | vs React | vs fallback |
+| ------ | --------------: | ----------------: | -------: | ----------: |
+| Static |        21.00 ms |          32.00 ms |    3.49x |       1.52x |
+| Hybrid |        20.80 ms |          48.00 ms |    3.52x |       2.31x |
+
+Both modes passed the 2x React and 1.25x compiled-control floors. The surrounding React median was
+73.20 ms. Every sample checked all 9,999 survivor positions and identities, the rejected row's
+disconnection, one fresh final row, the final 10,000-row count, browser errors, and zero compiled
+owner executions. The broad 10% no-regression gate and optimization-persistence gate also passed.
+
+Compiler and runtime tests cover filter and slice sources, multiple later appends, duplicate-key
+fallback before mutation, an intervening unhinted update, collection-reading bindings, multiple
+keyed boundaries, controlled-input focus and selection, Strict Mode hydration,
+unmount-before-flush cleanup, and 2,000 randomized row removals/appends matched with normal React.
+The dedicated optional runtime is 17,262 bytes gzip in its isolated fixture; every pre-existing
+fixture remains byte-for-byte equal to the merged parent when rebuilt in the same environment.
+
+Numbers are medians from a reduced complete-dashboard run with 2 warmups and 5 measured samples per
+compiler mode, bracketed by 10 React samples, using Chrome 151.0.7922.34 and Node.js 23.11.0 on
+Apple M1 macOS arm64. Correctness and the new performance gate passed. Several unchanged,
+near-threshold feature gates were noisy at this reduced sample count, so this run is not described
+as a full default all-gates pass.
+
 ## Queued structural maps through reorder setters — 2026-09-10
 
 Adjacent keyed-row setters may now keep one committed-row proof across compiler-safe `filter()`,

--- a/examples/react-compiler-dashboard/README.md
+++ b/examples/react-compiler-dashboard/README.md
@@ -75,6 +75,15 @@ modes must remain at least 4x faster than React at 10,000 and up to 20,000 rows,
 faster than the compiled control. The report must contain a nonzero `keyedArrayAppendHints` count;
 deterministic package tests separately require work to equal only the appended suffix.
 
+Queued structural appends have an independent 10,000-row comparison. One concise setter removes a
+row with `filter()` and the immediately adjacent setter appends one fresh row, while the
+block-bodied pair remains the compiled fallback control. Both compiler modes must remain at least
+2x faster than React and 1.25x faster than the compiled control. Every sample verifies the exact
+9,999 survivor identities and order, the disconnected rejected row, and the fresh final row.
+Package tests also cover bounded slices, multiple later appends, 2,000 randomized transitions,
+controlled-input focus and selection, multi-boundary sharing, hydration, unmount cleanup, and
+pre-mutation fallback.
+
 Keyed array prepends have the same independent comparison. A concise functional prepend is
 measured against bracketed React and an equivalent block-bodied compiled snapshot control. Both
 compiler modes must remain at least 3x faster than React at 10,000 and 20,000 existing rows, and at
@@ -350,6 +359,10 @@ The default JSON report is `/tmp/farm-react-dashboard-benchmark.json`; change it
   complete entry scan.
 - The append snapshot control creates the same 1,000 array items and DOM rows but intentionally uses
   an unsupported block-bodied updater, isolating the saved full key-and-binding scan.
+- The queued structural-append control removes one keyed row and appends one fresh row across
+  adjacent setters. Its block-bodied pair performs the same native array and DOM-visible work
+  through complete reconciliation; the hinted path reuses survivor positions and reads only the
+  appended suffix.
 - The prepend snapshot control does the same work at the beginning of the array. It isolates the
   saved suffix scan while the hinted path still creates and inserts every required new DOM row.
 - The slice snapshot control retains the same 9,000-row suffix through an unsupported block-bodied

--- a/examples/react-compiler-dashboard/scripts/benchmark.mjs
+++ b/examples/react-compiler-dashboard/scripts/benchmark.mjs
@@ -1198,6 +1198,42 @@ async function measureTrial(browser, trial, compilerMode, port) {
             ),
         );
 
+        const measureStructuralAppend = async (action) => {
+          const rows = [...table.querySelectorAll("tbody tr")];
+          const removed = rows.find(
+            (row) => Number(row.getAttribute("data-row-id")) % 10_000 === 7_001,
+          );
+          if (!removed) throw new Error("Queued structural-append source row is missing.");
+          const survivors = rows.filter((row) => row !== removed);
+          await runTableAction(action, () => {
+            const nextRows = [...table.querySelectorAll("tbody tr")];
+            const appended = nextRows.at(-1);
+            return (
+              nextRows.length === 10_000 &&
+              rowsMatch(nextRows.slice(0, -1), survivors) &&
+              appended?.querySelector("td:nth-child(2)")?.textContent === "queued incoming row" &&
+              !rows.includes(appended) &&
+              !removed.isConnected
+            );
+          });
+        };
+
+        const tableStructuralAppendQueued = await measureTable(
+          async () => create10000(),
+          async () =>
+            measureStructuralAppend(() =>
+              tableButton("table-structural-append-queued").click(),
+            ),
+        );
+
+        const tableStructuralAppendQueuedSnapshot = await measureTable(
+          async () => create10000(),
+          async () =>
+            measureStructuralAppend(() =>
+              tableButton("table-structural-append-queued-snapshot").click(),
+            ),
+        );
+
         const prepareMapStructuralReorderPipeline = async () => {
           await create10000();
           const rows = [...table.querySelectorAll("tbody tr")];
@@ -1955,6 +1991,8 @@ async function measureTrial(browser, trial, compilerMode, port) {
             executionsAdded: Number(tableExecutions.textContent) - initialTableExecutions,
             filterReorderPipeline: tableFilterReorderPipeline,
             filterReorderPipelineSnapshot: tableFilterReorderPipelineSnapshot,
+            structuralAppendQueued: tableStructuralAppendQueued,
+            structuralAppendQueuedSnapshot: tableStructuralAppendQueuedSnapshot,
             mapStructuralReorderPipeline: tableMapStructuralReorderPipeline,
             mapStructuralReorderPipelineSnapshot: tableMapStructuralReorderPipelineSnapshot,
             mapReorderPipeline: tableMapReorderPipeline,
@@ -2099,6 +2137,8 @@ async function measureTrial(browser, trial, compilerMode, port) {
         executionsAdded: result.table.executionsAdded,
         filterReorderPipeline: timingSummary(result.table.filterReorderPipeline),
         filterReorderPipelineSnapshot: timingSummary(result.table.filterReorderPipelineSnapshot),
+        structuralAppendQueued: timingSummary(result.table.structuralAppendQueued),
+        structuralAppendQueuedSnapshot: timingSummary(result.table.structuralAppendQueuedSnapshot),
         mapStructuralReorderPipeline: timingSummary(result.table.mapStructuralReorderPipeline),
         mapStructuralReorderPipelineSnapshot: timingSummary(
           result.table.mapStructuralReorderPipelineSnapshot,
@@ -2314,6 +2354,8 @@ const tableMetrics = [
   "denseMapLookup",
   "filterReorderPipeline",
   "filterReorderPipelineSnapshot",
+  "structuralAppendQueued",
+  "structuralAppendQueuedSnapshot",
   "mapStructuralReorderPipeline",
   "mapStructuralReorderPipelineSnapshot",
   "mapReorderPipeline",
@@ -2972,6 +3014,29 @@ const keyedStructuralReorderRegressions = keyedStructuralReorderResults.filter(
     !Number.isFinite(snapshotSpeedup) ||
     snapshotSpeedup < keyedStructuralReorderMinimumSnapshotSpeedup,
 );
+// A filter or bounded slice followed by an adjacent immutable append keeps the same committed
+// source. The hinted path should remove only rejected rows, create only the final suffix, and stay
+// ahead of React and the equivalent block-bodied compiled control at 10,000 rows.
+const keyedStructuralAppendMinimumSpeedup = 2;
+const keyedStructuralAppendMinimumSnapshotSpeedup = 1.25;
+const keyedStructuralAppendResults = ["static", "hybrid"].map((mode) => {
+  const pipelineMedianMs = comparisons.table.structuralAppendQueued[mode].medianMs;
+  const snapshotMedianMs = comparisons.table.structuralAppendQueuedSnapshot[mode].medianMs;
+  return {
+    mode,
+    pipelineMedianMs,
+    snapshotMedianMs,
+    snapshotSpeedup: snapshotMedianMs / pipelineMedianMs,
+    speedup: comparisons.table.structuralAppendQueued[`${mode}VsBaseline`].speedup,
+  };
+});
+const keyedStructuralAppendRegressions = keyedStructuralAppendResults.filter(
+  ({ snapshotSpeedup, speedup }) =>
+    !Number.isFinite(speedup) ||
+    speedup < keyedStructuralAppendMinimumSpeedup ||
+    !Number.isFinite(snapshotSpeedup) ||
+    snapshotSpeedup < keyedStructuralAppendMinimumSnapshotSpeedup,
+);
 // A safe filter, terminal map, and two native reverses in adjacent setters change membership and
 // row data while restoring the survivor order in one queued commit. The combined path must remove
 // the rejected row, patch the changed survivor, and retain structural lineage through both reorder
@@ -3387,6 +3452,7 @@ const passed =
   keyedQueuedReorderRegressions.length === 0 &&
   keyedReorderPipelineRegressions.length === 0 &&
   keyedStructuralReorderRegressions.length === 0 &&
+  keyedStructuralAppendRegressions.length === 0 &&
   keyedMappedStructuralReorderRegressions.length === 0 &&
   keyedMapReorderRegressions.length === 0 &&
   keyedMultiMapReorderRegressions.length === 0 &&
@@ -3562,6 +3628,13 @@ const report = {
     regressions: keyedStructuralReorderRegressions,
     results: keyedStructuralReorderResults,
     status: keyedStructuralReorderRegressions.length === 0 ? "PASS" : "FAIL",
+  },
+  keyedStructuralAppendHintGate: {
+    minimumSnapshotSpeedup: keyedStructuralAppendMinimumSnapshotSpeedup,
+    minimumSpeedup: keyedStructuralAppendMinimumSpeedup,
+    regressions: keyedStructuralAppendRegressions,
+    results: keyedStructuralAppendResults,
+    status: keyedStructuralAppendRegressions.length === 0 ? "PASS" : "FAIL",
   },
   keyedMappedStructuralReorderHintGate: {
     minimumSnapshotSpeedup: keyedMappedStructuralReorderMinimumSnapshotSpeedup,

--- a/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
+++ b/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
@@ -871,6 +871,48 @@ export function StandardTableBenchmark() {
           Filter + reorder pipeline (snapshot control)
         </button>
         <button
+          data-action="table-structural-append-queued"
+          type="button"
+          onClick={() => {
+            const incoming = {
+              id: (seed + 1_000_000) * 10_000 + 1,
+              label: "queued incoming row",
+              amount: 2_048,
+              region: "AMR" as const,
+              status: "review" as const,
+            };
+            setRows((current) => current.filter((row) => row.id % 10_000 !== 7_001));
+            setRows((current) => [...current, incoming]);
+            setOperation("remove and append across queued setters");
+            setRevision((value) => value + 1);
+          }}
+        >
+          Queued remove + append
+        </button>
+        <button
+          data-action="table-structural-append-queued-snapshot"
+          type="button"
+          onClick={() => {
+            const incoming = {
+              id: (seed + 1_000_000) * 10_000 + 1,
+              label: "queued incoming row",
+              amount: 2_048,
+              region: "AMR" as const,
+              status: "review" as const,
+            };
+            setRows((current) => {
+              return current.filter((row) => row.id % 10_000 !== 7_001);
+            });
+            setRows((current) => {
+              return [...current, incoming];
+            });
+            setOperation("remove and append across queued setters (snapshot control)");
+            setRevision((value) => value + 1);
+          }}
+        >
+          Queued remove + append (snapshot control)
+        </button>
+        <button
           data-action="table-map-structural-reorder-pipeline"
           type="button"
           onClick={() => {

--- a/packages/farm-react/README.md
+++ b/packages/farm-react/README.md
@@ -258,6 +258,33 @@ reconciliation. A key that reads the collection prevents hint emission entirely.
 report exposes the emitted-site count as
 `keyedArrayAppendHints`.
 
+Adjacent removal and append setters can share the same committed-row proof:
+
+```tsx
+setItems((current) => current.filter((item) => item.id !== expiredId));
+setItems((current) => [...current, incoming]);
+
+setItems((current) => current.slice(start, end));
+setItems((current) => [...current, ...incoming]);
+```
+
+The setters still execute in order and still create their normal native arrays. Before changing the
+DOM, Farm validates the original committed token, every filter or slice survivor, the complete final
+length, and every incoming key. It prepares all incoming keys, descriptors, bindings, and detached
+host rows first; only then does it remove rejected rows, update survivor indexes, and append the new
+suffix in one fragment. Existing survivors are neither rebound nor recreated, and additional
+adjacent append setters are collapsed into the same final suffix. This keeps the unavoidable native
+filter or slice work while removing the keyed runtime's second full scan.
+
+Only concise updater results that form one direct chain for the same state array are linked. The row
+and key must be compiler-owned and index-independent. A map or reorder between the structural step
+and append, an unhinted update to that state, another dirty row dependency, collection-reading
+binding, custom, sparse, or subclassed array, nested or React-owned row, duplicate final key, or
+reuse of any committed key in the appended suffix keeps complete React reconciliation before a DOM
+write. No API or configuration is added. Compiler reports use the existing
+`keyedArrayFilterHints`, `keyedArraySliceHints`, and `keyedArrayAppendHints` counts, and modules
+without both accepted operations omit the composed runtime.
+
 The mirror-image prepend form is supported when the keyed row and key do not read the row index:
 
 ```tsx

--- a/packages/farm-react/RUNTIME_SIZE_RESULTS.json
+++ b/packages/farm-react/RUNTIME_SIZE_RESULTS.json
@@ -26,14 +26,14 @@
         "brotli": 51897
       },
       "compilerOn": {
-        "raw": 232658,
-        "gzip": 71404,
-        "brotli": 61097
+        "raw": 232739,
+        "gzip": 71431,
+        "brotli": 61193
       },
       "compilerPremium": {
-        "raw": 39539,
-        "gzip": 11225,
-        "brotli": 9200
+        "raw": 39620,
+        "gzip": 11252,
+        "brotli": 9296
       }
     },
     "keyedAppend": {
@@ -43,14 +43,14 @@
         "brotli": 51772
       },
       "compilerOn": {
-        "raw": 233983,
-        "gzip": 71716,
-        "brotli": 61486
+        "raw": 234064,
+        "gzip": 71748,
+        "brotli": 61436
       },
       "compilerPremium": {
-        "raw": 41082,
-        "gzip": 11631,
-        "brotli": 9714
+        "raw": 41163,
+        "gzip": 11663,
+        "brotli": 9664
       }
     },
     "keyedFilter": {
@@ -60,14 +60,31 @@
         "brotli": 51833
       },
       "compilerOn": {
-        "raw": 235919,
-        "gzip": 72289,
-        "brotli": 61957
+        "raw": 236259,
+        "gzip": 72398,
+        "brotli": 62073
       },
       "compilerPremium": {
-        "raw": 43039,
-        "gzip": 12201,
-        "brotli": 10124
+        "raw": 43379,
+        "gzip": 12310,
+        "brotli": 10240
+      }
+    },
+    "keyedStructuralAppend": {
+      "compilerOff": {
+        "raw": 192927,
+        "gzip": 60114,
+        "brotli": 51823
+      },
+      "compilerOn": {
+        "raw": 257231,
+        "gzip": 77376,
+        "brotli": 66262
+      },
+      "compilerPremium": {
+        "raw": 64304,
+        "gzip": 17262,
+        "brotli": 14439
       }
     },
     "keyedPrepend": {
@@ -77,14 +94,14 @@
         "brotli": 51826
       },
       "compilerOn": {
-        "raw": 235483,
-        "gzip": 72086,
-        "brotli": 61715
+        "raw": 235541,
+        "gzip": 72102,
+        "brotli": 61727
       },
       "compilerPremium": {
-        "raw": 42581,
-        "gzip": 11999,
-        "brotli": 9889
+        "raw": 42639,
+        "gzip": 12015,
+        "brotli": 9901
       }
     },
     "keyedPosition": {
@@ -94,14 +111,14 @@
         "brotli": 51741
       },
       "compilerOn": {
-        "raw": 236334,
-        "gzip": 72378,
-        "brotli": 62052
+        "raw": 236346,
+        "gzip": 72371,
+        "brotli": 62002
       },
       "compilerPremium": {
-        "raw": 43436,
-        "gzip": 12302,
-        "brotli": 10311
+        "raw": 43448,
+        "gzip": 12295,
+        "brotli": 10261
       }
     },
     "keyedBatchPosition": {
@@ -111,14 +128,14 @@
         "brotli": 51753
       },
       "compilerOn": {
-        "raw": 237582,
-        "gzip": 72567,
-        "brotli": 62221
+        "raw": 237571,
+        "gzip": 72551,
+        "brotli": 62177
       },
       "compilerPremium": {
-        "raw": 44665,
-        "gzip": 12476,
-        "brotli": 10468
+        "raw": 44654,
+        "gzip": 12460,
+        "brotli": 10424
       }
     },
     "keyedWindowPosition": {
@@ -128,14 +145,14 @@
         "brotli": 51793
       },
       "compilerOn": {
-        "raw": 243370,
-        "gzip": 74328,
-        "brotli": 63836
+        "raw": 243290,
+        "gzip": 74309,
+        "brotli": 63734
       },
       "compilerPremium": {
-        "raw": 50379,
-        "gzip": 14204,
-        "brotli": 12043
+        "raw": 50299,
+        "gzip": 14185,
+        "brotli": 11941
       }
     },
     "keyedReorder": {
@@ -145,14 +162,14 @@
         "brotli": 51795
       },
       "compilerOn": {
-        "raw": 235870,
-        "gzip": 72278,
-        "brotli": 61907
+        "raw": 235587,
+        "gzip": 72166,
+        "brotli": 61850
       },
       "compilerPremium": {
-        "raw": 43023,
-        "gzip": 12220,
-        "brotli": 10112
+        "raw": 42740,
+        "gzip": 12108,
+        "brotli": 10055
       }
     },
     "keyedMapReorder": {
@@ -162,14 +179,14 @@
         "brotli": 51734
       },
       "compilerOn": {
-        "raw": 239547,
-        "gzip": 73253,
-        "brotli": 62736
+        "raw": 240271,
+        "gzip": 73454,
+        "brotli": 62956
       },
       "compilerPremium": {
-        "raw": 46619,
-        "gzip": 13143,
-        "brotli": 11002
+        "raw": 47343,
+        "gzip": 13344,
+        "brotli": 11222
       }
     },
     "keyedSort": {
@@ -179,14 +196,14 @@
         "brotli": 51829
       },
       "compilerOn": {
-        "raw": 236003,
-        "gzip": 72332,
-        "brotli": 61941
+        "raw": 235668,
+        "gzip": 72206,
+        "brotli": 62009
       },
       "compilerPremium": {
-        "raw": 43127,
-        "gzip": 12255,
-        "brotli": 10112
+        "raw": 42792,
+        "gzip": 12129,
+        "brotli": 10180
       }
     },
     "keyedSlice": {
@@ -196,14 +213,14 @@
         "brotli": 51855
       },
       "compilerOn": {
-        "raw": 235971,
-        "gzip": 72315,
-        "brotli": 62027
+        "raw": 236311,
+        "gzip": 72435,
+        "brotli": 62151
       },
       "compilerPremium": {
-        "raw": 43100,
-        "gzip": 12240,
-        "brotli": 10172
+        "raw": 43440,
+        "gzip": 12360,
+        "brotli": 10296
       }
     },
     "keyedRollingWindow": {
@@ -213,14 +230,14 @@
         "brotli": 51859
       },
       "compilerOn": {
-        "raw": 240050,
-        "gzip": 73237,
-        "brotli": 62753
+        "raw": 240367,
+        "gzip": 73344,
+        "brotli": 62831
       },
       "compilerPremium": {
-        "raw": 47121,
-        "gzip": 13129,
-        "brotli": 10894
+        "raw": 47438,
+        "gzip": 13236,
+        "brotli": 10972
       }
     },
     "isolatedRuntime": {
@@ -230,18 +247,18 @@
         "brotli": 51666
       },
       "full": {
-        "raw": 290969,
-        "gzip": 82543,
-        "brotli": 70368
+        "raw": 291278,
+        "gzip": 82739,
+        "brotli": 70496
       },
       "coreOnly": {
         "raw": 204922,
         "gzip": 63685,
         "brotli": 54902
       },
-      "fullRuntimePremiumGzip": 22624,
+      "fullRuntimePremiumGzip": 22820,
       "coreRuntimePremiumGzip": 3766,
-      "gzipReductionPercent": 83.4
+      "gzipReductionPercent": 83.5
     }
   }
 }

--- a/packages/farm-react/fixtures/runtime-size/keyed-structural-append.tsx
+++ b/packages/farm-react/fixtures/runtime-size/keyed-structural-append.tsx
@@ -1,0 +1,34 @@
+import React, { useState } from "react";
+import { createRoot } from "react-dom/client";
+
+interface Row {
+  id: number;
+  label: string;
+}
+
+export function StructuralAppendTable() {
+  const [rows, setRows] = useState<Row[]>(
+    Array.from({ length: 1_000 }, (_, id) => ({ id, label: `Row ${id}` })),
+  );
+  return (
+    <main>
+      <button
+        onClick={() => {
+          setRows((current) => current.filter((row) => row.id !== 500));
+          setRows((current) => [...current, { id: 1_001, label: "Appended row" }]);
+        }}
+      >
+        Replace
+      </button>
+      <ul>
+        {rows.map((row) => (
+          <li data-id={row.id} key={row.id}>
+            {row.label}
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}
+
+createRoot(document.body).render(<StructuralAppendTable />);

--- a/packages/farm-react/scripts/benchmark-runtime-size.mjs
+++ b/packages/farm-react/scripts/benchmark-runtime-size.mjs
@@ -57,6 +57,8 @@ const [
   keyedAppendOn,
   keyedFilterOff,
   keyedFilterOn,
+  keyedStructuralAppendOff,
+  keyedStructuralAppendOn,
   keyedPrependOff,
   keyedPrependOn,
   keyedPositionOff,
@@ -87,6 +89,8 @@ const [
   bundle("keyed-append.tsx", true),
   bundle("keyed-filter.tsx", false),
   bundle("keyed-filter.tsx", true),
+  bundle("keyed-structural-append.tsx", false),
+  bundle("keyed-structural-append.tsx", true),
   bundle("keyed-prepend.tsx", false),
   bundle("keyed-prepend.tsx", true),
   bundle("keyed-position.tsx", false),
@@ -159,6 +163,13 @@ if (
   !keyedFilterOn.code.includes("filterIndexIndependent")
 ) {
   throw new Error("Keyed filter fixture did not retain its optional filter-hint runtime.");
+}
+if (
+  !keyedStructuralAppendOn.code.includes("FarmCompiledKeyedRows") ||
+  !keyedStructuralAppendOn.code.includes("keyed-rows:structural-append-hinted") ||
+  !keyedStructuralAppendOn.code.includes("filterIndexIndependent")
+) {
+  throw new Error("Keyed structural-append fixture did not retain its isolated composed runtime.");
 }
 if (
   !keyedPrependOn.code.includes("FarmCompiledKeyedRows") ||
@@ -256,6 +267,9 @@ for (const [name, output] of [
   ) {
     throw new Error(`${name} fixture retained the optional prepend-hint runtime.`);
   }
+  if (output.code.includes("keyed-rows:structural-append-hinted")) {
+    throw new Error(`${name} fixture retained the optional structural-append runtime.`);
+  }
   if (output.code.includes("keyed-rows:all-hinted")) {
     throw new Error(`${name} fixture retained the optional rolling-window runtime.`);
   }
@@ -342,6 +356,23 @@ const results = {
         raw: keyedFilterOn.raw - keyedFilterOff.raw,
         gzip: keyedFilterOn.gzip - keyedFilterOff.gzip,
         brotli: keyedFilterOn.brotli - keyedFilterOff.brotli,
+      },
+    },
+    keyedStructuralAppend: {
+      compilerOff: {
+        raw: keyedStructuralAppendOff.raw,
+        gzip: keyedStructuralAppendOff.gzip,
+        brotli: keyedStructuralAppendOff.brotli,
+      },
+      compilerOn: {
+        raw: keyedStructuralAppendOn.raw,
+        gzip: keyedStructuralAppendOn.gzip,
+        brotli: keyedStructuralAppendOn.brotli,
+      },
+      compilerPremium: {
+        raw: keyedStructuralAppendOn.raw - keyedStructuralAppendOff.raw,
+        gzip: keyedStructuralAppendOn.gzip - keyedStructuralAppendOff.gzip,
+        brotli: keyedStructuralAppendOn.brotli - keyedStructuralAppendOff.brotli,
       },
     },
     keyedPrepend: {
@@ -534,6 +565,13 @@ if (checkOnly) {
       name: "keyed filter compiler premium",
       current: results.fixtures.keyedFilter.compilerPremium.gzip,
       maximum: (reference.fixtures.keyedFilter?.compilerPremium.gzip ?? 12_000) + 264,
+    },
+    {
+      name: "keyed structural-append compiler premium",
+      current: results.fixtures.keyedStructuralAppend.compilerPremium.gzip,
+      maximum:
+        (reference.fixtures.keyedStructuralAppend?.compilerPremium.gzip ??
+          results.fixtures.keyedStructuralAppend.compilerPremium.gzip) + 256,
     },
     {
       name: "keyed prepend compiler premium",

--- a/packages/farm-react/scripts/test-react-version.mjs
+++ b/packages/farm-react/scripts/test-react-version.mjs
@@ -52,8 +52,10 @@ const testSource = String.raw`
     createCompilerKeyedArrayReorder,
     createCompilerKeyedArraySort,
     createCompilerKeyedArraySlice,
+    createCompilerKeyedArrayStructuralAppend,
     createCompilerKeyedArrayWindowReplace,
     createCompilerKeyedMapUpdate,
+    keyedRowsStructuralAppendHintedRuntimeFeature,
   } = await import(
     "@farm.js/react/compiler-runtime"
   );
@@ -2244,6 +2246,85 @@ const testSource = String.raw`
   assert.equal(derivedCollectionContainer.querySelector("[data-key='b']"), originalBeta);
   assert.equal(derivedCollectionExecutions, initialDerivedCollectionExecutions);
   flushSync(() => derivedCollectionRoot.unmount());
+
+  let structuralAppendRows = () => undefined;
+  let structuralAppendExecutions = 0;
+  const StructuralAppendRows = createCompiledComponentWithFeatures({
+    displayName: "CompatibilityStructuralAppendRows",
+    initialize: () => [[
+      { id: "a", label: "Alpha" },
+      { id: "b", label: "Beta" },
+      { id: "c", label: "Gamma" },
+    ]],
+    render(_props, state, blocks) {
+      structuralAppendExecutions += 1;
+      const items = () => state[0].get();
+      structuralAppendRows = () => {
+        state[0].set((previous) =>
+          createCompilerKeyedArrayFilter(
+            previous,
+            previous.filter,
+            (item) => item.id !== "b",
+          ),
+        );
+        state[0].set((previous) =>
+          createCompilerKeyedArrayStructuralAppend(previous, [
+            ...previous,
+            { id: "d", label: "Delta" },
+          ]),
+        );
+      };
+      return React.createElement(
+        "section",
+        null,
+        React.createElement(blocks.KeyedRows, {
+          collectionDependency: 0,
+          dependencies: [0],
+          filterIndexIndependent: true,
+          id: 0,
+          items,
+          structureDependencies: [0],
+          render: () =>
+            React.createElement(
+              "ol",
+              null,
+              items().map((item) =>
+                React.createElement("li", { key: item.id, "data-key": item.id }, item.label),
+              ),
+            ),
+          rowKey: (item) => item.id,
+          create: (item) => ({
+            kind: "element",
+            tag: "li",
+            attributes: [{ name: "data-key", value: item.id }],
+            styles: [],
+            children: [item.label],
+          }),
+          bindings: [{ kind: "text", path: [], dependencies: [], read: (item) => [item.label] }],
+        }),
+      );
+    },
+    bindings: [{ kind: "block", id: 0, dependencies: [0] }],
+  }, [keyedRowsStructuralAppendHintedRuntimeFeature]);
+  const structuralAppendContainer = document.createElement("div");
+  document.body.append(structuralAppendContainer);
+  const structuralAppendRoot = createRoot(structuralAppendContainer);
+  flushSync(() => structuralAppendRoot.render(React.createElement(StructuralAppendRows)));
+  const structuralAlpha = structuralAppendContainer.querySelector("[data-key='a']");
+  const structuralGamma = structuralAppendContainer.querySelector("[data-key='c']");
+  const structuralBeta = structuralAppendContainer.querySelector("[data-key='b']");
+  structuralAppendRows();
+  await Promise.resolve();
+  await Promise.resolve();
+  assert.deepEqual(
+    [...structuralAppendContainer.querySelectorAll("li")].map((row) => row.textContent),
+    ["Alpha", "Gamma", "Delta"],
+  );
+  assert.equal(structuralAppendContainer.querySelector("[data-key='a']"), structuralAlpha);
+  assert.equal(structuralAppendContainer.querySelector("[data-key='c']"), structuralGamma);
+  assert.equal(structuralBeta.isConnected, false);
+  assert.equal(structuralAppendExecutions, 1);
+  flushSync(() => structuralAppendRoot.unmount());
 
   let islandExecutions = 0;
   let islandChildExecutions = 0;

--- a/packages/farm-react/src/__tests__/compiler-keyed-array-append-hints.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-keyed-array-append-hints.test.ts
@@ -69,6 +69,75 @@ describe("React AOT keyed-array append hints", () => {
     expect(result.code).toContain("collectionDependency={0}");
   });
 
+  it("emits composable filter and append hints for adjacent queued setters", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Inventory({ expiredId, incoming }) {
+        const [rows, setRows] = useState([{ id: "a", label: "Alpha" }]);
+        return <main>
+          <button onClick={() => {
+            setRows((current) => current.filter((row) => row.id !== expiredId));
+            setRows((current) => [...current, incoming]);
+          }}>
+            Replace expired row
+          </button>
+          <button onClick={() => setRows((current) => current.toReversed())}>Reverse</button>
+          <ul>{rows.map((row) => <li key={row.id}>{row.label}</li>)}</ul>
+        </main>;
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Inventory"]);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.optimizations.keyedArrayFilterHints).toBe(1);
+    expect(result.optimizations.keyedArrayAppendHints).toBe(1);
+    expect(result.optimizations.keyedArrayReorderHints).toBe(1);
+    expect(result.code).toContain("createCompilerKeyedArrayFilter");
+    expect(result.code).toContain("createCompilerKeyedArrayStructuralAppend");
+    expect(result.code).toContain("keyedRowsStructuralAppendHintedRuntimeFeature");
+    expect(result.code).not.toContain("keyedRowsFilterHintedRuntimeFeature");
+    await expect(
+      transformWithEsbuild(result.code, "/app/KeyedArrayAppendHints.tsx", {
+        loader: "tsx",
+        jsx: "automatic",
+      }),
+    ).resolves.toMatchObject({
+      code: expect.stringContaining("createCompilerKeyedArrayAppend"),
+    });
+  });
+
+  it("links a bounded slice to multiple following append setters", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Inventory({ incoming, extra }) {
+        const [rows, setRows] = useState([
+          { id: "a", label: "Alpha" },
+          { id: "b", label: "Beta" },
+          { id: "c", label: "Gamma" },
+          { id: "d", label: "Delta" },
+        ]);
+        return <main>
+          <button onClick={() => {
+            setRows((current) => current.slice(1, 3));
+            setRows((current) => [...current, incoming]);
+            setRows((current) => [...current, extra]);
+          }}>
+            Replace edges
+          </button>
+          <ul>{rows.map((row) => <li key={row.id}>{row.label}</li>)}</ul>
+        </main>;
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Inventory"]);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.optimizations.keyedArraySliceHints).toBe(1);
+    expect(result.optimizations.keyedArrayAppendHints).toBe(2);
+    expect(result.code).toContain("createCompilerKeyedArraySlice");
+    expect(result.code).toContain("createCompilerKeyedArrayStructuralAppend");
+    expect(result.code).toContain("keyedRowsStructuralAppendHintedRuntimeFeature");
+  });
+
   it("does not hint a collection when an existing row key reads its length", async () => {
     const result = await compile(`
       import { useState } from "react";

--- a/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-append-hints.test.tsx
+++ b/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-append-hints.test.tsx
@@ -4,8 +4,12 @@ import { createRoot, hydrateRoot, type Root } from "react-dom/client";
 import { renderToString } from "react-dom/server";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
-  createCompiledComponent,
+  createCompiledComponentWithFeatures,
   createCompilerKeyedArrayAppend,
+  createCompilerKeyedArrayFilter,
+  createCompilerKeyedArraySlice,
+  createCompilerKeyedArrayStructuralAppend,
+  keyedRowsStructuralAppendHintedRuntimeFeature,
   type CompilerKeyedRowElement,
 } from "../compiler-runtime";
 
@@ -48,6 +52,22 @@ function hintedAppend(previous: Item[], additions: readonly Item[]): unknown {
   return createCompilerKeyedArrayAppend(previous, [...previous, ...additions]);
 }
 
+function hintedStructuralAppend(previous: Item[], additions: readonly Item[]): unknown {
+  return createCompilerKeyedArrayStructuralAppend(previous, [...previous, ...additions]);
+}
+
+function hintedFilter(previous: Item[], removed: ReadonlySet<string>): unknown {
+  return createCompilerKeyedArrayFilter(
+    previous,
+    previous.filter,
+    (item: Item) => !removed.has(item.id),
+  );
+}
+
+function hintedSlice(previous: Item[], start: number, end: number): unknown {
+  return createCompilerKeyedArraySlice(previous, previous.slice, start, end);
+}
+
 function rowDescriptor(item: Item, text = item.label): CompilerKeyedRowElement {
   return {
     kind: "element",
@@ -58,7 +78,11 @@ function rowDescriptor(item: Item, text = item.label): CompilerKeyedRowElement {
   };
 }
 
-function createAppendHarness(initialItems: Item[], readsCollection = false) {
+function createAppendHarness(
+  initialItems: Item[],
+  readsCollection = false,
+  structuralAppend = false,
+) {
   const counters: Counters = {
     executions: 0,
     listRenders: 0,
@@ -67,71 +91,95 @@ function createAppendHarness(initialItems: Item[], readsCollection = false) {
     bindingReads: 0,
   };
   let append: (additions: readonly Item[]) => void = () => undefined;
+  let filterThenAppend: (removed: ReadonlySet<string>, additions: readonly Item[]) => void = () =>
+    undefined;
+  let sliceThenAppend: (start: number, end: number, additions: readonly Item[]) => void = () =>
+    undefined;
   let plainThenAppend: (addition: Item) => void = () => undefined;
-  const Inventory = createCompiledComponent({
-    displayName: "AppendInventory",
-    initialize: () => [initialItems],
-    render(_props: Record<string, never>, state, blocks) {
-      counters.executions += 1;
-      const items = () => state[0].get() as Item[];
-      append = (additions) =>
-        state[0].set((previous) => hintedAppend(previous as Item[], additions));
-      plainThenAppend = (addition) => {
-        state[0].set((previous) => [...(previous as Item[])]);
-        state[0].set((previous) => hintedAppend(previous as Item[], [addition]));
-      };
-      const text = (item: Item) =>
-        readsCollection ? `${items().length}: ${item.label}` : item.label;
-      return (
-        <section>
-          <blocks.KeyedRows
-            collectionDependency={0}
-            dependencies={[0]}
-            id={0}
-            items={items}
-            structureDependencies={[0]}
-            render={() => {
-              counters.listRenders += 1;
-              return (
-                <ul>
-                  {items().map((item) => (
-                    <li data-key={item.id} key={item.id}>
-                      {text(item)}
-                    </li>
-                  ))}
-                </ul>
-              );
-            }}
-            rowKey={(item) => {
-              counters.keyReads += 1;
-              return (item as Item).id;
-            }}
-            create={(item) => {
-              counters.descriptorReads += 1;
-              const row = item as Item;
-              return rowDescriptor(row, text(row));
-            }}
-            bindings={[
-              {
-                kind: "text",
-                path: [],
-                dependencies: readsCollection ? [0] : [],
-                read: (item) => {
-                  counters.bindingReads += 1;
-                  return [text(item as Item)];
+  const Inventory = createCompiledComponentWithFeatures(
+    {
+      displayName: "AppendInventory",
+      initialize: () => [initialItems],
+      render(_props: Record<string, never>, state, blocks) {
+        counters.executions += 1;
+        const items = () => state[0].get() as Item[];
+        append = (additions) =>
+          state[0].set((previous) =>
+            structuralAppend
+              ? hintedStructuralAppend(previous as Item[], additions)
+              : hintedAppend(previous as Item[], additions),
+          );
+        filterThenAppend = (removed, additions) => {
+          state[0].set((previous) => hintedFilter(previous as Item[], removed));
+          state[0].set((previous) => hintedStructuralAppend(previous as Item[], additions));
+        };
+        sliceThenAppend = (start, end, additions) => {
+          state[0].set((previous) => hintedSlice(previous as Item[], start, end));
+          state[0].set((previous) => hintedStructuralAppend(previous as Item[], additions));
+        };
+        plainThenAppend = (addition) => {
+          state[0].set((previous) => [...(previous as Item[])]);
+          state[0].set((previous) => hintedAppend(previous as Item[], [addition]));
+        };
+        const text = (item: Item) =>
+          readsCollection ? `${items().length}: ${item.label}` : item.label;
+        return (
+          <section>
+            <blocks.KeyedRows
+              collectionDependency={0}
+              dependencies={[0]}
+              filterIndexIndependent={!readsCollection}
+              id={0}
+              items={items}
+              structureDependencies={[0]}
+              render={() => {
+                counters.listRenders += 1;
+                return (
+                  <ul>
+                    {items().map((item) => (
+                      <li data-key={item.id} key={item.id}>
+                        {text(item)}
+                      </li>
+                    ))}
+                  </ul>
+                );
+              }}
+              rowKey={(item) => {
+                counters.keyReads += 1;
+                return (item as Item).id;
+              }}
+              create={(item) => {
+                counters.descriptorReads += 1;
+                const row = item as Item;
+                return rowDescriptor(row, text(row));
+              }}
+              bindings={[
+                {
+                  kind: "text",
+                  path: [],
+                  dependencies: readsCollection ? [0] : [],
+                  read: (item) => {
+                    counters.bindingReads += 1;
+                    return [text(item as Item)];
+                  },
                 },
-              },
-            ]}
-          />
-        </section>
-      );
+              ]}
+            />
+          </section>
+        );
+      },
+      bindings: [{ kind: "block", id: 0, dependencies: [0] }],
     },
-    bindings: [{ kind: "block", id: 0, dependencies: [0] }],
-  });
+    [keyedRowsStructuralAppendHintedRuntimeFeature],
+  );
   return {
     Inventory,
     counters,
     append: (additions: readonly Item[]) => append(additions),
+    filterThenAppend: (removed: ReadonlySet<string>, additions: readonly Item[]) =>
+      filterThenAppend(removed, additions),
+    sliceThenAppend: (start: number, end: number, additions: readonly Item[]) =>
+      sliceThenAppend(start, end, additions),
     plainThenAppend: (addition: Item) => plainThenAppend(addition),
   };
 }
@@ -200,6 +248,274 @@ describe("compiled keyed-array append hints", () => {
     expect(harness.counters.keyReads).toBe(3);
   });
 
+  it("removes rejected rows and creates only the appended suffix in one queued commit", async () => {
+    const initialItems = Array.from(
+      { length: 2_048 },
+      (_, index): Item => ({ id: `row-${index}`, label: `Row ${index}` }),
+    );
+    const harness = createAppendHarness(initialItems, false, true);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Inventory />));
+    const first = container.querySelector('[data-key="row-0"]');
+    const last = container.querySelector('[data-key="row-2047"]');
+    const removed = container.querySelector('[data-key="row-1024"]');
+    harness.counters.keyReads = 0;
+    harness.counters.descriptorReads = 0;
+    harness.counters.bindingReads = 0;
+
+    await act(async () => {
+      harness.filterThenAppend(new Set(["row-1024"]), [{ id: "row-2048", label: "Row 2048" }]);
+      await flushCompilerUpdates();
+    });
+
+    expect(container.querySelector('[data-key="row-0"]')).toBe(first);
+    expect(container.querySelector('[data-key="row-2047"]')).toBe(last);
+    expect(container.querySelector('[data-key="row-1024"]')).toBeNull();
+    expect(removed?.isConnected).toBe(false);
+    expect(container.querySelectorAll("li")).toHaveLength(2_048);
+    expect(container.querySelector("li:last-child")?.textContent).toBe("Row 2048");
+    expect(harness.counters.executions).toBe(1);
+    expect(harness.counters.listRenders).toBe(1);
+    expect(harness.counters.descriptorReads).toBe(1);
+    expect(harness.counters.bindingReads).toBe(1);
+  });
+
+  it("composes multiple queued appends after one structural update", async () => {
+    const harness = createAppendHarness(
+      [
+        { id: "a", label: "Alpha" },
+        { id: "b", label: "Beta" },
+        { id: "c", label: "Gamma" },
+        { id: "d", label: "Delta" },
+      ],
+      false,
+      true,
+    );
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Inventory />));
+    const alpha = container.querySelector('[data-key="a"]');
+    const delta = container.querySelector('[data-key="d"]');
+    harness.counters.descriptorReads = 0;
+    harness.counters.bindingReads = 0;
+
+    await act(async () => {
+      harness.filterThenAppend(new Set(["b", "c"]), [{ id: "e", label: "Epsilon" }]);
+      harness.append([{ id: "f", label: "Phi" }]);
+      await flushCompilerUpdates();
+    });
+
+    expect([...container.querySelectorAll("li")].map((row) => row.textContent)).toEqual([
+      "Alpha",
+      "Delta",
+      "Epsilon",
+      "Phi",
+    ]);
+    expect(container.querySelector('[data-key="a"]')).toBe(alpha);
+    expect(container.querySelector('[data-key="d"]')).toBe(delta);
+    expect(harness.counters.descriptorReads).toBe(2);
+    expect(harness.counters.bindingReads).toBe(2);
+  });
+
+  it("retains a sliced interval before appending a fresh suffix", async () => {
+    const harness = createAppendHarness(
+      [
+        { id: "a", label: "Alpha" },
+        { id: "b", label: "Beta" },
+        { id: "c", label: "Gamma" },
+        { id: "d", label: "Delta" },
+      ],
+      false,
+      true,
+    );
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Inventory />));
+    const beta = container.querySelector('[data-key="b"]');
+    const gamma = container.querySelector('[data-key="c"]');
+    harness.counters.keyReads = 0;
+    harness.counters.descriptorReads = 0;
+    harness.counters.bindingReads = 0;
+
+    await act(async () => {
+      harness.sliceThenAppend(1, 3, [{ id: "e", label: "Epsilon" }]);
+      await flushCompilerUpdates();
+    });
+
+    expect([...container.querySelectorAll("li")].map((row) => row.textContent)).toEqual([
+      "Beta",
+      "Gamma",
+      "Epsilon",
+    ]);
+    expect(container.querySelector('[data-key="b"]')).toBe(beta);
+    expect(container.querySelector('[data-key="c"]')).toBe(gamma);
+    expect(harness.counters.keyReads).toBe(1);
+    expect(harness.counters.descriptorReads).toBe(1);
+    expect(harness.counters.bindingReads).toBe(1);
+  });
+
+  it("preserves focus and selection on a surviving controlled input", async () => {
+    const initialItems: Item[] = [
+      { id: "a", label: "Alpha" },
+      { id: "b", label: "Beta" },
+      { id: "c", label: "Gamma" },
+    ];
+    let replaceFirst: () => void = () => undefined;
+    const Inventory = createCompiledComponentWithFeatures(
+      {
+        displayName: "StructuralAppendForm",
+        initialize: () => [initialItems],
+        render(_props: Record<string, never>, state, blocks) {
+          const items = () => state[0].get() as Item[];
+          replaceFirst = () => {
+            state[0].set((previous) => hintedFilter(previous as Item[], new Set(["a"])));
+            state[0].set((previous) =>
+              hintedStructuralAppend(previous as Item[], [{ id: "d", label: "Delta" }]),
+            );
+          };
+          return (
+            <section>
+              <blocks.KeyedRows
+                collectionDependency={0}
+                dependencies={[0]}
+                filterIndexIndependent
+                id={0}
+                items={items}
+                structureDependencies={[0]}
+                render={() => (
+                  <div>
+                    {items().map((item) => (
+                      <input data-key={item.id} key={item.id} readOnly value={item.label} />
+                    ))}
+                  </div>
+                )}
+                rowKey={(item) => (item as Item).id}
+                create={(item) => ({
+                  kind: "element",
+                  tag: "input",
+                  attributes: [
+                    { name: "data-key", value: (item as Item).id },
+                    { name: "readOnly", value: true },
+                    { name: "value", value: (item as Item).label },
+                  ],
+                  styles: [],
+                  children: [],
+                })}
+                bindings={[
+                  {
+                    kind: "attribute",
+                    name: "value",
+                    path: [],
+                    read: (item) => (item as Item).label,
+                  },
+                ]}
+              />
+            </section>
+          );
+        },
+        bindings: [{ kind: "block", id: 0, dependencies: [0] }],
+      },
+      [keyedRowsStructuralAppendHintedRuntimeFeature],
+    );
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<Inventory />));
+    const beta = container.querySelector('[data-key="b"]') as HTMLInputElement;
+    beta.focus();
+    beta.setSelectionRange(1, 3);
+
+    await act(async () => {
+      replaceFirst();
+      await flushCompilerUpdates();
+    });
+
+    expect(container.querySelector('[data-key="b"]')).toBe(beta);
+    expect(document.activeElement).toBe(beta);
+    expect([beta.selectionStart, beta.selectionEnd]).toEqual([1, 3]);
+    expect([...container.querySelectorAll("input")].map((input) => input.value)).toEqual([
+      "Beta",
+      "Gamma",
+      "Delta",
+    ]);
+  });
+
+  it("unmounts cleanly after a nested structural append", async () => {
+    const harness = createAppendHarness(
+      [
+        { id: "a", label: "Alpha" },
+        { id: "b", label: "Beta" },
+        { id: "c", label: "Gamma" },
+      ],
+      false,
+      true,
+    );
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () =>
+      root.render(
+        <main>
+          <harness.Inventory />
+        </main>,
+      ),
+    );
+
+    await act(async () => {
+      harness.filterThenAppend(new Set(["a"]), [{ id: "d", label: "Delta" }]);
+      await flushCompilerUpdates();
+    });
+
+    roots.pop();
+    await expect(
+      act(async () => {
+        root.unmount();
+      }),
+    ).resolves.toBeUndefined();
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("falls back before reusing a key removed earlier in the queued chain", async () => {
+    const harness = createAppendHarness(
+      [
+        { id: "a", label: "Alpha" },
+        { id: "b", label: "Beta" },
+        { id: "c", label: "Gamma" },
+      ],
+      false,
+      true,
+    );
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Inventory />));
+    const beta = container.querySelector('[data-key="b"]');
+    harness.counters.bindingReads = 0;
+
+    await act(async () => {
+      harness.filterThenAppend(new Set(["b"]), [{ id: "b", label: "Beta moved" }]);
+      await flushCompilerUpdates();
+    });
+
+    expect([...container.querySelectorAll("li")].map((row) => row.textContent)).toEqual([
+      "Alpha",
+      "Gamma",
+      "Beta moved",
+    ]);
+    expect(container.querySelector('[data-key="b"]')).toBe(beta);
+    expect(harness.counters.bindingReads).toBe(3);
+  });
+
   it("rejects a hint chained after an unhinted update in the same flush", async () => {
     const harness = createAppendHarness([
       { id: "a", label: "Alpha" },
@@ -251,6 +567,8 @@ describe("compiled keyed-array append hints", () => {
     const next: Item[] = [{ id: "safe", label: "Safe" }];
     expect(() => createCompilerKeyedArrayAppend(proxy, next)).not.toThrow();
     expect(createCompilerKeyedArrayAppend(proxy, next)).toBe(next);
+    expect(() => createCompilerKeyedArrayStructuralAppend(proxy, next)).not.toThrow();
+    expect(createCompilerKeyedArrayStructuralAppend(proxy, next)).toBe(next);
   });
 
   it("keeps complete reconciliation when existing rows read collection state", async () => {
@@ -279,57 +597,81 @@ describe("compiled keyed-array append hints", () => {
       "3: Gamma",
     ]);
     expect(harness.counters.keyReads).toBe(3);
+
+    harness.counters.keyReads = 0;
+    await act(async () => {
+      harness.filterThenAppend(new Set(["b"]), [{ id: "d", label: "Delta" }]);
+      await flushCompilerUpdates();
+    });
+
+    expect([...container.querySelectorAll("li")].map((row) => row.textContent)).toEqual([
+      "3: Alpha",
+      "3: Gamma",
+      "3: Delta",
+    ]);
+    expect(harness.counters.keyReads).toBe(3);
   });
 
   it("shares one append hint across multiple keyed boundaries", async () => {
     const initialItems: Item[] = [{ id: "a", label: "Alpha" }];
     let append: () => void = () => undefined;
+    let filterThenAppend: () => void = () => undefined;
     let keyReads = 0;
-    const Inventory = createCompiledComponent({
-      displayName: "SharedAppendInventory",
-      initialize: () => [initialItems],
-      render(_props: Record<string, never>, state, blocks) {
-        const items = () => state[0].get() as Item[];
-        append = () =>
-          state[0].set((previous) =>
-            hintedAppend(previous as Item[], [{ id: "b", label: "Beta" }]),
+    const Inventory = createCompiledComponentWithFeatures(
+      {
+        displayName: "SharedAppendInventory",
+        initialize: () => [initialItems],
+        render(_props: Record<string, never>, state, blocks) {
+          const items = () => state[0].get() as Item[];
+          append = () =>
+            state[0].set((previous) =>
+              hintedAppend(previous as Item[], [{ id: "b", label: "Beta" }]),
+            );
+          filterThenAppend = () => {
+            state[0].set((previous) => hintedFilter(previous as Item[], new Set(["a"])));
+            state[0].set((previous) =>
+              hintedStructuralAppend(previous as Item[], [{ id: "c", label: "Gamma" }]),
+            );
+          };
+          const list = (id: number, owner: string) => (
+            <blocks.KeyedRows
+              collectionDependency={0}
+              dependencies={[0]}
+              filterIndexIndependent
+              id={id}
+              items={items}
+              structureDependencies={[0]}
+              render={() => (
+                <ul data-owner={owner}>
+                  {items().map((item) => (
+                    <li data-key={item.id} key={item.id}>
+                      {item.label}
+                    </li>
+                  ))}
+                </ul>
+              )}
+              rowKey={(item) => {
+                keyReads += 1;
+                return (item as Item).id;
+              }}
+              create={(item) => rowDescriptor(item as Item)}
+              bindings={[{ kind: "text", path: [], read: (item) => [(item as Item).label] }]}
+            />
           );
-        const list = (id: number, owner: string) => (
-          <blocks.KeyedRows
-            collectionDependency={0}
-            dependencies={[0]}
-            id={id}
-            items={items}
-            structureDependencies={[0]}
-            render={() => (
-              <ul data-owner={owner}>
-                {items().map((item) => (
-                  <li data-key={item.id} key={item.id}>
-                    {item.label}
-                  </li>
-                ))}
-              </ul>
-            )}
-            rowKey={(item) => {
-              keyReads += 1;
-              return (item as Item).id;
-            }}
-            create={(item) => rowDescriptor(item as Item)}
-            bindings={[{ kind: "text", path: [], read: (item) => [(item as Item).label] }]}
-          />
-        );
-        return (
-          <section>
-            {list(0, "first")}
-            {list(1, "second")}
-          </section>
-        );
+          return (
+            <section>
+              {list(0, "first")}
+              {list(1, "second")}
+            </section>
+          );
+        },
+        bindings: [
+          { kind: "block", id: 0, dependencies: [0] },
+          { kind: "block", id: 1, dependencies: [0] },
+        ],
       },
-      bindings: [
-        { kind: "block", id: 0, dependencies: [0] },
-        { kind: "block", id: 1, dependencies: [0] },
-      ],
-    });
+      [keyedRowsStructuralAppendHintedRuntimeFeature],
+    );
     const container = document.createElement("div");
     document.body.append(container);
     const root = createRoot(container);
@@ -345,6 +687,16 @@ describe("compiled keyed-array append hints", () => {
     expect(container.querySelector('[data-owner="first"]')?.textContent).toBe("AlphaBeta");
     expect(container.querySelector('[data-owner="second"]')?.textContent).toBe("AlphaBeta");
     expect(keyReads).toBe(2);
+
+    keyReads = 0;
+    await act(async () => {
+      filterThenAppend();
+      await flushCompilerUpdates();
+    });
+
+    expect(container.querySelector('[data-owner="first"]')?.textContent).toBe("BetaGamma");
+    expect(container.querySelector('[data-owner="second"]')?.textContent).toBe("BetaGamma");
+    expect(keyReads).toBe(4);
   });
 
   it("matches React through 2,000 deterministic appends", async () => {
@@ -399,8 +751,93 @@ describe("compiled keyed-array append hints", () => {
     expect(harness.counters.executions).toBe(1);
   }, 15_000);
 
+  it("matches React across 2,000 randomized queued structural removals and appends", async () => {
+    const initialItems = Array.from(
+      { length: 1_001 },
+      (_, index): Item => ({ id: `row-${index}`, label: `Row ${index}` }),
+    );
+    const harness = createAppendHarness(initialItems, false, true);
+    let updateReact: (
+      kind: "filter" | "slice",
+      removed: ReadonlySet<string>,
+      additions: readonly Item[],
+    ) => void = () => undefined;
+    function Normal() {
+      const [items, setItems] = useState(initialItems);
+      updateReact = (kind, removed, additions) => {
+        setItems((previous) =>
+          kind === "slice"
+            ? previous.slice(0, previous.length - removed.size)
+            : previous.filter((item) => !removed.has(item.id)),
+        );
+        setItems((previous) => [...previous, ...additions]);
+      };
+      return (
+        <ol data-owner="react">
+          {items.map((item) => (
+            <li data-key={item.id} key={item.id}>
+              {item.label}
+            </li>
+          ))}
+        </ol>
+      );
+    }
+    const compiledContainer = document.createElement("div");
+    const reactContainer = document.createElement("div");
+    document.body.append(compiledContainer, reactContainer);
+    const compiledRoot = createRoot(compiledContainer);
+    const reactRoot = createRoot(reactContainer);
+    roots.push(compiledRoot, reactRoot);
+    await act(async () => {
+      compiledRoot.render(<harness.Inventory />);
+      reactRoot.render(<Normal />);
+    });
+    const stableRow = compiledContainer.querySelector('[data-key="row-0"]');
+    let active = initialItems.map((item) => item.id);
+    let seed = 0x9e3779b9;
+    let nextId = initialItems.length;
+
+    for (let batch = 0; batch < 200; batch += 1) {
+      const kind = batch % 2 === 0 ? "filter" : "slice";
+      const removed = new Set<string>();
+      if (kind === "slice") {
+        for (const id of active.slice(-5)) removed.add(id);
+      } else {
+        const removable = active.slice(1);
+        while (removed.size < 5) {
+          seed = (Math.imul(seed, 1_664_525) + 1_013_904_223) >>> 0;
+          removed.add(removable[seed % removable.length]);
+        }
+      }
+      const additions = Array.from({ length: 5 }, () => {
+        const id = `row-${nextId++}`;
+        return { id, label: `Queued ${id}` };
+      });
+      await act(async () => {
+        if (kind === "slice") {
+          harness.sliceThenAppend(0, active.length - removed.size, additions);
+        } else {
+          harness.filterThenAppend(removed, additions);
+        }
+        updateReact(kind, removed, additions);
+        await flushCompilerUpdates();
+      });
+      expect([...compiledContainer.querySelectorAll("li")].map((row) => row.outerHTML)).toEqual(
+        [...reactContainer.querySelectorAll("li")].map((row) => row.outerHTML),
+      );
+      active =
+        kind === "slice"
+          ? active.slice(0, active.length - removed.size)
+          : active.filter((id) => !removed.has(id));
+      active.push(...additions.map((item) => item.id));
+    }
+
+    expect(compiledContainer.querySelector('[data-key="row-0"]')).toBe(stableRow);
+    expect(harness.counters.executions).toBe(1);
+  }, 20_000);
+
   it("hydrates in StrictMode and drops a queued append after unmount", async () => {
-    const harness = createAppendHarness([{ id: "a", label: "Alpha" }]);
+    const harness = createAppendHarness([{ id: "a", label: "Alpha" }], false, true);
     const container = document.createElement("div");
     container.innerHTML = renderToString(
       <StrictMode>
@@ -428,9 +865,15 @@ describe("compiled keyed-array append hints", () => {
     expect(container.textContent).toBe("AlphaBeta");
     expect(recoverable).toEqual([]);
 
+    await act(async () => {
+      harness.filterThenAppend(new Set(["a"]), [{ id: "c", label: "Gamma" }]);
+      await flushCompilerUpdates();
+    });
+    expect(container.textContent).toBe("BetaGamma");
+
     roots.pop();
     act(() => {
-      harness.append([{ id: "c", label: "Gamma" }]);
+      harness.filterThenAppend(new Set(["b"]), [{ id: "d", label: "Delta" }]);
       root.unmount();
     });
     await flushCompilerUpdates();

--- a/packages/farm-react/src/compiler-runtime.tsx
+++ b/packages/farm-react/src/compiler-runtime.tsx
@@ -15,6 +15,7 @@ interface CompilerKeyedArrayAppendHint {
   readonly sourceToken: object;
   readonly startIndex: number;
   readonly resultLength: number;
+  readonly structuralUpdate?: CompilerKeyedArrayFilterHint;
   readonly previous?: CompilerKeyedArrayAppendHint;
 }
 
@@ -250,6 +251,60 @@ function compilerKeyedArrayAppendStart(
     length = current.resultLength;
   }
   return length === value.length ? expectedStart : undefined;
+}
+
+function compilerKeyedArrayStructuralAppendUpdate(
+  value: unknown,
+  sourceToken: object | undefined,
+  expectedStart: number,
+):
+  | {
+      readonly startIndex: number;
+      readonly structuralUpdate?: CompilerKeyedArrayFilterHint;
+      readonly structuralSurvivors?: {
+        readonly indices: readonly number[];
+        readonly keysStable: boolean;
+      };
+    }
+  | undefined {
+  const target = compilerObject(value);
+  if (!target || !sourceToken || !Array.isArray(value)) return undefined;
+  const update = COMPILER_KEYED_ARRAY_APPENDS.get(target);
+  if (!update || update.sourceToken !== sourceToken) return undefined;
+  const updates: CompilerKeyedArrayAppendHint[] = [];
+  for (
+    let current: CompilerKeyedArrayAppendHint | undefined = update;
+    current;
+    current = current.previous
+  ) {
+    if (current.sourceToken !== sourceToken) return undefined;
+    updates.push(current);
+  }
+  updates.reverse();
+  const structuralUpdate = update.structuralUpdate;
+  const first = updates[0];
+  const survivorResult = structuralUpdate
+    ? compilerKeyedArrayFilterSurvivorsFromUpdate(
+        structuralUpdate,
+        sourceToken,
+        expectedStart,
+        first.startIndex,
+      )
+    : undefined;
+  if (structuralUpdate && !survivorResult) return undefined;
+  let length = structuralUpdate ? first.startIndex : expectedStart;
+  const startIndex = length;
+  for (const current of updates) {
+    if (current.startIndex !== length || current.resultLength < length) return undefined;
+    length = current.resultLength;
+  }
+  return length === value.length
+    ? {
+        startIndex,
+        structuralUpdate,
+        ...(survivorResult ? { structuralSurvivors: survivorResult } : {}),
+      }
+    : undefined;
 }
 
 function compilerKeyedArrayFilterSurvivors(
@@ -924,6 +979,59 @@ export function createCompilerKeyedArrayAppend(previous: unknown, value: unknown
       sourceToken: previousUpdate?.sourceToken || sourceToken,
       startIndex,
       resultLength: value.length,
+      ...(previousUpdate ? { previous: previousUpdate } : {}),
+    });
+    return value;
+  } catch {
+    // Metadata must never change the behavior of an otherwise valid update.
+    return value;
+  }
+}
+
+/** @internal Records an append that may follow a compiler-proven structural update. */
+export function createCompilerKeyedArrayStructuralAppend(
+  previous: unknown,
+  value: unknown,
+): unknown {
+  try {
+    const previousTarget = compilerObject(previous);
+    const valueTarget = compilerObject(value);
+    if (
+      !previousTarget ||
+      !valueTarget ||
+      !Array.isArray(previous) ||
+      !Array.isArray(value) ||
+      Object.getPrototypeOf(previous) !== NATIVE_ARRAY_PROTOTYPE ||
+      Object.getPrototypeOf(value) !== NATIVE_ARRAY_PROTOTYPE ||
+      previous[Symbol.iterator] !== NATIVE_ARRAY_ITERATOR
+    ) {
+      return value;
+    }
+    const startIndex = previous.length;
+    if (value.length < startIndex) return value;
+    const committedSource = COMPILER_KEYED_COMMITTED_COLLECTIONS.has(previousTarget);
+    const previousUpdate = committedSource
+      ? undefined
+      : COMPILER_KEYED_ARRAY_APPENDS.get(previousTarget);
+    const directStructuralUpdate =
+      !committedSource && !previousUpdate
+        ? COMPILER_KEYED_ARRAY_FILTERS.get(previousTarget)
+        : undefined;
+    const structuralSource = directStructuralUpdate
+      ? compilerKeyedArrayFilterSource(directStructuralUpdate, previous.length)
+      : undefined;
+    const structuralUpdate =
+      previousUpdate?.structuralUpdate || (structuralSource ? directStructuralUpdate : undefined);
+    const sourceToken =
+      previousUpdate?.sourceToken ||
+      structuralSource?.sourceToken ||
+      compilerKeyedCollectionToken(previousTarget);
+    if (!sourceToken) return value;
+    COMPILER_KEYED_ARRAY_APPENDS.set(valueTarget, {
+      sourceToken,
+      startIndex,
+      resultLength: value.length,
+      ...(structuralUpdate ? { structuralUpdate } : {}),
       ...(previousUpdate ? { previous: previousUpdate } : {}),
     });
     return value;
@@ -5011,6 +5119,11 @@ const keyedWindowEveryUpdateRuntime: KeyedUpdateRuntime = {
   position: reconcileCompilerKeyedArrayPositionWithWindow,
 };
 
+const keyedWindowEveryStructuralAppendUpdateRuntime: KeyedUpdateRuntime = {
+  ...keyedWindowEveryUpdateRuntime,
+  append: reconcileCompilerKeyedArrayAppendWithStructural,
+};
+
 interface KeyedRowsRuntimeOptions {
   conditionals?: KeyedRowConditionalRuntime;
   hostBlocks?: KeyedRowHostRuntime;
@@ -5267,6 +5380,115 @@ function reconcileCompilerKeyedArrayAppend(
     root.append(fragment);
   }
   return nextInstances;
+}
+
+function reconcileCompilerKeyedArrayStructuralAppend(
+  props: CompilerKeyedRowsBlockProps,
+  dirtyState: ReadonlySet<number>,
+  collectionToken: object | undefined,
+  instances: ReadonlyMap<string, CompilerKeyedRowInstance>,
+  root: Element,
+  reactOwnedRows: boolean,
+): ReadonlyMap<string, CompilerKeyedRowInstance> | undefined {
+  if (
+    reactOwnedRows ||
+    props.hostBlocks ||
+    (props.conditionals?.length || 0) > 0 ||
+    !props.filterIndexIndependent ||
+    props.collectionDependency === undefined
+  ) {
+    return undefined;
+  }
+  const collectionDependency = props.collectionDependency;
+  if (props.bindings.some((binding) => binding.dependencies?.includes(collectionDependency))) {
+    return undefined;
+  }
+  const dependencies = props.dependencies || props.structureDependencies;
+  const relevantDirty = (dependencies || []).filter((index) => dirtyState.has(index));
+  if (relevantDirty.length !== 1 || relevantDirty[0] !== collectionDependency) {
+    return undefined;
+  }
+
+  const finalValue = props.items();
+  const update = compilerKeyedArrayStructuralAppendUpdate(
+    finalValue,
+    collectionToken,
+    instances.size,
+  );
+  const structuralUpdate = update?.structuralUpdate;
+  const survivorResult = update?.structuralSurvivors;
+  if (
+    !update ||
+    !structuralUpdate ||
+    !survivorResult ||
+    structuralUpdate.mappedItemSources ||
+    !Array.isArray(finalValue)
+  ) {
+    return undefined;
+  }
+
+  const previousInstances = [...instances.values()];
+  const survivors: CompilerKeyedRowInstance[] = [];
+  const knownKeys = new Set(instances.keys());
+  const appended: CompilerKeyedRowInstance[] = [];
+  try {
+    for (let index = 0; index < survivorResult.indices.length; index += 1) {
+      const sourceIndex = survivorResult.indices[index];
+      const instance = previousInstances[sourceIndex];
+      const item = finalValue[index];
+      if (
+        !instance ||
+        instance.index !== sourceIndex ||
+        !Object.is(instance.item, item) ||
+        (!survivorResult.keysStable && keyedRowIdentity(props.rowKey(item, index)) !== instance.key)
+      ) {
+        return undefined;
+      }
+      survivors.push(instance);
+    }
+    for (let index = update.startIndex; index < finalValue.length; index += 1) {
+      const item = finalValue[index];
+      const key = keyedRowIdentity(props.rowKey(item, index));
+      // A new suffix row that reuses any committed key must take complete
+      // reconciliation so React can preserve that row's existing identity.
+      if (knownKeys.has(key)) return undefined;
+      knownKeys.add(key);
+      const descriptor = props.create(item, index);
+      appended.push({
+        key,
+        element: createCompilerHostElement(root.ownerDocument, descriptor),
+        values: readKeyedRowBindingValues(props, item, index),
+        item,
+        index,
+        conditionalValues: EMPTY_KEYED_ROW_CONDITIONAL_VALUES,
+      });
+    }
+  } catch {
+    return undefined;
+  }
+
+  const survivorSet = new Set(survivorResult.indices);
+  for (let index = 0; index < previousInstances.length; index += 1) {
+    if (survivorSet.has(index)) continue;
+    previousInstances[index].scope?.cleanup();
+    previousInstances[index].element.remove();
+  }
+  for (let index = 0; index < survivors.length; index += 1) survivors[index].index = index;
+  if (appended.length > 0) {
+    const fragment = root.ownerDocument.createDocumentFragment();
+    for (const instance of appended) fragment.append(instance.element);
+    root.append(fragment);
+  }
+  return keyedRowInstancesByKey([...survivors, ...appended]);
+}
+
+function reconcileCompilerKeyedArrayAppendWithStructural(
+  ...args: Parameters<typeof reconcileCompilerKeyedArrayAppend>
+): ReadonlyMap<string, CompilerKeyedRowInstance> | undefined {
+  return (
+    reconcileCompilerKeyedArrayStructuralAppend(...args) ||
+    reconcileCompilerKeyedArrayAppend(...args)
+  );
 }
 
 function reconcileCompilerKeyedArrayRollingWindow(
@@ -8208,6 +8430,15 @@ export const keyedRowsFilterHintedRuntimeFeature: CompilerRuntimeFeature = {
   }),
 };
 
+export const keyedRowsStructuralAppendHintedRuntimeFeature: CompilerRuntimeFeature = {
+  name: "keyed-rows:structural-append-hinted",
+  create: (owner) => ({
+    KeyedRows: createKeyedRowsBlockComponent(owner, {
+      keyedUpdates: keyedWindowEveryStructuralAppendUpdateRuntime,
+    }),
+  }),
+};
+
 export const keyedRowsPrependHintedRuntimeFeature: CompilerRuntimeFeature = {
   name: "keyed-rows:prepend-hinted",
   create: (owner) => ({
@@ -8331,6 +8562,16 @@ export const keyedRowsConditionalFilterHintedRuntimeFeature: CompilerRuntimeFeat
     KeyedRows: createKeyedRowsBlockComponent(owner, {
       conditionals: createKeyedRowConditionalRuntime(),
       keyedUpdates: keyedFilterUpdateRuntime,
+    }),
+  }),
+};
+
+export const keyedRowsConditionalStructuralAppendHintedRuntimeFeature: CompilerRuntimeFeature = {
+  name: "keyed-rows:conditional:structural-append-hinted",
+  create: (owner) => ({
+    KeyedRows: createKeyedRowsBlockComponent(owner, {
+      conditionals: createKeyedRowConditionalRuntime(),
+      keyedUpdates: keyedWindowEveryStructuralAppendUpdateRuntime,
     }),
   }),
 };
@@ -8460,6 +8701,16 @@ export const keyedRowsHostFilterHintedRuntimeFeature: CompilerRuntimeFeature = {
     KeyedRows: createKeyedRowsBlockComponent(owner, {
       hostBlocks: createKeyedRowHostRuntime(),
       keyedUpdates: keyedFilterUpdateRuntime,
+    }),
+  }),
+};
+
+export const keyedRowsHostStructuralAppendHintedRuntimeFeature: CompilerRuntimeFeature = {
+  name: "keyed-rows:host:structural-append-hinted",
+  create: (owner) => ({
+    KeyedRows: createKeyedRowsBlockComponent(owner, {
+      hostBlocks: createKeyedRowHostRuntime(),
+      keyedUpdates: keyedWindowEveryStructuralAppendUpdateRuntime,
     }),
   }),
 };
@@ -8600,6 +8851,17 @@ export const keyedRowsCompleteFilterHintedRuntimeFeature: CompilerRuntimeFeature
       conditionals: createKeyedRowConditionalRuntime(),
       hostBlocks: createKeyedRowHostRuntime(),
       keyedUpdates: keyedFilterUpdateRuntime,
+    }),
+  }),
+};
+
+export const keyedRowsCompleteStructuralAppendHintedRuntimeFeature: CompilerRuntimeFeature = {
+  name: "keyed-rows:complete:structural-append-hinted",
+  create: (owner) => ({
+    KeyedRows: createKeyedRowsBlockComponent(owner, {
+      conditionals: createKeyedRowConditionalRuntime(),
+      hostBlocks: createKeyedRowHostRuntime(),
+      keyedUpdates: keyedWindowEveryStructuralAppendUpdateRuntime,
     }),
   }),
 };

--- a/packages/farm-react/src/compiler.ts
+++ b/packages/farm-react/src/compiler.ts
@@ -377,6 +377,7 @@ type CompilerRuntimeFeatureName =
   | "keyed-rows-batch-every-hinted"
   | "keyed-rows-window-every-hinted"
   | "keyed-rows-filter-hinted"
+  | "keyed-rows-structural-append-hinted"
   | "keyed-rows-prepend-hinted"
   | "keyed-rows-filter-prepend-hinted"
   | "keyed-rows-conditional"
@@ -390,6 +391,7 @@ type CompilerRuntimeFeatureName =
   | "keyed-rows-conditional-batch-every-hinted"
   | "keyed-rows-conditional-window-every-hinted"
   | "keyed-rows-conditional-filter-hinted"
+  | "keyed-rows-conditional-structural-append-hinted"
   | "keyed-rows-conditional-prepend-hinted"
   | "keyed-rows-conditional-filter-prepend-hinted"
   | "keyed-rows-host"
@@ -403,6 +405,7 @@ type CompilerRuntimeFeatureName =
   | "keyed-rows-host-batch-every-hinted"
   | "keyed-rows-host-window-every-hinted"
   | "keyed-rows-host-filter-hinted"
+  | "keyed-rows-host-structural-append-hinted"
   | "keyed-rows-host-prepend-hinted"
   | "keyed-rows-host-filter-prepend-hinted"
   | "keyed-rows-complete"
@@ -416,6 +419,7 @@ type CompilerRuntimeFeatureName =
   | "keyed-rows-complete-batch-every-hinted"
   | "keyed-rows-complete-window-every-hinted"
   | "keyed-rows-complete-filter-hinted"
+  | "keyed-rows-complete-structural-append-hinted"
   | "keyed-rows-complete-prepend-hinted"
   | "keyed-rows-complete-filter-prepend-hinted"
   | "keyed-ranges"
@@ -439,6 +443,7 @@ const COMPILER_RUNTIME_FEATURE_EXPORTS: Record<CompilerRuntimeFeatureName, strin
   "keyed-rows-batch-every-hinted": "keyedRowsBatchEveryHintedRuntimeFeature",
   "keyed-rows-window-every-hinted": "keyedRowsWindowEveryHintedRuntimeFeature",
   "keyed-rows-filter-hinted": "keyedRowsFilterHintedRuntimeFeature",
+  "keyed-rows-structural-append-hinted": "keyedRowsStructuralAppendHintedRuntimeFeature",
   "keyed-rows-prepend-hinted": "keyedRowsPrependHintedRuntimeFeature",
   "keyed-rows-filter-prepend-hinted": "keyedRowsFilterPrependHintedRuntimeFeature",
   "keyed-rows-conditional": "keyedRowsConditionalRuntimeFeature",
@@ -455,6 +460,8 @@ const COMPILER_RUNTIME_FEATURE_EXPORTS: Record<CompilerRuntimeFeatureName, strin
   "keyed-rows-conditional-window-every-hinted":
     "keyedRowsConditionalWindowEveryHintedRuntimeFeature",
   "keyed-rows-conditional-filter-hinted": "keyedRowsConditionalFilterHintedRuntimeFeature",
+  "keyed-rows-conditional-structural-append-hinted":
+    "keyedRowsConditionalStructuralAppendHintedRuntimeFeature",
   "keyed-rows-conditional-prepend-hinted": "keyedRowsConditionalPrependHintedRuntimeFeature",
   "keyed-rows-conditional-filter-prepend-hinted":
     "keyedRowsConditionalFilterPrependHintedRuntimeFeature",
@@ -469,6 +476,7 @@ const COMPILER_RUNTIME_FEATURE_EXPORTS: Record<CompilerRuntimeFeatureName, strin
   "keyed-rows-host-batch-every-hinted": "keyedRowsHostBatchEveryHintedRuntimeFeature",
   "keyed-rows-host-window-every-hinted": "keyedRowsHostWindowEveryHintedRuntimeFeature",
   "keyed-rows-host-filter-hinted": "keyedRowsHostFilterHintedRuntimeFeature",
+  "keyed-rows-host-structural-append-hinted": "keyedRowsHostStructuralAppendHintedRuntimeFeature",
   "keyed-rows-host-prepend-hinted": "keyedRowsHostPrependHintedRuntimeFeature",
   "keyed-rows-host-filter-prepend-hinted": "keyedRowsHostFilterPrependHintedRuntimeFeature",
   "keyed-rows-complete": "keyedRowsCompleteRuntimeFeature",
@@ -483,6 +491,8 @@ const COMPILER_RUNTIME_FEATURE_EXPORTS: Record<CompilerRuntimeFeatureName, strin
   "keyed-rows-complete-batch-every-hinted": "keyedRowsCompleteBatchEveryHintedRuntimeFeature",
   "keyed-rows-complete-window-every-hinted": "keyedRowsCompleteWindowEveryHintedRuntimeFeature",
   "keyed-rows-complete-filter-hinted": "keyedRowsCompleteFilterHintedRuntimeFeature",
+  "keyed-rows-complete-structural-append-hinted":
+    "keyedRowsCompleteStructuralAppendHintedRuntimeFeature",
   "keyed-rows-complete-prepend-hinted": "keyedRowsCompletePrependHintedRuntimeFeature",
   "keyed-rows-complete-filter-prepend-hinted": "keyedRowsCompleteFilterPrependHintedRuntimeFeature",
   "keyed-ranges": "keyedRangesRuntimeFeature",
@@ -494,6 +504,7 @@ function runtimeFeaturesForPlans(
   plans: readonly ComposableBlockPlan[],
   keyedMapUpdateHints: boolean,
   keyedArrayFilterHints: boolean,
+  keyedArrayStructuralAppendHints: boolean,
   keyedArrayPrependHints: boolean,
   keyedArrayPositionHints: boolean,
   keyedArrayBatchInsertHints: boolean,
@@ -526,34 +537,36 @@ function runtimeFeaturesForPlans(
             : "keyed-rows";
     const arrayRangeHints =
       keyedArrayRollingWindowHints || keyedArrayFilterHints || keyedArrayPrependHints;
-    const hintSuffix = keyedArrayWindowReplaceHints
-      ? arrayRangeHints || keyedArrayReorderHints
-        ? "-window-every-hinted"
-        : "-window-position-hinted"
-      : keyedArrayBatchInsertHints
+    const hintSuffix = keyedArrayStructuralAppendHints
+      ? "-structural-append-hinted"
+      : keyedArrayWindowReplaceHints
         ? arrayRangeHints || keyedArrayReorderHints
-          ? "-batch-every-hinted"
-          : "-batch-position-hinted"
-        : (keyedArrayPositionHints && (arrayRangeHints || keyedArrayReorderHints)) ||
-            (keyedArrayReorderHints && arrayRangeHints)
-          ? "-every-hinted"
-          : keyedArrayRollingWindowHints
-            ? "-all-hinted"
-            : keyedArrayPositionHints
-              ? "-position-hinted"
-              : keyedArrayMapReorderHints && keyedRowsFeature === "keyed-rows"
-                ? "-map-reorder-hinted"
-                : keyedArrayReorderHints
-                  ? "-reorder-hinted"
-                  : keyedArrayFilterHints && keyedArrayPrependHints
-                    ? "-filter-prepend-hinted"
-                    : keyedArrayFilterHints
-                      ? "-filter-hinted"
-                      : keyedArrayPrependHints
-                        ? "-prepend-hinted"
-                        : keyedMapUpdateHints
-                          ? "-hinted"
-                          : "";
+          ? "-window-every-hinted"
+          : "-window-position-hinted"
+        : keyedArrayBatchInsertHints
+          ? arrayRangeHints || keyedArrayReorderHints
+            ? "-batch-every-hinted"
+            : "-batch-position-hinted"
+          : (keyedArrayPositionHints && (arrayRangeHints || keyedArrayReorderHints)) ||
+              (keyedArrayReorderHints && arrayRangeHints)
+            ? "-every-hinted"
+            : keyedArrayRollingWindowHints
+              ? "-all-hinted"
+              : keyedArrayPositionHints
+                ? "-position-hinted"
+                : keyedArrayMapReorderHints && keyedRowsFeature === "keyed-rows"
+                  ? "-map-reorder-hinted"
+                  : keyedArrayReorderHints
+                    ? "-reorder-hinted"
+                    : keyedArrayFilterHints && keyedArrayPrependHints
+                      ? "-filter-prepend-hinted"
+                      : keyedArrayFilterHints
+                        ? "-filter-hinted"
+                        : keyedArrayPrependHints
+                          ? "-prepend-hinted"
+                          : keyedMapUpdateHints
+                            ? "-hinted"
+                            : "";
     features.add(`${keyedRowsFeature}${hintSuffix}` as CompilerRuntimeFeatureName);
   }
   return [...features].sort();
@@ -9041,6 +9054,8 @@ function compileCandidate(
     blockPlans,
     hasKeyedUpdateHints,
     hasKeyedArrayRemovalHints,
+    appliedKeyedArrayAppendHints > 0 &&
+      (appliedKeyedArrayFilterHints > 0 || appliedKeyedArraySliceHints > 0),
     appliedKeyedArrayPrependHints > 0,
     appliedKeyedArrayPositionHints > 0,
     appliedKeyedArrayBatchInsertHints > 0,
@@ -9429,6 +9444,10 @@ export async function compileReactModule(
           compilerUsage.keyedArrayMapUpdateHints > compilerUsage.keyedArrayQueuedMapUpdateHints;
         const hasKeyedArrayMapReorderHints =
           compilerUsage.keyedArrayMapReorderHints + compilerUsage.keyedArrayMapSortHints > 0;
+        const hasKeyedArrayStructuralAppendHints =
+          optimizationCounts.keyedArrayAppendHints > 0 &&
+          (optimizationCounts.keyedArrayFilterHints > 0 ||
+            optimizationCounts.keyedArraySliceHints > 0);
         if (compiled.length > 0) {
           programPath.unshiftContainer(
             "body",
@@ -9482,7 +9501,11 @@ export async function compileReactModule(
                   ? [
                       t.importSpecifier(
                         keyedArrayAppendIdentifier,
-                        t.identifier("createCompilerKeyedArrayAppend"),
+                        t.identifier(
+                          hasKeyedArrayStructuralAppendHints
+                            ? "createCompilerKeyedArrayStructuralAppend"
+                            : "createCompilerKeyedArrayAppend",
+                        ),
                       ),
                     ]
                   : []),

--- a/packages/farm-react/vitest.stress.config.ts
+++ b/packages/farm-react/vitest.stress.config.ts
@@ -18,10 +18,11 @@ export default defineConfig({
       "src/__tests__/compiler-runtime-keyed-array-sort-hints.test.tsx",
       "src/__tests__/compiler-runtime-keyed-array-map-reorder-hints.test.tsx",
       "src/__tests__/compiler-runtime-keyed-array-structural-reorder-hints.test.tsx",
+      "src/__tests__/compiler-runtime-keyed-array-append-hints.test.tsx",
     ],
     setupFiles: ["src/__tests__/stress.setup.ts"],
     testNamePattern:
-      /2,000 deterministic mapped reorder updates|2,000 deterministic mapped reversal parity updates|2,000 queued reverse, map, and reverse updates|2,000 reverse-or-sort then map updates|2,000 queued reorder then standalone map updates|2,000 queued map then reorder updates|2,000 queued map and consecutive reorder updates|2,000 mapped structural removals|2,000 randomized interleaved map and structural removals|2,000 randomized terminal structural-map row transitions|2,000 randomized mapped terminal-structural row transitions|2,000 randomized queued mapped structural transitions|2,000 randomized queued structural mapped transitions|2,000 randomized queued structural mapped reorders|3,000 deterministic recursive updates|4,096 rows/,
+      /2,000 deterministic mapped reorder updates|2,000 deterministic mapped reversal parity updates|2,000 queued reverse, map, and reverse updates|2,000 reverse-or-sort then map updates|2,000 queued reorder then standalone map updates|2,000 queued map then reorder updates|2,000 queued map and consecutive reorder updates|2,000 mapped structural removals|2,000 randomized interleaved map and structural removals|2,000 randomized terminal structural-map row transitions|2,000 randomized mapped terminal-structural row transitions|2,000 randomized queued mapped structural transitions|2,000 randomized queued structural mapped transitions|2,000 randomized queued structural mapped reorders|2,000 randomized queued structural removals and appends|3,000 deterministic recursive updates|4,096 rows/,
     testTimeout: 30_000,
   },
 });


### PR DESCRIPTION
## Problem

A compiled keyed list can already preserve row identity across a queued filter or bounded slice, and it can cheaply append new rows. When those operations happen together before React commits, however, the append step loses the structural lineage of the removal. The runtime falls back instead of proving that surviving rows can stay in place while only removed rows are detached and new suffix rows are created.

## Root cause

The append hint only related its result to the immediately preceding array token. It did not carry the committed filter or slice survivor mapping needed to validate the complete queued transition. Without that evidence, mutating the DOM would be unsafe because the runtime could not prove which committed rows survived.

## Change

- Add a compiler-selected structural append helper when a direct same-state append follows supported filter or bounded-slice lineage.
- Validate the committed token, survivor indexes, item and key identity, dependency state, DOM ownership, descriptors, bindings, and appended suffix before any DOM mutation.
- Preserve surviving DOM nodes and selection, clean up removed row scopes, and create only the appended suffix.
- Collapse multiple later supported append steps into the same validated transition.
- Keep the ordinary append helper unchanged for append-only modules.
- Add deterministic, randomized, compatibility, runtime-size, and production-browser benchmark coverage.

## Safety and compatibility

Unsupported or ambiguous cases use the complete React fallback, including custom or sparse collections, subclassed arrays, proxies, mapped structures, collection-reading bindings, reused committed keys, unsupported ownership, and failed runtime validation. The optimization is React-specific and remains behind the existing experimental compiler option. It introduces no new public configuration or syntax. React 18 and React 19 compatibility coverage passes. The optional runtime is emitted only when both structural and append hints are present; existing runtime-size fixtures are unchanged when rebuilt in the same environment.

## Verification

- `pnpm --filter @farm.js/react type-check`
- Focused compiler/runtime suites: 78 passing tests
- Stress matrix: 18 passing tests; final randomized structural append oracle: 1 passing, 100 skipped by focus
- `pnpm --filter @farm.js/react test:compat` with React 18.3.1 and 19.2.8
- `pnpm --filter @farm.js/react test:runtime-size`
- Dashboard type-check and production build
- `pnpm docs:check-navigation`
- `pnpm docs:build` using the Vercel production preset
- Focused `oxlint` and `git diff --check`

The reduced production-browser benchmark kept all 9,999 survivor nodes by identity, disconnected the removed node, created one appended row, produced the exact 10,000-row result, and recorded zero compiled owner reruns. Static mode measured 21.0 ms versus 73.2 ms for normal React (3.49x); hybrid mode measured 20.8 ms (3.52x). Both also cleared the 1.25x compiled-fallback control. The general performance and optimization-persistence gates passed. Several older near-threshold scenario gates were noisy in the intentionally reduced five-sample run; their code and thresholds are unchanged.

The full non-stress package run reported 773 passes, 10 skips, and two existing 20-second parallel timeouts. Both timed-out files passed when rerun alone (35 passes, 1 skip). `farm generate --check` still reports the pre-existing stale docs content declarations reproduced on the clean parent; this PR does not change those generated routes.

## Documentation and release

Updated the React renderer guide, package README, dashboard example and benchmark report, plus the checked-in runtime-size report. No version or release-flow changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves row identity across adjacent filter or slice and append setters in compiled keyed lists, avoiding full reconciliation when both happen before commit.

**What changed**
- Compiler now selects a structural append helper when a direct append follows a supported filter or slice lineage.
- Runtime validates the full chain before touching the DOM, then removes only rejected rows and creates only the appended suffix.
- Multiple later append setters are collapsed into the same validated transition.

**Safety**
- Unsupported or ambiguous cases still use the standard React reconciliation path.
- Optimization is React-specific and behind the existing experimental compiler option; no API or configuration changes.

<sup>Written for commit 7abaeccc0c0ad06f391ebce94d096386cfd70761. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/883?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

