### PR TITLE
perf(react): retain sliced append lineage through maps

### DIFF
--- a/docs/src/app/docs/renderers/react/page.md
+++ b/docs/src/app/docs/renderers/react/page.md
@@ -974,6 +974,12 @@ setItems((current) => [...current, incoming]);
 
 setItems((current) => current.slice(start, end));
 setItems((current) => [...current, ...incoming]);
+
+setItems((current) => current.slice(start, end));
+setItems((current) => [...current, incoming]);
+setItems((current) =>
+  current.map((item) => (item.id === targetId ? { ...item, label: nextLabel } : item)),
+);
 ```
 
 The setters still execute in order and still create their normal native arrays. Before changing the
@@ -984,12 +990,22 @@ suffix in one fragment. Existing survivors are neither rebound nor recreated, an
 adjacent append setters are collapsed into the same final suffix. This keeps the unavoidable native
 filter or slice work while removing the keyed runtime's second full scan.
 
+After a bounded slice, one or more immediately following safe same-key `map()` setters can retain
+that proof too. Farm records changed indices while the native maps already visit them, validates the
+final dense array before touching the DOM, and patches only changed survivors. A mapped incoming
+suffix is still created directly from its final value. The owner stays mounted, sliced-away rows
+are removed, survivor DOM identity is preserved, and the suffix is appended once. Filter-based
+chains keep complete reconciliation because Farm must revalidate every survivor key after indexes
+shift; this avoids trading React identity semantics for a misleading fast path.
+
 Only concise updater results that form one direct chain for the same state array are linked. The row
-and key must be compiler-owned and index-independent. A map or reorder between the structural step
-and append, an unhinted update to that state, another dirty row dependency, collection-reading
-binding, custom, sparse, or subclassed array, nested or React-owned row, duplicate final key, or
-reuse of any committed key in the appended suffix keeps complete React reconciliation before a DOM
-write. No API or configuration is added. Compiler reports use the existing
+and key must be compiler-owned and index-independent. A filter before append, a map or reorder
+between the structural step and append, an unsupported or non-adjacent map after append, an
+unhinted update to that state, another dirty row dependency, collection-reading binding, custom,
+sparse, or subclassed array, nested or React-owned row, duplicate final key, or reuse of any
+committed key in the appended suffix keeps complete React reconciliation before a DOM write. A
+mapped survivor whose key changes also falls back before mutation. No API or configuration is
+added. Compiler reports use the existing
 `keyedArrayFilterHints`, `keyedArraySliceHints`, and `keyedArrayAppendHints` counts, and modules
 without both accepted operations omit the composed runtime.
 
@@ -2321,10 +2337,12 @@ The package and example test suites verify more than generated code:
 - 2,000 deterministic keyed-array appends match normal React; targeted tests require key,
   descriptor, and binding reads to equal only the appended suffix and cover queued updates,
   multi-boundary sharing, StrictMode hydration/unmount, and conservative fallback;
-- 2,000 randomized queued filter-or-slice then append transitions match normal React; targeted
-  tests require survivor DOM identity, suffix-only descriptor and binding reads, controlled-input
-  focus and selection, multi-boundary sharing, Strict Mode hydration, nested unmount cleanup,
-  removed-key reuse fallback, and atomic validation before mutation;
+- 2,000 randomized queued filter-or-slice, append, and map transitions match normal React, with
+  bounded slices taking the composed fast path and filters retaining complete reconciliation;
+  targeted slice tests require survivor DOM identity, changed-survivor-only binding writes,
+  controlled-input focus and selection, multiple maps, multi-boundary sharing, Strict Mode
+  hydration, nested unmount cleanup, changed-key and removed-key reuse fallback, and atomic
+  validation before mutation;
 - 2,000 deterministic keyed-array prepends match normal React; targeted tests require key,
   descriptor, and binding reads to equal only the inserted prefix, preserve every existing DOM
   row, update delegated event indexes, and cover queued updates, StrictMode hydration, unmount,

--- a/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
+++ b/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
@@ -2,6 +2,40 @@
 
 Latest run: 2026-09-10
 
+## Queued slice, append, and maps — 2026-09-10
+
+Adjacent keyed-row setters can now retain one positional proof through a bounded `slice()`, one or
+more immutable appends, and one or more immediately following same-key `map()` updates. Previously,
+the map result lost the append lineage and the final commit used complete keyed reconciliation. The
+new path validates the native arrays and every mapped survivor before its first DOM write, removes
+only sliced-away rows, patches only changed survivors, and creates the mapped suffix from its final
+value.
+
+| Mode   | Slice + append + maps | Compiled fallback | vs React | vs fallback |
+| ------ | --------------------: | ----------------: | -------: | ----------: |
+| Static |              16.40 ms |          29.80 ms |    4.24x |       1.82x |
+| Hybrid |              13.60 ms |          22.60 ms |    5.11x |       1.66x |
+
+Both modes passed the 2x React and 1.25x compiled-control floors. The bracketed React median was
+69.55 ms. Every sample verified the final 10,000-row order, complete survivor DOM identity, the
+sliced row's disconnection, the changed survivor's final label and amount, and the final mapped
+suffix. The broad 10% no-regression gate, optimization-persistence gate, and zero-owner-execution
+checks also passed.
+
+Compiler and runtime coverage includes multiple following maps, a mapped incoming suffix,
+changed-key fallback, filters retaining complete reconciliation, controlled-input focus and
+selection, custom and revoked methods, external mutation, Strict Mode, hydration, unmount before
+flush, React 18.3.1 and 19.2.8, and 2,000 randomized transitions matched with normal React. The new
+optional runtime measures 18,408 bytes gzip in its isolated fixture. The older structural-append
+fixture grew by only 23 bytes gzip for the shared instance argument, and the core-only fixture is
+unchanged.
+
+Numbers are medians from a reduced complete-dashboard run with 2 warmups and 7 measured samples per
+compiler action, bracketed by 14 React samples, using Chrome 153.0.8010.36 and Node.js 23.11.0 on
+Apple M1 macOS arm64. Correctness and the new performance gate passed. One unchanged hybrid
+structural-reorder control measured 1.14x against its 1.25x fallback threshold, so the aggregate
+reduced-sample command reported that isolated timing miss rather than a full all-gates pass.
+
 ## Queued removal followed by append — 2026-09-10
 
 Adjacent keyed-row setters may now keep one committed-row proof when an index-independent

--- a/examples/react-compiler-dashboard/README.md
+++ b/examples/react-compiler-dashboard/README.md
@@ -84,6 +84,15 @@ Package tests also cover bounded slices, multiple later appends, 2,000 randomize
 controlled-input focus and selection, multi-boundary sharing, hydration, unmount cleanup, and
 pre-mutation fallback.
 
+A second structural-append comparison uses a bounded `slice()`, appends one row, and adds two
+immediately following safe same-key maps. It verifies that the changed survivor keeps its DOM node
+and receives its final label and amount, the sliced-away row disconnects, and the mapped incoming
+suffix is newly mounted. Both compiler modes must remain at least 2x faster than React and 1.25x
+faster than the equivalent block-bodied compiled control. Package tests compare 2,000 randomized
+filter-or-slice, append, and map transitions with normal React; bounded slices take the fast path
+while filters retain complete reconciliation. The suite also covers multiple maps, controlled-input
+selection, hydration, unmount, native method errors, changed keys, and pre-mutation fallback.
+
 Keyed array prepends have the same independent comparison. A concise functional prepend is
 measured against bracketed React and an equivalent block-bodied compiled snapshot control. Both
 compiler modes must remain at least 3x faster than React at 10,000 and 20,000 existing rows, and at
@@ -363,6 +372,10 @@ The default JSON report is `/tmp/farm-react-dashboard-benchmark.json`; change it
   adjacent setters. Its block-bodied pair performs the same native array and DOM-visible work
   through complete reconciliation; the hinted path reuses survivor positions and reads only the
   appended suffix.
+- The queued structural-append-map control follows that pair with a same-key native map. Its
+  block-bodied control reaches the same DOM through complete reconciliation; the hinted path
+  validates the final positional lineage once, patches only changed survivors, and mounts the final
+  incoming suffix without recreating unchanged rows.
 - The prepend snapshot control does the same work at the beginning of the array. It isolates the
   saved suffix scan while the hinted path still creates and inserts every required new DOM row.
 - The slice snapshot control retains the same 9,000-row suffix through an unsupported block-bodied

--- a/examples/react-compiler-dashboard/scripts/benchmark.mjs
+++ b/examples/react-compiler-dashboard/scripts/benchmark.mjs
@@ -1234,6 +1234,50 @@ async function measureTrial(browser, trial, compilerMode, port) {
             ),
         );
 
+        const measureStructuralAppendMap = async (action) => {
+          const rows = [...table.querySelectorAll("tbody tr")];
+          const removed = rows[0];
+          const target = rows.find(
+            (row) => Number(row.getAttribute("data-row-id")) % 10_000 === 5_001,
+          );
+          const amount = Number(target?.querySelector("td:nth-child(4)")?.textContent?.slice(1));
+          if (!removed || !target || !Number.isFinite(amount)) {
+            throw new Error("Queued structural-append-map source rows are invalid.");
+          }
+          const survivors = rows.slice(1);
+          await runTableAction(action, () => {
+            const nextRows = [...table.querySelectorAll("tbody tr")];
+            const appended = nextRows.at(-1);
+            return (
+              nextRows.length === 10_000 &&
+              rowsMatch(nextRows.slice(0, -1), survivors) &&
+              target.querySelector("td:nth-child(2)")?.textContent?.endsWith(" reviewed") ===
+                true &&
+              target.querySelector("td:nth-child(4)")?.textContent === `$${amount + 1}` &&
+              appended?.querySelector("td:nth-child(2)")?.textContent ===
+                "queued mapped incoming row" &&
+              !rows.includes(appended) &&
+              !removed.isConnected
+            );
+          });
+        };
+
+        const tableStructuralAppendMapQueued = await measureTable(
+          async () => create10000(),
+          async () =>
+            measureStructuralAppendMap(() =>
+              tableButton("table-structural-append-map-queued").click(),
+            ),
+        );
+
+        const tableStructuralAppendMapQueuedSnapshot = await measureTable(
+          async () => create10000(),
+          async () =>
+            measureStructuralAppendMap(() =>
+              tableButton("table-structural-append-map-queued-snapshot").click(),
+            ),
+        );
+
         const prepareMapStructuralReorderPipeline = async () => {
           await create10000();
           const rows = [...table.querySelectorAll("tbody tr")];
@@ -1993,6 +2037,8 @@ async function measureTrial(browser, trial, compilerMode, port) {
             filterReorderPipelineSnapshot: tableFilterReorderPipelineSnapshot,
             structuralAppendQueued: tableStructuralAppendQueued,
             structuralAppendQueuedSnapshot: tableStructuralAppendQueuedSnapshot,
+            structuralAppendMapQueued: tableStructuralAppendMapQueued,
+            structuralAppendMapQueuedSnapshot: tableStructuralAppendMapQueuedSnapshot,
             mapStructuralReorderPipeline: tableMapStructuralReorderPipeline,
             mapStructuralReorderPipelineSnapshot: tableMapStructuralReorderPipelineSnapshot,
             mapReorderPipeline: tableMapReorderPipeline,
@@ -2139,6 +2185,10 @@ async function measureTrial(browser, trial, compilerMode, port) {
         filterReorderPipelineSnapshot: timingSummary(result.table.filterReorderPipelineSnapshot),
         structuralAppendQueued: timingSummary(result.table.structuralAppendQueued),
         structuralAppendQueuedSnapshot: timingSummary(result.table.structuralAppendQueuedSnapshot),
+        structuralAppendMapQueued: timingSummary(result.table.structuralAppendMapQueued),
+        structuralAppendMapQueuedSnapshot: timingSummary(
+          result.table.structuralAppendMapQueuedSnapshot,
+        ),
         mapStructuralReorderPipeline: timingSummary(result.table.mapStructuralReorderPipeline),
         mapStructuralReorderPipelineSnapshot: timingSummary(
           result.table.mapStructuralReorderPipelineSnapshot,
@@ -2356,6 +2406,8 @@ const tableMetrics = [
   "filterReorderPipelineSnapshot",
   "structuralAppendQueued",
   "structuralAppendQueuedSnapshot",
+  "structuralAppendMapQueued",
+  "structuralAppendMapQueuedSnapshot",
   "mapStructuralReorderPipeline",
   "mapStructuralReorderPipelineSnapshot",
   "mapReorderPipeline",
@@ -3037,6 +3089,29 @@ const keyedStructuralAppendRegressions = keyedStructuralAppendResults.filter(
     !Number.isFinite(snapshotSpeedup) ||
     snapshotSpeedup < keyedStructuralAppendMinimumSnapshotSpeedup,
 );
+// A following same-key map can keep a bounded slice's stable-key and suffix proof. The hinted path
+// should patch only changed survivors while retaining the structural append speedup over React and
+// the equivalent block-bodied compiled control.
+const keyedStructuralAppendMapMinimumSpeedup = 2;
+const keyedStructuralAppendMapMinimumSnapshotSpeedup = 1.25;
+const keyedStructuralAppendMapResults = ["static", "hybrid"].map((mode) => {
+  const pipelineMedianMs = comparisons.table.structuralAppendMapQueued[mode].medianMs;
+  const snapshotMedianMs = comparisons.table.structuralAppendMapQueuedSnapshot[mode].medianMs;
+  return {
+    mode,
+    pipelineMedianMs,
+    snapshotMedianMs,
+    snapshotSpeedup: snapshotMedianMs / pipelineMedianMs,
+    speedup: comparisons.table.structuralAppendMapQueued[`${mode}VsBaseline`].speedup,
+  };
+});
+const keyedStructuralAppendMapRegressions = keyedStructuralAppendMapResults.filter(
+  ({ snapshotSpeedup, speedup }) =>
+    !Number.isFinite(speedup) ||
+    speedup < keyedStructuralAppendMapMinimumSpeedup ||
+    !Number.isFinite(snapshotSpeedup) ||
+    snapshotSpeedup < keyedStructuralAppendMapMinimumSnapshotSpeedup,
+);
 // A safe filter, terminal map, and two native reverses in adjacent setters change membership and
 // row data while restoring the survivor order in one queued commit. The combined path must remove
 // the rejected row, patch the changed survivor, and retain structural lineage through both reorder
@@ -3453,6 +3528,7 @@ const passed =
   keyedReorderPipelineRegressions.length === 0 &&
   keyedStructuralReorderRegressions.length === 0 &&
   keyedStructuralAppendRegressions.length === 0 &&
+  keyedStructuralAppendMapRegressions.length === 0 &&
   keyedMappedStructuralReorderRegressions.length === 0 &&
   keyedMapReorderRegressions.length === 0 &&
   keyedMultiMapReorderRegressions.length === 0 &&
@@ -3635,6 +3711,13 @@ const report = {
     regressions: keyedStructuralAppendRegressions,
     results: keyedStructuralAppendResults,
     status: keyedStructuralAppendRegressions.length === 0 ? "PASS" : "FAIL",
+  },
+  keyedStructuralAppendMapHintGate: {
+    minimumSnapshotSpeedup: keyedStructuralAppendMapMinimumSnapshotSpeedup,
+    minimumSpeedup: keyedStructuralAppendMapMinimumSpeedup,
+    regressions: keyedStructuralAppendMapRegressions,
+    results: keyedStructuralAppendMapResults,
+    status: keyedStructuralAppendMapRegressions.length === 0 ? "PASS" : "FAIL",
   },
   keyedMappedStructuralReorderHintGate: {
     minimumSnapshotSpeedup: keyedMappedStructuralReorderMinimumSnapshotSpeedup,

--- a/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
+++ b/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
@@ -913,6 +913,72 @@ export function StandardTableBenchmark() {
           Queued remove + append (snapshot control)
         </button>
         <button
+          data-action="table-structural-append-map-queued"
+          type="button"
+          onClick={() => {
+            const incoming = {
+              id: (seed + 1_100_000) * 10_000 + 1,
+              label: "queued incoming row",
+              amount: 4_096,
+              region: "AMR" as const,
+              status: "review" as const,
+            };
+            setRows((current) => current.slice(1));
+            setRows((current) => [...current, incoming]);
+            setRows((current) =>
+              current.map((row) =>
+                row.id % 10_000 === 5_001
+                  ? { ...row, amount: row.amount + 1, label: `${row.label} reviewed` }
+                  : row,
+              ),
+            );
+            setRows((current) =>
+              current.map((row) =>
+                row.id === incoming.id ? { ...row, label: "queued mapped incoming row" } : row,
+              ),
+            );
+            setOperation("remove, append, and map across queued setters");
+            setRevision((value) => value + 1);
+          }}
+        >
+          Queued remove + append + map
+        </button>
+        <button
+          data-action="table-structural-append-map-queued-snapshot"
+          type="button"
+          onClick={() => {
+            const incoming = {
+              id: (seed + 1_100_000) * 10_000 + 1,
+              label: "queued incoming row",
+              amount: 4_096,
+              region: "AMR" as const,
+              status: "review" as const,
+            };
+            setRows((current) => {
+              return current.slice(1);
+            });
+            setRows((current) => {
+              return [...current, incoming];
+            });
+            setRows((current) => {
+              return current.map((row) =>
+                row.id % 10_000 === 5_001
+                  ? { ...row, amount: row.amount + 1, label: `${row.label} reviewed` }
+                  : row,
+              );
+            });
+            setRows((current) => {
+              return current.map((row) =>
+                row.id === incoming.id ? { ...row, label: "queued mapped incoming row" } : row,
+              );
+            });
+            setOperation("remove, append, and map (snapshot control)");
+            setRevision((value) => value + 1);
+          }}
+        >
+          Queued remove + append + map (snapshot control)
+        </button>
+        <button
           data-action="table-map-structural-reorder-pipeline"
           type="button"
           onClick={() => {

--- a/packages/farm-react/README.md
+++ b/packages/farm-react/README.md
@@ -266,6 +266,12 @@ setItems((current) => [...current, incoming]);
 
 setItems((current) => current.slice(start, end));
 setItems((current) => [...current, ...incoming]);
+
+setItems((current) => current.slice(start, end));
+setItems((current) => [...current, incoming]);
+setItems((current) =>
+  current.map((item) => (item.id === targetId ? { ...item, label: nextLabel } : item)),
+);
 ```
 
 The setters still execute in order and still create their normal native arrays. Before changing the
@@ -276,12 +282,22 @@ suffix in one fragment. Existing survivors are neither rebound nor recreated, an
 adjacent append setters are collapsed into the same final suffix. This keeps the unavoidable native
 filter or slice work while removing the keyed runtime's second full scan.
 
+After a bounded slice, one or more immediately following safe same-key `map()` setters can retain
+that proof too. Farm records changed indices while the native maps already visit them, validates the
+final dense array before touching the DOM, and patches only changed survivors. A mapped incoming
+suffix is still created directly from its final value. The owner stays mounted, sliced-away rows
+are removed, survivor DOM identity is preserved, and the suffix is appended once. Filter-based
+chains keep complete reconciliation because Farm must revalidate every survivor key after indexes
+shift; this avoids trading React identity semantics for a misleading fast path.
+
 Only concise updater results that form one direct chain for the same state array are linked. The row
-and key must be compiler-owned and index-independent. A map or reorder between the structural step
-and append, an unhinted update to that state, another dirty row dependency, collection-reading
-binding, custom, sparse, or subclassed array, nested or React-owned row, duplicate final key, or
-reuse of any committed key in the appended suffix keeps complete React reconciliation before a DOM
-write. No API or configuration is added. Compiler reports use the existing
+and key must be compiler-owned and index-independent. A filter before append, a map or reorder
+between the structural step and append, an unsupported or non-adjacent map after append, an
+unhinted update to that state, another dirty row dependency, collection-reading binding, custom,
+sparse, or subclassed array, nested or React-owned row, duplicate final key, or reuse of any
+committed key in the appended suffix keeps complete React reconciliation before a DOM write. A
+mapped survivor whose key changes also falls back before mutation. No API or configuration is
+added. Compiler reports use the existing
 `keyedArrayFilterHints`, `keyedArraySliceHints`, and `keyedArrayAppendHints` counts, and modules
 without both accepted operations omit the composed runtime.
 

--- a/packages/farm-react/RUNTIME_SIZE_RESULTS.json
+++ b/packages/farm-react/RUNTIME_SIZE_RESULTS.json
@@ -26,14 +26,14 @@
         "brotli": 51897
       },
       "compilerOn": {
-        "raw": 232739,
-        "gzip": 71431,
-        "brotli": 61193
+        "raw": 232773,
+        "gzip": 71443,
+        "brotli": 61209
       },
       "compilerPremium": {
-        "raw": 39620,
-        "gzip": 11252,
-        "brotli": 9296
+        "raw": 39654,
+        "gzip": 11264,
+        "brotli": 9312
       }
     },
     "keyedAppend": {
@@ -43,14 +43,14 @@
         "brotli": 51772
       },
       "compilerOn": {
-        "raw": 234064,
-        "gzip": 71748,
-        "brotli": 61436
+        "raw": 234098,
+        "gzip": 71761,
+        "brotli": 61505
       },
       "compilerPremium": {
-        "raw": 41163,
-        "gzip": 11663,
-        "brotli": 9664
+        "raw": 41197,
+        "gzip": 11676,
+        "brotli": 9733
       }
     },
     "keyedFilter": {
@@ -60,14 +60,14 @@
         "brotli": 51833
       },
       "compilerOn": {
-        "raw": 236259,
-        "gzip": 72398,
-        "brotli": 62073
+        "raw": 236293,
+        "gzip": 72410,
+        "brotli": 62154
       },
       "compilerPremium": {
-        "raw": 43379,
-        "gzip": 12310,
-        "brotli": 10240
+        "raw": 43413,
+        "gzip": 12322,
+        "brotli": 10321
       }
     },
     "keyedStructuralAppend": {
@@ -77,14 +77,31 @@
         "brotli": 51823
       },
       "compilerOn": {
-        "raw": 257231,
-        "gzip": 77376,
-        "brotli": 66262
+        "raw": 257275,
+        "gzip": 77399,
+        "brotli": 66315
       },
       "compilerPremium": {
-        "raw": 64304,
-        "gzip": 17262,
-        "brotli": 14439
+        "raw": 64348,
+        "gzip": 17285,
+        "brotli": 14492
+      }
+    },
+    "keyedStructuralAppendMap": {
+      "compilerOff": {
+        "raw": 192981,
+        "gzip": 60138,
+        "brotli": 51844
+      },
+      "compilerOn": {
+        "raw": 261669,
+        "gzip": 78546,
+        "brotli": 67291
+      },
+      "compilerPremium": {
+        "raw": 68688,
+        "gzip": 18408,
+        "brotli": 15447
       }
     },
     "keyedPrepend": {
@@ -94,14 +111,14 @@
         "brotli": 51826
       },
       "compilerOn": {
-        "raw": 235541,
-        "gzip": 72102,
-        "brotli": 61727
+        "raw": 235575,
+        "gzip": 72111,
+        "brotli": 61832
       },
       "compilerPremium": {
-        "raw": 42639,
-        "gzip": 12015,
-        "brotli": 9901
+        "raw": 42673,
+        "gzip": 12024,
+        "brotli": 10006
       }
     },
     "keyedPosition": {
@@ -111,14 +128,14 @@
         "brotli": 51741
       },
       "compilerOn": {
-        "raw": 236346,
-        "gzip": 72371,
-        "brotli": 62002
+        "raw": 236380,
+        "gzip": 72384,
+        "brotli": 62017
       },
       "compilerPremium": {
-        "raw": 43448,
-        "gzip": 12295,
-        "brotli": 10261
+        "raw": 43482,
+        "gzip": 12308,
+        "brotli": 10276
       }
     },
     "keyedBatchPosition": {
@@ -128,14 +145,14 @@
         "brotli": 51753
       },
       "compilerOn": {
-        "raw": 237571,
-        "gzip": 72551,
-        "brotli": 62177
+        "raw": 237605,
+        "gzip": 72563,
+        "brotli": 62186
       },
       "compilerPremium": {
-        "raw": 44654,
-        "gzip": 12460,
-        "brotli": 10424
+        "raw": 44688,
+        "gzip": 12472,
+        "brotli": 10433
       }
     },
     "keyedWindowPosition": {
@@ -145,14 +162,14 @@
         "brotli": 51793
       },
       "compilerOn": {
-        "raw": 243290,
-        "gzip": 74309,
-        "brotli": 63734
+        "raw": 243324,
+        "gzip": 74322,
+        "brotli": 63825
       },
       "compilerPremium": {
-        "raw": 50299,
-        "gzip": 14185,
-        "brotli": 11941
+        "raw": 50333,
+        "gzip": 14198,
+        "brotli": 12032
       }
     },
     "keyedReorder": {
@@ -162,14 +179,14 @@
         "brotli": 51795
       },
       "compilerOn": {
-        "raw": 235587,
-        "gzip": 72166,
-        "brotli": 61850
+        "raw": 235621,
+        "gzip": 72178,
+        "brotli": 61889
       },
       "compilerPremium": {
-        "raw": 42740,
-        "gzip": 12108,
-        "brotli": 10055
+        "raw": 42774,
+        "gzip": 12120,
+        "brotli": 10094
       }
     },
     "keyedMapReorder": {
@@ -179,14 +196,14 @@
         "brotli": 51734
       },
       "compilerOn": {
-        "raw": 240271,
-        "gzip": 73454,
-        "brotli": 62956
+        "raw": 240305,
+        "gzip": 73464,
+        "brotli": 62944
       },
       "compilerPremium": {
-        "raw": 47343,
-        "gzip": 13344,
-        "brotli": 11222
+        "raw": 47377,
+        "gzip": 13354,
+        "brotli": 11210
       }
     },
     "keyedSort": {
@@ -196,14 +213,14 @@
         "brotli": 51829
       },
       "compilerOn": {
-        "raw": 235668,
-        "gzip": 72206,
-        "brotli": 62009
+        "raw": 235702,
+        "gzip": 72220,
+        "brotli": 61942
       },
       "compilerPremium": {
-        "raw": 42792,
-        "gzip": 12129,
-        "brotli": 10180
+        "raw": 42826,
+        "gzip": 12143,
+        "brotli": 10113
       }
     },
     "keyedSlice": {
@@ -213,14 +230,14 @@
         "brotli": 51855
       },
       "compilerOn": {
-        "raw": 236311,
-        "gzip": 72435,
-        "brotli": 62151
+        "raw": 236345,
+        "gzip": 72447,
+        "brotli": 62170
       },
       "compilerPremium": {
-        "raw": 43440,
-        "gzip": 12360,
-        "brotli": 10296
+        "raw": 43474,
+        "gzip": 12372,
+        "brotli": 10315
       }
     },
     "keyedRollingWindow": {
@@ -230,14 +247,14 @@
         "brotli": 51859
       },
       "compilerOn": {
-        "raw": 240367,
-        "gzip": 73344,
-        "brotli": 62831
+        "raw": 240401,
+        "gzip": 73355,
+        "brotli": 62805
       },
       "compilerPremium": {
-        "raw": 47438,
-        "gzip": 13236,
-        "brotli": 10972
+        "raw": 47472,
+        "gzip": 13247,
+        "brotli": 10946
       }
     },
     "isolatedRuntime": {
@@ -247,16 +264,16 @@
         "brotli": 51666
       },
       "full": {
-        "raw": 291278,
-        "gzip": 82739,
-        "brotli": 70496
+        "raw": 291312,
+        "gzip": 82753,
+        "brotli": 70614
       },
       "coreOnly": {
         "raw": 204922,
         "gzip": 63685,
         "brotli": 54902
       },
-      "fullRuntimePremiumGzip": 22820,
+      "fullRuntimePremiumGzip": 22834,
       "coreRuntimePremiumGzip": 3766,
       "gzipReductionPercent": 83.5
     }

--- a/packages/farm-react/fixtures/runtime-size/keyed-structural-append-map.tsx
+++ b/packages/farm-react/fixtures/runtime-size/keyed-structural-append-map.tsx
@@ -1,0 +1,37 @@
+import React, { useState } from "react";
+import { createRoot } from "react-dom/client";
+
+interface Row {
+  id: number;
+  label: string;
+}
+
+export function StructuralAppendMapTable() {
+  const [rows, setRows] = useState<Row[]>(
+    Array.from({ length: 1_000 }, (_, id) => ({ id, label: `Row ${id}` })),
+  );
+  return (
+    <main>
+      <button
+        onClick={() => {
+          setRows((current) => current.slice(1));
+          setRows((current) => [...current, { id: 1_001, label: "Appended row" }]);
+          setRows((current) =>
+            current.map((row) => (row.id === 750 ? { ...row, label: "Updated row" } : row)),
+          );
+        }}
+      >
+        Replace and update
+      </button>
+      <ul>
+        {rows.map((row) => (
+          <li data-id={row.id} key={row.id}>
+            {row.label}
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}
+
+createRoot(document.body).render(<StructuralAppendMapTable />);

--- a/packages/farm-react/scripts/benchmark-runtime-size.mjs
+++ b/packages/farm-react/scripts/benchmark-runtime-size.mjs
@@ -59,6 +59,8 @@ const [
   keyedFilterOn,
   keyedStructuralAppendOff,
   keyedStructuralAppendOn,
+  keyedStructuralAppendMapOff,
+  keyedStructuralAppendMapOn,
   keyedPrependOff,
   keyedPrependOn,
   keyedPositionOff,
@@ -91,6 +93,8 @@ const [
   bundle("keyed-filter.tsx", true),
   bundle("keyed-structural-append.tsx", false),
   bundle("keyed-structural-append.tsx", true),
+  bundle("keyed-structural-append-map.tsx", false),
+  bundle("keyed-structural-append-map.tsx", true),
   bundle("keyed-prepend.tsx", false),
   bundle("keyed-prepend.tsx", true),
   bundle("keyed-position.tsx", false),
@@ -170,6 +174,14 @@ if (
   !keyedStructuralAppendOn.code.includes("filterIndexIndependent")
 ) {
   throw new Error("Keyed structural-append fixture did not retain its isolated composed runtime.");
+}
+if (
+  !keyedStructuralAppendMapOn.code.includes("FarmCompiledKeyedRows") ||
+  !keyedStructuralAppendMapOn.code.includes("keyed-rows:structural-append-map-hinted")
+) {
+  throw new Error(
+    `Keyed structural-append-map fixture did not retain its optional runtime: rows=${keyedStructuralAppendMapOn.code.includes("FarmCompiledKeyedRows")}, feature=${keyedStructuralAppendMapOn.code.includes("keyed-rows:structural-append-map-hinted")}.`,
+  );
 }
 if (
   !keyedPrependOn.code.includes("FarmCompiledKeyedRows") ||
@@ -375,6 +387,23 @@ const results = {
         brotli: keyedStructuralAppendOn.brotli - keyedStructuralAppendOff.brotli,
       },
     },
+    keyedStructuralAppendMap: {
+      compilerOff: {
+        raw: keyedStructuralAppendMapOff.raw,
+        gzip: keyedStructuralAppendMapOff.gzip,
+        brotli: keyedStructuralAppendMapOff.brotli,
+      },
+      compilerOn: {
+        raw: keyedStructuralAppendMapOn.raw,
+        gzip: keyedStructuralAppendMapOn.gzip,
+        brotli: keyedStructuralAppendMapOn.brotli,
+      },
+      compilerPremium: {
+        raw: keyedStructuralAppendMapOn.raw - keyedStructuralAppendMapOff.raw,
+        gzip: keyedStructuralAppendMapOn.gzip - keyedStructuralAppendMapOff.gzip,
+        brotli: keyedStructuralAppendMapOn.brotli - keyedStructuralAppendMapOff.brotli,
+      },
+    },
     keyedPrepend: {
       compilerOff: {
         raw: keyedPrependOff.raw,
@@ -572,6 +601,13 @@ if (checkOnly) {
       maximum:
         (reference.fixtures.keyedStructuralAppend?.compilerPremium.gzip ??
           results.fixtures.keyedStructuralAppend.compilerPremium.gzip) + 256,
+    },
+    {
+      name: "keyed structural-append-map compiler premium",
+      current: results.fixtures.keyedStructuralAppendMap.compilerPremium.gzip,
+      maximum:
+        (reference.fixtures.keyedStructuralAppendMap?.compilerPremium.gzip ??
+          results.fixtures.keyedStructuralAppendMap.compilerPremium.gzip) + 256,
     },
     {
       name: "keyed prepend compiler premium",

--- a/packages/farm-react/scripts/test-react-version.mjs
+++ b/packages/farm-react/scripts/test-react-version.mjs
@@ -53,9 +53,10 @@ const testSource = String.raw`
     createCompilerKeyedArraySort,
     createCompilerKeyedArraySlice,
     createCompilerKeyedArrayStructuralAppend,
+    createCompilerKeyedArrayStructuralAppendMapPipeline,
     createCompilerKeyedArrayWindowReplace,
     createCompilerKeyedMapUpdate,
-    keyedRowsStructuralAppendHintedRuntimeFeature,
+    keyedRowsStructuralAppendMapHintedRuntimeFeature,
   } = await import(
     "@farm.js/react/compiler-runtime"
   );
@@ -2261,10 +2262,10 @@ const testSource = String.raw`
       const items = () => state[0].get();
       structuralAppendRows = () => {
         state[0].set((previous) =>
-          createCompilerKeyedArrayFilter(
+          createCompilerKeyedArraySlice(
             previous,
-            previous.filter,
-            (item) => item.id !== "b",
+            previous.slice,
+            1,
           ),
         );
         state[0].set((previous) =>
@@ -2272,6 +2273,15 @@ const testSource = String.raw`
             ...previous,
             { id: "d", label: "Delta" },
           ]),
+        );
+        state[0].set((previous) =>
+          createCompilerKeyedArrayStructuralAppendMapPipeline(
+            previous,
+            (current, applyMap) =>
+              applyMap(current, current.map, (item) =>
+                item.id === "c" ? { ...item, label: "Gamma edited" } : item,
+              ),
+          ),
         );
       };
       return React.createElement(
@@ -2305,24 +2315,24 @@ const testSource = String.raw`
       );
     },
     bindings: [{ kind: "block", id: 0, dependencies: [0] }],
-  }, [keyedRowsStructuralAppendHintedRuntimeFeature]);
+  }, [keyedRowsStructuralAppendMapHintedRuntimeFeature]);
   const structuralAppendContainer = document.createElement("div");
   document.body.append(structuralAppendContainer);
   const structuralAppendRoot = createRoot(structuralAppendContainer);
   flushSync(() => structuralAppendRoot.render(React.createElement(StructuralAppendRows)));
-  const structuralAlpha = structuralAppendContainer.querySelector("[data-key='a']");
-  const structuralGamma = structuralAppendContainer.querySelector("[data-key='c']");
   const structuralBeta = structuralAppendContainer.querySelector("[data-key='b']");
+  const structuralGamma = structuralAppendContainer.querySelector("[data-key='c']");
+  const structuralAlpha = structuralAppendContainer.querySelector("[data-key='a']");
   structuralAppendRows();
   await Promise.resolve();
   await Promise.resolve();
   assert.deepEqual(
     [...structuralAppendContainer.querySelectorAll("li")].map((row) => row.textContent),
-    ["Alpha", "Gamma", "Delta"],
+    ["Beta", "Gamma edited", "Delta"],
   );
-  assert.equal(structuralAppendContainer.querySelector("[data-key='a']"), structuralAlpha);
+  assert.equal(structuralAppendContainer.querySelector("[data-key='b']"), structuralBeta);
   assert.equal(structuralAppendContainer.querySelector("[data-key='c']"), structuralGamma);
-  assert.equal(structuralBeta.isConnected, false);
+  assert.equal(structuralAlpha.isConnected, false);
   assert.equal(structuralAppendExecutions, 1);
   flushSync(() => structuralAppendRoot.unmount());
 

--- a/packages/farm-react/src/__tests__/compiler-keyed-array-append-hints.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-keyed-array-append-hints.test.ts
@@ -138,6 +138,130 @@ describe("React AOT keyed-array append hints", () => {
     expect(result.code).toContain("keyedRowsStructuralAppendHintedRuntimeFeature");
   });
 
+  it("retains structural append lineage through following safe map setters", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Inventory({ expiredId, incoming, editedId, nextLabel }) {
+        const [rows, setRows] = useState([{ id: "a", label: "Alpha" }]);
+        return <main>
+          <button onClick={() => {
+            setRows((current) => current.slice(1));
+            setRows((current) => [...current, incoming]);
+            setRows((current) => current.map((row) =>
+              row.id === editedId ? { ...row, label: nextLabel } : row
+            ));
+            setRows((current) => current.map((row) =>
+              row.id === incoming.id ? { ...row, selected: true } : row
+            ));
+          }}>
+            Refresh rows
+          </button>
+          <ul>{rows.map((row) => <li key={row.id}>{row.label}</li>)}</ul>
+        </main>;
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Inventory"]);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.optimizations.keyedArraySliceHints).toBe(1);
+    expect(result.optimizations.keyedArrayAppendHints).toBe(1);
+    expect(result.optimizations.keyedMapUpdateHints).toBe(2);
+    expect(result.code).toContain("createCompilerKeyedArrayStructuralAppend");
+    expect(result.code).toContain("createCompilerKeyedArrayStructuralAppendMapPipeline");
+    expect(result.code).not.toContain("createCompilerKeyedArrayMapPipeline as");
+    expect(result.code).toContain("keyedRowsStructuralAppendMapHintedRuntimeFeature");
+    await expect(
+      transformWithEsbuild(result.code, "/app/KeyedArrayAppendHints.tsx", {
+        loader: "tsx",
+        jsx: "automatic",
+      }),
+    ).resolves.toMatchObject({
+      code: expect.stringContaining("createCompilerKeyedArrayStructuralAppendMapPipeline"),
+    });
+  });
+
+  it("does not link a map across an intervening statement after structural append", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Inventory({ expiredId, incoming, editedId, nextLabel }) {
+        const [rows, setRows] = useState([{ id: "a", label: "Alpha" }]);
+        return <main>
+          <button onClick={() => {
+            setRows((current) => current.slice(1));
+            setRows((current) => [...current, incoming]);
+            logRefresh();
+            setRows((current) => current.map((row) =>
+              row.id === editedId ? { ...row, label: nextLabel } : row
+            ));
+          }}>
+            Refresh rows
+          </button>
+          <ul>{rows.map((row) => <li key={row.id}>{row.label}</li>)}</ul>
+        </main>;
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Inventory"]);
+    expect(result.optimizations.keyedArraySliceHints).toBe(1);
+    expect(result.optimizations.keyedArrayAppendHints).toBe(1);
+    expect(result.code).not.toContain("createCompilerKeyedArrayStructuralAppendMapPipeline");
+  });
+
+  it("keeps filter, append, and map chains on complete reconciliation", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Inventory({ expiredId, incoming, editedId, nextLabel }) {
+        const [rows, setRows] = useState([{ id: "a", label: "Alpha" }]);
+        return <main>
+          <button onClick={() => {
+            setRows((current) => current.filter((row) => row.id !== expiredId));
+            setRows((current) => [...current, incoming]);
+            setRows((current) => current.map((row) =>
+              row.id === editedId ? { ...row, label: nextLabel } : row
+            ));
+          }}>
+            Refresh rows
+          </button>
+          <ul>{rows.map((row) => <li key={row.id}>{row.label}</li>)}</ul>
+        </main>;
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Inventory"]);
+    expect(result.optimizations.keyedArrayFilterHints).toBe(1);
+    expect(result.optimizations.keyedArrayAppendHints).toBe(1);
+    expect(result.optimizations.keyedMapUpdateHints).toBe(1);
+    expect(result.code).toContain("createCompilerKeyedMapUpdate");
+    expect(result.code).not.toContain("createCompilerKeyedArrayStructuralAppendMapPipeline");
+  });
+
+  it("does not retain structural append lineage when a map runs before the append", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Inventory({ expiredId, incoming, editedId, nextLabel }) {
+        const [rows, setRows] = useState([{ id: "a", label: "Alpha" }]);
+        return <main>
+          <button onClick={() => {
+            setRows((current) => current.filter((row) => row.id !== expiredId));
+            setRows((current) => current.map((row) =>
+              row.id === editedId ? { ...row, label: nextLabel } : row
+            ));
+            setRows((current) => [...current, incoming]);
+            setRows((current) => current.map((row) =>
+              row.id === incoming.id ? { ...row, selected: true } : row
+            ));
+          }}>
+            Refresh rows
+          </button>
+          <ul>{rows.map((row) => <li key={row.id}>{row.label}</li>)}</ul>
+        </main>;
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Inventory"]);
+    expect(result.code).not.toContain("createCompilerKeyedArrayStructuralAppendMapPipeline");
+  });
+
   it("does not hint a collection when an existing row key reads its length", async () => {
     const result = await compile(`
       import { useState } from "react";

--- a/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-append-hints.test.tsx
+++ b/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-append-hints.test.tsx
@@ -9,6 +9,8 @@ import {
   createCompilerKeyedArrayFilter,
   createCompilerKeyedArraySlice,
   createCompilerKeyedArrayStructuralAppend,
+  createCompilerKeyedArrayStructuralAppendMapPipeline,
+  keyedRowsStructuralAppendMapHintedRuntimeFeature,
   keyedRowsStructuralAppendHintedRuntimeFeature,
   type CompilerKeyedRowElement,
 } from "../compiler-runtime";
@@ -56,6 +58,15 @@ function hintedStructuralAppend(previous: Item[], additions: readonly Item[]): u
   return createCompilerKeyedArrayStructuralAppend(previous, [...previous, ...additions]);
 }
 
+function hintedStructuralAppendMap(
+  previous: Item[],
+  mapper: (item: Item, index: number) => Item,
+): unknown {
+  return createCompilerKeyedArrayStructuralAppendMapPipeline(previous, (current, applyMap) =>
+    applyMap(current, (current as Item[]).map, mapper),
+  );
+}
+
 function hintedFilter(previous: Item[], removed: ReadonlySet<string>): unknown {
   return createCompilerKeyedArrayFilter(
     previous,
@@ -95,6 +106,32 @@ function createAppendHarness(
     undefined;
   let sliceThenAppend: (start: number, end: number, additions: readonly Item[]) => void = () =>
     undefined;
+  let filterAppendThenMap: (
+    removed: ReadonlySet<string>,
+    additions: readonly Item[],
+    editedId: string,
+    nextLabel: string,
+    secondLabel?: string,
+  ) => void = () => undefined;
+  let sliceAppendThenMap: (
+    start: number,
+    end: number,
+    additions: readonly Item[],
+    editedId: string,
+    nextLabel: string,
+    secondLabel?: string,
+  ) => void = () => undefined;
+  let filterAppendThenTransform: (
+    removed: ReadonlySet<string>,
+    additions: readonly Item[],
+    mapper: (item: Item, index: number) => Item,
+  ) => void = () => undefined;
+  let sliceAppendThenTransform: (
+    start: number,
+    end: number,
+    additions: readonly Item[],
+    mapper: (item: Item, index: number) => Item,
+  ) => void = () => undefined;
   let plainThenAppend: (addition: Item) => void = () => undefined;
   const Inventory = createCompiledComponentWithFeatures(
     {
@@ -116,6 +153,48 @@ function createAppendHarness(
         sliceThenAppend = (start, end, additions) => {
           state[0].set((previous) => hintedSlice(previous as Item[], start, end));
           state[0].set((previous) => hintedStructuralAppend(previous as Item[], additions));
+        };
+        filterAppendThenMap = (removed, additions, editedId, nextLabel, secondLabel) => {
+          state[0].set((previous) => hintedFilter(previous as Item[], removed));
+          state[0].set((previous) => hintedStructuralAppend(previous as Item[], additions));
+          state[0].set((previous) =>
+            hintedStructuralAppendMap(previous as Item[], (item) =>
+              item.id === editedId ? { ...item, label: nextLabel } : item,
+            ),
+          );
+          if (secondLabel !== undefined) {
+            state[0].set((previous) =>
+              hintedStructuralAppendMap(previous as Item[], (item) =>
+                item.id === editedId ? { ...item, label: secondLabel } : item,
+              ),
+            );
+          }
+        };
+        sliceAppendThenMap = (start, end, additions, editedId, nextLabel, secondLabel) => {
+          state[0].set((previous) => hintedSlice(previous as Item[], start, end));
+          state[0].set((previous) => hintedStructuralAppend(previous as Item[], additions));
+          state[0].set((previous) =>
+            hintedStructuralAppendMap(previous as Item[], (item) =>
+              item.id === editedId ? { ...item, label: nextLabel } : item,
+            ),
+          );
+          if (secondLabel !== undefined) {
+            state[0].set((previous) =>
+              hintedStructuralAppendMap(previous as Item[], (item) =>
+                item.id === editedId ? { ...item, label: secondLabel } : item,
+              ),
+            );
+          }
+        };
+        filterAppendThenTransform = (removed, additions, mapper) => {
+          state[0].set((previous) => hintedFilter(previous as Item[], removed));
+          state[0].set((previous) => hintedStructuralAppend(previous as Item[], additions));
+          state[0].set((previous) => hintedStructuralAppendMap(previous as Item[], mapper));
+        };
+        sliceAppendThenTransform = (start, end, additions, mapper) => {
+          state[0].set((previous) => hintedSlice(previous as Item[], start, end));
+          state[0].set((previous) => hintedStructuralAppend(previous as Item[], additions));
+          state[0].set((previous) => hintedStructuralAppendMap(previous as Item[], mapper));
         };
         plainThenAppend = (addition) => {
           state[0].set((previous) => [...(previous as Item[])]);
@@ -170,7 +249,7 @@ function createAppendHarness(
       },
       bindings: [{ kind: "block", id: 0, dependencies: [0] }],
     },
-    [keyedRowsStructuralAppendHintedRuntimeFeature],
+    [keyedRowsStructuralAppendMapHintedRuntimeFeature],
   );
   return {
     Inventory,
@@ -180,6 +259,32 @@ function createAppendHarness(
       filterThenAppend(removed, additions),
     sliceThenAppend: (start: number, end: number, additions: readonly Item[]) =>
       sliceThenAppend(start, end, additions),
+    filterAppendThenMap: (
+      removed: ReadonlySet<string>,
+      additions: readonly Item[],
+      editedId: string,
+      nextLabel: string,
+      secondLabel?: string,
+    ) => filterAppendThenMap(removed, additions, editedId, nextLabel, secondLabel),
+    sliceAppendThenMap: (
+      start: number,
+      end: number,
+      additions: readonly Item[],
+      editedId: string,
+      nextLabel: string,
+      secondLabel?: string,
+    ) => sliceAppendThenMap(start, end, additions, editedId, nextLabel, secondLabel),
+    filterAppendThenTransform: (
+      removed: ReadonlySet<string>,
+      additions: readonly Item[],
+      mapper: (item: Item, index: number) => Item,
+    ) => filterAppendThenTransform(removed, additions, mapper),
+    sliceAppendThenTransform: (
+      start: number,
+      end: number,
+      additions: readonly Item[],
+      mapper: (item: Item, index: number) => Item,
+    ) => sliceAppendThenTransform(start, end, additions, mapper),
     plainThenAppend: (addition: Item) => plainThenAppend(addition),
   };
 }
@@ -283,6 +388,126 @@ describe("compiled keyed-array append hints", () => {
     expect(harness.counters.bindingReads).toBe(1);
   });
 
+  it("patches mapped survivors while creating only the appended suffix", async () => {
+    const initialItems = Array.from(
+      { length: 2_048 },
+      (_, index): Item => ({ id: `row-${index}`, label: `Row ${index}` }),
+    );
+    const harness = createAppendHarness(initialItems, false, true);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Inventory />));
+    const edited = container.querySelector('[data-key="row-512"]');
+    const untouched = container.querySelector('[data-key="row-1536"]');
+    const removed = container.querySelector('[data-key="row-0"]');
+    harness.counters.keyReads = 0;
+    harness.counters.descriptorReads = 0;
+    harness.counters.bindingReads = 0;
+
+    await act(async () => {
+      harness.sliceAppendThenMap(
+        1,
+        initialItems.length,
+        [
+          { id: "row-2048", label: "Row 2048" },
+          { id: "row-2049", label: "Row 2049" },
+        ],
+        "row-512",
+        "Edited survivor",
+        "Edited survivor twice",
+      );
+      await flushCompilerUpdates();
+    });
+
+    expect(container.querySelector('[data-key="row-512"]')).toBe(edited);
+    expect(container.querySelector('[data-key="row-1536"]')).toBe(untouched);
+    expect(container.querySelector('[data-key="row-0"]')).toBeNull();
+    expect(removed?.isConnected).toBe(false);
+    expect(edited?.textContent).toBe("Edited survivor twice");
+    expect(container.querySelector("li:last-child")?.textContent).toBe("Row 2049");
+    expect(container.querySelectorAll("li")).toHaveLength(2_049);
+    expect(harness.counters.executions).toBe(1);
+    expect(harness.counters.listRenders).toBe(1);
+    expect(harness.counters.descriptorReads).toBe(2);
+    expect(harness.counters.bindingReads).toBe(3);
+  });
+
+  it("creates an appended row from its final mapped value", async () => {
+    const harness = createAppendHarness(
+      [
+        { id: "a", label: "Alpha" },
+        { id: "b", label: "Beta" },
+        { id: "c", label: "Gamma" },
+      ],
+      false,
+      true,
+    );
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Inventory />));
+
+    await act(async () => {
+      harness.sliceAppendThenTransform(0, 2, [{ id: "d", label: "Delta" }], (item) =>
+        item.id === "b" || item.id === "d" ? { ...item, label: `${item.label} mapped` } : item,
+      );
+      await flushCompilerUpdates();
+    });
+
+    expect(container.querySelector('[data-key="a"]')).not.toBeNull();
+    expect([...container.querySelectorAll("li")].map((row) => row.textContent)).toEqual([
+      "Alpha",
+      "Beta mapped",
+      "Delta mapped",
+    ]);
+    expect(harness.counters.executions).toBe(1);
+    expect(harness.counters.listRenders).toBe(1);
+  });
+
+  it("falls back completely when a filter precedes the append and map", async () => {
+    const harness = createAppendHarness(
+      [
+        { id: "a", label: "Alpha" },
+        { id: "b", label: "Beta" },
+        { id: "c", label: "Gamma" },
+      ],
+      false,
+      true,
+    );
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Inventory />));
+    const alpha = container.querySelector('[data-key="a"]');
+    const gamma = container.querySelector('[data-key="c"]');
+    harness.counters.keyReads = 0;
+    harness.counters.bindingReads = 0;
+
+    await act(async () => {
+      harness.filterAppendThenMap(
+        new Set(["b"]),
+        [{ id: "d", label: "Delta" }],
+        "c",
+        "Gamma edited",
+      );
+      await flushCompilerUpdates();
+    });
+
+    expect([...container.querySelectorAll("li")].map((row) => row.textContent)).toEqual([
+      "Alpha",
+      "Gamma edited",
+      "Delta",
+    ]);
+    expect(container.querySelector('[data-key="a"]')).toBe(alpha);
+    expect(container.querySelector('[data-key="c"]')).toBe(gamma);
+    expect(harness.counters.keyReads).toBe(3);
+    expect(harness.counters.bindingReads).toBe(3);
+  });
+
   it("composes multiple queued appends after one structural update", async () => {
     const harness = createAppendHarness(
       [
@@ -379,6 +604,11 @@ describe("compiled keyed-array append hints", () => {
             state[0].set((previous) =>
               hintedStructuralAppend(previous as Item[], [{ id: "d", label: "Delta" }]),
             );
+            state[0].set((previous) =>
+              hintedStructuralAppendMap(previous as Item[], (item) =>
+                item.id === "b" ? { ...item, label: "Beta edited" } : item,
+              ),
+            );
           };
           return (
             <section>
@@ -422,7 +652,7 @@ describe("compiled keyed-array append hints", () => {
         },
         bindings: [{ kind: "block", id: 0, dependencies: [0] }],
       },
-      [keyedRowsStructuralAppendHintedRuntimeFeature],
+      [keyedRowsStructuralAppendMapHintedRuntimeFeature],
     );
     const container = document.createElement("div");
     document.body.append(container);
@@ -442,7 +672,7 @@ describe("compiled keyed-array append hints", () => {
     expect(document.activeElement).toBe(beta);
     expect([beta.selectionStart, beta.selectionEnd]).toEqual([1, 3]);
     expect([...container.querySelectorAll("input")].map((input) => input.value)).toEqual([
-      "Beta",
+      "Beta edited",
       "Gamma",
       "Delta",
     ]);
@@ -516,6 +746,72 @@ describe("compiled keyed-array append hints", () => {
     expect(harness.counters.bindingReads).toBe(3);
   });
 
+  it("falls back atomically when a following map changes a surviving key", async () => {
+    const harness = createAppendHarness(
+      [
+        { id: "a", label: "Alpha" },
+        { id: "b", label: "Beta" },
+        { id: "c", label: "Gamma" },
+      ],
+      false,
+      true,
+    );
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Inventory />));
+    const alpha = container.querySelector('[data-key="a"]');
+
+    await act(async () => {
+      harness.sliceAppendThenTransform(0, 2, [{ id: "d", label: "Delta" }], (item) =>
+        item.id === "b" ? { ...item, id: "renamed-b", label: "Renamed" } : item,
+      );
+      await flushCompilerUpdates();
+    });
+
+    expect([...container.querySelectorAll("li")].map((row) => row.textContent)).toEqual([
+      "Alpha",
+      "Renamed",
+      "Delta",
+    ]);
+    expect(container.querySelector('[data-key="a"]')).toBe(alpha);
+    expect(container.querySelector('[data-key="b"]')).toBeNull();
+    expect(container.querySelector('[data-key="renamed-b"]')).not.toBeNull();
+  });
+
+  it("falls back when the committed array was mutated before the sliced map chain", async () => {
+    const initialItems: Item[] = [
+      { id: "a", label: "Alpha" },
+      { id: "b", label: "Beta" },
+      { id: "c", label: "Gamma" },
+    ];
+    const harness = createAppendHarness(initialItems, false, true);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Inventory />));
+    const alpha = container.querySelector('[data-key="a"]');
+    const beta = container.querySelector('[data-key="b"]');
+    initialItems[1] = { id: "b", label: "Beta externally replaced" };
+    harness.counters.keyReads = 0;
+
+    await act(async () => {
+      harness.sliceAppendThenMap(0, 2, [{ id: "d", label: "Delta" }], "a", "Alpha edited");
+      await flushCompilerUpdates();
+    });
+
+    expect([...container.querySelectorAll("li")].map((row) => row.textContent)).toEqual([
+      "Alpha edited",
+      "Beta externally replaced",
+      "Delta",
+    ]);
+    expect(container.querySelector('[data-key="a"]')).toBe(alpha);
+    expect(container.querySelector('[data-key="b"]')).toBe(beta);
+    expect(harness.counters.keyReads).toBe(3);
+  });
+
   it("rejects a hint chained after an unhinted update in the same flush", async () => {
     const harness = createAppendHarness([
       { id: "a", label: "Alpha" },
@@ -569,6 +865,21 @@ describe("compiled keyed-array append hints", () => {
     expect(createCompilerKeyedArrayAppend(proxy, next)).toBe(next);
     expect(() => createCompilerKeyedArrayStructuralAppend(proxy, next)).not.toThrow();
     expect(createCompilerKeyedArrayStructuralAppend(proxy, next)).toBe(next);
+    expect(() =>
+      createCompilerKeyedArrayStructuralAppendMapPipeline(proxy, () => next),
+    ).not.toThrow();
+    expect(createCompilerKeyedArrayStructuralAppendMapPipeline(proxy, () => next)).toBe(next);
+
+    const source = [{ id: "source", label: "Source" }];
+    const customMap = function (this: Item[], mapper: (item: Item) => Item) {
+      return this.map(mapper);
+    };
+    const customResult = createCompilerKeyedArrayStructuralAppendMapPipeline(
+      source,
+      (current, applyMap) =>
+        applyMap(current, customMap, (item: Item) => ({ ...item, label: "Custom" })),
+    );
+    expect(customResult).toEqual([{ id: "source", label: "Custom" }]);
   });
 
   it("keeps complete reconciliation when existing rows read collection state", async () => {
@@ -751,7 +1062,7 @@ describe("compiled keyed-array append hints", () => {
     expect(harness.counters.executions).toBe(1);
   }, 15_000);
 
-  it("matches React across 2,000 randomized queued structural removals and appends", async () => {
+  it("matches React across 2,000 randomized structural removals, appends, and maps", async () => {
     const initialItems = Array.from(
       { length: 1_001 },
       (_, index): Item => ({ id: `row-${index}`, label: `Row ${index}` }),
@@ -761,16 +1072,21 @@ describe("compiled keyed-array append hints", () => {
       kind: "filter" | "slice",
       removed: ReadonlySet<string>,
       additions: readonly Item[],
+      editedId: string,
+      nextLabel: string,
     ) => void = () => undefined;
     function Normal() {
       const [items, setItems] = useState(initialItems);
-      updateReact = (kind, removed, additions) => {
+      updateReact = (kind, removed, additions, editedId, nextLabel) => {
         setItems((previous) =>
           kind === "slice"
             ? previous.slice(0, previous.length - removed.size)
             : previous.filter((item) => !removed.has(item.id)),
         );
         setItems((previous) => [...previous, ...additions]);
+        setItems((previous) =>
+          previous.map((item) => (item.id === editedId ? { ...item, label: nextLabel } : item)),
+        );
       };
       return (
         <ol data-owner="react">
@@ -813,22 +1129,32 @@ describe("compiled keyed-array append hints", () => {
         const id = `row-${nextId++}`;
         return { id, label: `Queued ${id}` };
       });
+      const survivors =
+        kind === "slice"
+          ? active.slice(0, active.length - removed.size)
+          : active.filter((id) => !removed.has(id));
+      seed = (Math.imul(seed, 1_664_525) + 1_013_904_223) >>> 0;
+      const editedId = survivors[seed % survivors.length];
+      const nextLabel = `Edited ${batch}-${seed % 10_000}`;
       await act(async () => {
         if (kind === "slice") {
-          harness.sliceThenAppend(0, active.length - removed.size, additions);
+          harness.sliceAppendThenMap(
+            0,
+            active.length - removed.size,
+            additions,
+            editedId,
+            nextLabel,
+          );
         } else {
-          harness.filterThenAppend(removed, additions);
+          harness.filterAppendThenMap(removed, additions, editedId, nextLabel);
         }
-        updateReact(kind, removed, additions);
+        updateReact(kind, removed, additions, editedId, nextLabel);
         await flushCompilerUpdates();
       });
       expect([...compiledContainer.querySelectorAll("li")].map((row) => row.outerHTML)).toEqual(
         [...reactContainer.querySelectorAll("li")].map((row) => row.outerHTML),
       );
-      active =
-        kind === "slice"
-          ? active.slice(0, active.length - removed.size)
-          : active.filter((id) => !removed.has(id));
+      active = kind === "slice" ? active.slice(0, active.length - removed.size) : survivors;
       active.push(...additions.map((item) => item.id));
     }
 
@@ -866,14 +1192,14 @@ describe("compiled keyed-array append hints", () => {
     expect(recoverable).toEqual([]);
 
     await act(async () => {
-      harness.filterThenAppend(new Set(["a"]), [{ id: "c", label: "Gamma" }]);
+      harness.sliceAppendThenMap(1, 2, [{ id: "c", label: "Gamma" }], "b", "Beta edited");
       await flushCompilerUpdates();
     });
-    expect(container.textContent).toBe("BetaGamma");
+    expect(container.textContent).toBe("Beta editedGamma");
 
     roots.pop();
     act(() => {
-      harness.filterThenAppend(new Set(["b"]), [{ id: "d", label: "Delta" }]);
+      harness.sliceAppendThenMap(1, 2, [{ id: "d", label: "Delta" }], "c", "Gamma edited");
       root.unmount();
     });
     await flushCompilerUpdates();

--- a/packages/farm-react/src/compiler-runtime.tsx
+++ b/packages/farm-react/src/compiler-runtime.tsx
@@ -15,6 +15,9 @@ interface CompilerKeyedArrayAppendHint {
   readonly sourceToken: object;
   readonly startIndex: number;
   readonly resultLength: number;
+  readonly mappedItemSources?: ReadonlyMap<number, unknown>;
+  readonly mappedItemValues?: ReadonlyMap<number, unknown>;
+  readonly mappedSurvivorsValidated?: boolean;
   readonly structuralUpdate?: CompilerKeyedArrayFilterHint;
   readonly previous?: CompilerKeyedArrayAppendHint;
 }
@@ -164,6 +167,10 @@ const COMPILER_KEYED_COLLECTION_UPDATES = /* @__PURE__ */ new WeakMap<
   CompilerKeyedCollectionUpdateHint
 >();
 const COMPILER_KEYED_COMMITTED_COLLECTIONS = /* @__PURE__ */ new WeakSet<object>();
+const COMPILER_KEYED_COMMITTED_ITEM_SNAPSHOTS = /* @__PURE__ */ new WeakMap<
+  object,
+  readonly unknown[]
+>();
 const NATIVE_ARRAY_PROTOTYPE = Array.prototype;
 const NATIVE_ARRAY_ITERATOR = Array.prototype[Symbol.iterator];
 const NATIVE_ARRAY_FILTER = Array.prototype.filter;
@@ -205,6 +212,30 @@ function commitCompilerKeyedCollection(value: unknown): object | undefined {
   if (!target) return undefined;
   COMPILER_KEYED_COMMITTED_COLLECTIONS.add(target);
   return compilerKeyedCollectionToken(target);
+}
+
+function commitCompilerKeyedCollectionWithItemSnapshot(
+  value: unknown,
+  instances?: ReadonlyMap<string, CompilerKeyedRowInstance>,
+): object | undefined {
+  const token = commitCompilerKeyedCollection(value);
+  if (!token) return undefined;
+  if (!instances) {
+    COMPILER_KEYED_COMMITTED_ITEM_SNAPSHOTS.delete(token);
+    return token;
+  }
+  const items: unknown[] = [];
+  let index = 0;
+  for (const instance of instances.values()) {
+    if (instance.index !== index) {
+      COMPILER_KEYED_COMMITTED_ITEM_SNAPSHOTS.delete(token);
+      return token;
+    }
+    items.push(instance.item);
+    index += 1;
+  }
+  COMPILER_KEYED_COMMITTED_ITEM_SNAPSHOTS.set(token, items);
+  return token;
 }
 
 function compilerKeyedMapChangedIndices(
@@ -375,6 +406,109 @@ function compilerKeyedArrayFilterSurvivorsFromUpdate(
     survivors = survivors.filter((_sourceIndex, index) => !removed.has(index));
   }
   return survivors.length === resultLength ? { indices: survivors, keysStable } : undefined;
+}
+
+function compilerKeyedArraySliceSurvivorRangeFromUpdate(
+  update: CompilerKeyedArrayFilterHint,
+  sourceToken: object | undefined,
+  expectedLength: number,
+  resultLength: number,
+): { readonly end: number; readonly start: number } | undefined {
+  if (!sourceToken || update.sourceToken !== sourceToken) return undefined;
+  const updates: CompilerKeyedArrayFilterHint[] = [];
+  for (
+    let current: CompilerKeyedArrayFilterHint | undefined = update;
+    current;
+    current = current.previous
+  ) {
+    if (current.sourceToken !== sourceToken || current.kind !== "slice") return undefined;
+    updates.push(current);
+  }
+
+  let length = expectedLength;
+  let start = 0;
+  for (let index = updates.length - 1; index >= 0; index -= 1) {
+    const current = updates[index];
+    const retainedStart = current.retainedStart;
+    const retainedEnd = current.retainedEnd;
+    if (
+      current.sourceLength !== length ||
+      retainedStart === undefined ||
+      retainedEnd === undefined ||
+      !Number.isSafeInteger(retainedStart) ||
+      !Number.isSafeInteger(retainedEnd) ||
+      retainedStart < 0 ||
+      retainedEnd < retainedStart ||
+      retainedEnd > current.sourceLength ||
+      current.resultLength !== retainedEnd - retainedStart
+    ) {
+      return undefined;
+    }
+    start += retainedStart;
+    length = current.resultLength;
+  }
+  return length === resultLength ? { end: start + length, start } : undefined;
+}
+
+function compilerKeyedArrayStructuralAppendMapUpdate(
+  value: unknown,
+  sourceToken: object | undefined,
+  expectedStart: number,
+  requireMappedUpdate = false,
+):
+  | {
+      readonly startIndex: number;
+      readonly mappedItemSources?: ReadonlyMap<number, unknown>;
+      readonly mappedSurvivorsValidated?: true;
+      readonly structuralSurvivorRange: {
+        readonly end: number;
+        readonly start: number;
+      };
+    }
+  | undefined {
+  const target = compilerObject(value);
+  if (!target || !sourceToken || !Array.isArray(value)) return undefined;
+  const update = COMPILER_KEYED_ARRAY_APPENDS.get(target);
+  if (
+    !update ||
+    update.sourceToken !== sourceToken ||
+    !update.structuralUpdate ||
+    (requireMappedUpdate && (!update.mappedItemSources || !update.mappedSurvivorsValidated))
+  ) {
+    return undefined;
+  }
+  const updates: CompilerKeyedArrayAppendHint[] = [];
+  for (
+    let current: CompilerKeyedArrayAppendHint | undefined = update;
+    current;
+    current = current.previous
+  ) {
+    if (current.sourceToken !== sourceToken) return undefined;
+    updates.push(current);
+  }
+  updates.reverse();
+  const first = updates[0];
+  const structuralSurvivorRange = compilerKeyedArraySliceSurvivorRangeFromUpdate(
+    update.structuralUpdate,
+    sourceToken,
+    expectedStart,
+    first.startIndex,
+  );
+  if (!structuralSurvivorRange) return undefined;
+  let length = first.startIndex;
+  const startIndex = length;
+  for (const current of updates) {
+    if (current.startIndex !== length || current.resultLength < length) return undefined;
+    length = current.resultLength;
+  }
+  return length === value.length
+    ? {
+        startIndex,
+        structuralSurvivorRange,
+        ...(update.mappedItemSources ? { mappedItemSources: update.mappedItemSources } : {}),
+        ...(update.mappedSurvivorsValidated ? { mappedSurvivorsValidated: true as const } : {}),
+      }
+    : undefined;
 }
 
 function compilerKeyedArrayFilterSource(
@@ -1039,6 +1173,142 @@ export function createCompilerKeyedArrayStructuralAppend(
     // Metadata must never change the behavior of an otherwise valid update.
     return value;
   }
+}
+
+/** @internal Executes safe maps while retaining structural append lineage. */
+export function createCompilerKeyedArrayStructuralAppendMapPipeline(
+  previous: unknown,
+  pipeline: (...values: readonly unknown[]) => unknown,
+): unknown {
+  let appendUpdate: CompilerKeyedArrayAppendHint | undefined;
+  let committedItems: readonly unknown[] | undefined;
+  let survivorRange: { readonly end: number; readonly start: number } | undefined;
+  let mappedItemSources = new Map<number, unknown>();
+  let mappedItemValues = new Map<number, unknown>();
+  try {
+    const previousTarget = compilerObject(previous);
+    if (
+      !previousTarget ||
+      !Array.isArray(previous) ||
+      Object.getPrototypeOf(previous) !== NATIVE_ARRAY_PROTOTYPE ||
+      !(appendUpdate = COMPILER_KEYED_ARRAY_APPENDS.get(previousTarget)) ||
+      !appendUpdate.structuralUpdate ||
+      appendUpdate.resultLength !== previous.length
+    ) {
+      appendUpdate = undefined;
+    } else {
+      committedItems = COMPILER_KEYED_COMMITTED_ITEM_SNAPSHOTS.get(appendUpdate.sourceToken);
+      const structuralAppend = committedItems
+        ? compilerKeyedArrayStructuralAppendMapUpdate(
+            previous,
+            appendUpdate.sourceToken,
+            committedItems.length,
+          )
+        : undefined;
+      survivorRange = structuralAppend?.structuralSurvivorRange;
+      if (!survivorRange) {
+        appendUpdate = undefined;
+      } else {
+        if (appendUpdate.mappedItemSources) {
+          mappedItemSources = new Map(appendUpdate.mappedItemSources);
+        }
+        if (appendUpdate.mappedItemValues) {
+          mappedItemValues = new Map(appendUpdate.mappedItemValues);
+        }
+      }
+    }
+  } catch {
+    appendUpdate = undefined;
+  }
+
+  let eligible = appendUpdate !== undefined;
+  const applyMap = (collection: unknown, method: unknown, callback: unknown): unknown => {
+    if (method !== NATIVE_ARRAY_MAP || !eligible) {
+      const value = NATIVE_REFLECT_APPLY(
+        method as (...values: readonly unknown[]) => unknown,
+        collection,
+        [callback],
+      );
+      if (method !== NATIVE_ARRAY_MAP) eligible = false;
+      return value;
+    }
+
+    let expectedIndex = 0;
+    let expectedLength = -1;
+    try {
+      if (
+        !Array.isArray(collection) ||
+        Object.getPrototypeOf(collection) !== NATIVE_ARRAY_PROTOTYPE
+      ) {
+        eligible = false;
+      } else {
+        expectedLength = collection.length;
+      }
+    } catch {
+      eligible = false;
+    }
+    const wrappedCallback = (item: unknown, index: number, source: unknown): unknown => {
+      if (index !== expectedIndex) eligible = false;
+      expectedIndex = index + 1;
+      const survivorCount = survivorRange ? survivorRange.end - survivorRange.start : 0;
+      let committedItem: unknown;
+      if (index < survivorCount) {
+        committedItem = committedItems?.[survivorRange!.start + index];
+        const expectedItem = mappedItemValues.has(index)
+          ? mappedItemValues.get(index)
+          : committedItem;
+        if (!Object.is(item, expectedItem)) eligible = false;
+      }
+      const mappedItem = NATIVE_REFLECT_APPLY(
+        callback as (...values: readonly unknown[]) => unknown,
+        undefined,
+        [item, index, source],
+      );
+      if (index < survivorCount) {
+        if (Object.is(mappedItem, committedItem)) {
+          mappedItemSources.delete(index);
+          mappedItemValues.delete(index);
+        } else {
+          mappedItemSources.set(index, committedItem);
+          mappedItemValues.set(index, mappedItem);
+        }
+      }
+      return mappedItem;
+    };
+    const value = NATIVE_REFLECT_APPLY(
+      method as (...values: readonly unknown[]) => unknown,
+      collection,
+      [wrappedCallback],
+    );
+    try {
+      if (
+        expectedIndex !== expectedLength ||
+        !Array.isArray(value) ||
+        Object.getPrototypeOf(value) !== NATIVE_ARRAY_PROTOTYPE ||
+        value.length !== expectedLength
+      ) {
+        eligible = false;
+      }
+    } catch {
+      eligible = false;
+    }
+    return value;
+  };
+  const value = NATIVE_REFLECT_APPLY(pipeline, undefined, [previous, applyMap]);
+  if (!eligible || !appendUpdate) return value;
+  try {
+    const valueTarget = compilerObject(value);
+    if (!valueTarget) return value;
+    COMPILER_KEYED_ARRAY_APPENDS.set(valueTarget, {
+      ...appendUpdate,
+      mappedItemSources,
+      mappedItemValues,
+      mappedSurvivorsValidated: true,
+    });
+  } catch {
+    // Metadata must never change the result of a successful native update.
+  }
+  return value;
 }
 
 /** @internal Records a compiler-proven immutable keyed-array prepend and returns the Array. */
@@ -4984,7 +5254,10 @@ interface KeyedRowHostRuntime {
 }
 
 interface KeyedUpdateRuntime {
-  commit(value: unknown): object | undefined;
+  commit(
+    value: unknown,
+    instances?: ReadonlyMap<string, CompilerKeyedRowInstance>,
+  ): object | undefined;
   append(
     props: CompilerKeyedRowsBlockProps,
     dirtyState: ReadonlySet<number>,
@@ -5122,6 +5395,12 @@ const keyedWindowEveryUpdateRuntime: KeyedUpdateRuntime = {
 const keyedWindowEveryStructuralAppendUpdateRuntime: KeyedUpdateRuntime = {
   ...keyedWindowEveryUpdateRuntime,
   append: reconcileCompilerKeyedArrayAppendWithStructural,
+};
+
+const keyedWindowEveryStructuralAppendMapUpdateRuntime: KeyedUpdateRuntime = {
+  ...keyedWindowEveryStructuralAppendUpdateRuntime,
+  append: reconcileCompilerKeyedArrayAppendMapWithStructural,
+  commit: commitCompilerKeyedCollectionWithItemSnapshot,
 };
 
 interface KeyedRowsRuntimeOptions {
@@ -5482,10 +5761,136 @@ function reconcileCompilerKeyedArrayStructuralAppend(
   return keyedRowInstancesByKey([...survivors, ...appended]);
 }
 
+function reconcileCompilerKeyedArrayStructuralAppendMap(
+  props: CompilerKeyedRowsBlockProps,
+  dirtyState: ReadonlySet<number>,
+  collectionToken: object | undefined,
+  instances: ReadonlyMap<string, CompilerKeyedRowInstance>,
+  root: Element,
+  reactOwnedRows: boolean,
+): ReadonlyMap<string, CompilerKeyedRowInstance> | undefined {
+  if (
+    reactOwnedRows ||
+    props.hostBlocks ||
+    (props.conditionals?.length || 0) > 0 ||
+    !props.filterIndexIndependent ||
+    props.collectionDependency === undefined
+  ) {
+    return undefined;
+  }
+  const collectionDependency = props.collectionDependency;
+  if (props.bindings.some((binding) => binding.dependencies?.includes(collectionDependency))) {
+    return undefined;
+  }
+  const dependencies = props.dependencies || props.structureDependencies;
+  const relevantDirty = (dependencies || []).filter((index) => dirtyState.has(index));
+  if (relevantDirty.length !== 1 || relevantDirty[0] !== collectionDependency) {
+    return undefined;
+  }
+
+  const finalValue = props.items();
+  const update = compilerKeyedArrayStructuralAppendMapUpdate(
+    finalValue,
+    collectionToken,
+    instances.size,
+    true,
+  );
+  if (!update || !update.mappedItemSources || !Array.isArray(finalValue)) return undefined;
+
+  const previousInstances = [...instances.values()];
+  const survivorRange = update.structuralSurvivorRange;
+  const survivorCount = survivorRange.end - survivorRange.start;
+  const changed: Array<{
+    bindingUpdates: CompilerPreparedKeyedRowBindingUpdate[];
+    instance: CompilerKeyedRowInstance;
+    item: unknown;
+  }> = [];
+  const appendedKeys = new Set<string>();
+  const appended: CompilerKeyedRowInstance[] = [];
+  try {
+    for (const [index, sourceItem] of update.mappedItemSources) {
+      if (!Number.isSafeInteger(index) || index < 0 || index >= survivorCount) {
+        return undefined;
+      }
+      const sourceIndex = survivorRange.start + index;
+      const instance = previousInstances[sourceIndex];
+      const item = finalValue[index];
+      if (
+        !instance ||
+        instance.index !== sourceIndex ||
+        !Object.is(instance.item, sourceItem) ||
+        keyedRowIdentity(props.rowKey(item, index)) !== instance.key
+      ) {
+        return undefined;
+      }
+      const bindingUpdates = prepareKeyedRowBindingUpdates(props, instance, item, index);
+      if (!bindingUpdates) return undefined;
+      changed.push({ bindingUpdates, instance, item });
+    }
+    for (let index = update.startIndex; index < finalValue.length; index += 1) {
+      const item = finalValue[index];
+      const key = keyedRowIdentity(props.rowKey(item, index));
+      if (instances.has(key) || appendedKeys.has(key)) return undefined;
+      appendedKeys.add(key);
+      const descriptor = props.create(item, index);
+      appended.push({
+        key,
+        element: createCompilerHostElement(root.ownerDocument, descriptor),
+        values: readKeyedRowBindingValues(props, item, index),
+        item,
+        index,
+        conditionalValues: EMPTY_KEYED_ROW_CONDITIONAL_VALUES,
+      });
+    }
+  } catch {
+    return undefined;
+  }
+
+  const mutableInstances = instances as Map<string, CompilerKeyedRowInstance>;
+  for (let index = 0; index < survivorRange.start; index += 1) {
+    const instance = previousInstances[index];
+    instance.scope?.cleanup();
+    instance.element.remove();
+    mutableInstances.delete(instance.key);
+  }
+  for (let index = survivorRange.end; index < previousInstances.length; index += 1) {
+    const instance = previousInstances[index];
+    instance.scope?.cleanup();
+    instance.element.remove();
+    mutableInstances.delete(instance.key);
+  }
+  for (let index = survivorRange.start; index < survivorRange.end; index += 1) {
+    previousInstances[index].index = index - survivorRange.start;
+  }
+  if (appended.length > 0) {
+    const fragment = root.ownerDocument.createDocumentFragment();
+    for (const instance of appended) {
+      fragment.append(instance.element);
+      mutableInstances.set(instance.key, instance);
+    }
+    root.append(fragment);
+  }
+  for (const { bindingUpdates, instance, item } of changed) {
+    applyPreparedKeyedRowBindingUpdates(props, instance, bindingUpdates);
+    instance.item = item;
+  }
+  return mutableInstances;
+}
+
 function reconcileCompilerKeyedArrayAppendWithStructural(
   ...args: Parameters<typeof reconcileCompilerKeyedArrayAppend>
 ): ReadonlyMap<string, CompilerKeyedRowInstance> | undefined {
   return (
+    reconcileCompilerKeyedArrayStructuralAppend(...args) ||
+    reconcileCompilerKeyedArrayAppend(...args)
+  );
+}
+
+function reconcileCompilerKeyedArrayAppendMapWithStructural(
+  ...args: Parameters<typeof reconcileCompilerKeyedArrayAppend>
+): ReadonlyMap<string, CompilerKeyedRowInstance> | undefined {
+  return (
+    reconcileCompilerKeyedArrayStructuralAppendMap(...args) ||
     reconcileCompilerKeyedArrayStructuralAppend(...args) ||
     reconcileCompilerKeyedArrayAppend(...args)
   );
@@ -7004,7 +7409,10 @@ function createKeyedRowsBlockComponent(
     }
 
     private commitCurrentCollection(dirtyState?: ReadonlySet<number>): void {
-      this.collectionToken = options.keyedUpdates?.commit(this.currentProps.items());
+      this.collectionToken = options.keyedUpdates?.commit(
+        this.currentProps.items(),
+        this.instances,
+      );
       this.commitKeyedTargets(dirtyState);
     }
 
@@ -7674,7 +8082,8 @@ function createKeyedRowsBlockComponent(
           this.hasReactOwnedRows(),
         );
         if (appendedInstances) {
-          this.instances = new Map(appendedInstances);
+          this.instances =
+            appendedInstances instanceof Map ? appendedInstances : new Map(appendedInstances);
           this.rebuildElementIndex(this.instances);
           this.commitCurrentCollection(dirtyState);
           afterCommit?.();
@@ -8439,6 +8848,15 @@ export const keyedRowsStructuralAppendHintedRuntimeFeature: CompilerRuntimeFeatu
   }),
 };
 
+export const keyedRowsStructuralAppendMapHintedRuntimeFeature: CompilerRuntimeFeature = {
+  name: "keyed-rows:structural-append-map-hinted",
+  create: (owner) => ({
+    KeyedRows: createKeyedRowsBlockComponent(owner, {
+      keyedUpdates: keyedWindowEveryStructuralAppendMapUpdateRuntime,
+    }),
+  }),
+};
+
 export const keyedRowsPrependHintedRuntimeFeature: CompilerRuntimeFeature = {
   name: "keyed-rows:prepend-hinted",
   create: (owner) => ({
@@ -8572,6 +8990,16 @@ export const keyedRowsConditionalStructuralAppendHintedRuntimeFeature: CompilerR
     KeyedRows: createKeyedRowsBlockComponent(owner, {
       conditionals: createKeyedRowConditionalRuntime(),
       keyedUpdates: keyedWindowEveryStructuralAppendUpdateRuntime,
+    }),
+  }),
+};
+
+export const keyedRowsConditionalStructuralAppendMapHintedRuntimeFeature: CompilerRuntimeFeature = {
+  name: "keyed-rows:conditional:structural-append-map-hinted",
+  create: (owner) => ({
+    KeyedRows: createKeyedRowsBlockComponent(owner, {
+      conditionals: createKeyedRowConditionalRuntime(),
+      keyedUpdates: keyedWindowEveryStructuralAppendMapUpdateRuntime,
     }),
   }),
 };
@@ -8711,6 +9139,16 @@ export const keyedRowsHostStructuralAppendHintedRuntimeFeature: CompilerRuntimeF
     KeyedRows: createKeyedRowsBlockComponent(owner, {
       hostBlocks: createKeyedRowHostRuntime(),
       keyedUpdates: keyedWindowEveryStructuralAppendUpdateRuntime,
+    }),
+  }),
+};
+
+export const keyedRowsHostStructuralAppendMapHintedRuntimeFeature: CompilerRuntimeFeature = {
+  name: "keyed-rows:host:structural-append-map-hinted",
+  create: (owner) => ({
+    KeyedRows: createKeyedRowsBlockComponent(owner, {
+      hostBlocks: createKeyedRowHostRuntime(),
+      keyedUpdates: keyedWindowEveryStructuralAppendMapUpdateRuntime,
     }),
   }),
 };
@@ -8862,6 +9300,17 @@ export const keyedRowsCompleteStructuralAppendHintedRuntimeFeature: CompilerRunt
       conditionals: createKeyedRowConditionalRuntime(),
       hostBlocks: createKeyedRowHostRuntime(),
       keyedUpdates: keyedWindowEveryStructuralAppendUpdateRuntime,
+    }),
+  }),
+};
+
+export const keyedRowsCompleteStructuralAppendMapHintedRuntimeFeature: CompilerRuntimeFeature = {
+  name: "keyed-rows:complete:structural-append-map-hinted",
+  create: (owner) => ({
+    KeyedRows: createKeyedRowsBlockComponent(owner, {
+      conditionals: createKeyedRowConditionalRuntime(),
+      hostBlocks: createKeyedRowHostRuntime(),
+      keyedUpdates: keyedWindowEveryStructuralAppendMapUpdateRuntime,
     }),
   }),
 };

--- a/packages/farm-react/src/compiler.ts
+++ b/packages/farm-react/src/compiler.ts
@@ -378,6 +378,7 @@ type CompilerRuntimeFeatureName =
   | "keyed-rows-window-every-hinted"
   | "keyed-rows-filter-hinted"
   | "keyed-rows-structural-append-hinted"
+  | "keyed-rows-structural-append-map-hinted"
   | "keyed-rows-prepend-hinted"
   | "keyed-rows-filter-prepend-hinted"
   | "keyed-rows-conditional"
@@ -392,6 +393,7 @@ type CompilerRuntimeFeatureName =
   | "keyed-rows-conditional-window-every-hinted"
   | "keyed-rows-conditional-filter-hinted"
   | "keyed-rows-conditional-structural-append-hinted"
+  | "keyed-rows-conditional-structural-append-map-hinted"
   | "keyed-rows-conditional-prepend-hinted"
   | "keyed-rows-conditional-filter-prepend-hinted"
   | "keyed-rows-host"
@@ -406,6 +408,7 @@ type CompilerRuntimeFeatureName =
   | "keyed-rows-host-window-every-hinted"
   | "keyed-rows-host-filter-hinted"
   | "keyed-rows-host-structural-append-hinted"
+  | "keyed-rows-host-structural-append-map-hinted"
   | "keyed-rows-host-prepend-hinted"
   | "keyed-rows-host-filter-prepend-hinted"
   | "keyed-rows-complete"
@@ -420,6 +423,7 @@ type CompilerRuntimeFeatureName =
   | "keyed-rows-complete-window-every-hinted"
   | "keyed-rows-complete-filter-hinted"
   | "keyed-rows-complete-structural-append-hinted"
+  | "keyed-rows-complete-structural-append-map-hinted"
   | "keyed-rows-complete-prepend-hinted"
   | "keyed-rows-complete-filter-prepend-hinted"
   | "keyed-ranges"
@@ -444,6 +448,7 @@ const COMPILER_RUNTIME_FEATURE_EXPORTS: Record<CompilerRuntimeFeatureName, strin
   "keyed-rows-window-every-hinted": "keyedRowsWindowEveryHintedRuntimeFeature",
   "keyed-rows-filter-hinted": "keyedRowsFilterHintedRuntimeFeature",
   "keyed-rows-structural-append-hinted": "keyedRowsStructuralAppendHintedRuntimeFeature",
+  "keyed-rows-structural-append-map-hinted": "keyedRowsStructuralAppendMapHintedRuntimeFeature",
   "keyed-rows-prepend-hinted": "keyedRowsPrependHintedRuntimeFeature",
   "keyed-rows-filter-prepend-hinted": "keyedRowsFilterPrependHintedRuntimeFeature",
   "keyed-rows-conditional": "keyedRowsConditionalRuntimeFeature",
@@ -462,6 +467,8 @@ const COMPILER_RUNTIME_FEATURE_EXPORTS: Record<CompilerRuntimeFeatureName, strin
   "keyed-rows-conditional-filter-hinted": "keyedRowsConditionalFilterHintedRuntimeFeature",
   "keyed-rows-conditional-structural-append-hinted":
     "keyedRowsConditionalStructuralAppendHintedRuntimeFeature",
+  "keyed-rows-conditional-structural-append-map-hinted":
+    "keyedRowsConditionalStructuralAppendMapHintedRuntimeFeature",
   "keyed-rows-conditional-prepend-hinted": "keyedRowsConditionalPrependHintedRuntimeFeature",
   "keyed-rows-conditional-filter-prepend-hinted":
     "keyedRowsConditionalFilterPrependHintedRuntimeFeature",
@@ -477,6 +484,8 @@ const COMPILER_RUNTIME_FEATURE_EXPORTS: Record<CompilerRuntimeFeatureName, strin
   "keyed-rows-host-window-every-hinted": "keyedRowsHostWindowEveryHintedRuntimeFeature",
   "keyed-rows-host-filter-hinted": "keyedRowsHostFilterHintedRuntimeFeature",
   "keyed-rows-host-structural-append-hinted": "keyedRowsHostStructuralAppendHintedRuntimeFeature",
+  "keyed-rows-host-structural-append-map-hinted":
+    "keyedRowsHostStructuralAppendMapHintedRuntimeFeature",
   "keyed-rows-host-prepend-hinted": "keyedRowsHostPrependHintedRuntimeFeature",
   "keyed-rows-host-filter-prepend-hinted": "keyedRowsHostFilterPrependHintedRuntimeFeature",
   "keyed-rows-complete": "keyedRowsCompleteRuntimeFeature",
@@ -493,6 +502,8 @@ const COMPILER_RUNTIME_FEATURE_EXPORTS: Record<CompilerRuntimeFeatureName, strin
   "keyed-rows-complete-filter-hinted": "keyedRowsCompleteFilterHintedRuntimeFeature",
   "keyed-rows-complete-structural-append-hinted":
     "keyedRowsCompleteStructuralAppendHintedRuntimeFeature",
+  "keyed-rows-complete-structural-append-map-hinted":
+    "keyedRowsCompleteStructuralAppendMapHintedRuntimeFeature",
   "keyed-rows-complete-prepend-hinted": "keyedRowsCompletePrependHintedRuntimeFeature",
   "keyed-rows-complete-filter-prepend-hinted": "keyedRowsCompleteFilterPrependHintedRuntimeFeature",
   "keyed-ranges": "keyedRangesRuntimeFeature",
@@ -505,6 +516,7 @@ function runtimeFeaturesForPlans(
   keyedMapUpdateHints: boolean,
   keyedArrayFilterHints: boolean,
   keyedArrayStructuralAppendHints: boolean,
+  keyedArrayStructuralAppendMapHints: boolean,
   keyedArrayPrependHints: boolean,
   keyedArrayPositionHints: boolean,
   keyedArrayBatchInsertHints: boolean,
@@ -537,36 +549,38 @@ function runtimeFeaturesForPlans(
             : "keyed-rows";
     const arrayRangeHints =
       keyedArrayRollingWindowHints || keyedArrayFilterHints || keyedArrayPrependHints;
-    const hintSuffix = keyedArrayStructuralAppendHints
-      ? "-structural-append-hinted"
-      : keyedArrayWindowReplaceHints
-        ? arrayRangeHints || keyedArrayReorderHints
-          ? "-window-every-hinted"
-          : "-window-position-hinted"
-        : keyedArrayBatchInsertHints
+    const hintSuffix = keyedArrayStructuralAppendMapHints
+      ? "-structural-append-map-hinted"
+      : keyedArrayStructuralAppendHints
+        ? "-structural-append-hinted"
+        : keyedArrayWindowReplaceHints
           ? arrayRangeHints || keyedArrayReorderHints
-            ? "-batch-every-hinted"
-            : "-batch-position-hinted"
-          : (keyedArrayPositionHints && (arrayRangeHints || keyedArrayReorderHints)) ||
-              (keyedArrayReorderHints && arrayRangeHints)
-            ? "-every-hinted"
-            : keyedArrayRollingWindowHints
-              ? "-all-hinted"
-              : keyedArrayPositionHints
-                ? "-position-hinted"
-                : keyedArrayMapReorderHints && keyedRowsFeature === "keyed-rows"
-                  ? "-map-reorder-hinted"
-                  : keyedArrayReorderHints
-                    ? "-reorder-hinted"
-                    : keyedArrayFilterHints && keyedArrayPrependHints
-                      ? "-filter-prepend-hinted"
-                      : keyedArrayFilterHints
-                        ? "-filter-hinted"
-                        : keyedArrayPrependHints
-                          ? "-prepend-hinted"
-                          : keyedMapUpdateHints
-                            ? "-hinted"
-                            : "";
+            ? "-window-every-hinted"
+            : "-window-position-hinted"
+          : keyedArrayBatchInsertHints
+            ? arrayRangeHints || keyedArrayReorderHints
+              ? "-batch-every-hinted"
+              : "-batch-position-hinted"
+            : (keyedArrayPositionHints && (arrayRangeHints || keyedArrayReorderHints)) ||
+                (keyedArrayReorderHints && arrayRangeHints)
+              ? "-every-hinted"
+              : keyedArrayRollingWindowHints
+                ? "-all-hinted"
+                : keyedArrayPositionHints
+                  ? "-position-hinted"
+                  : keyedArrayMapReorderHints && keyedRowsFeature === "keyed-rows"
+                    ? "-map-reorder-hinted"
+                    : keyedArrayReorderHints
+                      ? "-reorder-hinted"
+                      : keyedArrayFilterHints && keyedArrayPrependHints
+                        ? "-filter-prepend-hinted"
+                        : keyedArrayFilterHints
+                          ? "-filter-hinted"
+                          : keyedArrayPrependHints
+                            ? "-prepend-hinted"
+                            : keyedMapUpdateHints
+                              ? "-hinted"
+                              : "";
     features.add(`${keyedRowsFeature}${hintSuffix}` as CompilerRuntimeFeatureName);
   }
   return [...features].sort();
@@ -2611,30 +2625,41 @@ function rewriteQueuedKeyedArrayStructuralMapHints(
   statesBySetter: ReadonlyMap<string, StateBinding>,
   mapUpdateIdentifier: t.Identifier,
   mapPipelineIdentifier: t.Identifier,
+  appendIdentifier: t.Identifier,
+  structuralAppendMapPipelineIdentifier: t.Identifier,
   filterIdentifier: t.Identifier,
   sliceIdentifier: t.Identifier,
   allowed: boolean,
-): { root: t.JSXElement; mapCount: number; stateIndices: ReadonlySet<number> } {
+): {
+  root: t.JSXElement;
+  mapCount: number;
+  structuralAppendMapCount: number;
+  stateIndices: ReadonlySet<number>;
+} {
   if (!allowed) {
-    return { root: t.cloneNode(root, true), mapCount: 0, stateIndices: new Set() };
+    return {
+      root: t.cloneNode(root, true),
+      mapCount: 0,
+      structuralAppendMapCount: 0,
+      stateIndices: new Set(),
+    };
   }
   const file = expressionFile(t.cloneNode(root, true));
   let mapCount = 0;
+  let structuralAppendMapCount = 0;
   const stateIndices = new Set<number>();
 
-  const returnsStructuralValue = (updater: t.ArrowFunctionExpression): boolean => {
-    if (!t.isBlockStatement(updater.body)) return false;
+  const structuralUpdateKind = (
+    updater: t.ArrowFunctionExpression,
+  ): "filter" | "slice" | undefined => {
+    if (!t.isBlockStatement(updater.body)) return undefined;
     const statement = updater.body.body.at(-1);
-    if (!t.isReturnStatement(statement) || !statement.argument) return false;
-    let found = false;
+    if (!t.isReturnStatement(statement) || !statement.argument) return undefined;
+    let found: "filter" | "slice" | undefined;
     t.traverseFast(statement.argument, (node) => {
-      if (
-        !found &&
-        t.isCallExpression(node) &&
-        t.isIdentifier(node.callee) &&
-        (node.callee.name === filterIdentifier.name || node.callee.name === sliceIdentifier.name)
-      ) {
-        found = true;
+      if (!found && t.isCallExpression(node) && t.isIdentifier(node.callee)) {
+        if (node.callee.name === filterIdentifier.name) found = "filter";
+        if (node.callee.name === sliceIdentifier.name) found = "slice";
       }
     });
     return found;
@@ -2643,11 +2668,17 @@ function rewriteQueuedKeyedArrayStructuralMapHints(
   traverse(file, {
     BlockStatement(path) {
       let structuralState: number | undefined;
+      let structuralAppendState: number | undefined;
+      let structuralMapState: number | undefined;
+      let structuralKind: "filter" | "slice" | undefined;
       const statements = path.get("body") as NodePath<t.Statement>[];
       for (const statementPath of statements) {
         const statement = statementPath.node;
         if (!t.isExpressionStatement(statement) || !t.isCallExpression(statement.expression)) {
           structuralState = undefined;
+          structuralAppendState = undefined;
+          structuralMapState = undefined;
+          structuralKind = undefined;
           continue;
         }
         const setterCall = statement.expression;
@@ -2657,6 +2688,9 @@ function rewriteQueuedKeyedArrayStructuralMapHints(
           setterCall.arguments.length !== 1
         ) {
           structuralState = undefined;
+          structuralAppendState = undefined;
+          structuralMapState = undefined;
+          structuralKind = undefined;
           continue;
         }
         const state = statesBySetter.get(setterCall.callee.name);
@@ -2670,22 +2704,66 @@ function rewriteQueuedKeyedArrayStructuralMapHints(
           !t.isIdentifier(updater.params[0])
         ) {
           structuralState = undefined;
+          structuralAppendState = undefined;
+          structuralMapState = undefined;
+          structuralKind = undefined;
           continue;
         }
 
-        if (returnsStructuralValue(updater)) {
+        const nextStructuralKind = structuralUpdateKind(updater);
+        if (nextStructuralKind) {
           structuralState = state.index;
+          structuralAppendState = undefined;
+          structuralMapState = undefined;
+          structuralKind = nextStructuralKind;
+          continue;
+        }
+
+        let containsAppend = false;
+        t.traverseFast(updater.body, (node) => {
+          if (
+            !containsAppend &&
+            t.isCallExpression(node) &&
+            t.isIdentifier(node.callee, { name: appendIdentifier.name })
+          ) {
+            containsAppend = true;
+          }
+        });
+        if (containsAppend) {
+          if (
+            structuralState === state.index &&
+            structuralKind === "slice" &&
+            structuralMapState !== state.index
+          ) {
+            structuralAppendState = state.index;
+          } else {
+            structuralState = undefined;
+            structuralAppendState = undefined;
+            structuralMapState = undefined;
+            structuralKind = undefined;
+          }
           continue;
         }
 
         const pipelineMapCount = countKeyedArrayMapPipeline(updater, mapUpdateIdentifier);
         if (structuralState !== state.index || pipelineMapCount === 0) {
           structuralState = undefined;
+          structuralAppendState = undefined;
+          structuralMapState = undefined;
+          structuralKind = undefined;
           continue;
         }
         (updater as t.ArrowFunctionExpression & { body: t.CallExpression }).body.callee =
-          t.cloneNode(mapPipelineIdentifier);
+          t.cloneNode(
+            structuralAppendState === state.index
+              ? structuralAppendMapPipelineIdentifier
+              : mapPipelineIdentifier,
+          );
         mapCount += pipelineMapCount;
+        if (structuralAppendState === state.index) {
+          structuralAppendMapCount += pipelineMapCount;
+        }
+        structuralMapState = state.index;
         stateIndices.add(state.index);
       }
     },
@@ -2693,6 +2771,7 @@ function rewriteQueuedKeyedArrayStructuralMapHints(
   return {
     root: (file.program.body[0] as t.ExpressionStatement).expression as t.JSXElement,
     mapCount,
+    structuralAppendMapCount,
     stateIndices,
   };
 }
@@ -8026,6 +8105,7 @@ function compileCandidate(
   keyedArrayAppendIdentifier: t.Identifier,
   keyedArrayFilterIdentifier: t.Identifier,
   keyedArrayMapPipelineIdentifier: t.Identifier,
+  keyedArrayStructuralAppendMapPipelineIdentifier: t.Identifier,
   keyedArrayQueuedMapPipelineIdentifier: t.Identifier,
   keyedArrayMapReorderIdentifier: t.Identifier,
   keyedArrayMappedStructuralIdentifier: t.Identifier,
@@ -8065,6 +8145,7 @@ function compileCandidate(
     keyedArrayMapUpdateHints: number;
     keyedArrayMappedStructuralHints: number;
     keyedArrayQueuedMapUpdateHints: number;
+    keyedArrayStructuralAppendMapHints: number;
     keyedArrayStructuralReorderHints: number;
     keyedArrayStructuralSortHints: number;
     keyedArrayWindowReplaceHints: number;
@@ -8817,11 +8898,14 @@ function compileCandidate(
     statesBySetter,
     keyedMapUpdateIdentifier,
     keyedArrayMapPipelineIdentifier,
+    keyedArrayAppendIdentifier,
+    keyedArrayStructuralAppendMapPipelineIdentifier,
     keyedArrayFilterIdentifier,
     keyedArraySliceIdentifier,
     allowKeyedArrayMapPipelines,
   );
   let appliedQueuedStructuralMapHints = 0;
+  let appliedQueuedStructuralAppendMapHints = 0;
   if (queuedStructuralMapHintedRoot.mapCount > 0) {
     const hintedBlockAnalysis = analyzeComposableBlocks(
       queuedStructuralMapHintedRoot.root,
@@ -8844,12 +8928,16 @@ function compileCandidate(
       blockAnalysis = hintedBlockAnalysis;
       analysis = hintedAnalysis;
       appliedQueuedStructuralMapHints = queuedStructuralMapHintedRoot.mapCount;
+      appliedQueuedStructuralAppendMapHints =
+        queuedStructuralMapHintedRoot.structuralAppendMapCount;
       appliedKeyedArrayReorderHints += queuedStructuralMapHintedRoot.mapCount;
       appliedReorderHintedStateIndices = new Set([
         ...appliedReorderHintedStateIndices,
         ...queuedStructuralMapHintedRoot.stateIndices,
       ]);
       compilerUsage.keyedArrayMapUpdateHints += queuedStructuralMapHintedRoot.mapCount;
+      compilerUsage.keyedArrayStructuralAppendMapHints +=
+        queuedStructuralMapHintedRoot.structuralAppendMapCount;
     }
   }
   const queuedMapReorderHintedRoot = rewriteQueuedKeyedArrayMapReorderHints(
@@ -9056,6 +9144,7 @@ function compileCandidate(
     hasKeyedArrayRemovalHints,
     appliedKeyedArrayAppendHints > 0 &&
       (appliedKeyedArrayFilterHints > 0 || appliedKeyedArraySliceHints > 0),
+    appliedQueuedStructuralAppendMapHints > 0,
     appliedKeyedArrayPrependHints > 0,
     appliedKeyedArrayPositionHints > 0,
     appliedKeyedArrayBatchInsertHints > 0,
@@ -9281,6 +9370,7 @@ export async function compileReactModule(
     keyedArrayMapUpdateHints: 0,
     keyedArrayMappedStructuralHints: 0,
     keyedArrayQueuedMapUpdateHints: 0,
+    keyedArrayStructuralAppendMapHints: 0,
     keyedArrayStructuralReorderHints: 0,
     keyedArrayStructuralSortHints: 0,
     keyedArrayWindowReplaceHints: 0,
@@ -9334,6 +9424,10 @@ export async function compileReactModule(
         const keyedArrayMapPipelineIdentifier = programPath.scope.generateUidIdentifier(
           "createCompilerKeyedArrayMapPipeline",
         );
+        const keyedArrayStructuralAppendMapPipelineIdentifier =
+          programPath.scope.generateUidIdentifier(
+            "createCompilerKeyedArrayStructuralAppendMapPipeline",
+          );
         const keyedArrayQueuedMapPipelineIdentifier = programPath.scope.generateUidIdentifier(
           "createCompilerKeyedArrayQueuedMapPipeline",
         );
@@ -9404,6 +9498,7 @@ export async function compileReactModule(
             keyedArrayAppendIdentifier,
             keyedArrayFilterIdentifier,
             keyedArrayMapPipelineIdentifier,
+            keyedArrayStructuralAppendMapPipelineIdentifier,
             keyedArrayQueuedMapPipelineIdentifier,
             keyedArrayMapReorderIdentifier,
             keyedArrayMappedStructuralIdentifier,
@@ -9441,7 +9536,9 @@ export async function compileReactModule(
         }
 
         const hasEagerKeyedArrayMapUpdateHints =
-          compilerUsage.keyedArrayMapUpdateHints > compilerUsage.keyedArrayQueuedMapUpdateHints;
+          compilerUsage.keyedArrayMapUpdateHints >
+          compilerUsage.keyedArrayQueuedMapUpdateHints +
+            compilerUsage.keyedArrayStructuralAppendMapHints;
         const hasKeyedArrayMapReorderHints =
           compilerUsage.keyedArrayMapReorderHints + compilerUsage.keyedArrayMapSortHints > 0;
         const hasKeyedArrayStructuralAppendHints =
@@ -9470,6 +9567,14 @@ export async function compileReactModule(
                       t.importSpecifier(
                         keyedArrayMapPipelineIdentifier,
                         t.identifier("createCompilerKeyedArrayMapPipeline"),
+                      ),
+                    ]
+                  : []),
+                ...(compilerUsage.keyedArrayStructuralAppendMapHints > 0
+                  ? [
+                      t.importSpecifier(
+                        keyedArrayStructuralAppendMapPipelineIdentifier,
+                        t.identifier("createCompilerKeyedArrayStructuralAppendMapPipeline"),
                       ),
                     ]
                   : []),

--- a/packages/farm-react/vitest.stress.config.ts
+++ b/packages/farm-react/vitest.stress.config.ts
@@ -22,7 +22,7 @@ export default defineConfig({
     ],
     setupFiles: ["src/__tests__/stress.setup.ts"],
     testNamePattern:
-      /2,000 deterministic mapped reorder updates|2,000 deterministic mapped reversal parity updates|2,000 queued reverse, map, and reverse updates|2,000 reverse-or-sort then map updates|2,000 queued reorder then standalone map updates|2,000 queued map then reorder updates|2,000 queued map and consecutive reorder updates|2,000 mapped structural removals|2,000 randomized interleaved map and structural removals|2,000 randomized terminal structural-map row transitions|2,000 randomized mapped terminal-structural row transitions|2,000 randomized queued mapped structural transitions|2,000 randomized queued structural mapped transitions|2,000 randomized queued structural mapped reorders|2,000 randomized queued structural removals and appends|3,000 deterministic recursive updates|4,096 rows/,
+      /2,000 deterministic mapped reorder updates|2,000 deterministic mapped reversal parity updates|2,000 queued reverse, map, and reverse updates|2,000 reverse-or-sort then map updates|2,000 queued reorder then standalone map updates|2,000 queued map then reorder updates|2,000 queued map and consecutive reorder updates|2,000 mapped structural removals|2,000 randomized interleaved map and structural removals|2,000 randomized terminal structural-map row transitions|2,000 randomized mapped terminal-structural row transitions|2,000 randomized queued mapped structural transitions|2,000 randomized queued structural mapped transitions|2,000 randomized queued structural mapped reorders|2,000 randomized structural removals, appends, and maps|3,000 deterministic recursive updates|4,096 rows/,
     testTimeout: 30_000,
   },
 });


### PR DESCRIPTION
## Problem

A keyed-row update could preserve structural lineage through a bounded `slice()` and an immutable append, but an immediately following safe same-key `map()` discarded that proof. The final commit then performed complete keyed reconciliation even though the native maps already visited every survivor and the appended suffix had a known boundary.

## Root cause

Queued structural-map linking recognized filter-or-slice followed by maps and structural append linking recognized filter-or-slice followed by appends, but those two proofs were not composed. The runtime also lacked a committed item snapshot with which to validate mapped positional survivors before any DOM mutation.

## Change

- Link adjacent same-state `slice → append(s) → map(s)` setters at compile time.
- Snapshot committed row item identities only for the selected optional runtime.
- Validate dense native arrays, positional survivor lineage, mapped keys, bindings, and suffix keys before the first DOM write.
- Remove only sliced edges, patch only changed survivors, and create the mapped suffix from its final value.
- Keep filter chains, unsupported syntax, custom/sparse/subclassed arrays, changed keys, ambiguous ownership, and failed runtime validation on complete reconciliation.
- Add the maintained dashboard comparison, an isolated runtime-size fixture, React compatibility coverage, randomized stress coverage, package docs, and renderer docs.

## Safety and compatibility

Normal React setter and native method evaluation order is preserved. The optimization is limited to compiler-owned, index-independent host rows with one known collection dependency. A filter source or any failed proof falls back before mutation. No public API or configuration changes. React 18.3.1 and React 19.2.8 pass. The map-specific runtime is tree-shaken unless emitted; the older structural-append fixture grew by 23 gzip bytes for the shared instance argument, while the core-only fixture is unchanged.

## Verification

- `pnpm --filter @farm.js/react test` — 785 passed, 10 skipped
- `pnpm --filter @farm.js/react test:stress` — 18 passed, 88 skipped, including 2,000 randomized slice/filter, append, and map transitions
- `pnpm --filter @farm.js/react type-check`
- `pnpm --filter @farm.js/react test:compat`
- `pnpm --filter @farm.js/react test:runtime-size`
- `pnpm --filter farm-react-compiler-dashboard-example type-check`
- `pnpm --filter farm-react-compiler-dashboard-example build`
- `pnpm docs:check-navigation`
- `pnpm --dir docs exec farm generate --check`
- `pnpm docs:build`
- focused `oxlint` and `git diff --check`

Browser benchmark on Chrome 153.0.8010.36, Node.js 23.11.0, Apple M1 macOS arm64:

| Mode | Slice + append + maps | Compiled fallback | vs React | vs fallback |
| --- | ---: | ---: | ---: | ---: |
| Static | 16.40 ms | 29.80 ms | 4.24x | 1.82x |
| Hybrid | 13.60 ms | 22.60 ms | 5.11x | 1.66x |

The new gate, correctness, broad 10% no-regression gate, optimization-persistence gate, and zero-owner-execution checks passed. One unchanged hybrid structural-reorder control measured 1.14x against its 1.25x fallback threshold in the reduced-sample run; its correctness and the broad regression gate passed.

## Documentation and release

Updated the React renderer documentation, package README, dashboard README, reproducible benchmark results, benchmark runner, and isolated runtime-size baseline. No release version changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes keyed structural append lineage survive immediately following safe same-key `map()` setters, so the runtime patches only changed survivors instead of reconciling the whole keyed list.

**Safety and compatibility**
- Compiler links adjacent `slice → append(s) → map(s)` setters and snapshots committed row identities only for the emitted map-specific runtime.
- Falls back to complete reconciliation for filter sources, unsupported syntax, custom/sparse/subclassed arrays, changed keys, ambiguous ownership, and any failed runtime validation.
- No public API or config changes; React 18.3.1 and React 19.2.8 pass.
- Adds 23 gzip bytes to the older structural-append fixture for the shared instance argument; the core-only fixture is unchanged.

**Verification**
- Full test, stress (2,000 randomized transitions), type-check, compat, and runtime-size suites pass.
- Dashboard benchmark shows 4.24x/5.11x vs React and 1.82x/1.66x vs the compiled fallback for static/hybrid modes.
- Updated renderer docs, package READMEs, benchmark runner, and isolated runtime-size baseline.

<sup>Written for commit 5b5c4c48f099f8ec03747392918007a9511ac523. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/888?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

