### PR TITLE
perf(react): retain filtered append lineage through maps

### DIFF
--- a/docs/src/app/docs/renderers/react/page.md
+++ b/docs/src/app/docs/renderers/react/page.md
@@ -990,17 +990,18 @@ suffix in one fragment. Existing survivors are neither rebound nor recreated, an
 adjacent append setters are collapsed into the same final suffix. This keeps the unavoidable native
 filter or slice work while removing the keyed runtime's second full scan.
 
-After a bounded slice, one or more immediately following safe same-key `map()` setters can retain
-that proof too. Farm records changed indices while the native maps already visit them, validates the
-final dense array before touching the DOM, and patches only changed survivors. A mapped incoming
-suffix is still created directly from its final value. The owner stays mounted, sliced-away rows
-are removed, survivor DOM identity is preserved, and the suffix is appended once. Filter-based
-chains keep complete reconciliation because Farm must revalidate every survivor key after indexes
-shift; this avoids trading React identity semantics for a misleading fast path.
+After an index-independent filter or bounded slice, one or more immediately following safe same-key
+`map()` setters can retain that proof too. Farm carries the filter's original survivor indices or
+the slice's retained interval into the native maps, validates each visited survivor against the
+committed item snapshot, and records only changed indices. Before touching the DOM it revalidates
+the complete dense result, every changed key and binding, and every incoming row. It then removes
+only rejected rows, patches only changed survivors, and creates the mapped suffix directly from its
+final values. The owner stays mounted, survivor DOM identity is preserved, and the suffix is
+appended once.
 
 Only concise updater results that form one direct chain for the same state array are linked. The row
-and key must be compiler-owned and index-independent. A filter before append, a map or reorder
-between the structural step and append, an unsupported or non-adjacent map after append, an
+and key must be compiler-owned and index-independent. A map or reorder between the structural step
+and append, an unsupported or non-adjacent map after append, an
 unhinted update to that state, another dirty row dependency, collection-reading binding, custom,
 sparse, or subclassed array, nested or React-owned row, duplicate final key, or reuse of any
 committed key in the appended suffix keeps complete React reconciliation before a DOM write. A
@@ -2338,9 +2339,10 @@ The package and example test suites verify more than generated code:
   descriptor, and binding reads to equal only the appended suffix and cover queued updates,
   multi-boundary sharing, StrictMode hydration/unmount, and conservative fallback;
 - 2,000 randomized queued filter-or-slice, append, and map transitions match normal React, with
-  bounded slices taking the composed fast path and filters retaining complete reconciliation;
-  targeted slice tests require survivor DOM identity, changed-survivor-only binding writes,
-  controlled-input focus and selection, multiple maps, multi-boundary sharing, Strict Mode
+  both structural sources retaining their committed survivor positions through the composed fast
+  path; targeted tests require survivor DOM identity, changed-survivor-only binding writes, mixed
+  filter/slice chains, controlled-input focus and selection, multiple maps, multi-boundary sharing,
+  Strict Mode
   hydration, nested unmount cleanup, changed-key and removed-key reuse fallback, and atomic
   validation before mutation;
 - 2,000 deterministic keyed-array prepends match normal React; targeted tests require key,

--- a/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
+++ b/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
@@ -2,6 +2,38 @@
 
 Latest run: 2026-09-10
 
+## Queued filter, append, and maps — 2026-09-10
+
+An index-independent keyed-row `filter()` can now retain its original survivor positions through
+one or more adjacent immutable appends and immediately following same-key `map()` setters. The map
+wrapper validates every survivor against the committed item snapshot while native `map()` already
+visits it. The commit then removes only rejected rows, patches only changed survivors, and creates
+the mapped suffix from its final values, with all keys, bindings, and detached rows prepared before
+the first DOM write.
+
+| Mode   | Filter + append + maps | Compiled fallback | vs React | vs fallback |
+| ------ | ---------------------: | ----------------: | -------: | ----------: |
+| Static |               18.00 ms |          32.10 ms |    4.35x |       1.78x |
+| Hybrid |               18.60 ms |          29.20 ms |    4.21x |       1.57x |
+
+Both modes passed the 2x React and 1.25x compiled-control floors. The bracketed React median was
+78.30 ms. Every sample verified the final 10,000-row order, complete survivor DOM identity, the
+middle row's disconnection, the changed survivor's final label and amount, and the fresh mapped
+suffix. The existing bounded-slice comparison remained separate and also passed at 9.79x and 10.38x
+versus React. Correctness, the broad 10% no-regression gate, optimization persistence, and zero
+compiled-owner executions passed.
+
+Package coverage includes mixed filter/slice lineage, multiple following maps, mapped incoming
+rows, changed-key fallback, external mutation, controlled-input focus and selection, multiple keyed
+boundaries, Strict Mode hydration, unmount before flush, React 18.3.1 and 19.2.8, and 2,000
+randomized transitions matched with normal React. The optional structural-append-map runtime is
+18,633 bytes gzip, within its persisted 18,664-byte cap.
+
+Numbers are medians from a reduced complete-dashboard run with 2 warmups and 7 measured samples per
+compiler action, bracketed by 14 React samples, using Chrome 153.0.8010.36 and Node.js 23.11.0 on
+Apple M1 macOS arm64. The aggregate correctness, performance, and optimization-persistence result
+passed.
+
 ## Queued slice, append, and maps — 2026-09-10
 
 Adjacent keyed-row setters can now retain one positional proof through a bounded `slice()`, one or
@@ -23,7 +55,7 @@ suffix. The broad 10% no-regression gate, optimization-persistence gate, and zer
 checks also passed.
 
 Compiler and runtime coverage includes multiple following maps, a mapped incoming suffix,
-changed-key fallback, filters retaining complete reconciliation, controlled-input focus and
+changed-key fallback, controlled-input focus and
 selection, custom and revoked methods, external mutation, Strict Mode, hydration, unmount before
 flush, React 18.3.1 and 19.2.8, and 2,000 randomized transitions matched with normal React. The new
 optional runtime measures 18,408 bytes gzip in its isolated fixture. The older structural-append

--- a/examples/react-compiler-dashboard/README.md
+++ b/examples/react-compiler-dashboard/README.md
@@ -89,9 +89,14 @@ immediately following safe same-key maps. It verifies that the changed survivor 
 and receives its final label and amount, the sliced-away row disconnects, and the mapped incoming
 suffix is newly mounted. Both compiler modes must remain at least 2x faster than React and 1.25x
 faster than the equivalent block-bodied compiled control. Package tests compare 2,000 randomized
-filter-or-slice, append, and map transitions with normal React; bounded slices take the fast path
-while filters retain complete reconciliation. The suite also covers multiple maps, controlled-input
-selection, hydration, unmount, native method errors, changed keys, and pre-mutation fallback.
+filter-or-slice, append, and map transitions with normal React. The suite also covers multiple maps,
+mixed filter/slice chains, controlled-input selection, hydration, unmount, native method errors,
+changed keys, external mutation, and pre-mutation fallback.
+
+A separate filter-based comparison removes a middle row, appends one row, and runs the same two
+safe maps. The filter's recorded survivor positions let the commit avoid a second key-and-binding
+scan while still validating the complete native result before mutation. Both compiler modes must
+remain at least 2x faster than React and 1.25x faster than the block-bodied compiled control.
 
 Keyed array prepends have the same independent comparison. A concise functional prepend is
 measured against bracketed React and an equivalent block-bodied compiled snapshot control. Both

--- a/examples/react-compiler-dashboard/scripts/benchmark.mjs
+++ b/examples/react-compiler-dashboard/scripts/benchmark.mjs
@@ -1278,6 +1278,50 @@ async function measureTrial(browser, trial, compilerMode, port) {
             ),
         );
 
+        const measureFilterAppendMap = async (action) => {
+          const rows = [...table.querySelectorAll("tbody tr")];
+          const removed = rows.find(
+            (row) => Number(row.getAttribute("data-row-id")) % 10_000 === 7_001,
+          );
+          const target = rows.find(
+            (row) => Number(row.getAttribute("data-row-id")) % 10_000 === 5_001,
+          );
+          const amount = Number(target?.querySelector("td:nth-child(4)")?.textContent?.slice(1));
+          if (!removed || !target || !Number.isFinite(amount)) {
+            throw new Error("Queued filter-append-map source rows are invalid.");
+          }
+          const survivors = rows.filter((row) => row !== removed);
+          await runTableAction(action, () => {
+            const nextRows = [...table.querySelectorAll("tbody tr")];
+            const appended = nextRows.at(-1);
+            return (
+              nextRows.length === 10_000 &&
+              rowsMatch(nextRows.slice(0, -1), survivors) &&
+              target.querySelector("td:nth-child(2)")?.textContent?.endsWith(" reviewed") ===
+                true &&
+              target.querySelector("td:nth-child(4)")?.textContent === `$${amount + 1}` &&
+              appended?.querySelector("td:nth-child(2)")?.textContent ===
+                "queued filter mapped incoming row" &&
+              !rows.includes(appended) &&
+              !removed.isConnected
+            );
+          });
+        };
+
+        const tableFilterAppendMapQueued = await measureTable(
+          async () => create10000(),
+          async () =>
+            measureFilterAppendMap(() => tableButton("table-filter-append-map-queued").click()),
+        );
+
+        const tableFilterAppendMapQueuedSnapshot = await measureTable(
+          async () => create10000(),
+          async () =>
+            measureFilterAppendMap(() =>
+              tableButton("table-filter-append-map-queued-snapshot").click(),
+            ),
+        );
+
         const prepareMapStructuralReorderPipeline = async () => {
           await create10000();
           const rows = [...table.querySelectorAll("tbody tr")];
@@ -2035,6 +2079,8 @@ async function measureTrial(browser, trial, compilerMode, port) {
             executionsAdded: Number(tableExecutions.textContent) - initialTableExecutions,
             filterReorderPipeline: tableFilterReorderPipeline,
             filterReorderPipelineSnapshot: tableFilterReorderPipelineSnapshot,
+            filterAppendMapQueued: tableFilterAppendMapQueued,
+            filterAppendMapQueuedSnapshot: tableFilterAppendMapQueuedSnapshot,
             structuralAppendQueued: tableStructuralAppendQueued,
             structuralAppendQueuedSnapshot: tableStructuralAppendQueuedSnapshot,
             structuralAppendMapQueued: tableStructuralAppendMapQueued,
@@ -2183,6 +2229,8 @@ async function measureTrial(browser, trial, compilerMode, port) {
         executionsAdded: result.table.executionsAdded,
         filterReorderPipeline: timingSummary(result.table.filterReorderPipeline),
         filterReorderPipelineSnapshot: timingSummary(result.table.filterReorderPipelineSnapshot),
+        filterAppendMapQueued: timingSummary(result.table.filterAppendMapQueued),
+        filterAppendMapQueuedSnapshot: timingSummary(result.table.filterAppendMapQueuedSnapshot),
         structuralAppendQueued: timingSummary(result.table.structuralAppendQueued),
         structuralAppendQueuedSnapshot: timingSummary(result.table.structuralAppendQueuedSnapshot),
         structuralAppendMapQueued: timingSummary(result.table.structuralAppendMapQueued),
@@ -2404,6 +2452,8 @@ const tableMetrics = [
   "denseMapLookup",
   "filterReorderPipeline",
   "filterReorderPipelineSnapshot",
+  "filterAppendMapQueued",
+  "filterAppendMapQueuedSnapshot",
   "structuralAppendQueued",
   "structuralAppendQueuedSnapshot",
   "structuralAppendMapQueued",
@@ -3112,6 +3162,28 @@ const keyedStructuralAppendMapRegressions = keyedStructuralAppendMapResults.filt
     !Number.isFinite(snapshotSpeedup) ||
     snapshotSpeedup < keyedStructuralAppendMapMinimumSnapshotSpeedup,
 );
+// A safe filter can retain its original survivor positions through adjacent append and map setters.
+// Keep this distinct from the bounded-slice gate so both structural lineage variants remain covered.
+const keyedFilterAppendMapMinimumSpeedup = 2;
+const keyedFilterAppendMapMinimumSnapshotSpeedup = 1.25;
+const keyedFilterAppendMapResults = ["static", "hybrid"].map((mode) => {
+  const pipelineMedianMs = comparisons.table.filterAppendMapQueued[mode].medianMs;
+  const snapshotMedianMs = comparisons.table.filterAppendMapQueuedSnapshot[mode].medianMs;
+  return {
+    mode,
+    pipelineMedianMs,
+    snapshotMedianMs,
+    snapshotSpeedup: snapshotMedianMs / pipelineMedianMs,
+    speedup: comparisons.table.filterAppendMapQueued[`${mode}VsBaseline`].speedup,
+  };
+});
+const keyedFilterAppendMapRegressions = keyedFilterAppendMapResults.filter(
+  ({ snapshotSpeedup, speedup }) =>
+    !Number.isFinite(speedup) ||
+    speedup < keyedFilterAppendMapMinimumSpeedup ||
+    !Number.isFinite(snapshotSpeedup) ||
+    snapshotSpeedup < keyedFilterAppendMapMinimumSnapshotSpeedup,
+);
 // A safe filter, terminal map, and two native reverses in adjacent setters change membership and
 // row data while restoring the survivor order in one queued commit. The combined path must remove
 // the rejected row, patch the changed survivor, and retain structural lineage through both reorder
@@ -3529,6 +3601,7 @@ const passed =
   keyedStructuralReorderRegressions.length === 0 &&
   keyedStructuralAppendRegressions.length === 0 &&
   keyedStructuralAppendMapRegressions.length === 0 &&
+  keyedFilterAppendMapRegressions.length === 0 &&
   keyedMappedStructuralReorderRegressions.length === 0 &&
   keyedMapReorderRegressions.length === 0 &&
   keyedMultiMapReorderRegressions.length === 0 &&
@@ -3718,6 +3791,13 @@ const report = {
     regressions: keyedStructuralAppendMapRegressions,
     results: keyedStructuralAppendMapResults,
     status: keyedStructuralAppendMapRegressions.length === 0 ? "PASS" : "FAIL",
+  },
+  keyedFilterAppendMapHintGate: {
+    minimumSnapshotSpeedup: keyedFilterAppendMapMinimumSnapshotSpeedup,
+    minimumSpeedup: keyedFilterAppendMapMinimumSpeedup,
+    regressions: keyedFilterAppendMapRegressions,
+    results: keyedFilterAppendMapResults,
+    status: keyedFilterAppendMapRegressions.length === 0 ? "PASS" : "FAIL",
   },
   keyedMappedStructuralReorderHintGate: {
     minimumSnapshotSpeedup: keyedMappedStructuralReorderMinimumSnapshotSpeedup,

--- a/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
+++ b/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
@@ -979,6 +979,76 @@ export function StandardTableBenchmark() {
           Queued remove + append + map (snapshot control)
         </button>
         <button
+          data-action="table-filter-append-map-queued"
+          type="button"
+          onClick={() => {
+            const incoming = {
+              id: (seed + 1_200_000) * 10_000 + 1,
+              label: "queued incoming row",
+              amount: 4_096,
+              region: "AMR" as const,
+              status: "review" as const,
+            };
+            setRows((current) => current.filter((row) => row.id % 10_000 !== 7_001));
+            setRows((current) => [...current, incoming]);
+            setRows((current) =>
+              current.map((row) =>
+                row.id % 10_000 === 5_001
+                  ? { ...row, amount: row.amount + 1, label: `${row.label} reviewed` }
+                  : row,
+              ),
+            );
+            setRows((current) =>
+              current.map((row) =>
+                row.id === incoming.id
+                  ? { ...row, label: "queued filter mapped incoming row" }
+                  : row,
+              ),
+            );
+            setOperation("filter, append, and map across queued setters");
+            setRevision((value) => value + 1);
+          }}
+        >
+          Queued filter + append + map
+        </button>
+        <button
+          data-action="table-filter-append-map-queued-snapshot"
+          type="button"
+          onClick={() => {
+            const incoming = {
+              id: (seed + 1_200_000) * 10_000 + 1,
+              label: "queued incoming row",
+              amount: 4_096,
+              region: "AMR" as const,
+              status: "review" as const,
+            };
+            setRows((current) => {
+              return current.filter((row) => row.id % 10_000 !== 7_001);
+            });
+            setRows((current) => {
+              return [...current, incoming];
+            });
+            setRows((current) => {
+              return current.map((row) =>
+                row.id % 10_000 === 5_001
+                  ? { ...row, amount: row.amount + 1, label: `${row.label} reviewed` }
+                  : row,
+              );
+            });
+            setRows((current) => {
+              return current.map((row) =>
+                row.id === incoming.id
+                  ? { ...row, label: "queued filter mapped incoming row" }
+                  : row,
+              );
+            });
+            setOperation("filter, append, and map (snapshot control)");
+            setRevision((value) => value + 1);
+          }}
+        >
+          Queued filter + append + map (snapshot control)
+        </button>
+        <button
           data-action="table-map-structural-reorder-pipeline"
           type="button"
           onClick={() => {

--- a/packages/farm-react/README.md
+++ b/packages/farm-react/README.md
@@ -282,17 +282,18 @@ suffix in one fragment. Existing survivors are neither rebound nor recreated, an
 adjacent append setters are collapsed into the same final suffix. This keeps the unavoidable native
 filter or slice work while removing the keyed runtime's second full scan.
 
-After a bounded slice, one or more immediately following safe same-key `map()` setters can retain
-that proof too. Farm records changed indices while the native maps already visit them, validates the
-final dense array before touching the DOM, and patches only changed survivors. A mapped incoming
-suffix is still created directly from its final value. The owner stays mounted, sliced-away rows
-are removed, survivor DOM identity is preserved, and the suffix is appended once. Filter-based
-chains keep complete reconciliation because Farm must revalidate every survivor key after indexes
-shift; this avoids trading React identity semantics for a misleading fast path.
+After an index-independent filter or bounded slice, one or more immediately following safe same-key
+`map()` setters can retain that proof too. Farm carries the filter's original survivor indices or
+the slice's retained interval into the native maps, validates each visited survivor against the
+committed item snapshot, and records only changed indices. Before touching the DOM it revalidates
+the complete dense result, every changed key and binding, and every incoming row. It then removes
+only rejected rows, patches only changed survivors, and creates the mapped suffix directly from its
+final values. The owner stays mounted, survivor DOM identity is preserved, and the suffix is
+appended once.
 
 Only concise updater results that form one direct chain for the same state array are linked. The row
-and key must be compiler-owned and index-independent. A filter before append, a map or reorder
-between the structural step and append, an unsupported or non-adjacent map after append, an
+and key must be compiler-owned and index-independent. A map or reorder between the structural step
+and append, an unsupported or non-adjacent map after append, an
 unhinted update to that state, another dirty row dependency, collection-reading binding, custom,
 sparse, or subclassed array, nested or React-owned row, duplicate final key, or reuse of any
 committed key in the appended suffix keeps complete React reconciliation before a DOM write. A

--- a/packages/farm-react/RUNTIME_SIZE_RESULTS.json
+++ b/packages/farm-react/RUNTIME_SIZE_RESULTS.json
@@ -94,14 +94,14 @@
         "brotli": 51844
       },
       "compilerOn": {
-        "raw": 261669,
-        "gzip": 78546,
-        "brotli": 67291
+        "raw": 262343,
+        "gzip": 78771,
+        "brotli": 67528
       },
       "compilerPremium": {
-        "raw": 68688,
-        "gzip": 18408,
-        "brotli": 15447
+        "raw": 69362,
+        "gzip": 18633,
+        "brotli": 15684
       }
     },
     "keyedPrepend": {

--- a/packages/farm-react/scripts/test-react-version.mjs
+++ b/packages/farm-react/scripts/test-react-version.mjs
@@ -2262,10 +2262,10 @@ const testSource = String.raw`
       const items = () => state[0].get();
       structuralAppendRows = () => {
         state[0].set((previous) =>
-          createCompilerKeyedArraySlice(
+          createCompilerKeyedArrayFilter(
             previous,
-            previous.slice,
-            1,
+            previous.filter,
+            (item) => item.id !== "a",
           ),
         );
         state[0].set((previous) =>

--- a/packages/farm-react/src/__tests__/compiler-keyed-array-append-hints.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-keyed-array-append-hints.test.ts
@@ -207,7 +207,7 @@ describe("React AOT keyed-array append hints", () => {
     expect(result.code).not.toContain("createCompilerKeyedArrayStructuralAppendMapPipeline");
   });
 
-  it("keeps filter, append, and map chains on complete reconciliation", async () => {
+  it("retains filtered survivor lineage through following safe map setters", async () => {
     const result = await compile(`
       import { useState } from "react";
       export function Inventory({ expiredId, incoming, editedId, nextLabel }) {
@@ -231,8 +231,9 @@ describe("React AOT keyed-array append hints", () => {
     expect(result.optimizations.keyedArrayFilterHints).toBe(1);
     expect(result.optimizations.keyedArrayAppendHints).toBe(1);
     expect(result.optimizations.keyedMapUpdateHints).toBe(1);
-    expect(result.code).toContain("createCompilerKeyedMapUpdate");
-    expect(result.code).not.toContain("createCompilerKeyedArrayStructuralAppendMapPipeline");
+    expect(result.code).toContain("createCompilerKeyedArrayStructuralAppend");
+    expect(result.code).toContain("createCompilerKeyedArrayStructuralAppendMapPipeline");
+    expect(result.code).toContain("keyedRowsStructuralAppendMapHintedRuntimeFeature");
   });
 
   it("does not retain structural append lineage when a map runs before the append", async () => {

--- a/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-append-hints.test.tsx
+++ b/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-append-hints.test.tsx
@@ -11,7 +11,6 @@ import {
   createCompilerKeyedArrayStructuralAppend,
   createCompilerKeyedArrayStructuralAppendMapPipeline,
   keyedRowsStructuralAppendMapHintedRuntimeFeature,
-  keyedRowsStructuralAppendHintedRuntimeFeature,
   type CompilerKeyedRowElement,
 } from "../compiler-runtime";
 
@@ -132,6 +131,14 @@ function createAppendHarness(
     additions: readonly Item[],
     mapper: (item: Item, index: number) => Item,
   ) => void = () => undefined;
+  let filterSliceAppendThenMap: (
+    removed: ReadonlySet<string>,
+    start: number,
+    end: number,
+    additions: readonly Item[],
+    editedId: string,
+    nextLabel: string,
+  ) => void = () => undefined;
   let plainThenAppend: (addition: Item) => void = () => undefined;
   const Inventory = createCompiledComponentWithFeatures(
     {
@@ -195,6 +202,16 @@ function createAppendHarness(
           state[0].set((previous) => hintedSlice(previous as Item[], start, end));
           state[0].set((previous) => hintedStructuralAppend(previous as Item[], additions));
           state[0].set((previous) => hintedStructuralAppendMap(previous as Item[], mapper));
+        };
+        filterSliceAppendThenMap = (removed, start, end, additions, editedId, nextLabel) => {
+          state[0].set((previous) => hintedFilter(previous as Item[], removed));
+          state[0].set((previous) => hintedSlice(previous as Item[], start, end));
+          state[0].set((previous) => hintedStructuralAppend(previous as Item[], additions));
+          state[0].set((previous) =>
+            hintedStructuralAppendMap(previous as Item[], (item) =>
+              item.id === editedId ? { ...item, label: nextLabel } : item,
+            ),
+          );
         };
         plainThenAppend = (addition) => {
           state[0].set((previous) => [...(previous as Item[])]);
@@ -285,6 +302,14 @@ function createAppendHarness(
       additions: readonly Item[],
       mapper: (item: Item, index: number) => Item,
     ) => sliceAppendThenTransform(start, end, additions, mapper),
+    filterSliceAppendThenMap: (
+      removed: ReadonlySet<string>,
+      start: number,
+      end: number,
+      additions: readonly Item[],
+      editedId: string,
+      nextLabel: string,
+    ) => filterSliceAppendThenMap(removed, start, end, additions, editedId, nextLabel),
     plainThenAppend: (addition: Item) => plainThenAppend(addition),
   };
 }
@@ -467,7 +492,7 @@ describe("compiled keyed-array append hints", () => {
     expect(harness.counters.listRenders).toBe(1);
   });
 
-  it("falls back completely when a filter precedes the append and map", async () => {
+  it("removes filtered rows, patches mapped survivors, and creates only the suffix", async () => {
     const harness = createAppendHarness(
       [
         { id: "a", label: "Alpha" },
@@ -484,7 +509,9 @@ describe("compiled keyed-array append hints", () => {
     await act(async () => root.render(<harness.Inventory />));
     const alpha = container.querySelector('[data-key="a"]');
     const gamma = container.querySelector('[data-key="c"]');
+    const beta = container.querySelector('[data-key="b"]');
     harness.counters.keyReads = 0;
+    harness.counters.descriptorReads = 0;
     harness.counters.bindingReads = 0;
 
     await act(async () => {
@@ -493,19 +520,75 @@ describe("compiled keyed-array append hints", () => {
         [{ id: "d", label: "Delta" }],
         "c",
         "Gamma edited",
+        "Gamma edited twice",
       );
       await flushCompilerUpdates();
     });
 
     expect([...container.querySelectorAll("li")].map((row) => row.textContent)).toEqual([
       "Alpha",
-      "Gamma edited",
+      "Gamma edited twice",
       "Delta",
     ]);
     expect(container.querySelector('[data-key="a"]')).toBe(alpha);
     expect(container.querySelector('[data-key="c"]')).toBe(gamma);
-    expect(harness.counters.keyReads).toBe(3);
-    expect(harness.counters.bindingReads).toBe(3);
+    expect(beta?.isConnected).toBe(false);
+    expect(harness.counters.executions).toBe(1);
+    expect(harness.counters.listRenders).toBe(1);
+    expect(harness.counters.keyReads).toBe(2);
+    expect(harness.counters.descriptorReads).toBe(1);
+    expect(harness.counters.bindingReads).toBe(2);
+  });
+
+  it("retains original survivor positions through queued filter and slice chains", async () => {
+    const harness = createAppendHarness(
+      [
+        { id: "a", label: "Alpha" },
+        { id: "b", label: "Beta" },
+        { id: "c", label: "Gamma" },
+        { id: "d", label: "Delta" },
+        { id: "e", label: "Epsilon" },
+      ],
+      false,
+      true,
+    );
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Inventory />));
+    const gamma = container.querySelector('[data-key="c"]');
+    const epsilon = container.querySelector('[data-key="e"]');
+    const removed = [
+      ...container.querySelectorAll('[data-key="a"], [data-key="b"], [data-key="d"]'),
+    ];
+    harness.counters.keyReads = 0;
+    harness.counters.descriptorReads = 0;
+    harness.counters.bindingReads = 0;
+
+    await act(async () => {
+      harness.filterSliceAppendThenMap(
+        new Set(["b", "d"]),
+        1,
+        3,
+        [{ id: "f", label: "Phi" }],
+        "e",
+        "Epsilon edited",
+      );
+      await flushCompilerUpdates();
+    });
+
+    expect([...container.querySelectorAll("li")].map((row) => row.textContent)).toEqual([
+      "Gamma",
+      "Epsilon edited",
+      "Phi",
+    ]);
+    expect(container.querySelector('[data-key="c"]')).toBe(gamma);
+    expect(container.querySelector('[data-key="e"]')).toBe(epsilon);
+    expect(removed.every((row) => !row.isConnected)).toBe(true);
+    expect(harness.counters.keyReads).toBe(2);
+    expect(harness.counters.descriptorReads).toBe(1);
+    expect(harness.counters.bindingReads).toBe(2);
   });
 
   it("composes multiple queued appends after one structural update", async () => {
@@ -764,7 +847,7 @@ describe("compiled keyed-array append hints", () => {
     const alpha = container.querySelector('[data-key="a"]');
 
     await act(async () => {
-      harness.sliceAppendThenTransform(0, 2, [{ id: "d", label: "Delta" }], (item) =>
+      harness.filterAppendThenTransform(new Set(["c"]), [{ id: "d", label: "Delta" }], (item) =>
         item.id === "b" ? { ...item, id: "renamed-b", label: "Renamed" } : item,
       );
       await flushCompilerUpdates();
@@ -780,7 +863,7 @@ describe("compiled keyed-array append hints", () => {
     expect(container.querySelector('[data-key="renamed-b"]')).not.toBeNull();
   });
 
-  it("falls back when the committed array was mutated before the sliced map chain", async () => {
+  it("falls back when the committed array was mutated before the filtered map chain", async () => {
     const initialItems: Item[] = [
       { id: "a", label: "Alpha" },
       { id: "b", label: "Beta" },
@@ -798,7 +881,12 @@ describe("compiled keyed-array append hints", () => {
     harness.counters.keyReads = 0;
 
     await act(async () => {
-      harness.sliceAppendThenMap(0, 2, [{ id: "d", label: "Delta" }], "a", "Alpha edited");
+      harness.filterAppendThenMap(
+        new Set(["c"]),
+        [{ id: "d", label: "Delta" }],
+        "a",
+        "Alpha edited",
+      );
       await flushCompilerUpdates();
     });
 
@@ -943,6 +1031,11 @@ describe("compiled keyed-array append hints", () => {
             state[0].set((previous) =>
               hintedStructuralAppend(previous as Item[], [{ id: "c", label: "Gamma" }]),
             );
+            state[0].set((previous) =>
+              hintedStructuralAppendMap(previous as Item[], (item) =>
+                item.id === "b" ? { ...item, label: "Beta edited" } : item,
+              ),
+            );
           };
           const list = (id: number, owner: string) => (
             <blocks.KeyedRows
@@ -981,7 +1074,7 @@ describe("compiled keyed-array append hints", () => {
           { kind: "block", id: 1, dependencies: [0] },
         ],
       },
-      [keyedRowsStructuralAppendHintedRuntimeFeature],
+      [keyedRowsStructuralAppendMapHintedRuntimeFeature],
     );
     const container = document.createElement("div");
     document.body.append(container);
@@ -1005,8 +1098,8 @@ describe("compiled keyed-array append hints", () => {
       await flushCompilerUpdates();
     });
 
-    expect(container.querySelector('[data-owner="first"]')?.textContent).toBe("BetaGamma");
-    expect(container.querySelector('[data-owner="second"]')?.textContent).toBe("BetaGamma");
+    expect(container.querySelector('[data-owner="first"]')?.textContent).toBe("Beta editedGamma");
+    expect(container.querySelector('[data-owner="second"]')?.textContent).toBe("Beta editedGamma");
     expect(keyReads).toBe(4);
   });
 
@@ -1192,14 +1285,24 @@ describe("compiled keyed-array append hints", () => {
     expect(recoverable).toEqual([]);
 
     await act(async () => {
-      harness.sliceAppendThenMap(1, 2, [{ id: "c", label: "Gamma" }], "b", "Beta edited");
+      harness.filterAppendThenMap(
+        new Set(["a"]),
+        [{ id: "c", label: "Gamma" }],
+        "b",
+        "Beta edited",
+      );
       await flushCompilerUpdates();
     });
     expect(container.textContent).toBe("Beta editedGamma");
 
     roots.pop();
     act(() => {
-      harness.sliceAppendThenMap(1, 2, [{ id: "d", label: "Delta" }], "c", "Gamma edited");
+      harness.filterAppendThenMap(
+        new Set(["b"]),
+        [{ id: "d", label: "Delta" }],
+        "c",
+        "Gamma edited",
+      );
       root.unmount();
     });
     await flushCompilerUpdates();

--- a/packages/farm-react/src/compiler-runtime.tsx
+++ b/packages/farm-react/src/compiler-runtime.tsx
@@ -460,10 +460,11 @@ function compilerKeyedArrayStructuralAppendMapUpdate(
       readonly startIndex: number;
       readonly mappedItemSources?: ReadonlyMap<number, unknown>;
       readonly mappedSurvivorsValidated?: true;
-      readonly structuralSurvivorRange: {
+      readonly structuralSurvivorRange?: {
         readonly end: number;
         readonly start: number;
       };
+      readonly structuralSurvivors?: readonly number[];
     }
   | undefined {
   const target = compilerObject(value);
@@ -494,7 +495,15 @@ function compilerKeyedArrayStructuralAppendMapUpdate(
     expectedStart,
     first.startIndex,
   );
-  if (!structuralSurvivorRange) return undefined;
+  const structuralSurvivors = structuralSurvivorRange
+    ? undefined
+    : compilerKeyedArrayFilterSurvivorsFromUpdate(
+        update.structuralUpdate,
+        sourceToken,
+        expectedStart,
+        first.startIndex,
+      )?.indices;
+  if (!structuralSurvivorRange && !structuralSurvivors) return undefined;
   let length = first.startIndex;
   const startIndex = length;
   for (const current of updates) {
@@ -504,7 +513,8 @@ function compilerKeyedArrayStructuralAppendMapUpdate(
   return length === value.length
     ? {
         startIndex,
-        structuralSurvivorRange,
+        ...(structuralSurvivorRange ? { structuralSurvivorRange } : {}),
+        ...(structuralSurvivors ? { structuralSurvivors } : {}),
         ...(update.mappedItemSources ? { mappedItemSources: update.mappedItemSources } : {}),
         ...(update.mappedSurvivorsValidated ? { mappedSurvivorsValidated: true as const } : {}),
       }
@@ -1183,6 +1193,7 @@ export function createCompilerKeyedArrayStructuralAppendMapPipeline(
   let appendUpdate: CompilerKeyedArrayAppendHint | undefined;
   let committedItems: readonly unknown[] | undefined;
   let survivorRange: { readonly end: number; readonly start: number } | undefined;
+  let survivorIndices: readonly number[] | undefined;
   let mappedItemSources = new Map<number, unknown>();
   let mappedItemValues = new Map<number, unknown>();
   try {
@@ -1206,7 +1217,8 @@ export function createCompilerKeyedArrayStructuralAppendMapPipeline(
           )
         : undefined;
       survivorRange = structuralAppend?.structuralSurvivorRange;
-      if (!survivorRange) {
+      survivorIndices = structuralAppend?.structuralSurvivors;
+      if (!survivorRange && !survivorIndices) {
         appendUpdate = undefined;
       } else {
         if (appendUpdate.mappedItemSources) {
@@ -1250,10 +1262,13 @@ export function createCompilerKeyedArrayStructuralAppendMapPipeline(
     const wrappedCallback = (item: unknown, index: number, source: unknown): unknown => {
       if (index !== expectedIndex) eligible = false;
       expectedIndex = index + 1;
-      const survivorCount = survivorRange ? survivorRange.end - survivorRange.start : 0;
+      const survivorCount = survivorRange
+        ? survivorRange.end - survivorRange.start
+        : (survivorIndices?.length ?? 0);
       let committedItem: unknown;
       if (index < survivorCount) {
-        committedItem = committedItems?.[survivorRange!.start + index];
+        const sourceIndex = survivorRange ? survivorRange.start + index : survivorIndices?.[index];
+        committedItem = sourceIndex === undefined ? undefined : committedItems?.[sourceIndex];
         const expectedItem = mappedItemValues.has(index)
           ? mappedItemValues.get(index)
           : committedItem;
@@ -5799,7 +5814,11 @@ function reconcileCompilerKeyedArrayStructuralAppendMap(
 
   const previousInstances = [...instances.values()];
   const survivorRange = update.structuralSurvivorRange;
-  const survivorCount = survivorRange.end - survivorRange.start;
+  const survivorIndices = update.structuralSurvivors;
+  const survivorCount = survivorRange
+    ? survivorRange.end - survivorRange.start
+    : (survivorIndices?.length ?? 0);
+  if (!survivorRange && !survivorIndices) return undefined;
   const changed: Array<{
     bindingUpdates: CompilerPreparedKeyedRowBindingUpdate[];
     instance: CompilerKeyedRowInstance;
@@ -5808,16 +5827,32 @@ function reconcileCompilerKeyedArrayStructuralAppendMap(
   const appendedKeys = new Set<string>();
   const appended: CompilerKeyedRowInstance[] = [];
   try {
+    if (survivorIndices) {
+      for (let index = 0; index < survivorCount; index += 1) {
+        const sourceIndex = survivorIndices[index];
+        const instance = previousInstances[sourceIndex];
+        const item = finalValue[index];
+        const expectedItem = update.mappedItemSources.has(index)
+          ? update.mappedItemSources.get(index)
+          : item;
+        if (
+          !instance ||
+          instance.index !== sourceIndex ||
+          !Object.is(instance.item, expectedItem)
+        ) {
+          return undefined;
+        }
+      }
+    }
     for (const [index, sourceItem] of update.mappedItemSources) {
       if (!Number.isSafeInteger(index) || index < 0 || index >= survivorCount) {
         return undefined;
       }
-      const sourceIndex = survivorRange.start + index;
-      const instance = previousInstances[sourceIndex];
+      const instance =
+        previousInstances[survivorRange ? survivorRange.start + index : survivorIndices![index]];
       const item = finalValue[index];
       if (
         !instance ||
-        instance.index !== sourceIndex ||
         !Object.is(instance.item, sourceItem) ||
         keyedRowIdentity(props.rowKey(item, index)) !== instance.key
       ) {
@@ -5847,20 +5882,34 @@ function reconcileCompilerKeyedArrayStructuralAppendMap(
   }
 
   const mutableInstances = instances as Map<string, CompilerKeyedRowInstance>;
-  for (let index = 0; index < survivorRange.start; index += 1) {
-    const instance = previousInstances[index];
-    instance.scope?.cleanup();
-    instance.element.remove();
-    mutableInstances.delete(instance.key);
-  }
-  for (let index = survivorRange.end; index < previousInstances.length; index += 1) {
-    const instance = previousInstances[index];
-    instance.scope?.cleanup();
-    instance.element.remove();
-    mutableInstances.delete(instance.key);
-  }
-  for (let index = survivorRange.start; index < survivorRange.end; index += 1) {
-    previousInstances[index].index = index - survivorRange.start;
+  if (survivorRange) {
+    for (let index = 0; index < survivorRange.start; index += 1) {
+      const instance = previousInstances[index];
+      instance.scope?.cleanup();
+      instance.element.remove();
+      mutableInstances.delete(instance.key);
+    }
+    for (let index = survivorRange.end; index < previousInstances.length; index += 1) {
+      const instance = previousInstances[index];
+      instance.scope?.cleanup();
+      instance.element.remove();
+      mutableInstances.delete(instance.key);
+    }
+    for (let index = survivorRange.start; index < survivorRange.end; index += 1) {
+      previousInstances[index].index = index - survivorRange.start;
+    }
+  } else {
+    const survivorSet = new Set(survivorIndices);
+    for (let index = 0; index < previousInstances.length; index += 1) {
+      if (survivorSet.has(index)) continue;
+      const instance = previousInstances[index];
+      instance.scope?.cleanup();
+      instance.element.remove();
+      mutableInstances.delete(instance.key);
+    }
+    for (let index = 0; index < survivorIndices!.length; index += 1) {
+      previousInstances[survivorIndices![index]].index = index;
+    }
   }
   if (appended.length > 0) {
     const fragment = root.ownerDocument.createDocumentFragment();

--- a/packages/farm-react/src/compiler.ts
+++ b/packages/farm-react/src/compiler.ts
@@ -2732,7 +2732,7 @@ function rewriteQueuedKeyedArrayStructuralMapHints(
         if (containsAppend) {
           if (
             structuralState === state.index &&
-            structuralKind === "slice" &&
+            structuralKind !== undefined &&
             structuralMapState !== state.index
           ) {
             structuralAppendState = state.index;


### PR DESCRIPTION
## Problem

The experimental React compiler retains keyed-row lineage across a bounded `slice()`, appends, and following same-key maps, but the equivalent index-independent `filter()` chain falls back to complete keyed reconciliation. This repeats key and binding work after the native filter and maps have already established the surviving rows.

## Root cause

The compiler linked the structural-append-map pipeline only when the structural source was a slice. The runtime metadata represented a contiguous survivor interval, so it could not carry the non-contiguous original indices produced by a filter into later maps and the final commit.

## Change

- Link eligible index-independent filter → append → map setter chains to the existing structural-append-map runtime feature.
- Carry filter-proven original survivor indices through one or more native same-key maps.
- Validate the committed snapshot, survivor identity, changed keys and bindings, appended keys, and detached incoming rows before the first DOM write.
- Remove only rejected rows, patch only changed survivors, and mount only the final mapped suffix.
- Add a distinct 10,000-row dashboard action and performance gate instead of replacing the existing slice comparison.

## Safety and compatibility

- There is no new public API or configuration.
- Compiler-disabled applications and unrelated renderer paths are unchanged.
- Unsupported syntax, custom or unsafe arrays, changed keys, duplicate or reused keys, stale committed data, and failed validation use complete React reconciliation before any DOM mutation.
- The existing contiguous slice path remains direct and keeps its separate benchmark gate.
- React 18.3.1 and React 19.2.8 compatibility pass.
- The optional structural-append-map runtime premium is 18,633 bytes gzip, 225 bytes above main and within the persisted 256-byte allowance. Disabled applications do not include it.

## Verification

- `pnpm --filter @farm.js/react exec vitest run --maxWorkers=1 --reporter=dot` — 786 passed, 10 skipped.
- `pnpm --filter @farm.js/react test:stress` — 18 passed, 89 skipped by the focused stress configuration.
- `pnpm --filter @farm.js/react type-check`
- `pnpm --filter @farm.js/react test:compat`
- `pnpm --filter @farm.js/react test:runtime-size`
- `pnpm --dir examples/react-compiler-dashboard type-check`
- `pnpm --dir examples/react-compiler-dashboard build`
- `pnpm docs:check-navigation`
- `pnpm --dir docs exec farm generate --check`
- `pnpm docs:build`
- Focused `oxlint`, `oxfmt`, `node --check`, and `git diff --check` pass.
- Chrome 153.0.8010.36 on Apple M1 macOS: filter → append → maps measured 18.0 ms static and 18.6 ms hybrid versus 78.3 ms React, or 4.35× and 4.21× faster; both were also 1.78× and 1.57× faster than compiled snapshot controls. The existing slice path passed at 9.79× and 10.38× versus React. The aggregate correctness, no-regression, and optimization-persistence gates passed with zero compiled owner executions.

## Documentation and release

- Expanded the experimental React renderer documentation and package README.
- Added runnable dashboard controls, correctness assertions, a separate performance gate, and persisted benchmark results.
- No version or release changes.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extends the structural-append-map fast path to cover index-independent `filter()` chains, so filtered survivors now keep their DOM identity through following map setters instead of full React reconciliation. No public API or behavior change for unsupported paths; those still fall back to complete reconciliation.

**Details**
- Carries the filter's original survivor indices through one or more same-key maps and validates the final array before the first DOM write.
- Adds a separate 10,000-row filter benchmark gate with correctness and performance checks.
- Adds the optional runtime feature at 18,633 bytes gzip, within the persisted allowance.

<sup>Written for commit e875f763341b6ffc4de16818f98e464ff6833a29. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/891?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

