### PR TITLE
fix(content): make generated asset modules checkout-independent

### DIFF
--- a/packages/farm-content/src/assets.ts
+++ b/packages/farm-content/src/assets.ts
@@ -246,14 +246,15 @@ export async function resolveContentAsset(
       error,
     );
   }
-  assertInsideRoot(actualPath, await realpath(context.root), context, diagnosticPath);
+  const actualRoot = await realpath(context.root);
+  assertInsideRoot(actualPath, actualRoot, context, diagnosticPath);
   context.sourceFiles.add(actualPath);
   if (!fileStats.isFile()) {
     throw assetError(context, diagnosticPath, `Asset ${JSON.stringify(reference)} is not a file`);
   }
 
   const bytes = await readFile(actualPath);
-  const token = registerAssetImport(actualPath, context.imports);
+  const token = registerAssetImport(actualPath, actualRoot, context.imports);
   const common = {
     src: `${token}${parsed.suffix}`,
     source: reference,
@@ -433,8 +434,12 @@ function parseRelativeAssetReference(
   return { path: decodedPath, suffix };
 }
 
-function registerAssetImport(filePath: string, imports: Map<string, ContentAssetImport>): string {
-  const normalized = filePath.replace(/\\/g, "/");
+function registerAssetImport(
+  filePath: string,
+  root: string,
+  imports: Map<string, ContentAssetImport>,
+): string {
+  const normalized = path.relative(root, filePath).replace(/\\/g, "/");
   const token = `__FARM_CONTENT_ASSET_${createHash("sha256")
     .update(normalized)
     .digest("hex")

--- a/packages/farm-content/src/loader.test.ts
+++ b/packages/farm-content/src/loader.test.ts
@@ -48,6 +48,38 @@ const postSchema = {
 };
 
 describe("content collection loading", () => {
+  it("generates identical asset modules from identical checkout layouts", async () => {
+    const buildGeneratedModule = async () => {
+      const root = await fixtureRoot();
+      await writeFile(
+        path.join(root, "content", "posts", "hello.md"),
+        "---\ntitle: Hello\nhero: ./hero.svg\n---\nHello\n",
+      );
+      await writeFile(
+        path.join(root, "content", "posts", "hero.svg"),
+        '<svg xmlns="http://www.w3.org/2000/svg" width="640" height="360"/>',
+      );
+      const loaded = await loadContentCollections(root, {
+        posts: collection({
+          source: files("content/posts/hello.md"),
+          schema: {
+            parse(value: unknown) {
+              return { title: String((value as Record<string, unknown>).title) };
+            },
+          },
+          assets: { hero: asset.image() },
+        }),
+      });
+      const output = path.join(root, ".farm", "content", "server.mjs");
+      await writeContentServerModule(output, loaded.collections, loaded.assetImports);
+      const source = await readFile(output, "utf8");
+      expect(source).toContain('from "../../content/posts/hero.svg?url"');
+      return source;
+    };
+
+    expect(await buildGeneratedModule()).toBe(await buildGeneratedModule());
+  });
+
   it("loads Markdown, MDX, and JSON with stable IDs and transformed data", async () => {
     const root = await fixtureRoot();
     const loaded = await loadContentCollections(root, {

--- a/packages/farm-content/src/loader.ts
+++ b/packages/farm-content/src/loader.ts
@@ -1,4 +1,4 @@
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { mkdir, readFile, realpath, writeFile } from "node:fs/promises";
 import path from "node:path";
 import fg from "fast-glob";
 import matter from "gray-matter";
@@ -52,6 +52,9 @@ export async function writeContentServerModule(
   collections: Readonly<Record<string, readonly ContentEntry<any>[]>>,
   assetImports: ReadonlyMap<string, ContentAssetImport> = new Map(),
 ): Promise<void> {
+  const outputDirectory = path.dirname(outputFile);
+  await mkdir(outputDirectory, { recursive: true });
+  const actualOutputDirectory = await realpath(outputDirectory);
   const encoded = encodeContentValue(collections);
   const imports = [...assetImports.values()].sort((left, right) =>
     left.token.localeCompare(right.token),
@@ -59,7 +62,9 @@ export async function writeContentServerModule(
   const importSource = imports
     .map(
       (asset, index) =>
-        `import farmContentAsset${index} from ${JSON.stringify(`${toViteFileId(asset.filePath)}?url`)};`,
+        `import farmContentAsset${index} from ${JSON.stringify(
+          `${toViteImportSpecifier(actualOutputDirectory, asset.filePath)}?url`,
+        )};`,
     )
     .join("\n");
   const assetUrls = imports.length
@@ -77,7 +82,6 @@ export const getCollection = runtime.getCollection;
 export const getEntry = runtime.getEntry;
 export const getEntryOrThrow = runtime.getEntryOrThrow;
 `;
-  await mkdir(path.dirname(outputFile), { recursive: true });
   await writeFileIfChanged(outputFile, source);
 }
 
@@ -318,9 +322,9 @@ function normalizePath(value: string): string {
   return value.replace(/\\/g, "/");
 }
 
-function toViteFileId(filePath: string): string {
-  const normalized = normalizePath(filePath);
-  return normalized.startsWith("/") ? `/@fs${normalized}` : `/@fs/${normalized}`;
+function toViteImportSpecifier(outputDirectory: string, filePath: string): string {
+  const relative = normalizePath(path.relative(outputDirectory, filePath));
+  return relative.startsWith(".") ? relative : `./${relative}`;
 }
 
 type EncodedContentValue =


### PR DESCRIPTION
## Problem

Content collections with typed assets generate different server modules in otherwise identical checkouts. Absolute filesystem paths affect both asset tokens and Vite import specifiers, preventing deterministic output and reusable build caches.

## Root cause

Asset tokens hash the canonical absolute path, and generated modules emit /@fs imports containing that same checkout-specific path.

## Change

Hash asset paths relative to the canonical project root and emit imports relative to the generated module directory. Canonicalize that directory as well so symlinked temporary roots produce correct relative paths.

## Safety and compatibility

Asset traversal protection still uses canonical paths. Query and hash suffixes, URL imports, and runtime asset values remain unchanged. Only generated identities and import specifiers become checkout-independent.

## Verification

The regression creates two identical checkout layouts. It fails on the previous implementation because their tokens and /@fs imports differ, and passes with byte-identical generated modules after this change.

- pnpm --filter @farm.js/content test
- pnpm --filter @farm.js/content type-check
- pnpm --filter @farm.js/content build
- pnpm exec oxlint packages/farm-content/src/assets.ts packages/farm-content/src/loader.ts packages/farm-content/src/loader.test.ts

Tested on macOS with Node 23.11.0.

## Documentation and release

None. The public content API is unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes generated asset modules checkout-independent so identical checkouts produce byte-identical server output. Asset tokens now hash paths relative to the project root, and import specifiers are emitted relative to the generated module directory instead of absolute `/@fs` paths.

- Canonicalizes the output directory with `realpath` so symlinked temporary roots still get correct relative paths.
- Asset traversal protection still uses canonical paths; query/hash suffixes, URL imports, and runtime asset values are unchanged.
- Adds a regression test comparing generated modules from two identical checkout layouts.
- The public content API is unchanged.

<sup>Written for commit 7f9b10fc44408982c7d4871703cbdb1b1ca1b6ab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/894?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

