### PR TITLE
fix(stylex): detect injected development tags structurally

### DIFF
--- a/packages/farm-stylex/src/html.ts
+++ b/packages/farm-stylex/src/html.ts
@@ -5,12 +5,13 @@ const STYLEX_DEVELOPMENT_RUNTIME = "/@id/virtual:stylex:runtime";
 export function injectStylexDevelopmentAssets(html: string): string {
   const closingHead = html.search(/<\/head\s*>/i);
   if (closingHead < 0) return html;
+  const head = html.slice(0, closingHead);
 
   const tags: string[] = [];
-  if (!html.includes('data-farm-stylex="css"')) {
+  if (!hasStylexAsset(head, "link", "css")) {
     tags.push(`<link rel="stylesheet" href="${STYLEX_DEVELOPMENT_CSS}" data-farm-stylex="css">`);
   }
-  if (!html.includes('data-farm-stylex="runtime"')) {
+  if (!hasStylexAsset(head, "script", "runtime")) {
     tags.push(
       `<script type="module" src="${STYLEX_DEVELOPMENT_RUNTIME}" data-farm-stylex="runtime"></script>`,
     );
@@ -18,4 +19,25 @@ export function injectStylexDevelopmentAssets(html: string): string {
   if (tags.length === 0) return html;
 
   return `${html.slice(0, closingHead)}${tags.join("")}${html.slice(closingHead)}`;
+}
+
+function hasStylexAsset(html: string, tagName: "link" | "script", value: string): boolean {
+  const tags =
+    tagName === "link"
+      ? html.matchAll(/<link\b(?:[^>"']|"[^"]*"|'[^']*')*>/gi)
+      : html.matchAll(/<script\b(?:[^>"']|"[^"]*"|'[^']*')*>/gi);
+
+  for (const tag of tags) {
+    const attributes = tag[0].slice(tagName.length + 1, -1);
+    const parsed = attributes.matchAll(
+      /([^\s"'<>=]+)(?:\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'=<>]+)))?/g,
+    );
+    for (const attribute of parsed) {
+      const attributeValue = attribute[2] ?? attribute[3] ?? attribute[4];
+      if (attribute[1]?.toLowerCase() === "data-farm-stylex" && attributeValue === value) {
+        return true;
+      }
+    }
+  }
+  return false;
 }

--- a/packages/farm-stylex/src/index.test.ts
+++ b/packages/farm-stylex/src/index.test.ts
@@ -54,6 +54,22 @@ describe("stylex plugin", () => {
     expect((second as string).match(/virtual:stylex:runtime/g)).toHaveLength(1);
   });
 
+  it("does not mistake page content for injected development assets", async () => {
+    const plugin = stylex();
+    await plugin.configure?.({ plugins: [plugin] }, {
+      config: {} as never,
+      isDev: true,
+      isProd: false,
+    } as never);
+    const html =
+      '<!doctype html><html><head></head><body><code>data-farm-stylex="css" data-farm-stylex="runtime"</code></body></html>';
+
+    const result = await plugin.render?.html?.(html, { pathname: "/" }, { config: {} } as never);
+
+    expect(result).toContain('<link rel="stylesheet" href="/virtual:stylex.css"');
+    expect(result).toContain('<script type="module" src="/@id/virtual:stylex:runtime"');
+  });
+
   it("does not inject development assets into production HTML", async () => {
     const plugin = stylex();
     await plugin.configure?.({ plugins: [plugin] }, {


### PR DESCRIPTION
## Problem

StyleX development assets are skipped when page content merely contains the data-farm-stylex marker text. A code sample or serialized string can therefore prevent CSS and runtime injection.

## Root cause

The injection guard searches the complete HTML document for marker substrings instead of checking actual tags in the document head.

## Change

Inspect quote-aware link and script tags in the head and require the expected data-farm-stylex attribute value before considering each development asset present.

## Safety and compatibility

Production behavior is unchanged. Development injection remains idempotent and existing valid marker tags are still recognized.

## Verification

The regression fails on the previous implementation because marker text inside a body code element suppresses both assets.

- pnpm --filter @farm.js/stylex test
- pnpm --filter @farm.js/stylex type-check
- pnpm --filter @farm.js/stylex build
- pnpm exec oxlint packages/farm-stylex/src/html.ts packages/farm-stylex/src/index.test.ts

Tested on macOS with Node 23.11.0.

## Documentation and release

None. This corrects existing development injection behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes StyleX development asset injection so marker text in body content no longer suppresses CSS and runtime injection. Previously, any occurrence of `data-farm-stylex="css"` or `data-farm-stylex="runtime"` anywhere in the HTML would prevent the corresponding tag from being added, even if inside a code sample. Now the guard only recognizes actual link and script tags in the head with that attribute value, so body content is ignored. Production unchanged.

<sup>Written for commit 8fadac1cb43fdf7fd696632e505b168bc6fb67e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/893?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

