### PR TITLE
perf(react): retain structural lineage through prepends

### DIFF
--- a/docs/src/app/docs/renderers/react/page.md
+++ b/docs/src/app/docs/renderers/react/page.md
@@ -1023,6 +1023,12 @@ at the beginning:
 ```tsx
 setItems((current) => [nextItem, ...current]);
 setItems((current) => [...nextItems, ...current]);
+
+setItems((current) => current.filter((item) => item.id !== expiredId));
+setItems((current) => [nextItem, ...current]);
+
+setItems((current) => current.slice(start, end));
+setItems((current) => [...nextItems, ...current]);
 ```
 
 At build time, Farm recognizes a concise functional setter whose array literal ends with exactly
@@ -1036,14 +1042,22 @@ item before changing the DOM. It reads keys, descriptors, and bindings only for 
 creates only those host rows, inserts them before the first existing row, and shifts the stored
 indexes used by delegated row events. Existing row DOM is neither recreated nor rebound.
 
+An immediately adjacent compiler-proven `filter()` or bounded `slice()` may feed one or more of
+these prepends. Farm carries the original survivor positions or retained interval through the
+queued setters. Before mutation it validates the committed token, the complete dense final array,
+every survivor identity, and every prefix key, descriptor, and binding. It then removes rejected
+rows, inserts the prepared prefix once, and updates survivor event indexes. Surviving rows keep
+their exact DOM nodes and do not rerun their bindings.
+
 This proof requires compiler-owned host rows whose render callback and key do not read the row
 index. Index-aware rows, collection-derived keys, collection-reading bindings, React-owned or
-nested host-block rows, row conditionals, middle insertion, removal, direct replacement,
-block-bodied updaters, duplicate keys, custom, sparse, or subclassed arrays, an unrelated dirty
-dependency, or any failed runtime check keeps complete keyed reconciliation. A prepend queued
-after an unhinted update also falls back. Reports expose emitted sites as
-`keyedArrayPrependHints`; the optional runtime capability is retained only when a module emits the
-matching hint.
+nested host-block rows, row conditionals, middle insertion, direct replacement, block-bodied
+updaters, a reordered or mapped structural chain, duplicate final keys, reuse of any committed key
+in the prefix, custom, sparse, or subclassed arrays, an unrelated dirty dependency, or any failed
+runtime check keeps complete keyed reconciliation before a DOM write. A prepend queued after an
+unhinted update also falls back. Reports expose emitted sites as `keyedArrayPrependHints`; no option
+or component API is added, and modules without both removal and prepend sites omit the composed
+runtime.
 
 #### Keyed array slice hints
 
@@ -2354,7 +2368,9 @@ The package and example test suites verify more than generated code:
 - 2,000 deterministic keyed-array prepends match normal React; targeted tests require key,
   descriptor, and binding reads to equal only the inserted prefix, preserve every existing DOM
   row, update delegated event indexes, and cover queued updates, StrictMode hydration, unmount,
-  invalid metadata, custom arrays, and conservative fallback;
+  invalid metadata, custom arrays, and conservative fallback; another 2,000 randomized queued
+  filter-or-slice followed by prepend transitions match normal React while targeted tests preserve
+  survivor identity, controlled-input focus and selection, and atomic fallback;
 - 2,000 deterministic queued keyed-array slices and 1,000 randomized runtime-bound slices match
   normal React; compiler tests cover literal and compiler-safe runtime bounds while rejecting calls
   and mutations; targeted tests require zero surviving key, descriptor, and binding reads, preserve

--- a/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
+++ b/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
@@ -1,6 +1,38 @@
 # Complex dashboard and 21,000-row peak result
 
-Latest run: 2026-09-10
+Latest run: 2026-09-11
+
+## Queued removal followed by prepend — 2026-09-11
+
+An index-independent keyed-row `filter()` or bounded `slice()` can now retain its committed-row
+lineage through one or more immediately following immutable prepends. Previously, the prepend
+result lost the structural survivor proof and the final commit used complete keyed reconciliation.
+The new path validates the entire result before its first DOM write, removes only rejected rows,
+preserves every survivor, shifts delegated event indexes, and creates only the fresh prefix.
+
+| Mode   | Remove + prepend | Compiled fallback | vs React | vs fallback |
+| ------ | ---------------: | ----------------: | -------: | ----------: |
+| Static |          9.00 ms |          24.00 ms |    8.98x |       2.67x |
+| Hybrid |          7.80 ms |          23.30 ms |   10.37x |       2.99x |
+
+Both modes passed the 2x React and 1.25x compiled-control floors. The bracketed React median was
+80.85 ms. Every sample checked the final 10,000-row order, all 9,999 survivor DOM identities, the
+removed row's disconnection, the fresh first row, browser errors, and zero compiled owner
+executions. Correctness, the broad 10% no-regression gate, every established feature gate, and
+optimization persistence passed; the existing 10k/20k update persistence remained between 15.75x
+and 21.75x.
+
+Compiler and runtime coverage includes filter and slice sources, multiple queued prefixes,
+all-rows-rejected mounting, duplicate and mismatched-key fallback before mutation,
+collection-reading fallback, delegated event indexes, controlled-input focus and selection,
+Strict Mode hydration, unmount-before-flush cleanup, React 18.3.1 and 19.2.8, and 2,000 sequential
+randomized transitions matched with normal React. The dedicated structural-prepend fixture adds
+13,387 bytes gzip; the existing direct-prepend and structural-append premiums remain unchanged.
+
+Numbers are browser medians from a complete production-build run with 5 warmups, 10 measured
+samples per compiler action, 20 bracketed React samples, and 3 scale cycles, using Chrome
+153.0.8010.36 and Node.js 23.11.0 on Apple M1 macOS arm64. The aggregate command and every
+individual gate passed.
 
 ## Mapped survivors before a later append — 2026-09-10
 

--- a/examples/react-compiler-dashboard/README.md
+++ b/examples/react-compiler-dashboard/README.md
@@ -111,6 +111,13 @@ least 1.25x faster than the compiled control at 10,000 rows. The report must con
 `keyedArrayPrependHints` count; deterministic package tests separately require key, descriptor, and
 binding work to equal only the new prefix while preserving every existing DOM row.
 
+Queued structural prepends have a separate 10,000-row gate. One concise setter drops the oldest row
+with a bounded `slice()` and the adjacent setter prepends one fresh row; a block-bodied pair
+performs the same native array and DOM work through complete reconciliation. Both compiler modes
+must remain at least 2x faster than bracketed React and 1.25x faster than the compiled control.
+Every sample checks all 9,999 survivor identities and order, the disconnected rejected row, and the
+fresh first row.
+
 Keyed array slices have an independent retained-window comparison. A concise
 `slice(trimCount)` uses an event-local runtime bound and is measured against bracketed React and an
 equivalent block-bodied compiled snapshot control. Both compiler modes must remain at least 3x
@@ -383,6 +390,9 @@ The default JSON report is `/tmp/farm-react-dashboard-benchmark.json`; change it
   adjacent setters. Its block-bodied pair performs the same native array and DOM-visible work
   through complete reconciliation; the hinted path reuses survivor positions and reads only the
   appended suffix.
+- The queued structural-prepend control performs the mirror operation. Its hinted path reuses the
+  exact slice interval, creates only the new prefix, and shifts delegated event indexes while its
+  block-bodied pair uses complete reconciliation.
 - The queued structural-append-map control follows that pair with a same-key native map. Its
   block-bodied control reaches the same DOM through complete reconciliation; the hinted path
   validates the final positional lineage once, patches only changed survivors, and mounts the final

--- a/examples/react-compiler-dashboard/scripts/benchmark.mjs
+++ b/examples/react-compiler-dashboard/scripts/benchmark.mjs
@@ -1234,6 +1234,41 @@ async function measureTrial(browser, trial, compilerMode, port) {
             ),
         );
 
+        const measureStructuralPrepend = async (action) => {
+          const rows = [...table.querySelectorAll("tbody tr")];
+          const removed = rows[0];
+          if (!removed) throw new Error("Queued structural-prepend source row is missing.");
+          const survivors = rows.slice(1);
+          await runTableAction(action, () => {
+            const nextRows = [...table.querySelectorAll("tbody tr")];
+            const prepended = nextRows[0];
+            return (
+              nextRows.length === 10_000 &&
+              prepended?.querySelector("td:nth-child(2)")?.textContent ===
+                "queued prepended row" &&
+              !rows.includes(prepended) &&
+              rowsMatch(nextRows.slice(1), survivors) &&
+              !removed.isConnected
+            );
+          });
+        };
+
+        const tableStructuralPrependQueued = await measureTable(
+          async () => create10000(),
+          async () =>
+            measureStructuralPrepend(() =>
+              tableButton("table-structural-prepend-queued").click(),
+            ),
+        );
+
+        const tableStructuralPrependQueuedSnapshot = await measureTable(
+          async () => create10000(),
+          async () =>
+            measureStructuralPrepend(() =>
+              tableButton("table-structural-prepend-queued-snapshot").click(),
+            ),
+        );
+
         const measureStructuralAppendMap = async (action) => {
           const rows = [...table.querySelectorAll("tbody tr")];
           const removed = rows[0];
@@ -2129,6 +2164,8 @@ async function measureTrial(browser, trial, compilerMode, port) {
             filterMapAppendQueuedSnapshot: tableFilterMapAppendQueuedSnapshot,
             structuralAppendQueued: tableStructuralAppendQueued,
             structuralAppendQueuedSnapshot: tableStructuralAppendQueuedSnapshot,
+            structuralPrependQueued: tableStructuralPrependQueued,
+            structuralPrependQueuedSnapshot: tableStructuralPrependQueuedSnapshot,
             structuralAppendMapQueued: tableStructuralAppendMapQueued,
             structuralAppendMapQueuedSnapshot: tableStructuralAppendMapQueuedSnapshot,
             mapStructuralReorderPipeline: tableMapStructuralReorderPipeline,
@@ -2281,6 +2318,10 @@ async function measureTrial(browser, trial, compilerMode, port) {
         filterMapAppendQueuedSnapshot: timingSummary(result.table.filterMapAppendQueuedSnapshot),
         structuralAppendQueued: timingSummary(result.table.structuralAppendQueued),
         structuralAppendQueuedSnapshot: timingSummary(result.table.structuralAppendQueuedSnapshot),
+        structuralPrependQueued: timingSummary(result.table.structuralPrependQueued),
+        structuralPrependQueuedSnapshot: timingSummary(
+          result.table.structuralPrependQueuedSnapshot,
+        ),
         structuralAppendMapQueued: timingSummary(result.table.structuralAppendMapQueued),
         structuralAppendMapQueuedSnapshot: timingSummary(
           result.table.structuralAppendMapQueuedSnapshot,
@@ -2506,6 +2547,8 @@ const tableMetrics = [
   "filterMapAppendQueuedSnapshot",
   "structuralAppendQueued",
   "structuralAppendQueuedSnapshot",
+  "structuralPrependQueued",
+  "structuralPrependQueuedSnapshot",
   "structuralAppendMapQueued",
   "structuralAppendMapQueuedSnapshot",
   "mapStructuralReorderPipeline",
@@ -3189,6 +3232,29 @@ const keyedStructuralAppendRegressions = keyedStructuralAppendResults.filter(
     !Number.isFinite(snapshotSpeedup) ||
     snapshotSpeedup < keyedStructuralAppendMinimumSnapshotSpeedup,
 );
+// A bounded slice followed by an adjacent immutable prepend keeps an exact committed survivor
+// interval. The hinted path should remove only rejected rows, create only the new prefix, and stay
+// ahead of React and the equivalent block-bodied compiled control at 10,000 rows.
+const keyedStructuralPrependMinimumSpeedup = 2;
+const keyedStructuralPrependMinimumSnapshotSpeedup = 1.25;
+const keyedStructuralPrependResults = ["static", "hybrid"].map((mode) => {
+  const pipelineMedianMs = comparisons.table.structuralPrependQueued[mode].medianMs;
+  const snapshotMedianMs = comparisons.table.structuralPrependQueuedSnapshot[mode].medianMs;
+  return {
+    mode,
+    pipelineMedianMs,
+    snapshotMedianMs,
+    snapshotSpeedup: snapshotMedianMs / pipelineMedianMs,
+    speedup: comparisons.table.structuralPrependQueued[`${mode}VsBaseline`].speedup,
+  };
+});
+const keyedStructuralPrependRegressions = keyedStructuralPrependResults.filter(
+  ({ snapshotSpeedup, speedup }) =>
+    !Number.isFinite(speedup) ||
+    speedup < keyedStructuralPrependMinimumSpeedup ||
+    !Number.isFinite(snapshotSpeedup) ||
+    snapshotSpeedup < keyedStructuralPrependMinimumSnapshotSpeedup,
+);
 // A following same-key map can keep a bounded slice's stable-key and suffix proof. The hinted path
 // should patch only changed survivors while retaining the structural append speedup over React and
 // the equivalent block-bodied compiled control.
@@ -3672,6 +3738,7 @@ const passed =
   keyedReorderPipelineRegressions.length === 0 &&
   keyedStructuralReorderRegressions.length === 0 &&
   keyedStructuralAppendRegressions.length === 0 &&
+  keyedStructuralPrependRegressions.length === 0 &&
   keyedStructuralAppendMapRegressions.length === 0 &&
   keyedFilterAppendMapRegressions.length === 0 &&
   keyedFilterMapAppendRegressions.length === 0 &&
@@ -3857,6 +3924,13 @@ const report = {
     regressions: keyedStructuralAppendRegressions,
     results: keyedStructuralAppendResults,
     status: keyedStructuralAppendRegressions.length === 0 ? "PASS" : "FAIL",
+  },
+  keyedStructuralPrependHintGate: {
+    minimumSnapshotSpeedup: keyedStructuralPrependMinimumSnapshotSpeedup,
+    minimumSpeedup: keyedStructuralPrependMinimumSpeedup,
+    regressions: keyedStructuralPrependRegressions,
+    results: keyedStructuralPrependResults,
+    status: keyedStructuralPrependRegressions.length === 0 ? "PASS" : "FAIL",
   },
   keyedStructuralAppendMapHintGate: {
     minimumSnapshotSpeedup: keyedStructuralAppendMapMinimumSnapshotSpeedup,

--- a/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
+++ b/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
@@ -913,6 +913,48 @@ export function StandardTableBenchmark() {
           Queued remove + append (snapshot control)
         </button>
         <button
+          data-action="table-structural-prepend-queued"
+          type="button"
+          onClick={() => {
+            const incoming = {
+              id: (seed + 1_050_000) * 10_000 + 1,
+              label: "queued prepended row",
+              amount: 2_048,
+              region: "AMR" as const,
+              status: "review" as const,
+            };
+            setRows((current) => current.slice(1));
+            setRows((current) => [incoming, ...current]);
+            setOperation("remove and prepend across queued setters");
+            setRevision((value) => value + 1);
+          }}
+        >
+          Queued remove + prepend
+        </button>
+        <button
+          data-action="table-structural-prepend-queued-snapshot"
+          type="button"
+          onClick={() => {
+            const incoming = {
+              id: (seed + 1_050_000) * 10_000 + 1,
+              label: "queued prepended row",
+              amount: 2_048,
+              region: "AMR" as const,
+              status: "review" as const,
+            };
+            setRows((current) => {
+              return current.slice(1);
+            });
+            setRows((current) => {
+              return [incoming, ...current];
+            });
+            setOperation("remove and prepend across queued setters (snapshot control)");
+            setRevision((value) => value + 1);
+          }}
+        >
+          Queued remove + prepend (snapshot control)
+        </button>
+        <button
           data-action="table-structural-append-map-queued"
           type="button"
           onClick={() => {

--- a/packages/farm-react/README.md
+++ b/packages/farm-react/README.md
@@ -312,14 +312,27 @@ The mirror-image prepend form is supported when the keyed row and key do not rea
 ```tsx
 setItems((current) => [nextItem, ...current]);
 setItems((current) => [...nextItems, ...current]);
+
+setItems((current) => current.filter((item) => item.id !== expiredId));
+setItems((current) => [nextItem, ...current]);
+
+setItems((current) => current.slice(start, end));
+setItems((current) => [...nextItems, ...current]);
 ```
 
 Farm validates the committed source and queued prepend chain, creates only the new prefix, inserts
 it before the first existing row, and shifts the stored indexes used by delegated row events.
-Existing row DOM and bindings stay in place. Index-aware rows, collection-reading bindings or
-keys, React-owned row structures, middle insertion, direct replacement, duplicate keys, custom or
-sparse arrays, and failed validation use complete keyed reconciliation. The compiler report
-exposes the emitted-site count as `keyedArrayPrependHints`.
+When an adjacent filter or bounded slice runs first, the compiler also carries the exact survivor
+positions into the prepend. The runtime removes only rejected rows, preserves every surviving DOM
+node, and creates only the final prefix instead of rescanning and rebinding the whole result.
+Multiple adjacent prepends share the same proof.
+
+Index-aware rows, collection-reading bindings or keys, React-owned or nested row structures,
+middle insertion, direct replacement, a reordered or mapped structural chain, duplicate final
+keys, reuse of any committed key in the new prefix, custom or sparse arrays, and failed validation
+use complete keyed reconciliation before any DOM mutation. The compiler report exposes the
+emitted-site count as `keyedArrayPrependHints`; no option or component API is added, and modules
+without both removal and prepend sites omit the composed runtime.
 
 Native slices with compiler-safe bounds can carry their exact retained interval into the same
 removal runtime:

--- a/packages/farm-react/RUNTIME_SIZE_RESULTS.json
+++ b/packages/farm-react/RUNTIME_SIZE_RESULTS.json
@@ -94,14 +94,31 @@
         "brotli": 51861
       },
       "compilerOn": {
-        "raw": 263083,
-        "gzip": 78845,
-        "brotli": 67473
+        "raw": 263093,
+        "gzip": 78859,
+        "brotli": 67528
       },
       "compilerPremium": {
-        "raw": 70102,
-        "gzip": 18708,
-        "brotli": 15612
+        "raw": 70112,
+        "gzip": 18722,
+        "brotli": 15667
+      }
+    },
+    "keyedStructuralPrepend": {
+      "compilerOff": {
+        "raw": 192928,
+        "gzip": 60114,
+        "brotli": 51822
+      },
+      "compilerOn": {
+        "raw": 240865,
+        "gzip": 73501,
+        "brotli": 62944
+      },
+      "compilerPremium": {
+        "raw": 47937,
+        "gzip": 13387,
+        "brotli": 11122
       }
     },
     "keyedPrepend": {
@@ -264,18 +281,18 @@
         "brotli": 51666
       },
       "full": {
-        "raw": 291312,
-        "gzip": 82753,
-        "brotli": 70614
+        "raw": 299239,
+        "gzip": 84361,
+        "brotli": 71836
       },
       "coreOnly": {
         "raw": 204922,
         "gzip": 63685,
         "brotli": 54902
       },
-      "fullRuntimePremiumGzip": 22834,
+      "fullRuntimePremiumGzip": 24442,
       "coreRuntimePremiumGzip": 3766,
-      "gzipReductionPercent": 83.5
+      "gzipReductionPercent": 84.6
     }
   }
 }

--- a/packages/farm-react/RUNTIME_SIZE_RESULTS.md
+++ b/packages/farm-react/RUNTIME_SIZE_RESULTS.md
@@ -27,6 +27,7 @@ is enforced on every pull request instead of serving only as a manually recorded
 | Keyed rows, LIS, scalar, Set, and Map targeting   |          60,179 B |         71,373 B |         11,194 B |
 | Keyed rows with append hints                      |          60,085 B |         71,690 B |         11,605 B |
 | Keyed rows with prepend hints                     |          60,087 B |         72,055 B |         11,968 B |
+| Keyed rows with removal + prepend hints           |          60,114 B |         73,501 B |         13,387 B |
 | Keyed rows with filter hints                      |          60,088 B |         72,258 B |         12,170 B |
 | Keyed rows with slice hints                       |          60,075 B |         72,297 B |         12,222 B |
 | Keyed rows with known-position hints              |          60,076 B |         72,344 B |         12,268 B |
@@ -36,15 +37,16 @@ is enforced on every pull request instead of serving only as a manually recorded
 | Keyed rows with sort hints                        |          60,077 B |         72,207 B |         12,130 B |
 | Keyed rows with rolling-window hints              |          60,108 B |         73,177 B |         13,069 B |
 
-The isolated compatibility runtime contributes 21,619 B gzip over the React control. The
-compiler-selected core contributes 3,766 B, an **82.6% reduction**. This comparison uses the same
+The isolated compatibility runtime contributes 24,442 B gzip over the React control. The
+compiler-selected core contributes 3,766 B, an **84.6% reduction**. This comparison uses the same
 hand-authored compiled definition and changes only the runtime entry used to create it.
 
 The keyed fixture retains `FarmCompiledKeyedRows` plus compiler-emitted `identityTarget`,
 `membershipTarget`, and `mapLookupTarget` metadata, plus Set/Map producer-delta helpers. It rejects
 the optional row-conditional and keyed-update runtimes. Separate append, prepend, and filter
-fixtures prove that recognized functional updates retain only the matching hinted runtime. Slice
-reuses the filter removal capability. Position-only, batch-position, exact-window, and
+fixtures prove that recognized functional updates retain only the matching hinted runtime. The
+removal-plus-prepend fixture retains its composed capability without changing the prepend-only or
+structural-append bundles. Slice reuses the filter removal capability. Position-only, batch-position, exact-window, and
 rolling-window modules select separate hint runtimes only when the compiler emits those update
 shapes. Reverse and sort share the optional reorder capability; the direct and isolated core
 results remain byte-for-byte unchanged. Over the ordinary keyed fixture, position pays 1,074 B

--- a/packages/farm-react/fixtures/runtime-size/keyed-structural-prepend.tsx
+++ b/packages/farm-react/fixtures/runtime-size/keyed-structural-prepend.tsx
@@ -1,0 +1,34 @@
+import React, { useState } from "react";
+import { createRoot } from "react-dom/client";
+
+interface Row {
+  id: number;
+  label: string;
+}
+
+export function StructuralPrependTable() {
+  const [rows, setRows] = useState<Row[]>(
+    Array.from({ length: 1_000 }, (_, id) => ({ id, label: `Row ${id}` })),
+  );
+  return (
+    <main>
+      <button
+        onClick={() => {
+          setRows((current) => current.filter((row) => row.id !== 500));
+          setRows((current) => [{ id: 1_001, label: "Prepended row" }, ...current]);
+        }}
+      >
+        Replace
+      </button>
+      <ul>
+        {rows.map((row) => (
+          <li data-id={row.id} key={row.id}>
+            {row.label}
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}
+
+createRoot(document.body).render(<StructuralPrependTable />);

--- a/packages/farm-react/scripts/benchmark-runtime-size.mjs
+++ b/packages/farm-react/scripts/benchmark-runtime-size.mjs
@@ -61,6 +61,8 @@ const [
   keyedStructuralAppendOn,
   keyedStructuralAppendMapOff,
   keyedStructuralAppendMapOn,
+  keyedStructuralPrependOff,
+  keyedStructuralPrependOn,
   keyedPrependOff,
   keyedPrependOn,
   keyedPositionOff,
@@ -95,6 +97,8 @@ const [
   bundle("keyed-structural-append.tsx", true),
   bundle("keyed-structural-append-map.tsx", false),
   bundle("keyed-structural-append-map.tsx", true),
+  bundle("keyed-structural-prepend.tsx", false),
+  bundle("keyed-structural-prepend.tsx", true),
   bundle("keyed-prepend.tsx", false),
   bundle("keyed-prepend.tsx", true),
   bundle("keyed-position.tsx", false),
@@ -182,6 +186,14 @@ if (
   throw new Error(
     `Keyed structural-append-map fixture did not retain its optional runtime: rows=${keyedStructuralAppendMapOn.code.includes("FarmCompiledKeyedRows")}, feature=${keyedStructuralAppendMapOn.code.includes("keyed-rows:structural-append-map-hinted")}.`,
   );
+}
+if (
+  !keyedStructuralPrependOn.code.includes("FarmCompiledKeyedRows") ||
+  !keyedStructuralPrependOn.code.includes("keyed-rows:filter-prepend-hinted") ||
+  !keyedStructuralPrependOn.code.includes("filterIndexIndependent") ||
+  !keyedStructuralPrependOn.code.includes("prependIndexIndependent")
+) {
+  throw new Error("Keyed structural-prepend fixture did not retain its isolated composed runtime.");
 }
 if (
   !keyedPrependOn.code.includes("FarmCompiledKeyedRows") ||
@@ -404,6 +416,23 @@ const results = {
         brotli: keyedStructuralAppendMapOn.brotli - keyedStructuralAppendMapOff.brotli,
       },
     },
+    keyedStructuralPrepend: {
+      compilerOff: {
+        raw: keyedStructuralPrependOff.raw,
+        gzip: keyedStructuralPrependOff.gzip,
+        brotli: keyedStructuralPrependOff.brotli,
+      },
+      compilerOn: {
+        raw: keyedStructuralPrependOn.raw,
+        gzip: keyedStructuralPrependOn.gzip,
+        brotli: keyedStructuralPrependOn.brotli,
+      },
+      compilerPremium: {
+        raw: keyedStructuralPrependOn.raw - keyedStructuralPrependOff.raw,
+        gzip: keyedStructuralPrependOn.gzip - keyedStructuralPrependOff.gzip,
+        brotli: keyedStructuralPrependOn.brotli - keyedStructuralPrependOff.brotli,
+      },
+    },
     keyedPrepend: {
       compilerOff: {
         raw: keyedPrependOff.raw,
@@ -608,6 +637,13 @@ if (checkOnly) {
       maximum:
         (reference.fixtures.keyedStructuralAppendMap?.compilerPremium.gzip ??
           results.fixtures.keyedStructuralAppendMap.compilerPremium.gzip) + 256,
+    },
+    {
+      name: "keyed structural-prepend compiler premium",
+      current: results.fixtures.keyedStructuralPrepend.compilerPremium.gzip,
+      maximum:
+        (reference.fixtures.keyedStructuralPrepend?.compilerPremium.gzip ??
+          results.fixtures.keyedStructuralPrepend.compilerPremium.gzip) + 256,
     },
     {
       name: "keyed prepend compiler premium",

--- a/packages/farm-react/scripts/test-react-version.mjs
+++ b/packages/farm-react/scripts/test-react-version.mjs
@@ -55,6 +55,7 @@ const testSource = String.raw`
     createCompilerKeyedArraySlice,
     createCompilerKeyedArrayStructuralAppend,
     createCompilerKeyedArrayStructuralAppendMapPipeline,
+    createCompilerKeyedArrayStructuralPrepend,
     createCompilerKeyedArrayWindowReplace,
     createCompilerKeyedMapUpdate,
     keyedRowsStructuralAppendMapHintedRuntimeFeature,
@@ -1914,6 +1915,7 @@ const testSource = String.raw`
   flushSync(() => sliceRoot.unmount());
 
   let prependRows = () => undefined;
+  let refreshPrependRows = () => undefined;
   let prependKeyReads = 0;
   let prependBindingReads = 0;
   const PrependRows = createCompiledComponent({
@@ -1928,12 +1930,25 @@ const testSource = String.raw`
         state[0].set((previous) =>
           createCompilerKeyedArrayPrepend(previous, [addition, ...previous]),
         );
+      refreshPrependRows = (removedId, addition) => {
+        state[0].set((previous) =>
+          createCompilerKeyedArrayFilter(
+            previous,
+            previous.filter,
+            (item) => item.id !== removedId,
+          ),
+        );
+        state[0].set((previous) =>
+          createCompilerKeyedArrayStructuralPrepend(previous, [addition, ...previous]),
+        );
+      };
       return React.createElement(
         "section",
         null,
         React.createElement(blocks.KeyedRows, {
           collectionDependency: 0,
           dependencies: [0],
+          filterIndexIndependent: true,
           prependIndexIndependent: true,
           id: 0,
           items,
@@ -1988,6 +2003,16 @@ const testSource = String.raw`
   assert.equal(prependContainer.querySelector("[data-key='b']"), prependBeta);
   assert.equal(prependKeyReads, 2);
   assert.equal(prependBindingReads, 2);
+  prependKeyReads = 0;
+  prependBindingReads = 0;
+  refreshPrependRows("a", { id: "e", label: "Epsilon" });
+  await Promise.resolve();
+  await Promise.resolve();
+  assert.equal(prependContainer.textContent, "EpsilonDeltaGammaBeta");
+  assert.equal(prependContainer.querySelector("[data-key='a']"), null);
+  assert.equal(prependContainer.querySelector("[data-key='b']"), prependBeta);
+  assert.equal(prependKeyReads, 4);
+  assert.equal(prependBindingReads, 1);
   flushSync(() => prependRoot.unmount());
 
   let editableRowExecutions = 0;

--- a/packages/farm-react/src/__tests__/compiler-keyed-array-prepend-hints.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-keyed-array-prepend-hints.test.ts
@@ -86,6 +86,65 @@ describe("React AOT keyed-array prepend hints", () => {
 
   it.each([
     {
+      name: "filter",
+      remove: "current.filter((row) => row.id !== expiredId)",
+    },
+    {
+      name: "slice",
+      remove: "current.slice(start, end)",
+    },
+  ])("retains $name survivor lineage through a later prepend", async ({ remove }) => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Feed({ expiredId, start, end, incoming }) {
+        const [rows, setRows] = useState([{ id: "a", label: "Alpha" }]);
+        return <main>
+          <button onClick={() => {
+            setRows((current) => ${remove});
+            setRows((current) => [incoming, ...current]);
+          }}>
+            Refresh
+          </button>
+          <ul>{rows.map((row) => <li key={row.id}>{row.label}</li>)}</ul>
+        </main>;
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Feed"]);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.optimizations.keyedArrayPrependHints).toBe(1);
+    expect(result.code).toContain("createCompilerKeyedArrayStructuralPrepend");
+    expect(result.code).toContain("keyedRowsFilterPrependHintedRuntimeFeature");
+  });
+
+  it("keeps structural prepend available beside other keyed update capabilities", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Feed({ expiredId, incoming, trailing }) {
+        const [rows, setRows] = useState([{ id: "a", label: "Alpha" }]);
+        return <main>
+          <button onClick={() => {
+            setRows((current) => current.filter((row) => row.id !== expiredId));
+            setRows((current) => [incoming, ...current]);
+          }}>Prepend</button>
+          <button onClick={() => {
+            setRows((current) => current.filter((row) => row.id !== expiredId));
+            setRows((current) => [...current, trailing]);
+          }}>Append</button>
+          <ul>{rows.map((row) => <li key={row.id}>{row.label}</li>)}</ul>
+        </main>;
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Feed"]);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.code).toContain("createCompilerKeyedArrayStructuralPrepend");
+    expect(result.code).toContain("createCompilerKeyedArrayStructuralAppend");
+    expect(result.code).toContain("keyedRowsStructuralPrependHintedRuntimeFeature");
+  });
+
+  it.each([
+    {
       name: "an index-sensitive row",
       row: "(row, index) => <li key={row.id}>{index}: {row.label}</li>",
       update: 'setRows((current) => [{ id: "b", label: "Beta" }, ...current])',

--- a/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-prepend-hints.test.tsx
+++ b/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-prepend-hints.test.tsx
@@ -5,7 +5,10 @@ import { renderToString } from "react-dom/server";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   createCompiledComponent,
+  createCompilerKeyedArrayFilter,
   createCompilerKeyedArrayPrepend,
+  createCompilerKeyedArraySlice,
+  createCompilerKeyedArrayStructuralPrepend,
   type CompilerKeyedRowElement,
 } from "../compiler-runtime";
 
@@ -27,6 +30,7 @@ interface Counters {
 }
 
 const roots: Root[] = [];
+const stressIt = process.env.FARM_REACT_STRESS === "1" ? it : it.skip;
 
 beforeEach(() => {
   globalThis.IS_REACT_ACT_ENVIRONMENT = true;
@@ -48,6 +52,22 @@ function hintedPrepend(previous: Item[], additions: readonly Item[]): Item[] {
   return createCompilerKeyedArrayPrepend(previous, [...additions, ...previous]) as Item[];
 }
 
+function hintedFilter(previous: Item[], removed: ReadonlySet<string>): Item[] {
+  return createCompilerKeyedArrayFilter(
+    previous,
+    previous.filter,
+    (item: Item) => !removed.has(item.id),
+  ) as Item[];
+}
+
+function hintedSlice(previous: Item[], start: number, end?: number): Item[] {
+  return createCompilerKeyedArraySlice(previous, previous.slice, start, end) as Item[];
+}
+
+function hintedStructuralPrepend(previous: Item[], additions: readonly Item[]): Item[] {
+  return createCompilerKeyedArrayStructuralPrepend(previous, [...additions, ...previous]) as Item[];
+}
+
 function rowDescriptor(item: Item, text = item.label): CompilerKeyedRowElement {
   return {
     kind: "element",
@@ -67,6 +87,19 @@ function createPrependHarness(initialItems: Item[], readsCollection = false) {
     bindingReads: 0,
   };
   let prepend: (additions: readonly Item[]) => void = () => undefined;
+  let filterThenPrepend: (removed: ReadonlySet<string>, additions: readonly Item[]) => void = () =>
+    undefined;
+  let filterThenPrependTwice: (
+    removed: ReadonlySet<string>,
+    first: readonly Item[],
+    second: readonly Item[],
+  ) => void = () => undefined;
+  let sliceThenPrepend: (start: number, end: number, additions: readonly Item[]) => void = () =>
+    undefined;
+  let filterThenMismatchedPrepend: (removed: ReadonlySet<string>, addition: Item) => void = () =>
+    undefined;
+  let plainBetweenFilterAndPrepend: (removed: ReadonlySet<string>, addition: Item) => void = () =>
+    undefined;
   let plainThenPrepend: (addition: Item) => void = () => undefined;
   let mismatchedPrepend: (addition: Item) => void = () => undefined;
   const Feed = createCompiledComponent({
@@ -77,6 +110,34 @@ function createPrependHarness(initialItems: Item[], readsCollection = false) {
       const items = () => state[0].get() as Item[];
       prepend = (additions) =>
         state[0].set((previous) => hintedPrepend(previous as Item[], additions));
+      filterThenPrepend = (removed, additions) => {
+        state[0].set((previous) => hintedFilter(previous as Item[], removed));
+        state[0].set((previous) => hintedStructuralPrepend(previous as Item[], additions));
+      };
+      filterThenPrependTwice = (removed, first, second) => {
+        state[0].set((previous) => hintedFilter(previous as Item[], removed));
+        state[0].set((previous) => hintedStructuralPrepend(previous as Item[], first));
+        state[0].set((previous) => hintedStructuralPrepend(previous as Item[], second));
+      };
+      sliceThenPrepend = (start, end, additions) => {
+        state[0].set((previous) => hintedSlice(previous as Item[], start, end));
+        state[0].set((previous) => hintedStructuralPrepend(previous as Item[], additions));
+      };
+      filterThenMismatchedPrepend = (removed, addition) => {
+        state[0].set((previous) => hintedFilter(previous as Item[], removed));
+        state[0].set((previous) => {
+          const source = previous as Item[];
+          return createCompilerKeyedArrayStructuralPrepend(source, [
+            addition,
+            ...source.slice().reverse(),
+          ]) as Item[];
+        });
+      };
+      plainBetweenFilterAndPrepend = (removed, addition) => {
+        state[0].set((previous) => hintedFilter(previous as Item[], removed));
+        state[0].set((previous) => [...(previous as Item[])]);
+        state[0].set((previous) => hintedStructuralPrepend(previous as Item[], [addition]));
+      };
       plainThenPrepend = (addition) => {
         state[0].set((previous) => [...(previous as Item[])]);
         state[0].set((previous) => hintedPrepend(previous as Item[], [addition]));
@@ -99,6 +160,7 @@ function createPrependHarness(initialItems: Item[], readsCollection = false) {
             dependencies={[0]}
             id={0}
             items={items}
+            filterIndexIndependent
             prependIndexIndependent
             structureDependencies={[0]}
             render={() => {
@@ -142,9 +204,22 @@ function createPrependHarness(initialItems: Item[], readsCollection = false) {
   return {
     Feed,
     counters,
+    filterThenMismatchedPrepend: (removed: ReadonlySet<string>, addition: Item) =>
+      filterThenMismatchedPrepend(removed, addition),
+    filterThenPrepend: (removed: ReadonlySet<string>, additions: readonly Item[]) =>
+      filterThenPrepend(removed, additions),
+    filterThenPrependTwice: (
+      removed: ReadonlySet<string>,
+      first: readonly Item[],
+      second: readonly Item[],
+    ) => filterThenPrependTwice(removed, first, second),
     mismatchedPrepend: (addition: Item) => mismatchedPrepend(addition),
+    plainBetweenFilterAndPrepend: (removed: ReadonlySet<string>, addition: Item) =>
+      plainBetweenFilterAndPrepend(removed, addition),
     plainThenPrepend: (addition: Item) => plainThenPrepend(addition),
     prepend: (additions: readonly Item[]) => prepend(additions),
+    sliceThenPrepend: (start: number, end: number, additions: readonly Item[]) =>
+      sliceThenPrepend(start, end, additions),
   };
 }
 
@@ -185,6 +260,162 @@ describe("compiled keyed-array prepend hints", () => {
     expect(harness.counters.keyReads).toBe(2);
     expect(harness.counters.descriptorReads).toBe(2);
     expect(harness.counters.bindingReads).toBe(2);
+  });
+
+  it("removes rejected rows and creates only the prepended prefix", async () => {
+    const initialItems = Array.from(
+      { length: 2_048 },
+      (_, index): Item => ({ id: `row-${index}`, label: `Row ${index}` }),
+    );
+    const harness = createPrependHarness(initialItems);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Feed />));
+    const first = container.querySelector('[data-key="row-0"]');
+    const middle = container.querySelector('[data-key="row-1024"]');
+    const last = container.querySelector('[data-key="row-2047"]');
+    harness.counters.keyReads = 0;
+    harness.counters.descriptorReads = 0;
+    harness.counters.bindingReads = 0;
+
+    await act(async () => {
+      harness.filterThenPrependTwice(
+        new Set(["row-1024"]),
+        [{ id: "row-new-0", label: "New 0" }],
+        [{ id: "row-new-1", label: "New 1" }],
+      );
+      await flushCompilerUpdates();
+    });
+
+    expect([...container.querySelectorAll("li")].slice(0, 2).map((row) => row.textContent)).toEqual(
+      ["New 1", "New 0"],
+    );
+    expect(container.querySelector('[data-key="row-0"]')).toBe(first);
+    expect(container.querySelector('[data-key="row-1024"]')).toBeNull();
+    expect(middle?.isConnected).toBe(false);
+    expect(container.querySelector('[data-key="row-2047"]')).toBe(last);
+    expect(container.querySelectorAll("li")).toHaveLength(2_049);
+    expect(harness.counters.executions).toBe(1);
+    expect(harness.counters.listRenders).toBe(1);
+    expect(harness.counters.descriptorReads).toBe(2);
+    expect(harness.counters.bindingReads).toBe(2);
+  });
+
+  it("retains a sliced survivor interval through a batched prepend", async () => {
+    const harness = createPrependHarness([
+      { id: "a", label: "Alpha" },
+      { id: "b", label: "Beta" },
+      { id: "c", label: "Gamma" },
+      { id: "d", label: "Delta" },
+    ]);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Feed />));
+    const beta = container.querySelector('[data-key="b"]');
+    const gamma = container.querySelector('[data-key="c"]');
+    harness.counters.keyReads = 0;
+    harness.counters.descriptorReads = 0;
+    harness.counters.bindingReads = 0;
+
+    await act(async () => {
+      harness.sliceThenPrepend(1, 3, [
+        { id: "e", label: "Epsilon" },
+        { id: "f", label: "Phi" },
+      ]);
+      await flushCompilerUpdates();
+    });
+
+    expect([...container.querySelectorAll("li")].map((row) => row.textContent)).toEqual([
+      "Epsilon",
+      "Phi",
+      "Beta",
+      "Gamma",
+    ]);
+    expect(container.querySelector('[data-key="b"]')).toBe(beta);
+    expect(container.querySelector('[data-key="c"]')).toBe(gamma);
+    expect(harness.counters.executions).toBe(1);
+    expect(harness.counters.listRenders).toBe(1);
+    expect(harness.counters.keyReads).toBe(2);
+    expect(harness.counters.descriptorReads).toBe(2);
+    expect(harness.counters.bindingReads).toBe(2);
+  });
+
+  it("mounts only the prefix when the structural step rejects every row", async () => {
+    const harness = createPrependHarness([
+      { id: "a", label: "Alpha" },
+      { id: "b", label: "Beta" },
+    ]);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Feed />));
+    const previousRows = [...container.querySelectorAll("li")];
+    harness.counters.descriptorReads = 0;
+    harness.counters.bindingReads = 0;
+
+    await act(async () => {
+      harness.filterThenPrepend(new Set(["a", "b"]), [{ id: "c", label: "Gamma" }]);
+      await flushCompilerUpdates();
+    });
+
+    expect([...container.querySelectorAll("li")].map((row) => row.textContent)).toEqual(["Gamma"]);
+    expect(previousRows.every((row) => !row.isConnected)).toBe(true);
+    expect(harness.counters.descriptorReads).toBe(1);
+    expect(harness.counters.bindingReads).toBe(1);
+  });
+
+  it("falls back atomically for reused committed keys, invalid order, and broken lineage", async () => {
+    const harness = createPrependHarness([
+      { id: "a", label: "Alpha" },
+      { id: "b", label: "Beta" },
+      { id: "c", label: "Gamma" },
+    ]);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Feed />));
+    const beta = container.querySelector('[data-key="b"]');
+
+    await act(async () => {
+      harness.filterThenPrepend(new Set(["b"]), [{ id: "b", label: "Beta reused" }]);
+      await flushCompilerUpdates();
+    });
+    expect(container.querySelector('[data-key="b"]')).toBe(beta);
+    expect(container.querySelector('[data-key="b"]')?.textContent).toBe("Beta reused");
+
+    await act(async () => {
+      harness.filterThenMismatchedPrepend(new Set(["a"]), {
+        id: "d",
+        label: "Delta",
+      });
+      await flushCompilerUpdates();
+    });
+    expect([...container.querySelectorAll("li")].map((row) => row.textContent)).toEqual([
+      "Delta",
+      "Gamma",
+      "Beta reused",
+    ]);
+
+    harness.counters.bindingReads = 0;
+    await act(async () => {
+      harness.plainBetweenFilterAndPrepend(new Set(["c"]), {
+        id: "e",
+        label: "Epsilon",
+      });
+      await flushCompilerUpdates();
+    });
+    expect([...container.querySelectorAll("li")].map((row) => row.textContent)).toEqual([
+      "Epsilon",
+      "Delta",
+      "Beta reused",
+    ]);
+    expect(harness.counters.bindingReads).toBeGreaterThan(1);
   });
 
   it("composes queued prepends and rejects an unhinted or invalid source chain", async () => {
@@ -268,6 +499,125 @@ describe("compiled keyed-array prepend hints", () => {
     const next: Item[] = [{ id: "safe", label: "Safe" }];
     expect(() => createCompilerKeyedArrayPrepend(proxy, next)).not.toThrow();
     expect(createCompilerKeyedArrayPrepend(proxy, next)).toBe(next);
+    expect(() => createCompilerKeyedArrayStructuralPrepend(proxy, next)).not.toThrow();
+    expect(createCompilerKeyedArrayStructuralPrepend(proxy, next)).toBe(next);
+  });
+
+  it("keeps structural prepend on fallback when rows read the collection", async () => {
+    const harness = createPrependHarness(
+      [
+        { id: "a", label: "Alpha" },
+        { id: "b", label: "Beta" },
+        { id: "c", label: "Gamma" },
+      ],
+      true,
+    );
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Feed />));
+    harness.counters.bindingReads = 0;
+
+    await act(async () => {
+      harness.filterThenPrepend(new Set(["b"]), [{ id: "d", label: "Delta" }]);
+      await flushCompilerUpdates();
+    });
+
+    expect([...container.querySelectorAll("li")].map((row) => row.textContent)).toEqual([
+      "3: Delta",
+      "3: Alpha",
+      "3: Gamma",
+    ]);
+    expect(harness.counters.bindingReads).toBeGreaterThan(1);
+  });
+
+  it("preserves focus and selection on a surviving controlled input", async () => {
+    const initialItems: Item[] = [
+      { id: "a", label: "Alpha" },
+      { id: "b", label: "Beta" },
+      { id: "c", label: "Gamma" },
+    ];
+    let refresh = () => undefined;
+    const Feed = createCompiledComponent({
+      displayName: "StructuralPrependForm",
+      initialize: () => [initialItems],
+      render(_props: Record<string, never>, state, blocks) {
+        const items = () => state[0].get() as Item[];
+        refresh = () => {
+          state[0].set((previous) => hintedFilter(previous as Item[], new Set(["a", "c"])));
+          state[0].set((previous) =>
+            hintedStructuralPrepend(previous as Item[], [
+              { id: "d", label: "Delta" },
+              { id: "e", label: "Epsilon" },
+            ]),
+          );
+        };
+        return (
+          <section>
+            <blocks.KeyedRows
+              collectionDependency={0}
+              dependencies={[0]}
+              filterIndexIndependent
+              id={0}
+              items={items}
+              prependIndexIndependent
+              structureDependencies={[0]}
+              render={() => (
+                <div>
+                  {items().map((item) => (
+                    <input data-key={item.id} key={item.id} readOnly value={item.label} />
+                  ))}
+                </div>
+              )}
+              rowKey={(item) => (item as Item).id}
+              create={(item) => ({
+                kind: "element",
+                tag: "input",
+                attributes: [
+                  { name: "data-key", value: (item as Item).id },
+                  { name: "readOnly", value: true },
+                  { name: "value", value: (item as Item).label },
+                ],
+                styles: [],
+                children: [],
+              })}
+              bindings={[
+                {
+                  kind: "attribute",
+                  name: "value",
+                  path: [],
+                  read: (item) => (item as Item).label,
+                },
+              ]}
+            />
+          </section>
+        );
+      },
+      bindings: [{ kind: "block", id: 0, dependencies: [0] }],
+    });
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<Feed />));
+    const beta = container.querySelector('[data-key="b"]') as HTMLInputElement;
+    beta.focus();
+    beta.setSelectionRange(1, 3);
+
+    await act(async () => {
+      refresh();
+      await flushCompilerUpdates();
+    });
+
+    expect(container.querySelector('[data-key="b"]')).toBe(beta);
+    expect(document.activeElement).toBe(beta);
+    expect([beta.selectionStart, beta.selectionEnd]).toEqual([1, 3]);
+    expect([...container.querySelectorAll("input")].map((input) => input.value)).toEqual([
+      "Delta",
+      "Epsilon",
+      "Beta",
+    ]);
   });
 
   it("updates delegated event indexes after existing rows shift", async () => {
@@ -276,6 +626,7 @@ describe("compiled keyed-array prepend hints", () => {
       { id: "b", label: "Beta" },
     ];
     let prepend = () => undefined;
+    let removeAndPrepend = () => undefined;
     const calls: string[] = [];
     const Feed = createCompiledComponent({
       displayName: "PrependEventFeed",
@@ -286,6 +637,15 @@ describe("compiled keyed-array prepend hints", () => {
           state[0].set((previous) =>
             hintedPrepend(previous as Item[], [{ id: "x", label: "Extra" }]),
           );
+        removeAndPrepend = () => {
+          state[0].set((previous) => hintedFilter(previous as Item[], new Set(["a"])));
+          state[0].set((previous) =>
+            hintedStructuralPrepend(previous as Item[], [
+              { id: "y", label: "New Y" },
+              { id: "z", label: "New Z" },
+            ]),
+          );
+        };
         return (
           <section>
             <blocks.KeyedRows
@@ -301,6 +661,7 @@ describe("compiled keyed-array prepend hints", () => {
               ]}
               id={0}
               items={items}
+              filterIndexIndependent
               prependIndexIndependent
               structureDependencies={[0]}
               render={(event) => (
@@ -353,7 +714,14 @@ describe("compiled keyed-array prepend hints", () => {
     await act(async () => {
       (container.querySelector('[data-row-button="b"]') as HTMLButtonElement).click();
     });
-    expect(calls).toEqual(["b:2"]);
+    await act(async () => {
+      removeAndPrepend();
+      await flushCompilerUpdates();
+    });
+    await act(async () => {
+      (container.querySelector('[data-row-button="b"]') as HTMLButtonElement).click();
+    });
+    expect(calls).toEqual(["b:2", "b:3"]);
   });
 
   it("matches React through 2,000 deterministic prepends", async () => {
@@ -407,6 +775,87 @@ describe("compiled keyed-array prepend hints", () => {
     expect(harness.counters.executions).toBe(1);
   }, 15_000);
 
+  stressIt(
+    "matches React across 2,000 randomized structural prepend updates",
+    async () => {
+      const initialItems = Array.from(
+        { length: 64 },
+        (_, index): Item => ({ id: `seed-${index}`, label: `Seed ${index}` }),
+      );
+      const harness = createPrependHarness(initialItems);
+      let updateReact: (kind: "filter" | "slice", removedId: string, addition: Item) => void = () =>
+        undefined;
+      function Normal() {
+        const [items, setItems] = useState(initialItems);
+        updateReact = (kind, removedId, addition) =>
+          setItems((previous) => [
+            addition,
+            ...(kind === "filter"
+              ? previous.filter((item) => item.id !== removedId)
+              : previous.slice(1)),
+          ]);
+        return (
+          <ol data-owner="react">
+            {items.map((item) => (
+              <li data-key={item.id} key={item.id}>
+                {item.label}
+              </li>
+            ))}
+          </ol>
+        );
+      }
+      const compiledContainer = document.createElement("div");
+      const reactContainer = document.createElement("div");
+      document.body.append(compiledContainer, reactContainer);
+      const compiledRoot = createRoot(compiledContainer);
+      const reactRoot = createRoot(reactContainer);
+      roots.push(compiledRoot, reactRoot);
+      await act(async () => {
+        compiledRoot.render(<harness.Feed />);
+        reactRoot.render(<Normal />);
+      });
+      harness.counters.descriptorReads = 0;
+      harness.counters.bindingReads = 0;
+      let active = initialItems.map((item) => item.id);
+      let seed = 0x9e3779b9;
+      let nextId = 0;
+
+      for (let update = 0; update < 2_000; update += 1) {
+        seed = (Math.imul(seed, 1_664_525) + 1_013_904_223) >>> 0;
+        const kind = seed % 2 === 0 ? "filter" : "slice";
+        const removedId = kind === "filter" ? active[(seed >>> 1) % active.length] : active[0];
+        const addition = {
+          id: `new-${nextId}`,
+          label: `New ${nextId}`,
+        };
+        nextId += 1;
+        await act(async () => {
+          if (kind === "filter") {
+            harness.filterThenPrepend(new Set([removedId]), [addition]);
+          } else {
+            harness.sliceThenPrepend(1, active.length, [addition]);
+          }
+          updateReact(kind, removedId, addition);
+          await flushCompilerUpdates();
+        });
+        active =
+          kind === "filter"
+            ? [addition.id, ...active.filter((id) => id !== removedId)]
+            : [addition.id, ...active.slice(1)];
+        if ((update + 1) % 20 === 0) {
+          expect([...compiledContainer.querySelectorAll("li")].map((row) => row.outerHTML)).toEqual(
+            [...reactContainer.querySelectorAll("li")].map((row) => row.outerHTML),
+          );
+        }
+      }
+      expect(active).toHaveLength(64);
+      expect(harness.counters.executions).toBe(1);
+      expect(harness.counters.descriptorReads).toBe(2_000);
+      expect(harness.counters.bindingReads).toBe(2_000);
+    },
+    20_000,
+  );
+
   it("hydrates in StrictMode and drops a queued prepend after unmount", async () => {
     const harness = createPrependHarness([{ id: "a", label: "Alpha" }]);
     const container = document.createElement("div");
@@ -436,9 +885,16 @@ describe("compiled keyed-array prepend hints", () => {
     expect(container.textContent).toBe("BetaAlpha");
     expect(recoverable).toEqual([]);
 
+    await act(async () => {
+      harness.filterThenPrepend(new Set(["a"]), [{ id: "c", label: "Gamma" }]);
+      await flushCompilerUpdates();
+    });
+    expect(container.textContent).toBe("GammaBeta");
+    expect(recoverable).toEqual([]);
+
     roots.pop();
     act(() => {
-      harness.prepend([{ id: "c", label: "Gamma" }]);
+      harness.filterThenPrepend(new Set(["b"]), [{ id: "d", label: "Delta" }]);
       root.unmount();
     });
     await flushCompilerUpdates();

--- a/packages/farm-react/src/compiler-runtime.tsx
+++ b/packages/farm-react/src/compiler-runtime.tsx
@@ -39,6 +39,7 @@ interface CompilerKeyedArrayPrependHint {
   readonly sourceLength: number;
   readonly resultLength: number;
   readonly prefixLength: number;
+  readonly structuralUpdate?: CompilerKeyedArrayFilterHint;
   readonly previous?: CompilerKeyedArrayPrependHint;
 }
 
@@ -573,6 +574,67 @@ function compilerKeyedArrayPrependLength(
     prefixLength += current.prefixLength;
   }
   return length === value.length ? prefixLength : undefined;
+}
+
+function compilerKeyedArrayStructuralPrependUpdate(
+  value: unknown,
+  sourceToken: object | undefined,
+  expectedLength: number,
+):
+  | {
+      readonly prefixLength: number;
+      readonly structuralUpdate?: CompilerKeyedArrayFilterHint;
+      readonly structuralSurvivors?: {
+        readonly indices: readonly number[];
+        readonly keysStable: boolean;
+      };
+    }
+  | undefined {
+  const target = compilerObject(value);
+  if (!target || !sourceToken || !Array.isArray(value)) return undefined;
+  const update = COMPILER_KEYED_ARRAY_PREPENDS.get(target);
+  if (!update || update.sourceToken !== sourceToken) return undefined;
+  const updates: CompilerKeyedArrayPrependHint[] = [];
+  for (
+    let current: CompilerKeyedArrayPrependHint | undefined = update;
+    current;
+    current = current.previous
+  ) {
+    if (current.sourceToken !== sourceToken) return undefined;
+    updates.push(current);
+  }
+  updates.reverse();
+  const structuralUpdate = update.structuralUpdate;
+  const first = updates[0];
+  const survivorResult = structuralUpdate
+    ? compilerKeyedArrayFilterSurvivorsFromUpdate(
+        structuralUpdate,
+        sourceToken,
+        expectedLength,
+        first.sourceLength,
+      )
+    : undefined;
+  if (structuralUpdate && !survivorResult) return undefined;
+  let length = structuralUpdate ? first.sourceLength : expectedLength;
+  let prefixLength = 0;
+  for (const current of updates) {
+    if (
+      current.sourceLength !== length ||
+      current.prefixLength < 1 ||
+      current.resultLength !== current.sourceLength + current.prefixLength
+    ) {
+      return undefined;
+    }
+    length = current.resultLength;
+    prefixLength += current.prefixLength;
+  }
+  return length === value.length
+    ? {
+        prefixLength,
+        structuralUpdate,
+        ...(survivorResult ? { structuralSurvivors: survivorResult } : {}),
+      }
+    : undefined;
 }
 
 function compilerKeyedArrayRollingWindows(
@@ -1426,6 +1488,61 @@ export function createCompilerKeyedArrayPrepend(previous: unknown, value: unknow
       sourceLength,
       resultLength: value.length,
       prefixLength,
+      ...(previousUpdate ? { previous: previousUpdate } : {}),
+    });
+    return value;
+  } catch {
+    // Metadata must never change the behavior of an otherwise valid update.
+    return value;
+  }
+}
+
+/** @internal Records a prepend that may follow a compiler-proven structural update. */
+export function createCompilerKeyedArrayStructuralPrepend(
+  previous: unknown,
+  value: unknown,
+): unknown {
+  try {
+    const previousTarget = compilerObject(previous);
+    const valueTarget = compilerObject(value);
+    if (
+      !previousTarget ||
+      !valueTarget ||
+      !Array.isArray(previous) ||
+      !Array.isArray(value) ||
+      Object.getPrototypeOf(previous) !== NATIVE_ARRAY_PROTOTYPE ||
+      Object.getPrototypeOf(value) !== NATIVE_ARRAY_PROTOTYPE ||
+      previous[Symbol.iterator] !== NATIVE_ARRAY_ITERATOR
+    ) {
+      return value;
+    }
+    const sourceLength = previous.length;
+    const prefixLength = value.length - sourceLength;
+    if (prefixLength < 1) return value;
+    const committedSource = COMPILER_KEYED_COMMITTED_COLLECTIONS.has(previousTarget);
+    const previousUpdate = committedSource
+      ? undefined
+      : COMPILER_KEYED_ARRAY_PREPENDS.get(previousTarget);
+    const directStructuralUpdate =
+      !committedSource && !previousUpdate
+        ? COMPILER_KEYED_ARRAY_FILTERS.get(previousTarget)
+        : undefined;
+    const structuralSource = directStructuralUpdate
+      ? compilerKeyedArrayFilterSource(directStructuralUpdate, previous.length)
+      : undefined;
+    const structuralUpdate =
+      previousUpdate?.structuralUpdate || (structuralSource ? directStructuralUpdate : undefined);
+    const sourceToken =
+      previousUpdate?.sourceToken ||
+      structuralSource?.sourceToken ||
+      compilerKeyedCollectionToken(previousTarget);
+    if (!sourceToken) return value;
+    COMPILER_KEYED_ARRAY_PREPENDS.set(valueTarget, {
+      sourceToken,
+      sourceLength,
+      resultLength: value.length,
+      prefixLength,
+      ...(structuralUpdate ? { structuralUpdate } : {}),
       ...(previousUpdate ? { previous: previousUpdate } : {}),
     });
     return value;
@@ -5432,6 +5549,11 @@ const keyedFilterPrependUpdateRuntime: KeyedUpdateRuntime = {
   prepend: reconcileCompilerKeyedArrayPrepend,
 };
 
+const keyedStructuralPrependUpdateRuntime: KeyedUpdateRuntime = {
+  ...keyedFilterPrependUpdateRuntime,
+  prepend: reconcileCompilerKeyedArrayPrependWithStructural,
+};
+
 const keyedPositionUpdateRuntime: KeyedUpdateRuntime = {
   ...keyedUpdateRuntime,
   position: reconcileCompilerKeyedArrayPosition,
@@ -5487,6 +5609,11 @@ const keyedWindowEveryStructuralAppendMapUpdateRuntime: KeyedUpdateRuntime = {
   ...keyedWindowEveryStructuralAppendUpdateRuntime,
   append: reconcileCompilerKeyedArrayAppendMapWithStructural,
   commit: commitCompilerKeyedCollectionWithItemSnapshot,
+};
+
+const keyedCompleteCompatibilityUpdateRuntime: KeyedUpdateRuntime = {
+  ...keyedWindowEveryStructuralAppendMapUpdateRuntime,
+  prepend: reconcileCompilerKeyedArrayPrependWithStructural,
 };
 
 interface KeyedRowsRuntimeOptions {
@@ -7157,6 +7284,119 @@ function reconcileCompilerKeyedArrayPrepend(
     previousInstances[index].index = prefixLength + index;
   }
   return keyedRowInstancesByKey([...prepended, ...previousInstances]);
+}
+
+function reconcileCompilerKeyedArrayStructuralPrepend(
+  props: CompilerKeyedRowsBlockProps,
+  dirtyState: ReadonlySet<number>,
+  collectionToken: object | undefined,
+  instances: ReadonlyMap<string, CompilerKeyedRowInstance>,
+  root: Element,
+  reactOwnedRows: boolean,
+): ReadonlyMap<string, CompilerKeyedRowInstance> | undefined {
+  if (
+    reactOwnedRows ||
+    props.hostBlocks ||
+    (props.conditionals?.length || 0) > 0 ||
+    !props.filterIndexIndependent ||
+    !props.prependIndexIndependent ||
+    props.collectionDependency === undefined
+  ) {
+    return undefined;
+  }
+  const collectionDependency = props.collectionDependency;
+  if (props.bindings.some((binding) => binding.dependencies?.includes(collectionDependency))) {
+    return undefined;
+  }
+  const dependencies = props.dependencies || props.structureDependencies;
+  const relevantDirty = (dependencies || []).filter((index) => dirtyState.has(index));
+  if (relevantDirty.length !== 1 || relevantDirty[0] !== collectionDependency) {
+    return undefined;
+  }
+
+  const finalValue = props.items();
+  const update = compilerKeyedArrayStructuralPrependUpdate(
+    finalValue,
+    collectionToken,
+    instances.size,
+  );
+  const structuralUpdate = update?.structuralUpdate;
+  const survivorResult = update?.structuralSurvivors;
+  if (
+    !update ||
+    !structuralUpdate ||
+    !survivorResult ||
+    structuralUpdate.mappedItemSources ||
+    !Array.isArray(finalValue)
+  ) {
+    return undefined;
+  }
+
+  const previousInstances = [...instances.values()];
+  const survivors: CompilerKeyedRowInstance[] = [];
+  const knownKeys = new Set(instances.keys());
+  const prepended: CompilerKeyedRowInstance[] = [];
+  try {
+    for (let index = 0; index < survivorResult.indices.length; index += 1) {
+      const sourceIndex = survivorResult.indices[index];
+      const instance = previousInstances[sourceIndex];
+      const item = finalValue[update.prefixLength + index];
+      if (
+        !instance ||
+        instance.index !== sourceIndex ||
+        !Object.is(instance.item, item) ||
+        (!survivorResult.keysStable &&
+          keyedRowIdentity(props.rowKey(item, update.prefixLength + index)) !== instance.key)
+      ) {
+        return undefined;
+      }
+      survivors.push(instance);
+    }
+    for (let index = 0; index < update.prefixLength; index += 1) {
+      const item = finalValue[index];
+      const key = keyedRowIdentity(props.rowKey(item, index));
+      // A new prefix row that reuses any committed key must take complete
+      // reconciliation so React can preserve that row's existing identity.
+      if (knownKeys.has(key)) return undefined;
+      knownKeys.add(key);
+      const descriptor = props.create(item, index);
+      prepended.push({
+        key,
+        element: createCompilerHostElement(root.ownerDocument, descriptor),
+        values: readKeyedRowBindingValues(props, item, index),
+        item,
+        index,
+        conditionalValues: EMPTY_KEYED_ROW_CONDITIONAL_VALUES,
+      });
+    }
+  } catch {
+    return undefined;
+  }
+
+  const survivorSet = new Set(survivorResult.indices);
+  for (let index = 0; index < previousInstances.length; index += 1) {
+    if (survivorSet.has(index)) continue;
+    previousInstances[index].scope?.cleanup();
+    previousInstances[index].element.remove();
+  }
+  if (prepended.length > 0) {
+    const fragment = root.ownerDocument.createDocumentFragment();
+    for (const instance of prepended) fragment.append(instance.element);
+    root.insertBefore(fragment, survivors[0]?.element || root.firstChild);
+  }
+  for (let index = 0; index < survivors.length; index += 1) {
+    survivors[index].index = update.prefixLength + index;
+  }
+  return keyedRowInstancesByKey([...prepended, ...survivors]);
+}
+
+function reconcileCompilerKeyedArrayPrependWithStructural(
+  ...args: Parameters<typeof reconcileCompilerKeyedArrayPrepend>
+): ReadonlyMap<string, CompilerKeyedRowInstance> | undefined {
+  return (
+    reconcileCompilerKeyedArrayStructuralPrepend(...args) ||
+    reconcileCompilerKeyedArrayPrepend(...args)
+  );
 }
 
 function reconcileCompilerKeyedArrayFilter(
@@ -9007,6 +9247,15 @@ export const keyedRowsStructuralAppendMapHintedRuntimeFeature: CompilerRuntimeFe
   }),
 };
 
+export const keyedRowsStructuralPrependHintedRuntimeFeature: CompilerRuntimeFeature = {
+  name: "keyed-rows:structural-prepend-hinted",
+  create: (owner) => ({
+    KeyedRows: createKeyedRowsBlockComponent(owner, {
+      keyedUpdates: keyedCompleteCompatibilityUpdateRuntime,
+    }),
+  }),
+};
+
 export const keyedRowsPrependHintedRuntimeFeature: CompilerRuntimeFeature = {
   name: "keyed-rows:prepend-hinted",
   create: (owner) => ({
@@ -9020,7 +9269,7 @@ export const keyedRowsFilterPrependHintedRuntimeFeature: CompilerRuntimeFeature 
   name: "keyed-rows:filter-prepend-hinted",
   create: (owner) => ({
     KeyedRows: createKeyedRowsBlockComponent(owner, {
-      keyedUpdates: keyedFilterPrependUpdateRuntime,
+      keyedUpdates: keyedStructuralPrependUpdateRuntime,
     }),
   }),
 };
@@ -9150,6 +9399,16 @@ export const keyedRowsConditionalStructuralAppendMapHintedRuntimeFeature: Compil
     KeyedRows: createKeyedRowsBlockComponent(owner, {
       conditionals: createKeyedRowConditionalRuntime(),
       keyedUpdates: keyedWindowEveryStructuralAppendMapUpdateRuntime,
+    }),
+  }),
+};
+
+export const keyedRowsConditionalStructuralPrependHintedRuntimeFeature: CompilerRuntimeFeature = {
+  name: "keyed-rows:conditional:structural-prepend-hinted",
+  create: (owner) => ({
+    KeyedRows: createKeyedRowsBlockComponent(owner, {
+      conditionals: createKeyedRowConditionalRuntime(),
+      keyedUpdates: keyedCompleteCompatibilityUpdateRuntime,
     }),
   }),
 };
@@ -9299,6 +9558,16 @@ export const keyedRowsHostStructuralAppendMapHintedRuntimeFeature: CompilerRunti
     KeyedRows: createKeyedRowsBlockComponent(owner, {
       hostBlocks: createKeyedRowHostRuntime(),
       keyedUpdates: keyedWindowEveryStructuralAppendMapUpdateRuntime,
+    }),
+  }),
+};
+
+export const keyedRowsHostStructuralPrependHintedRuntimeFeature: CompilerRuntimeFeature = {
+  name: "keyed-rows:host:structural-prepend-hinted",
+  create: (owner) => ({
+    KeyedRows: createKeyedRowsBlockComponent(owner, {
+      hostBlocks: createKeyedRowHostRuntime(),
+      keyedUpdates: keyedCompleteCompatibilityUpdateRuntime,
     }),
   }),
 };
@@ -9465,6 +9734,17 @@ export const keyedRowsCompleteStructuralAppendMapHintedRuntimeFeature: CompilerR
   }),
 };
 
+export const keyedRowsCompleteStructuralPrependHintedRuntimeFeature: CompilerRuntimeFeature = {
+  name: "keyed-rows:complete:structural-prepend-hinted",
+  create: (owner) => ({
+    KeyedRows: createKeyedRowsBlockComponent(owner, {
+      conditionals: createKeyedRowConditionalRuntime(),
+      hostBlocks: createKeyedRowHostRuntime(),
+      keyedUpdates: keyedCompleteCompatibilityUpdateRuntime,
+    }),
+  }),
+};
+
 export const keyedRowsCompletePrependHintedRuntimeFeature: CompilerRuntimeFeature = {
   name: "keyed-rows:complete:prepend-hinted",
   create: (owner) => ({
@@ -9483,6 +9763,17 @@ export const keyedRowsCompleteFilterPrependHintedRuntimeFeature: CompilerRuntime
       conditionals: createKeyedRowConditionalRuntime(),
       hostBlocks: createKeyedRowHostRuntime(),
       keyedUpdates: keyedFilterPrependUpdateRuntime,
+    }),
+  }),
+};
+
+const keyedRowsCompleteCompatibilityRuntimeFeature: CompilerRuntimeFeature = {
+  name: "keyed-rows:complete:compatibility",
+  create: (owner) => ({
+    KeyedRows: createKeyedRowsBlockComponent(owner, {
+      conditionals: createKeyedRowConditionalRuntime(),
+      hostBlocks: createKeyedRowHostRuntime(),
+      keyedUpdates: keyedCompleteCompatibilityUpdateRuntime,
     }),
   }),
 };
@@ -10069,7 +10360,7 @@ const COMPLETE_RUNTIME_FEATURES: readonly CompilerRuntimeFeature[] = [
   hostConditionalRuntimeFeature,
   conditionalRangesRuntimeFeature,
   keyedListRuntimeFeature,
-  keyedRowsCompleteWindowEveryHintedRuntimeFeature,
+  keyedRowsCompleteCompatibilityRuntimeFeature,
   keyedRangesRuntimeFeature,
   mixedRangesRuntimeFeature,
   componentRuntimeFeature,

--- a/packages/farm-react/src/compiler.ts
+++ b/packages/farm-react/src/compiler.ts
@@ -379,6 +379,7 @@ type CompilerRuntimeFeatureName =
   | "keyed-rows-filter-hinted"
   | "keyed-rows-structural-append-hinted"
   | "keyed-rows-structural-append-map-hinted"
+  | "keyed-rows-structural-prepend-hinted"
   | "keyed-rows-prepend-hinted"
   | "keyed-rows-filter-prepend-hinted"
   | "keyed-rows-conditional"
@@ -394,6 +395,7 @@ type CompilerRuntimeFeatureName =
   | "keyed-rows-conditional-filter-hinted"
   | "keyed-rows-conditional-structural-append-hinted"
   | "keyed-rows-conditional-structural-append-map-hinted"
+  | "keyed-rows-conditional-structural-prepend-hinted"
   | "keyed-rows-conditional-prepend-hinted"
   | "keyed-rows-conditional-filter-prepend-hinted"
   | "keyed-rows-host"
@@ -409,6 +411,7 @@ type CompilerRuntimeFeatureName =
   | "keyed-rows-host-filter-hinted"
   | "keyed-rows-host-structural-append-hinted"
   | "keyed-rows-host-structural-append-map-hinted"
+  | "keyed-rows-host-structural-prepend-hinted"
   | "keyed-rows-host-prepend-hinted"
   | "keyed-rows-host-filter-prepend-hinted"
   | "keyed-rows-complete"
@@ -424,6 +427,7 @@ type CompilerRuntimeFeatureName =
   | "keyed-rows-complete-filter-hinted"
   | "keyed-rows-complete-structural-append-hinted"
   | "keyed-rows-complete-structural-append-map-hinted"
+  | "keyed-rows-complete-structural-prepend-hinted"
   | "keyed-rows-complete-prepend-hinted"
   | "keyed-rows-complete-filter-prepend-hinted"
   | "keyed-ranges"
@@ -449,6 +453,7 @@ const COMPILER_RUNTIME_FEATURE_EXPORTS: Record<CompilerRuntimeFeatureName, strin
   "keyed-rows-filter-hinted": "keyedRowsFilterHintedRuntimeFeature",
   "keyed-rows-structural-append-hinted": "keyedRowsStructuralAppendHintedRuntimeFeature",
   "keyed-rows-structural-append-map-hinted": "keyedRowsStructuralAppendMapHintedRuntimeFeature",
+  "keyed-rows-structural-prepend-hinted": "keyedRowsStructuralPrependHintedRuntimeFeature",
   "keyed-rows-prepend-hinted": "keyedRowsPrependHintedRuntimeFeature",
   "keyed-rows-filter-prepend-hinted": "keyedRowsFilterPrependHintedRuntimeFeature",
   "keyed-rows-conditional": "keyedRowsConditionalRuntimeFeature",
@@ -469,6 +474,8 @@ const COMPILER_RUNTIME_FEATURE_EXPORTS: Record<CompilerRuntimeFeatureName, strin
     "keyedRowsConditionalStructuralAppendHintedRuntimeFeature",
   "keyed-rows-conditional-structural-append-map-hinted":
     "keyedRowsConditionalStructuralAppendMapHintedRuntimeFeature",
+  "keyed-rows-conditional-structural-prepend-hinted":
+    "keyedRowsConditionalStructuralPrependHintedRuntimeFeature",
   "keyed-rows-conditional-prepend-hinted": "keyedRowsConditionalPrependHintedRuntimeFeature",
   "keyed-rows-conditional-filter-prepend-hinted":
     "keyedRowsConditionalFilterPrependHintedRuntimeFeature",
@@ -486,6 +493,7 @@ const COMPILER_RUNTIME_FEATURE_EXPORTS: Record<CompilerRuntimeFeatureName, strin
   "keyed-rows-host-structural-append-hinted": "keyedRowsHostStructuralAppendHintedRuntimeFeature",
   "keyed-rows-host-structural-append-map-hinted":
     "keyedRowsHostStructuralAppendMapHintedRuntimeFeature",
+  "keyed-rows-host-structural-prepend-hinted": "keyedRowsHostStructuralPrependHintedRuntimeFeature",
   "keyed-rows-host-prepend-hinted": "keyedRowsHostPrependHintedRuntimeFeature",
   "keyed-rows-host-filter-prepend-hinted": "keyedRowsHostFilterPrependHintedRuntimeFeature",
   "keyed-rows-complete": "keyedRowsCompleteRuntimeFeature",
@@ -504,6 +512,8 @@ const COMPILER_RUNTIME_FEATURE_EXPORTS: Record<CompilerRuntimeFeatureName, strin
     "keyedRowsCompleteStructuralAppendHintedRuntimeFeature",
   "keyed-rows-complete-structural-append-map-hinted":
     "keyedRowsCompleteStructuralAppendMapHintedRuntimeFeature",
+  "keyed-rows-complete-structural-prepend-hinted":
+    "keyedRowsCompleteStructuralPrependHintedRuntimeFeature",
   "keyed-rows-complete-prepend-hinted": "keyedRowsCompletePrependHintedRuntimeFeature",
   "keyed-rows-complete-filter-prepend-hinted": "keyedRowsCompleteFilterPrependHintedRuntimeFeature",
   "keyed-ranges": "keyedRangesRuntimeFeature",
@@ -518,6 +528,7 @@ function runtimeFeaturesForPlans(
   keyedArrayStructuralAppendHints: boolean,
   keyedArrayStructuralAppendMapHints: boolean,
   keyedArrayPrependHints: boolean,
+  keyedArrayStructuralPrependHints: boolean,
   keyedArrayPositionHints: boolean,
   keyedArrayBatchInsertHints: boolean,
   keyedArrayWindowReplaceHints: boolean,
@@ -549,38 +560,49 @@ function runtimeFeaturesForPlans(
             : "keyed-rows";
     const arrayRangeHints =
       keyedArrayRollingWindowHints || keyedArrayFilterHints || keyedArrayPrependHints;
-    const hintSuffix = keyedArrayStructuralAppendMapHints
-      ? "-structural-append-map-hinted"
-      : keyedArrayStructuralAppendHints
-        ? "-structural-append-hinted"
-        : keyedArrayWindowReplaceHints
-          ? arrayRangeHints || keyedArrayReorderHints
-            ? "-window-every-hinted"
-            : "-window-position-hinted"
-          : keyedArrayBatchInsertHints
+    const needsCombinedStructuralPrependRuntime =
+      keyedArrayStructuralPrependHints &&
+      (keyedArrayStructuralAppendMapHints ||
+        keyedArrayStructuralAppendHints ||
+        keyedArrayWindowReplaceHints ||
+        keyedArrayBatchInsertHints ||
+        keyedArrayPositionHints ||
+        keyedArrayReorderHints ||
+        keyedArrayRollingWindowHints);
+    const hintSuffix = needsCombinedStructuralPrependRuntime
+      ? "-structural-prepend-hinted"
+      : keyedArrayStructuralAppendMapHints
+        ? "-structural-append-map-hinted"
+        : keyedArrayStructuralAppendHints
+          ? "-structural-append-hinted"
+          : keyedArrayWindowReplaceHints
             ? arrayRangeHints || keyedArrayReorderHints
-              ? "-batch-every-hinted"
-              : "-batch-position-hinted"
-            : (keyedArrayPositionHints && (arrayRangeHints || keyedArrayReorderHints)) ||
-                (keyedArrayReorderHints && arrayRangeHints)
-              ? "-every-hinted"
-              : keyedArrayRollingWindowHints
-                ? "-all-hinted"
-                : keyedArrayPositionHints
-                  ? "-position-hinted"
-                  : keyedArrayMapReorderHints && keyedRowsFeature === "keyed-rows"
-                    ? "-map-reorder-hinted"
-                    : keyedArrayReorderHints
-                      ? "-reorder-hinted"
-                      : keyedArrayFilterHints && keyedArrayPrependHints
-                        ? "-filter-prepend-hinted"
-                        : keyedArrayFilterHints
-                          ? "-filter-hinted"
-                          : keyedArrayPrependHints
-                            ? "-prepend-hinted"
-                            : keyedMapUpdateHints
-                              ? "-hinted"
-                              : "";
+              ? "-window-every-hinted"
+              : "-window-position-hinted"
+            : keyedArrayBatchInsertHints
+              ? arrayRangeHints || keyedArrayReorderHints
+                ? "-batch-every-hinted"
+                : "-batch-position-hinted"
+              : (keyedArrayPositionHints && (arrayRangeHints || keyedArrayReorderHints)) ||
+                  (keyedArrayReorderHints && arrayRangeHints)
+                ? "-every-hinted"
+                : keyedArrayRollingWindowHints
+                  ? "-all-hinted"
+                  : keyedArrayPositionHints
+                    ? "-position-hinted"
+                    : keyedArrayMapReorderHints && keyedRowsFeature === "keyed-rows"
+                      ? "-map-reorder-hinted"
+                      : keyedArrayReorderHints
+                        ? "-reorder-hinted"
+                        : keyedArrayFilterHints && keyedArrayPrependHints
+                          ? "-filter-prepend-hinted"
+                          : keyedArrayFilterHints
+                            ? "-filter-hinted"
+                            : keyedArrayPrependHints
+                              ? "-prepend-hinted"
+                              : keyedMapUpdateHints
+                                ? "-hinted"
+                                : "";
     features.add(`${keyedRowsFeature}${hintSuffix}` as CompilerRuntimeFeatureName);
   }
   return [...features].sort();
@@ -9171,6 +9193,7 @@ function compileCandidate(
       (appliedKeyedArrayFilterHints > 0 || appliedKeyedArraySliceHints > 0),
     appliedQueuedStructuralAppendMapHints > 0,
     appliedKeyedArrayPrependHints > 0,
+    appliedKeyedArrayPrependHints > 0 && hasKeyedArrayRemovalHints,
     appliedKeyedArrayPositionHints > 0,
     appliedKeyedArrayBatchInsertHints > 0,
     appliedKeyedArrayWindowReplaceHints > 0,
@@ -9578,6 +9601,10 @@ export async function compileReactModule(
         const hasUnmappedKeyedArrayAppendHints =
           optimizationCounts.keyedArrayAppendHints >
           compilerUsage.keyedArrayMappedStructuralAppendHints;
+        const hasKeyedArrayStructuralPrependHints =
+          optimizationCounts.keyedArrayPrependHints > 0 &&
+          (optimizationCounts.keyedArrayFilterHints > 0 ||
+            optimizationCounts.keyedArraySliceHints > 0);
         if (compiled.length > 0) {
           programPath.unshiftContainer(
             "body",
@@ -9667,7 +9694,11 @@ export async function compileReactModule(
                   ? [
                       t.importSpecifier(
                         keyedArrayPrependIdentifier,
-                        t.identifier("createCompilerKeyedArrayPrepend"),
+                        t.identifier(
+                          hasKeyedArrayStructuralPrependHints
+                            ? "createCompilerKeyedArrayStructuralPrepend"
+                            : "createCompilerKeyedArrayPrepend",
+                        ),
                       ),
                     ]
                   : []),

--- a/packages/farm-react/vitest.stress.config.ts
+++ b/packages/farm-react/vitest.stress.config.ts
@@ -19,10 +19,11 @@ export default defineConfig({
       "src/__tests__/compiler-runtime-keyed-array-map-reorder-hints.test.tsx",
       "src/__tests__/compiler-runtime-keyed-array-structural-reorder-hints.test.tsx",
       "src/__tests__/compiler-runtime-keyed-array-append-hints.test.tsx",
+      "src/__tests__/compiler-runtime-keyed-array-prepend-hints.test.tsx",
     ],
     setupFiles: ["src/__tests__/stress.setup.ts"],
     testNamePattern:
-      /2,000 deterministic mapped reorder updates|2,000 deterministic mapped reversal parity updates|2,000 queued reverse, map, and reverse updates|2,000 reverse-or-sort then map updates|2,000 queued reorder then standalone map updates|2,000 queued map then reorder updates|2,000 queued map and consecutive reorder updates|2,000 mapped structural removals|2,000 randomized interleaved map and structural removals|2,000 randomized terminal structural-map row transitions|2,000 randomized mapped terminal-structural row transitions|2,000 randomized queued mapped structural transitions|2,000 randomized queued structural mapped transitions|2,000 randomized queued structural mapped reorders|2,000 randomized structural removals, appends, and maps|2,000 randomized removals, maps, and later appends|3,000 deterministic recursive updates|4,096 rows/,
+      /2,000 deterministic mapped reorder updates|2,000 deterministic mapped reversal parity updates|2,000 queued reverse, map, and reverse updates|2,000 reverse-or-sort then map updates|2,000 queued reorder then standalone map updates|2,000 queued map then reorder updates|2,000 queued map and consecutive reorder updates|2,000 mapped structural removals|2,000 randomized interleaved map and structural removals|2,000 randomized terminal structural-map row transitions|2,000 randomized mapped terminal-structural row transitions|2,000 randomized queued mapped structural transitions|2,000 randomized queued structural mapped transitions|2,000 randomized queued structural mapped reorders|2,000 randomized structural removals, appends, and maps|2,000 randomized removals, maps, and later appends|2,000 randomized structural prepend updates|3,000 deterministic recursive updates|4,096 rows/,
     testTimeout: 30_000,
   },
 });


### PR DESCRIPTION
## Problem

A compiler-proven keyed-row `filter()` or bounded `slice()` followed by an immutable prepend produced the correct DOM, but the prepend result lost the committed survivor proof and used complete keyed reconciliation. That rescanned and rebound surviving rows in feed, history, and log-style updates.

## Root cause

Prepend metadata described only a direct prefix over its immediate source. It did not retain or validate the structural filter/slice lineage that selected survivors from the committed collection.

## Change

Carry filter/slice lineage through one or more adjacent prepend setters. The runtime validates the complete dense result, committed token, survivor order and identity, prefix keys, descriptors, and bindings before mutation. Eligible commits remove only rejected rows, insert the prepared prefix once, preserve survivor DOM identity and selection, and shift delegated event indexes.

The compiler selects an isolated filter-plus-prepend runtime for the focused case and a combined runtime only when a component also needs other keyed update capabilities.

## Safety and compatibility

- React remains authoritative for initial render, SSR, hydration, and unsupported updates.
- Index-sensitive rows, collection-reading bindings, nested or React-owned rows, mapped or reordered structural chains, reused committed keys, duplicate keys, custom/sparse/subclassed arrays, unrelated dirty dependencies, and failed validation use complete reconciliation before any DOM mutation.
- No public API or configuration is added.
- Modules without the matching update shapes do not retain this optional runtime.
- Verified with React 18.3.1 and React 19.2.8.

## Verification

- `pnpm --filter @farm.js/react test` — 804 passed, 11 skipped; stress suite 20 passed, 107 skipped.
- `pnpm --filter @farm.js/react type-check`
- `pnpm --filter @farm.js/react test:compat`
- `pnpm --filter @farm.js/react test:runtime-size`
- `pnpm --dir examples/react-compiler-dashboard type-check`
- `pnpm --dir examples/react-compiler-dashboard build`
- `pnpm docs:check-navigation`
- `pnpm docs:build`
- `pnpm --dir examples/react-compiler-dashboard benchmark` — aggregate correctness and every performance gate passed.

The 10,000-row removal-plus-prepend benchmark measured 9.00 ms static and 7.80 ms hybrid versus an 80.85 ms bracketed React median: 8.98x and 10.37x speedups. The same paths were 2.67x and 2.99x faster than compiled snapshot controls. Existing 10k/20k persistence remained 15.75x–21.75x.

The isolated structural-prepend compiler premium is 13,387 bytes gzip. Direct prepend and structural append premiums remain unchanged, and no existing size ceiling was relaxed.

## Documentation and release

Updated the React renderer documentation, package README, compiler dashboard workload, reproducible benchmark gate/results, and runtime-size fixture/results. Release changes: none.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves the structural `filter()`/`slice()` lineage through adjacent prepends. Previously the prepend result lost that proof and used complete keyed reconciliation, rescanning and rebinding surviving rows.

**Bug Fixes**
- Validates the final array, survivor order and identity, prefix keys, descriptors, and bindings before mutating the DOM.
- Removes only rejected rows, inserts the prepared prefix once, preserves survivor DOM and controlled-input state, and shifts delegated event indexes.
- Invalid or unsupported update shapes fall back to complete reconciliation before any DOM write.
- Emits an isolated structural-prepend runtime for focused modules and a combined runtime when other keyed updates are also present.
- Adds no public API or config; modules without matching removal-plus-prepend shapes don't retain the optional runtime.
- The 10,000-row removal-plus-prepend benchmark is 8.98x static and 10.37x hybrid faster than React, with a 13,387-byte gzip runtime premium.

<sup>Written for commit 5ab3e0468d3ca211296f6ad66e51ea7add57b6ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/901?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

