### PR TITLE
fix(federation): keep RSC builds inside the server boundary

### DIFF
--- a/packages/farm-federation/src/vite.test.ts
+++ b/packages/farm-federation/src/vite.test.ts
@@ -69,6 +69,11 @@ describe("Farm federation Vite boundary", () => {
     expect(transform).not.toHaveBeenCalled();
     expect(wrapped.call({}, "source", "/src/file.ts", { ssr: false })).toEqual({ code: "client" });
     expect(transform).toHaveBeenCalledOnce();
+
+    expect(
+      wrapped.call({ environment: { name: "rsc" } }, "source", "/src/server-component.tsx", {}),
+    ).toBeNull();
+    expect(transform).toHaveBeenCalledOnce();
   });
 
   it("blocks configured remote imports from Farm's server graph", () => {
@@ -85,6 +90,14 @@ describe("Farm federation Vite boundary", () => {
     expect(resolveId.call({}, "local-module", "/src/page.tsx", { ssr: true })).toBeNull();
     expect(() =>
       resolveId.call({}, "checkout/CheckoutButton", "/src/page.tsx", { ssr: true }),
+    ).toThrow("browser modules only");
+    expect(() =>
+      resolveId.call(
+        { environment: { name: "rsc" } },
+        "checkout/CheckoutButton",
+        "/src/app/page.tsx",
+        {},
+      ),
     ).toThrow("browser modules only");
     expect(
       resolveId.call({}, "checkout/CheckoutButton", "/src/page.tsx", { ssr: false }),

--- a/packages/farm-federation/src/vite.ts
+++ b/packages/farm-federation/src/vite.ts
@@ -220,6 +220,7 @@ function wrapEnvironmentHook(hook: unknown, optionsIndex: number): unknown {
 function isServerEnvironment(context: unknown, options: unknown): boolean {
   const environmentName = (context as { environment?: { name?: unknown } })?.environment?.name;
   return (
+    environmentName === "rsc" ||
     environmentName === "ssr" ||
     environmentName === "server" ||
     Boolean((options as { ssr?: unknown } | undefined)?.ssr)


### PR DESCRIPTION
## Problem

Federation client transforms and remote imports can run in Farm's named RSC environment because the Vite hook does not always receive an ssr option. That can move browser-only federation code into the server graph.

## Root cause

The environment guard recognizes ssr and server names, but not Farm's rsc environment. It therefore depends on the optional hook-level ssr flag.

## Change

Treat the rsc environment as server execution for both wrapped upstream transforms and configured remote import guards.

## Safety and compatibility

Client federation behavior is unchanged. Existing ssr and server detection remains in place, including compatibility with hooks that provide the ssr option.

## Verification

The regression fails on the previous implementation because the upstream client transform runs and the remote import is accepted in the rsc environment.

- pnpm --filter @farm.js/federation test
- pnpm --filter @farm.js/federation type-check
- pnpm --filter @farm.js/federation build
- pnpm exec oxlint packages/farm-federation/src/vite.ts packages/farm-federation/src/vite.test.ts

Tested on macOS with Node 23.11.0.

## Documentation and release

None. This restores the existing server-only boundary.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes federation client transforms and remote imports running in Farm's RSC environment, which could move browser-only federation code into the server graph. RSC environments are now treated as server execution, matching existing `ssr` and `server` detection, while client federation behavior remains unchanged.

<sup>Written for commit 4b67ad07fd8251db0daa21603f2b11ab025faf86. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/895?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

