### PR TITLE
fix(federation): validate every remote URL form

### DIFF
--- a/docs/src/app/docs/plugins/federation/page.md
+++ b/docs/src/app/docs/plugins/federation/page.md
@@ -185,8 +185,9 @@ owns every shared-package rule.
 | `dev.remoteHmr` | `false`                          | Enable cross-application HMR or use `"full-reload"` while editing. |
 
 Remote entries may use absolute `http` or `https` URLs, root-relative URLs, or the standard Module
-Federation remote string form. Credentials are rejected in URLs. Put authentication at the API
-boundary rather than embedding secrets in a browser manifest URL.
+Federation `name@URL` string form. Farm applies the same protocol, credential, and network-path
+validation to every form. Put authentication at the API boundary rather than embedding secrets in
+a browser manifest URL.
 
 ## Deployment and CSS
 

--- a/packages/farm-federation/src/config.test.ts
+++ b/packages/farm-federation/src/config.test.ts
@@ -42,13 +42,14 @@ describe("resolveFederationOptions", () => {
         remotes: {
           checkout: { entry: "https://checkout.example.com/mf-manifest.json" },
           catalog: "catalog@https://catalog.example.com/remoteEntry.js",
+          account: "https://account.example.com/mf-manifest.json",
         },
         types: false,
       },
       reactRenderer,
     );
 
-    expect(resolved.remoteAliases).toEqual(["checkout", "catalog"]);
+    expect(resolved.remoteAliases).toEqual(["checkout", "catalog", "account"]);
     expect(resolved.upstream.remotes).toEqual({
       checkout: {
         name: "checkout",
@@ -56,6 +57,7 @@ describe("resolveFederationOptions", () => {
         type: "module",
       },
       catalog: "catalog@https://catalog.example.com/remoteEntry.js",
+      account: "https://account.example.com/mf-manifest.json",
     });
     expect(resolved.upstream.manifest).toBe(false);
     expect(resolved.upstream.dts).toBe(false);
@@ -103,6 +105,17 @@ describe("resolveFederationOptions", () => {
         reactRenderer,
       ),
     ).toThrow("must use HTTP");
+    for (const entry of [
+      "https://user:secret@checkout.example.com/remoteEntry.js",
+      "checkout@https://user:secret@checkout.example.com/remoteEntry.js",
+      "//checkout.example.com/remoteEntry.js",
+      "/\\checkout.example.com/remoteEntry.js",
+      "checkout@file:///tmp/remoteEntry.js",
+    ]) {
+      expect(() =>
+        resolveFederationOptions({ name: "host", remotes: { checkout: entry } }, reactRenderer),
+      ).toThrow();
+    }
     expect(() =>
       resolveFederationOptions({ name: "host", serverRemotes: {} } as never, reactRenderer),
     ).toThrow("issues/885");

--- a/packages/farm-federation/src/config.ts
+++ b/packages/farm-federation/src/config.ts
@@ -136,7 +136,7 @@ function normalizeRemotes(
     Object.entries(remotes).map(([alias, value]) => {
       normalizeRemoteAlias(alias);
       if (typeof value === "string") {
-        return [alias, nonEmptyString(value, `Federation remote ${alias}`)];
+        return [alias, normalizeRemoteString(value, alias)];
       }
       assertPlainObject(value, `Federation remote ${alias}`);
       const entry = normalizeRemoteEntry(value.entry, alias);
@@ -221,7 +221,17 @@ function normalizeRemoteAlias(value: string): string {
 
 function normalizeRemoteEntry(value: string, alias: string): string {
   const entry = nonEmptyString(value, `Federation remote ${alias} entry`);
-  if (entry.startsWith("/")) return entry;
+  if (entry.startsWith("/")) {
+    if (entry.startsWith("//") || entry.includes("\\")) {
+      throw new TypeError(
+        `Federation remote ${alias} entry must be a root-relative URL, not a network-path URL`,
+      );
+    }
+    return entry;
+  }
+  if (entry.includes("\\")) {
+    throw new TypeError(`Federation remote ${alias} entry must use URL separators`);
+  }
   let parsed: URL;
   try {
     parsed = new URL(entry);
@@ -238,6 +248,24 @@ function normalizeRemoteEntry(value: string, alias: string): string {
     throw new TypeError(`Federation remote ${alias} entry must use HTTP without URL credentials`);
   }
   return parsed.href;
+}
+
+function normalizeRemoteString(value: string, alias: string): string {
+  const remote = nonEmptyString(value, `Federation remote ${alias}`);
+  if (/^(?:https?:)?\//i.test(remote)) return normalizeRemoteEntry(remote, alias);
+
+  const separator = remote.indexOf("@");
+  if (separator <= 0 || separator === remote.length - 1) {
+    throw new TypeError(
+      `Federation remote ${alias} must be an HTTP URL, root-relative URL, or name@URL`,
+    );
+  }
+
+  const name = remote.slice(0, separator);
+  if (/\s|[/?#\\]/.test(name) || hasControlCharacter(name)) {
+    throw new TypeError(`Federation remote ${alias} has an invalid remote name`);
+  }
+  return `${name}@${normalizeRemoteEntry(remote.slice(separator + 1), alias)}`;
 }
 
 function normalizeShareScope(value: string | string[], alias: string): string | string[] {


### PR DESCRIPTION
## Problem

String federation remotes bypass the URL validation applied to object-form remotes. Credential-bearing URLs, network-path references, backslash paths, and unsupported protocols can reach the upstream federation plugin.

## Root cause

String values are checked only for non-empty content, while object entries pass through the protocol and credential validator.

## Change

Normalize direct string URLs and standard name@URL strings through the same remote-entry validator. Validate the remote name separately and document the accepted forms.

## Safety and compatibility

HTTP, HTTPS, root-relative, and name@URL remotes remain supported. Credential-bearing, protocol-relative, backslash, and non-HTTP absolute entries now fail early with an actionable configuration error.

## Verification

The regression fails on the previous implementation because unsafe string remotes are accepted.

- pnpm --filter @farm.js/federation test
- pnpm --filter @farm.js/federation type-check
- pnpm --filter @farm.js/federation build
- pnpm exec oxlint packages/farm-federation/src/config.ts packages/farm-federation/src/config.test.ts

Tested on macOS with Node 23.11.0.

## Documentation and release

Updated the Federation plugin documentation to describe name@URL support and the shared validation policy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Applies the same URL validation to string-form federation remotes that object-form remotes already received, so credential-bearing URLs, network-path references, backslash paths, and non-HTTP absolute entries now fail early with a configuration error.

- String remotes (`https://...` or `name@https://...`) now go through the shared remote-entry validator; only HTTP(S), root-relative, and `name@URL` forms are accepted.
- Remote names with whitespace, slashes, backslashes, query/hash characters, or control characters are rejected.
- Added regression tests for the unsafe string forms and updated the federation docs to describe the accepted `name@URL` form and shared validation policy.

<sup>Written for commit 4acd0e38f12398c4ab6f6e4a6e33d691827be2b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/892?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

