### PR TITLE
fix(routing): keep canonical links under basePath

### DIFF
--- a/packages/farm/src/__tests__/base-path.test.ts
+++ b/packages/farm/src/__tests__/base-path.test.ts
@@ -9,6 +9,20 @@ describe("Farm base paths", () => {
     expect(applyFarmBasePath("//cdn.example/reports", "/console")).toBe("//cdn.example/reports");
   });
 
+  it("canonicalizes app-relative hrefs before applying the base path", () => {
+    expect(applyFarmBasePath("/%2e%2e/admin?mode=edit#settings", "/console")).toBe(
+      "/console/admin?mode=edit#settings",
+    );
+    expect(applyFarmBasePath("/reports/../admin", "/console")).toBe("/console/admin");
+    expect(applyFarmBasePath("/console/%2e%2e/admin", "/console")).toBe("/console/admin");
+  });
+
+  it("rejects app-relative hrefs that browsers interpret as another origin", () => {
+    expect(() => applyFarmBasePath("/\\evil.example/path", "/console")).toThrow(
+      /cannot change the URL origin/,
+    );
+  });
+
   it("strips the base path without changing paths outside it", () => {
     expect(stripFarmBasePath("/console/reports", "/console")).toBe("/reports");
     expect(stripFarmBasePath("/console", "/console")).toBe("/");

--- a/packages/farm/src/base-path.ts
+++ b/packages/farm/src/base-path.ts
@@ -17,15 +17,25 @@ export function getFarmBasePath(): string {
 export function applyFarmBasePath(href: string, basePath = getFarmBasePath()): string {
   const normalizedBasePath = normalizeFarmBasePath(basePath);
   if (!normalizedBasePath || !href.startsWith("/") || href.startsWith("//")) return href;
+  const canonicalHref = canonicalizeAppRelativeHref(href);
   if (
-    href === normalizedBasePath ||
-    href.startsWith(`${normalizedBasePath}/`) ||
-    href.startsWith(`${normalizedBasePath}?`) ||
-    href.startsWith(`${normalizedBasePath}#`)
+    canonicalHref === normalizedBasePath ||
+    canonicalHref.startsWith(`${normalizedBasePath}/`) ||
+    canonicalHref.startsWith(`${normalizedBasePath}?`) ||
+    canonicalHref.startsWith(`${normalizedBasePath}#`)
   ) {
-    return href;
+    return canonicalHref;
   }
-  return `${normalizedBasePath}${href}`;
+  return `${normalizedBasePath}${canonicalHref}`;
+}
+
+function canonicalizeAppRelativeHref(href: string): string {
+  const origin = "http://farm.local";
+  const resolved = new URL(href, origin);
+  if (resolved.origin !== origin) {
+    throw new Error("Farm app-relative href cannot change the URL origin.");
+  }
+  return `${resolved.pathname}${resolved.search}${resolved.hash}`;
 }
 
 export function stripFarmBasePath(pathname: string, basePath = getFarmBasePath()): string {


### PR DESCRIPTION
## Problem

An app-relative link containing dot segments, including percent-encoded `..`, is prefixed as raw text. The browser canonicalizes it later and can navigate outside the configured `basePath`.

## Root cause

`applyFarmBasePath` checked and prefixed the original href before applying browser URL semantics.

## Change

Canonicalize root-relative hrefs with the URL parser before checking or applying the base path. Reject a nominally app-relative href if browser parsing changes its origin.

## Safety and compatibility

External and protocol-relative URLs remain untouched. Query strings and fragments are preserved. Normal links keep their existing output, while literal and encoded dot segments resolve inside the application base path.

## Verification

- `pnpm --filter @farm.js/core exec vitest run src/__tests__/base-path.test.ts`
- `pnpm --filter @farm.js/core type-check`
- `pnpm exec oxlint packages/farm/src/base-path.ts packages/farm/src/__tests__/base-path.test.ts`

The regression test fails before the fix because `/%2e%2e/admin` renders as `/console/%2e%2e/admin`, which browsers resolve to `/admin`.

## Documentation and release

None.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes base path handling for app-relative links so dot segments (including percent-encoded `..`) resolve inside the configured `basePath` instead of escaping it.

- Canonicalizes root-relative hrefs with the URL parser before applying the base path.
- Rejects app-relative hrefs that browsers resolve to a different origin.
- External and protocol-relative URLs are unchanged; query strings and fragments are preserved.

<sup>Written for commit 307781d9b485629b5e3221cbffff398f090623bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/903?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

