### PR TITLE
fix(stylex): serve development assets under basePath

### DIFF
--- a/packages/farm-stylex/src/html.ts
+++ b/packages/farm-stylex/src/html.ts
@@ -2,23 +2,37 @@ const STYLEX_DEVELOPMENT_CSS = "/virtual:stylex.css";
 const STYLEX_DEVELOPMENT_RUNTIME = "/@id/virtual:stylex:runtime";
 
 /** Add StyleX's development CSS before paint and connect its HMR runtime. */
-export function injectStylexDevelopmentAssets(html: string): string {
+export function injectStylexDevelopmentAssets(html: string, basePath = "/"): string {
   const closingHead = html.search(/<\/head\s*>/i);
   if (closingHead < 0) return html;
   const head = html.slice(0, closingHead);
+  const cssUrl = withBasePath(STYLEX_DEVELOPMENT_CSS, basePath);
+  const runtimeUrl = withBasePath(STYLEX_DEVELOPMENT_RUNTIME, basePath);
 
   const tags: string[] = [];
   if (!hasStylexAsset(head, "link", "css")) {
-    tags.push(`<link rel="stylesheet" href="${STYLEX_DEVELOPMENT_CSS}" data-farm-stylex="css">`);
+    tags.push(`<link rel="stylesheet" href="${cssUrl}" data-farm-stylex="css">`);
   }
   if (!hasStylexAsset(head, "script", "runtime")) {
-    tags.push(
-      `<script type="module" src="${STYLEX_DEVELOPMENT_RUNTIME}" data-farm-stylex="runtime"></script>`,
-    );
+    tags.push(`<script type="module" src="${runtimeUrl}" data-farm-stylex="runtime"></script>`);
   }
   if (tags.length === 0) return html;
 
   return `${html.slice(0, closingHead)}${tags.join("")}${html.slice(closingHead)}`;
+}
+
+/** Strip Farm's mount path before StyleX's development middleware resolves its virtual assets. */
+export function stripStylexDevelopmentBasePath(url: string, basePath: string): string {
+  const prefix = normalizeBasePath(basePath);
+  if (!prefix) return url;
+
+  for (const asset of [STYLEX_DEVELOPMENT_CSS, STYLEX_DEVELOPMENT_RUNTIME]) {
+    const prefixedAsset = `${prefix}${asset}`;
+    if (url === prefixedAsset || url.startsWith(`${prefixedAsset}?`)) {
+      return url.slice(prefix.length);
+    }
+  }
+  return url;
 }
 
 function hasStylexAsset(html: string, tagName: "link" | "script", value: string): boolean {
@@ -40,4 +54,13 @@ function hasStylexAsset(html: string, tagName: "link" | "script", value: string)
     }
   }
   return false;
+}
+
+function withBasePath(url: string, basePath: string): string {
+  return `${normalizeBasePath(basePath)}${url}`;
+}
+
+function normalizeBasePath(basePath: string): string {
+  const normalized = basePath.replace(/^\/+|\/+$/g, "");
+  return normalized ? `/${normalized}` : "";
 }

--- a/packages/farm-stylex/src/index.test.ts
+++ b/packages/farm-stylex/src/index.test.ts
@@ -1,6 +1,6 @@
 import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { build as viteBuild } from "vite";
 import { stylex } from "./index.js";
 
@@ -52,6 +52,44 @@ describe("stylex plugin", () => {
     expect(first).toContain('<script type="module" src="/@id/virtual:stylex:runtime"');
     expect((second as string).match(/virtual:stylex\.css/g)).toHaveLength(1);
     expect((second as string).match(/virtual:stylex:runtime/g)).toHaveLength(1);
+  });
+
+  it("prefixes development assets with Farm's base path", async () => {
+    const plugin = stylex();
+    const configured = await plugin.configure?.({ basePath: "/docs/", plugins: [plugin] }, {
+      config: {} as never,
+      isDev: true,
+      isProd: false,
+    } as never);
+    const html = "<!doctype html><html><head></head><body></body></html>";
+
+    const result = await plugin.render?.html?.(html, { pathname: "/docs" }, {
+      config: { basePath: "/docs/" },
+    } as never);
+
+    expect(result).toContain('<link rel="stylesheet" href="/docs/virtual:stylex.css"');
+    expect(result).toContain('<script type="module" src="/docs/@id/virtual:stylex:runtime"');
+
+    let middleware:
+      | ((request: { url?: string }, response: unknown, next: () => void) => void)
+      | undefined;
+    const basePathPlugin = (configured as any).vite.plugins[0];
+    expect(basePathPlugin.name).toBe("farm:stylex-base-path");
+    basePathPlugin.configureServer({
+      middlewares: {
+        use: (handler: typeof middleware) => {
+          middleware = handler;
+        },
+      },
+    });
+
+    const cssRequest = { url: "/docs/virtual:stylex.css?t=1" };
+    middleware?.(cssRequest, {}, vi.fn());
+    expect(cssRequest.url).toBe("/virtual:stylex.css?t=1");
+
+    const runtimeRequest = { url: "/docs/@id/virtual:stylex:runtime" };
+    middleware?.(runtimeRequest, {}, vi.fn());
+    expect(runtimeRequest.url).toBe("/@id/virtual:stylex:runtime");
   });
 
   it("does not mistake page content for injected development assets", async () => {

--- a/packages/farm-stylex/src/index.ts
+++ b/packages/farm-stylex/src/index.ts
@@ -1,7 +1,7 @@
 import { definePlugin } from "@farm.js/core/plugin";
 import stylexUnplugin, { type UserOptions } from "@stylexjs/unplugin";
 import { resolveStylexOptions, type StyleXOptions } from "./config.js";
-import { injectStylexDevelopmentAssets } from "./html.js";
+import { injectStylexDevelopmentAssets, stripStylexDevelopmentBasePath } from "./html.js";
 
 export type { StyleXOptions };
 
@@ -9,6 +9,7 @@ export type { StyleXOptions };
 export function stylex(options: StyleXOptions = {}) {
   const resolved = resolveStylexOptions(options);
   let development = false;
+  let configuredBasePath = "/";
 
   return definePlugin({
     name: "farm:stylex",
@@ -22,6 +23,7 @@ export function stylex(options: StyleXOptions = {}) {
       }
 
       development = context.isDev;
+      configuredBasePath = readBasePath(config.basePath) ?? "/";
       // @stylexjs/unplugin documents and implements externalPackages, but its
       // 0.19.0 UserOptions declaration does not include the property yet.
       const compilerOptions: Partial<UserOptions> & { externalPackages: string[] } = {
@@ -31,23 +33,63 @@ export function stylex(options: StyleXOptions = {}) {
         devMode: context.isDev ? "full" : "off",
       };
       const vitePlugin = createStylexVitePlugin(compilerOptions, context.isDev);
+      const basePathPlugin =
+        context.isDev && hasBasePath(configuredBasePath)
+          ? createStylexBasePathVitePlugin(configuredBasePath)
+          : undefined;
 
       return {
         ...config,
         vite: {
           ...config.vite,
-          plugins: [vitePlugin, ...(config.vite?.plugins ?? [])],
+          plugins: [
+            ...(basePathPlugin ? [basePathPlugin] : []),
+            vitePlugin,
+            ...(config.vite?.plugins ?? []),
+          ],
         },
       };
     },
 
     render: {
-      html(html) {
+      html(html, _render, context) {
         if (!development) return html;
-        return injectStylexDevelopmentAssets(html);
+        return injectStylexDevelopmentAssets(
+          html,
+          readBasePath(context.config.basePath) ?? configuredBasePath,
+        );
       },
     },
   });
+}
+
+function readBasePath(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+function hasBasePath(value: string): boolean {
+  return value.replace(/^\/+|\/+$/g, "").length > 0;
+}
+
+function createStylexBasePathVitePlugin(basePath: string) {
+  return {
+    name: "farm:stylex-base-path",
+    enforce: "pre" as const,
+    configureServer(server: {
+      middlewares: {
+        use(
+          middleware: (request: { url?: string }, response: unknown, next: () => void) => void,
+        ): void;
+      };
+    }) {
+      server.middlewares.use((request, _response, next) => {
+        if (request.url) {
+          request.url = stripStylexDevelopmentBasePath(request.url, basePath);
+        }
+        next();
+      });
+    },
+  };
 }
 
 function createStylexVitePlugin(


### PR DESCRIPTION
## Problem

StyleX development HTML always requested its extracted CSS and HMR runtime from root URLs. An app mounted at a Farm `basePath`, such as `/docs`, therefore did not use base-prefixed asset URLs.

## Root cause

Farm injects StyleX development tags through its SSR HTML hook rather than Vite's `transformIndexHtml` hook, so the upstream StyleX plugin never had an opportunity to apply Vite's base handling. Its CSS middleware also recognizes only the unprefixed virtual path.

## Change

Prefix both injected StyleX development URLs with Farm's configured `basePath`. A small development-only Vite middleware strips that prefix for exactly the StyleX CSS and runtime requests before the upstream StyleX plugin resolves them.

Regression coverage verifies the rendered URLs and both downstream request rewrites.

## Safety and compatibility

Root-mounted apps keep their existing URLs and do not install the extra middleware. The rewrite is limited to the two exact StyleX virtual assets, including query strings. Production HTML and build transforms are unchanged.

## Verification

Run on macOS with Node.js 23.11.0:

- `pnpm --filter @farm.js/stylex test` (16 tests)
- `pnpm --filter @farm.js/stylex type-check`
- `pnpm --filter @farm.js/stylex build`
- `pnpm exec oxlint packages/farm-stylex/src/html.ts packages/farm-stylex/src/index.ts packages/farm-stylex/src/index.test.ts`
- `pnpm exec oxfmt packages/farm-stylex/src/html.ts packages/farm-stylex/src/index.ts packages/farm-stylex/src/index.test.ts`

## Documentation and release

None. The existing `basePath` configuration now applies consistently to StyleX development assets.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `@farm.js/stylex` development assets so apps mounted under a Farm `basePath` no longer request StyleX CSS and HMR runtime from root URLs.

- Injected development HTML now points to `{basePath}/virtual:stylex.css` and `{basePath}/@id/virtual:stylex:runtime`.
- A development-only middleware strips that prefix only for those two virtual StyleX assets, including query strings.
- Root-mounted apps keep existing URLs and do not install the middleware; production HTML and build output are unchanged.

<sup>Written for commit 500a213d98153883f006d8851c1b55f6b4c7d5b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/897?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

