### PR TITLE
fix(content): recover HMR after failed rebuilds

### DIFF
--- a/packages/farm-content/src/index.test.ts
+++ b/packages/farm-content/src/index.test.ts
@@ -157,6 +157,100 @@ describe("content plugin", () => {
     await vi.waitFor(() => expect(send).toHaveBeenCalledWith({ type: "full-reload" }));
   });
 
+  it("recovers after a newly added content file is fixed", async () => {
+    const root = await createFixture();
+    const plugin = content({
+      collections: {
+        posts: collection({
+          source: files("content/*.{json,md}"),
+          schema: { parse: (value: unknown) => value as { title: string } },
+        }),
+      },
+    });
+    const configured = await plugin.configure?.({ root, plugins: [plugin] }, {
+      config: {} as never,
+      isDev: true,
+      isProd: false,
+    } as never);
+    const vitePlugin = (configured as any).vite.plugins[0];
+    let listener: ((event: string, file: string) => void) | undefined;
+    const send = vi.fn();
+    vitePlugin.configureServer({
+      watcher: {
+        on: (_event: string, callback: typeof listener) => {
+          listener = callback;
+        },
+      },
+      moduleGraph: {
+        getModulesByFile: () => new Set(),
+        invalidateModule: vi.fn(),
+      },
+      ws: { send },
+      httpServer: null,
+    });
+
+    const addedFile = path.join(root, "content", "new.json");
+    await writeFile(addedFile, "{");
+    listener?.("add", addedFile);
+    await vi.waitFor(() =>
+      expect(send).toHaveBeenCalledWith(expect.objectContaining({ type: "error" })),
+    );
+
+    send.mockClear();
+    await writeFile(addedFile, JSON.stringify({ title: "Recovered" }));
+    listener?.("change", addedFile);
+
+    await vi.waitFor(() => expect(send).toHaveBeenCalledWith({ type: "full-reload" }));
+  });
+
+  it("recovers when a missing referenced asset is created", async () => {
+    const root = await createFixture();
+    const plugin = content({
+      collections: {
+        posts: collection({
+          source: files("content/*.md"),
+          schema: { parse: (value: unknown) => value as { title: string } },
+          assets: true,
+        }),
+      },
+    });
+    const configured = await plugin.configure?.({ root, plugins: [plugin] }, {
+      config: {} as never,
+      isDev: true,
+      isProd: false,
+    } as never);
+    const vitePlugin = (configured as any).vite.plugins[0];
+    let listener: ((event: string, file: string) => void) | undefined;
+    const send = vi.fn();
+    vitePlugin.configureServer({
+      watcher: {
+        on: (_event: string, callback: typeof listener) => {
+          listener = callback;
+        },
+      },
+      moduleGraph: {
+        getModulesByFile: () => new Set(),
+        invalidateModule: vi.fn(),
+      },
+      ws: { send },
+      httpServer: null,
+    });
+
+    const contentFile = path.join(root, "content", "hello.md");
+    const missingAsset = path.join(root, "content", "guide.pdf");
+    await writeFile(contentFile, "---\ntitle: Hello\n---\n[Guide](./guide.pdf)\n");
+    listener?.("change", contentFile);
+    await vi.waitFor(() =>
+      expect(send).toHaveBeenCalledWith(expect.objectContaining({ type: "error" })),
+    );
+
+    send.mockClear();
+    await writeFile(missingAsset, "%PDF recovered\n");
+    listener?.("add", missingAsset);
+
+    await vi.waitFor(() => expect(send).toHaveBeenCalledWith({ type: "full-reload" }));
+  });
+
   it("rejects duplicate plugin instances", async () => {
     const root = await createFixture();
     const plugin = createPlugin();

--- a/packages/farm-content/src/index.ts
+++ b/packages/farm-content/src/index.ts
@@ -77,9 +77,15 @@ export function content<const TCollections extends ContentCollections>(
   }) as ContentPlugin<TCollections>;
 
   async function rebuild(): Promise<void> {
-    const loaded = await loadContentCollections(root, options.collections);
-    sourceFiles = new Set(loaded.sourceFiles);
-    await writeContentServerModule(generatedFile, loaded.collections, loaded.assetImports);
+    const attemptedSourceFiles = new Set<string>();
+    try {
+      const loaded = await loadContentCollections(root, options.collections, attemptedSourceFiles);
+      await writeContentServerModule(generatedFile, loaded.collections, loaded.assetImports);
+      sourceFiles = new Set(loaded.sourceFiles);
+    } catch (error) {
+      sourceFiles = new Set([...sourceFiles, ...attemptedSourceFiles]);
+      throw error;
+    }
   }
 
   function createContentVitePlugin() {

--- a/packages/farm-content/src/loader.ts
+++ b/packages/farm-content/src/loader.ts
@@ -29,9 +29,9 @@ export interface LoadedContent {
 export async function loadContentCollections(
   root: string,
   collections: ContentCollections,
+  sourceFiles: Set<string> = new Set(),
 ): Promise<LoadedContent> {
   const loaded: Record<string, readonly ContentEntry<any>[]> = Object.create(null);
-  const sourceFiles = new Set<string>();
   const assetImports = new Map<string, ContentAssetImport>();
 
   for (const [name, definition] of Object.entries(collections)) {


### PR DESCRIPTION
## Problem

A newly added content file can fail validation or parsing during development. Fixing that file emits a change event, but Content ignores it and never rebuilds again. The same failure occurs when a content edit references a missing asset and the asset is created afterward.

## Root cause

The development watcher only retained source and asset paths from successful collection loads. Paths discovered during a failed rebuild were discarded, so later change or add events for those paths did not qualify for another rebuild.

## Change

Allow the collection loader to populate a caller-owned source path set. A successful rebuild replaces the watched set as before. A failed rebuild merges every path discovered during that attempt into the watcher state so the next relevant file event can recover.

Regression coverage exercises both an invalid newly added JSON file that is corrected and a missing Markdown asset that is subsequently created.

## Safety and compatibility

This changes only development watcher bookkeeping. Failed rebuilds still preserve the last valid generated module, successful rebuilds reset stale paths, and production content generation is unchanged. No public package API changes.

## Verification

Run on macOS with Node.js 23.11.0:

- `pnpm --filter @farm.js/content test` (27 tests)
- `pnpm --filter @farm.js/content type-check`
- `pnpm --filter @farm.js/content build`
- `pnpm exec oxlint packages/farm-content/src/index.ts packages/farm-content/src/loader.ts packages/farm-content/src/index.test.ts`
- `pnpm exec oxfmt packages/farm-content/src/index.ts packages/farm-content/src/loader.ts packages/farm-content/src/index.test.ts`

## Documentation and release

None. This restores expected development HMR behavior without changing configuration.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes HMR in the content plugin so development recovers after a failed rebuild. Previously, when a newly added content file failed validation/parsing, or a content edit referenced a missing asset, fixing the file did not trigger another rebuild. Failed rebuilds now keep all source and asset paths discovered during the attempt in the watcher state, so a later change or add event recovers. Adds regression tests for both scenarios. Only dev watcher bookkeeping changes; production content generation and the public API are unaffected.

<sup>Written for commit b6b25a16923f54c515b3b4ab163436d7e9297870. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/898?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

