### PR TITLE
fix(pwa): match encoded static route paths

### DIFF
--- a/packages/farm-pwa/src/build.test.ts
+++ b/packages/farm-pwa/src/build.test.ts
@@ -136,6 +136,33 @@ describe("writePwaBuildArtifacts", () => {
     ]);
   });
 
+  it("matches static routes containing spaces and Unicode as browser pathnames", async () => {
+    const { root, publicDir } = await createOutput("node-server");
+    await mkdir(path.join(publicDir, "café"), { recursive: true });
+    await mkdir(path.join(publicDir, "release notes"), { recursive: true });
+    await writeFile(path.join(publicDir, "café", "index.html"), "<h1>Café</h1>");
+    await writeFile(path.join(publicDir, "release notes", "index.html"), "<h1>Release notes</h1>");
+
+    const result = await writePwaBuildArtifacts({
+      outputDir: root,
+      preset: "node-server",
+      basePath: "/app",
+      options: resolvePwaOptions({ offline: "/café", cache: "auto" }),
+    });
+
+    expect(result.staticRoutes).toMatchObject({
+      "/app/café": "café/index.html",
+      "/app/release notes": "release notes/index.html",
+    });
+    expect(result.precacheUrls).toContain("/app/caf%C3%A9/index.html");
+    expect(result.precacheUrls).toContain("/app/release%20notes/index.html");
+
+    const worker = await readFile(result.workerPath, "utf8");
+    expect(worker).toContain('"/app/caf%C3%A9":"/app/caf%C3%A9/index.html"');
+    expect(worker).toContain('"/app/release%20notes":"/app/release%20notes/index.html"');
+    expect(worker).toContain('const OFFLINE_FILE = "/app/caf%C3%A9/index.html"');
+  });
+
   it("fails the build when the offline fallback is not an emitted static page", async () => {
     const { root } = await createOutput("node-server");
     await expect(

--- a/packages/farm-pwa/src/build.ts
+++ b/packages/farm-pwa/src/build.ts
@@ -152,11 +152,13 @@ export interface GenerateServiceWorkerOptions {
 export function generateServiceWorker(options: GenerateServiceWorkerOptions): string {
   const routeFiles = Object.fromEntries(
     Object.entries(options.staticRoutes).map(([route, file]) => [
-      route,
+      encodePathname(route),
       toPublicUrl(file, options.basePath),
     ]),
   );
-  const offlineFile = options.offlineRoute ? (routeFiles[options.offlineRoute] ?? null) : null;
+  const offlineFile = options.offlineRoute
+    ? (routeFiles[encodePathname(options.offlineRoute)] ?? null)
+    : null;
   const cacheScope = createHash("sha256")
     .update(normalizeBasePath(options.basePath))
     .digest("hex")
@@ -391,4 +393,11 @@ function toPublicUrl(file: string, basePath: string): string {
     .map((segment) => encodeURIComponent(segment))
     .join("/")}`;
   return withBasePath(url, basePath);
+}
+
+function encodePathname(pathname: string): string {
+  return pathname
+    .split("/")
+    .map((segment) => encodeURIComponent(segment))
+    .join("/");
 }


### PR DESCRIPTION
## Problem

Generated service workers could precache static pages whose paths contain spaces or Unicode, but offline navigation could not retrieve them. For example, the worker stored a route key such as `/app/café` while the browser supplied `/app/caf%C3%A9`.

## Root cause

Precache URLs encoded filesystem path segments, while the generated `STATIC_ROUTES` lookup retained raw filesystem-derived route names. Browser `URL.pathname` uses the encoded representation, so those values never matched.

## Change

Encode each static route pathname segment when generating the worker lookup and use the same canonical key when resolving the offline fallback. The build result continues to expose logical route names while the browser-facing worker uses URL pathnames.

Regression coverage includes Unicode and space-containing routes under a non-root `basePath`, including a Unicode offline fallback.

## Safety and compatibility

ASCII route keys remain byte-for-byte equivalent. Existing precache URLs are unchanged, custom service workers are unaffected, and the change is limited to generated service workers.

## Verification

Run on macOS with Node.js 23.11.0:

- `pnpm --filter @farm.js/pwa test` (22 tests)
- `pnpm --filter @farm.js/pwa type-check`
- `pnpm --filter @farm.js/pwa build`
- `pnpm exec oxlint packages/farm-pwa/src/build.ts packages/farm-pwa/src/build.test.ts`
- `pnpm exec oxfmt packages/farm-pwa/src/build.ts packages/farm-pwa/src/build.test.ts`

## Documentation and release

None. This corrects generated worker behavior without changing PWA configuration.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes offline navigation for generated service workers when static routes contain spaces or Unicode. The worker now uses the same encoded pathname for route lookup and precache URLs, so the offline fallback resolves correctly. ASCII routes are unaffected, and the change only touches generated workers.

**Details**
- Encode each route segment when generating the worker lookup and offline fallback.
- Build output still exposes logical route names; only the worker uses encoded pathnames.
- Added tests for Unicode and space routes under a non-root `basePath`.

<sup>Written for commit 9f810042e589cf36338c20c91738da82130915b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/899?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

