### PR TITLE
fix(federation): reject unsafe public paths

### DIFF
--- a/packages/farm-federation/src/config.test.ts
+++ b/packages/farm-federation/src/config.test.ts
@@ -116,6 +116,13 @@ describe("resolveFederationOptions", () => {
         resolveFederationOptions({ name: "host", remotes: { checkout: entry } }, reactRenderer),
       ).toThrow();
     }
+    for (const publicPath of [
+      "//cdn.example.com/assets/",
+      "/\\cdn.example.com/assets/",
+      "https:\\cdn.example.com\\assets\\",
+    ]) {
+      expect(() => resolveFederationOptions({ name: "host", publicPath }, reactRenderer)).toThrow();
+    }
     expect(() =>
       resolveFederationOptions({ name: "host", serverRemotes: {} } as never, reactRenderer),
     ).toThrow("issues/885");

--- a/packages/farm-federation/src/config.ts
+++ b/packages/farm-federation/src/config.ts
@@ -294,7 +294,18 @@ function normalizeOutputFile(value: string): string {
 function optionalPublicPath(value: string | undefined): string | undefined {
   if (value === undefined) return undefined;
   const publicPath = nonEmptyString(value, "Federation publicPath");
-  if (publicPath === "auto" || publicPath.startsWith("/")) return publicPath;
+  if (publicPath === "auto") return publicPath;
+  if (publicPath.startsWith("/")) {
+    if (publicPath.startsWith("//") || publicPath.includes("\\")) {
+      throw new TypeError(
+        "Federation publicPath must be a root-relative URL, not a network-path URL",
+      );
+    }
+    return publicPath;
+  }
+  if (publicPath.includes("\\")) {
+    throw new TypeError("Federation publicPath must use URL separators");
+  }
   let parsed: URL;
   try {
     parsed = new URL(publicPath);


### PR DESCRIPTION
## Problem

Federation accepted `publicPath` values such as `//cdn.example.com/assets/` and `/\\cdn.example.com/assets/` as root-relative paths. Browsers can interpret these network-path forms as cross-origin URLs rather than application paths.

## Root cause

The validator returned every value beginning with `/` before checking for a second slash or backslash. Remote entry validation already rejected the same ambiguous forms, but `publicPath` did not apply that rule.

## Change

Reject protocol-relative and backslash-based root paths before accepting a root-relative `publicPath`. Also reject backslashes in non-root URL forms before URL parsing can reinterpret them.

Regression coverage includes protocol-relative, slash-backslash, and backslash-based HTTP inputs.

## Safety and compatibility

`auto`, ordinary root-relative paths, and credential-free HTTP or HTTPS URLs continue to work. Only ambiguous values that browsers can reinterpret are rejected. Runtime federation behavior and renderer sharing are unchanged.

## Verification

Run on macOS with Node.js 23.11.0:

- `pnpm --filter @farm.js/federation test` (22 tests)
- `pnpm --filter @farm.js/federation type-check`
- `pnpm --filter @farm.js/federation build`
- `pnpm exec oxlint packages/farm-federation/src/config.ts packages/farm-federation/src/config.test.ts`
- `pnpm exec oxfmt packages/farm-federation/src/config.ts packages/farm-federation/src/config.test.ts`

## Documentation and release

None. This aligns validation with the existing documented `publicPath` forms.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects unsafe federation `publicPath` values like protocol-relative (`//...`) or backslash-based paths that browsers interpret as cross-origin. Root-relative paths (`/...`) and credential-free HTTP(S) URLs continue to work, and `auto` is unchanged.

<sup>Written for commit 0c0b7a55462f0eeda429ba0f7b19fa289b9739e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/900?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

