### PR TITLE
fix(preview): keep gateway requests under target path

### DIFF
--- a/packages/farm-cli/src/preview-gateway.ts
+++ b/packages/farm-cli/src/preview-gateway.ts
@@ -307,7 +307,7 @@ export async function forwardGatewayRequest(
 
   const method = request.method.toUpperCase();
   const hasBody = method !== "GET" && method !== "HEAD" && Boolean(request.body);
-  const response = await fetch(`${target.localUrl}${request.path}`, {
+  const response = await fetch(resolveGatewayTargetUrl(target.localUrl, request.path), {
     method,
     headers,
     body: hasBody
@@ -345,6 +345,22 @@ export async function forwardGatewayRequest(
     body: responseBody.toString("base64"),
     encoding: "base64",
   };
+}
+
+function resolveGatewayTargetUrl(targetUrl: string, requestPath: string): URL {
+  if (!requestPath.startsWith("/") || /^[/\\]{2}/.test(requestPath)) {
+    throw new Error("Preview request path cannot change the local target authority.");
+  }
+
+  const base = new URL(targetUrl);
+  base.pathname = base.pathname.endsWith("/") ? base.pathname : `${base.pathname}/`;
+  base.search = "";
+  base.hash = "";
+  const resolved = new URL(requestPath.slice(1), base);
+  if (resolved.origin !== base.origin || !resolved.pathname.startsWith(base.pathname)) {
+    throw new Error("Preview request path cannot leave the local target path.");
+  }
+  return resolved;
 }
 
 async function readResponseBody(response: Response, maxBytes: number) {

--- a/packages/farm-cli/test/preview.test.mjs
+++ b/packages/farm-cli/test/preview.test.mjs
@@ -236,6 +236,44 @@ test("forwards a gateway request to the local target", async () => {
   }
 });
 
+test("keeps gateway requests beneath the configured target path", async () => {
+  const requests = [];
+  const server = await createTestServer((req, res) => {
+    requests.push(req.url);
+    res.end(req.url);
+  });
+  const target = {
+    localUrl: `http://localhost:${server.port}/console`,
+    host: "localhost",
+    port: server.port,
+    source: "url",
+  };
+
+  try {
+    const response = await forwardGatewayRequest(target, {
+      id: "req_nested",
+      method: "GET",
+      path: "/dashboard?view=compact",
+    });
+    assert.equal(
+      Buffer.from(response.body, "base64").toString(),
+      "/console/dashboard?view=compact",
+    );
+
+    await assert.rejects(
+      forwardGatewayRequest(target, {
+        id: "req_escape",
+        method: "GET",
+        path: "/%2e%2e/admin",
+      }),
+      /cannot leave the local target path/,
+    );
+    assert.deepEqual(requests, ["/console/dashboard?view=compact"]);
+  } finally {
+    await server.close();
+  }
+});
+
 test("forwards local redirects without following them", async () => {
   const server = await createTestServer((req, res) => {
     if (req.url === "/redirect") {


### PR DESCRIPTION
## Problem

A managed preview target may be mounted below a pathname such as `/console`. A gateway request containing an encoded parent segment can currently resolve outside that mount.

## Root cause

The compatibility gateway built the local URL with string concatenation and let `fetch` canonicalize it afterward.

## Change

Resolve gateway request paths against a trailing-slash target URL, then require the resolved URL to retain both the target origin and pathname prefix. This matches the native preview agent boundary.

## Safety and compatibility

Normal nested paths, query strings, request bodies, redirects, and root-mounted targets keep their current behavior. Authority-changing and mount-escaping paths are rejected before a local request is made.

## Verification

- `pnpm --filter @farm.js/cli test`
- `pnpm --filter @farm.js/cli type-check`
- `pnpm exec oxlint packages/farm-cli/src/preview-gateway.ts packages/farm-cli/test/preview.test.mjs`

The regression test fails before the fix because `/%2e%2e/admin` reaches `/admin` instead of remaining below `/console`.

## Documentation and release

None.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the preview gateway so a request path with an encoded parent segment can no longer resolve outside the configured target mount (e.g., `/console`). The gateway now resolves request paths against a trailing-slash target URL and rejects paths that change the origin or leave the target pathname prefix before making a local request. Normal nested paths, query strings, request bodies, redirects, and root-mounted targets keep their current behavior.

**Bug Fixes**
- Adds a regression test that fails before the fix because `/%2e%2e/admin` reached `/admin` instead of staying under `/console`.

<sup>Written for commit 83ebe0d07e11cad877e9e6fb57fbf4fce529654a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/904?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

