### PR TITLE
fix(preview): strip connection-nominated proxy headers

### DIFF
--- a/packages/farm-cli/src/preview-gateway.ts
+++ b/packages/farm-cli/src/preview-gateway.ts
@@ -73,6 +73,24 @@ const HOP_BY_HOP_HEADERS = new Set([
   "upgrade",
 ]);
 
+function getHopByHopHeaderNames(headers: Record<string, string | string[]> | Headers): Set<string> {
+  const names = new Set(HOP_BY_HOP_HEADERS);
+  let connection: string | string[] | null | undefined;
+  if (headers instanceof Headers) {
+    connection = headers.get("connection");
+  } else {
+    connection = Object.entries(headers).find(([name]) => name.toLowerCase() === "connection")?.[1];
+  }
+  const values = Array.isArray(connection) ? connection : connection ? [connection] : [];
+  for (const value of values) {
+    for (const name of value.split(",")) {
+      const normalized = name.trim().toLowerCase();
+      if (normalized) names.add(normalized);
+    }
+  }
+  return names;
+}
+
 export function createPreviewGatewayPlan(
   target: PreviewTarget,
   options: Pick<PreviewFarmOptions, "gatewayUrl" | "name"> = {},
@@ -295,9 +313,11 @@ export async function forwardGatewayRequest(
   options: ForwardGatewayRequestOptions = {},
 ): Promise<PreviewGatewayResponse> {
   const headers = new Headers();
-  for (const [key, value] of Object.entries(request.headers || {})) {
+  const requestHeaders = request.headers || {};
+  const requestHopByHopHeaders = getHopByHopHeaderNames(requestHeaders);
+  for (const [key, value] of Object.entries(requestHeaders)) {
     const normalized = key.toLowerCase();
-    if (HOP_BY_HOP_HEADERS.has(normalized) || normalized.startsWith("sec-websocket-")) {
+    if (requestHopByHopHeaders.has(normalized) || normalized.startsWith("sec-websocket-")) {
       continue;
     }
     headers.set(key, value);
@@ -318,12 +338,13 @@ export async function forwardGatewayRequest(
   });
 
   const responseHeaders: Record<string, string | string[]> = {};
+  const responseHopByHopHeaders = getHopByHopHeaderNames(response.headers);
   response.headers.forEach((value, key) => {
     const normalized = key.toLowerCase();
     // Set-Cookie is collected separately: Headers.forEach folds repeated
     // headers into one comma-joined value, which corrupts multiple cookies.
     if (
-      !HOP_BY_HOP_HEADERS.has(normalized) &&
+      !responseHopByHopHeaders.has(normalized) &&
       normalized !== "content-encoding" &&
       normalized !== "set-cookie"
     ) {

--- a/packages/farm-cli/test/preview.test.mjs
+++ b/packages/farm-cli/test/preview.test.mjs
@@ -274,6 +274,40 @@ test("keeps gateway requests beneath the configured target path", async () => {
   }
 });
 
+test("removes headers nominated by Connection in both gateway directions", async () => {
+  const server = await createTestServer((req, res) => {
+    res.setHeader("connection", "x-response-hop");
+    res.setHeader("x-response-hop", "remove-me");
+    res.setHeader("content-type", "application/json");
+    res.end(JSON.stringify({ requestHop: req.headers["x-request-hop"] }));
+  });
+
+  try {
+    const response = await forwardGatewayRequest(
+      {
+        localUrl: `http://localhost:${server.port}`,
+        host: "localhost",
+        port: server.port,
+        source: "port",
+      },
+      {
+        id: "req_connection_headers",
+        method: "GET",
+        path: "/",
+        headers: {
+          connection: "x-request-hop",
+          "x-request-hop": "remove-me",
+        },
+      },
+    );
+
+    assert.equal(JSON.parse(Buffer.from(response.body, "base64").toString()).requestHop, undefined);
+    assert.equal(response.headers["x-response-hop"], undefined);
+  } finally {
+    await server.close();
+  }
+});
+
 test("forwards local redirects without following them", async () => {
   const server = await createTestServer((req, res) => {
     if (req.url === "/redirect") {

--- a/packages/farm-preview-gateway/src/index.ts
+++ b/packages/farm-preview-gateway/src/index.ts
@@ -99,6 +99,22 @@ const HOP_BY_HOP_HEADERS = new Set([
   "upgrade",
 ]);
 
+function getHopByHopHeaderNames(headers: Headers | Record<string, string | string[]>): Set<string> {
+  const names = new Set(HOP_BY_HOP_HEADERS);
+  const connection =
+    headers instanceof Headers
+      ? headers.get("connection")
+      : Object.entries(headers).find(([name]) => name.toLowerCase() === "connection")?.[1];
+  const values = Array.isArray(connection) ? connection : connection ? [connection] : [];
+  for (const value of values) {
+    for (const name of value.split(",")) {
+      const normalized = name.trim().toLowerCase();
+      if (normalized) names.add(normalized);
+    }
+  }
+  return names;
+}
+
 export function createPreviewGatewayHandler(options: PreviewGatewayOptions = {}) {
   const store = options.store || createPreviewGatewayStoreFromEnv();
   const config = {
@@ -661,9 +677,10 @@ async function proxyPublicRequest(
   }
 
   const headers = new Headers();
+  const responseHopByHopHeaders = getHopByHopHeaderNames(response.headers || {});
   for (const [key, value] of Object.entries(response.headers || {})) {
     const normalized = key.toLowerCase();
-    if (HOP_BY_HOP_HEADERS.has(normalized)) {
+    if (responseHopByHopHeaders.has(normalized)) {
       continue;
     }
     // Append multi-valued headers (Set-Cookie) so every value reaches the
@@ -748,10 +765,11 @@ async function serializePreviewRequest(
 ): Promise<PreviewGatewayRequest> {
   const method = request.method.toUpperCase();
   const headers: Record<string, string> = {};
+  const requestHopByHopHeaders = getHopByHopHeaderNames(request.headers);
   request.headers.forEach((value, key) => {
     const normalized = key.toLowerCase();
     if (
-      !HOP_BY_HOP_HEADERS.has(normalized) &&
+      !requestHopByHopHeaders.has(normalized) &&
       normalized !== "forwarded" &&
       !normalized.startsWith("x-forwarded-")
     ) {

--- a/packages/farm-preview-gateway/test/gateway.test.mjs
+++ b/packages/farm-preview-gateway/test/gateway.test.mjs
@@ -177,6 +177,51 @@ test("replays every Set-Cookie header to the public visitor", async () => {
   }
 });
 
+test("removes headers nominated by Connection in both polling proxy directions", async () => {
+  const store = new MemoryPreviewGatewayStore();
+  const gateway = await createGatewayServer(store);
+
+  try {
+    const session = await fetch(`${gateway.url}/api/sessions`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name: "connection-check", localUrl: "http://localhost:4321" }),
+    }).then((response) => response.json());
+
+    const publicRequest = requestWithHeaders(`${gateway.url}/__preview/connection-check/headers`, {
+      connection: "x-request-hop",
+      "x-request-hop": "remove-me",
+    });
+    const poll = await fetch(
+      `${gateway.url}/api/sessions/${session.id}/requests?token=${session.token}&wait=1000`,
+    ).then((response) => response.json());
+    assert.equal(poll.requests[0].headers["x-request-hop"], undefined);
+
+    await fetch(
+      `${gateway.url}/api/sessions/${session.id}/responses/${poll.requests[0].id}?token=${session.token}`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          status: 200,
+          headers: {
+            connection: "x-response-hop",
+            "x-response-hop": "remove-me",
+          },
+          body: Buffer.from("ok").toString("base64"),
+          encoding: "base64",
+        }),
+      },
+    );
+
+    const response = await publicRequest;
+    assert.equal(response.status, 200);
+    assert.equal(response.headers["x-response-hop"], undefined);
+  } finally {
+    await gateway.close();
+  }
+});
+
 test("expires stale preview clients before queueing public requests", async () => {
   const store = new MemoryPreviewGatewayStore();
   const gateway = await createGatewayServer(store, {
@@ -362,4 +407,31 @@ async function createGatewayServer(store, options = {}) {
         server.close((error) => (error ? reject(error) : resolve()));
       }),
   };
+}
+
+function requestWithHeaders(value, headers) {
+  const url = new URL(value);
+  return new Promise((resolve, reject) => {
+    const request = createRequest(
+      {
+        host: url.hostname,
+        port: url.port,
+        path: `${url.pathname}${url.search}`,
+        headers,
+      },
+      (response) => {
+        const chunks = [];
+        response.on("data", (chunk) => chunks.push(chunk));
+        response.once("end", () => {
+          resolve({
+            status: response.statusCode,
+            body: Buffer.concat(chunks).toString(),
+            headers: response.headers,
+          });
+        });
+      },
+    );
+    request.once("error", reject);
+    request.end();
+  });
 }

--- a/packages/farm-preview-tunnel/src/agent.ts
+++ b/packages/farm-preview-tunnel/src/agent.ts
@@ -7,19 +7,7 @@ import type {
   TunnelResponseMessage,
 } from "./protocol.js";
 import { isRelayToAgentMessage } from "./protocol.js";
-
-const HOP_BY_HOP_HEADERS = new Set([
-  "connection",
-  "content-length",
-  "host",
-  "keep-alive",
-  "proxy-authenticate",
-  "proxy-authorization",
-  "te",
-  "trailer",
-  "transfer-encoding",
-  "upgrade",
-]);
+import { getHopByHopHeaderNames, getRecordHeader } from "./headers.js";
 
 export interface TypeScriptPreviewAgentOptions {
   relayUrl: string;
@@ -207,8 +195,11 @@ async function forwardRequest(
 
   try {
     const headers = new Headers();
+    const requestHopByHopHeaders = getHopByHopHeaderNames(
+      getRecordHeader(request.headers, "connection"),
+    );
     for (const [name, value] of Object.entries(request.headers)) {
-      if (!HOP_BY_HOP_HEADERS.has(name.toLowerCase())) headers.set(name, value);
+      if (!requestHopByHopHeaders.has(name.toLowerCase())) headers.set(name, value);
     }
     const method = request.method.toUpperCase();
     const result = await fetch(resolveTargetUrl(options.targetUrl, request.path), {
@@ -222,12 +213,13 @@ async function forwardRequest(
       signal: controller.signal,
     });
     const responseHeaders: Record<string, string | string[]> = {};
+    const responseHopByHopHeaders = getHopByHopHeaderNames(result.headers.get("connection"));
     for (const [name, value] of result.headers) {
       const normalizedName = name.toLowerCase();
       if (
         normalizedName !== "content-encoding" &&
         normalizedName !== "set-cookie" &&
-        !HOP_BY_HOP_HEADERS.has(normalizedName)
+        !responseHopByHopHeaders.has(normalizedName)
       ) {
         responseHeaders[name] = value;
       }

--- a/packages/farm-preview-tunnel/src/headers.ts
+++ b/packages/farm-preview-tunnel/src/headers.ts
@@ -1,0 +1,36 @@
+const STANDARD_HOP_BY_HOP_HEADERS = [
+  "connection",
+  "content-length",
+  "host",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "te",
+  "trailer",
+  "transfer-encoding",
+  "upgrade",
+] as const;
+
+export function getHopByHopHeaderNames(
+  connection: string | string[] | null | undefined,
+): Set<string> {
+  const names = new Set<string>(STANDARD_HOP_BY_HOP_HEADERS);
+  const values = Array.isArray(connection) ? connection : connection ? [connection] : [];
+  for (const value of values) {
+    for (const name of value.split(",")) {
+      const normalized = name.trim().toLowerCase();
+      if (normalized) names.add(normalized);
+    }
+  }
+  return names;
+}
+
+export function getRecordHeader(
+  headers: Record<string, string | string[]>,
+  expectedName: string,
+): string | string[] | undefined {
+  for (const [name, value] of Object.entries(headers)) {
+    if (name.toLowerCase() === expectedName) return value;
+  }
+  return undefined;
+}

--- a/packages/farm-preview-tunnel/src/relay.ts
+++ b/packages/farm-preview-tunnel/src/relay.ts
@@ -10,18 +10,7 @@ import {
   type TunnelRequestMessage,
   type TunnelResponseMessage,
 } from "./protocol.js";
-
-const HOP_BY_HOP_HEADERS = new Set([
-  "connection",
-  "content-length",
-  "keep-alive",
-  "proxy-authenticate",
-  "proxy-authorization",
-  "te",
-  "trailer",
-  "transfer-encoding",
-  "upgrade",
-]);
+import { getHopByHopHeaderNames, getRecordHeader } from "./headers.js";
 
 export interface PersistentPreviewRelayOptions {
   host?: string;
@@ -570,8 +559,9 @@ function getEncodedBodySize(body: string | undefined) {
 }
 
 function writeTunnelResponse(response: ServerResponse, message: TunnelResponseMessage) {
+  const hopByHopHeaders = getHopByHopHeaderNames(getRecordHeader(message.headers, "connection"));
   for (const [name, value] of Object.entries(message.headers)) {
-    if (!HOP_BY_HOP_HEADERS.has(name.toLowerCase())) {
+    if (!hopByHopHeaders.has(name.toLowerCase())) {
       response.setHeader(name, value);
     }
   }
@@ -656,11 +646,12 @@ function normalizeIncomingHeaders(
   publicDomain: string | undefined,
 ) {
   const normalized: Record<string, string> = {};
+  const hopByHopHeaders = getHopByHopHeaderNames(request.headers.connection);
   for (const [name, value] of Object.entries(request.headers)) {
     const lowerName = name.toLowerCase();
     if (
       value === undefined ||
-      HOP_BY_HOP_HEADERS.has(lowerName) ||
+      hopByHopHeaders.has(lowerName) ||
       lowerName === "forwarded" ||
       lowerName.startsWith("x-forwarded-")
     ) {

--- a/packages/farm-preview-tunnel/test/tunnel.test.mjs
+++ b/packages/farm-preview-tunnel/test/tunnel.test.mjs
@@ -124,6 +124,37 @@ test("replaces client-supplied forwarding headers at the relay boundary", async 
   }
 });
 
+test("removes headers nominated by Connection in both proxy directions", async () => {
+  const target = createServer((request, response) => {
+    response.setHeader("connection", "x-response-hop");
+    response.setHeader("x-response-hop", "remove-me");
+    response.setHeader("content-type", "application/json");
+    response.end(JSON.stringify({ requestHop: request.headers["x-request-hop"] }));
+  });
+  await listen(target);
+  const targetAddress = target.address();
+  const relay = createPersistentPreviewRelay();
+  const relayAddress = await relay.listen();
+  const agent = await startTypeScriptPreviewAgent({
+    relayUrl: relayAddress.websocketUrl,
+    name: "connection-headers",
+    targetUrl: `http://127.0.0.1:${targetAddress.port}`,
+  });
+
+  try {
+    const response = await requestWithHost(agent.publicUrl, new URL(agent.publicUrl).host, {
+      connection: "x-request-hop",
+      "x-request-hop": "remove-me",
+    });
+    assert.equal(JSON.parse(response.body).requestHop, undefined);
+    assert.equal(response.headers["x-response-hop"], undefined);
+  } finally {
+    await agent.close();
+    await relay.close();
+    await close(target);
+  }
+});
+
 test("preserves repeated cookies and removes encoding after decoding a response", async () => {
   const target = createServer((_request, response) => {
     response.statusCode = 200;
@@ -608,7 +639,7 @@ function startStalledUpload(value) {
   });
 }
 
-function requestWithHost(value, host) {
+function requestWithHost(value, host, headers = {}) {
   const url = new URL(value);
   return new Promise((resolve, reject) => {
     const request = createRequest(
@@ -616,7 +647,7 @@ function requestWithHost(value, host) {
         host: url.hostname,
         port: url.port,
         path: `${url.pathname}${url.search}`,
-        headers: { host },
+        headers: { ...headers, host },
       },
       (response) => {
         const chunks = [];
@@ -625,6 +656,7 @@ function requestWithHost(value, host) {
           resolve({
             status: response.statusCode,
             body: Buffer.concat(chunks).toString(),
+            headers: response.headers,
           });
         });
       },


### PR DESCRIPTION
## Problem

Preview proxy transports remove the fixed hop-by-hop header set, but still forward arbitrary headers named by the incoming `Connection` header. This can leak connection-scoped metadata in both request and response directions.

## Root cause

The hosted gateway, relay, TypeScript tunnel agent, and compatibility gateway filtered header names against a static set without parsing the comma-separated connection options.

## Change

Build the hop-by-hop set from both the standard names and every name nominated by `Connection` at each forwarding boundary. Cover the hosted polling gateway, persistent tunnel, and compatibility gateway in both directions.

## Safety and compatibility

Ordinary end-to-end headers, repeated cookies, redirects, and decoded response handling are unchanged. Only headers explicitly scoped to the current connection are removed.

## Verification

- `pnpm --filter @farm.js/preview-gateway test`
- `pnpm --filter @farm.js/preview-gateway type-check`
- `pnpm --filter @farm.js/preview-tunnel test`
- `pnpm --filter @farm.js/preview-tunnel type-check`
- `pnpm --filter @farm.js/cli test`
- `pnpm --filter @farm.js/cli type-check`
- focused `oxlint` on changed TypeScript and test files

The regression tests fail before the fix because each target receives `x-request-hop` and each public response exposes `x-response-hop`.

## Documentation and release

None.