### PR TITLE
fix(pwa): keep image revalidation alive

### DIFF
--- a/packages/farm-pwa/src/build.test.ts
+++ b/packages/farm-pwa/src/build.test.ts
@@ -283,8 +283,8 @@ describe("generateServiceWorker", () => {
       },
     });
 
-    expect(await (await responsePromise).text()).toBe("cached");
     expect(lifetimePromise).toBeDefined();
+    expect(await (await responsePromise).text()).toBe("cached");
     expect(stored).toBe(false);
 
     resolveNetworkResponse(new Response("updated", { headers: { "cache-control": "public" } }));

--- a/packages/farm-pwa/src/build.test.ts
+++ b/packages/farm-pwa/src/build.test.ts
@@ -1,6 +1,7 @@
 import { mkdtemp, mkdir, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { runInNewContext } from "node:vm";
 import { afterEach, describe, expect, it } from "vitest";
 import { generateServiceWorker, writePwaBuildArtifacts } from "./build";
 import { resolvePwaOptions } from "./config";
@@ -218,5 +219,76 @@ describe("generateServiceWorker", () => {
     expect(worker).toContain("if (IMAGE_OPTIONS && request.destination");
     expect(worker).toContain('request.headers.has("authorization")');
     expect(worker).toContain('policy.includes("no-cache")');
+  });
+
+  it("keeps a background image revalidation alive after returning a cached response", async () => {
+    const worker = generateServiceWorker({
+      basePath: "/",
+      cacheId: "test",
+      precacheUrls: [],
+      staticRoutes: {},
+      offlineRoute: false,
+      update: "prompt",
+      images: { strategy: "swr", limit: 10, ttlMs: 60_000 },
+    });
+    const listeners = new Map<string, (event: any) => void>();
+    let resolveNetworkResponse!: (response: Response) => void;
+    const networkResponse = new Promise<Response>((resolve) => {
+      resolveNetworkResponse = resolve;
+    });
+    let stored = false;
+    const cached = new Response("cached", {
+      headers: { "x-farm-pwa-cached-at": String(Date.now()) },
+    });
+    const cache = {
+      match: async () => cached,
+      put: async () => {
+        stored = true;
+      },
+      keys: async () => [],
+    };
+
+    runInNewContext(worker, {
+      caches: { open: async () => cache },
+      fetch: async () => networkResponse,
+      Headers,
+      Response,
+      Set,
+      URL,
+      self: {
+        addEventListener(type: string, listener: (event: any) => void) {
+          listeners.set(type, listener);
+        },
+        clients: { claim: async () => undefined },
+        location: { origin: "https://example.test" },
+        skipWaiting: async () => undefined,
+      },
+    });
+
+    let responsePromise!: Promise<Response>;
+    let lifetimePromise!: Promise<unknown>;
+    listeners.get("fetch")?.({
+      request: {
+        destination: "image",
+        headers: new Headers(),
+        method: "GET",
+        mode: "cors",
+        url: "https://example.test/photo.png",
+      },
+      respondWith(value: Promise<Response>) {
+        responsePromise = value;
+      },
+      waitUntil(value: Promise<unknown>) {
+        lifetimePromise = value;
+      },
+    });
+
+    expect(await (await responsePromise).text()).toBe("cached");
+    expect(lifetimePromise).toBeDefined();
+    expect(stored).toBe(false);
+
+    resolveNetworkResponse(new Response("updated", { headers: { "cache-control": "public" } }));
+    await lifetimePromise;
+    expect(stored).toBe(true);
   });
 });

--- a/packages/farm-pwa/src/build.ts
+++ b/packages/farm-pwa/src/build.ts
@@ -215,7 +215,7 @@ self.addEventListener("fetch", (event) => {
   }
 
   if (IMAGE_OPTIONS && request.destination === "image") {
-    event.respondWith(staleWhileRevalidateImage(request));
+    event.respondWith(staleWhileRevalidateImage(event, request));
   }
 });
 
@@ -242,7 +242,7 @@ async function handleNavigation(request, url) {
   }
 }
 
-async function staleWhileRevalidateImage(request) {
+async function staleWhileRevalidateImage(event, request) {
   if (request.headers.has("authorization")) return fetch(request);
 
   const cache = await caches.open(IMAGE_CACHE);
@@ -252,7 +252,7 @@ async function staleWhileRevalidateImage(request) {
   const update = fetchAndCacheImage(request, cache);
 
   if (fresh) {
-    void update.catch(() => undefined);
+    event.waitUntil(update.catch(() => undefined));
     return cached;
   }
 

--- a/packages/farm-pwa/src/build.ts
+++ b/packages/farm-pwa/src/build.ts
@@ -215,7 +215,9 @@ self.addEventListener("fetch", (event) => {
   }
 
   if (IMAGE_OPTIONS && request.destination === "image") {
-    event.respondWith(staleWhileRevalidateImage(event, request));
+    const image = staleWhileRevalidateImage(request);
+    event.respondWith(image.response);
+    event.waitUntil(image.lifetime);
   }
 });
 
@@ -242,26 +244,36 @@ async function handleNavigation(request, url) {
   }
 }
 
-async function staleWhileRevalidateImage(event, request) {
-  if (request.headers.has("authorization")) return fetch(request);
+function staleWhileRevalidateImage(request) {
+  let update = Promise.resolve();
+  const response = (async () => {
+    if (request.headers.has("authorization")) return fetch(request);
 
-  const cache = await caches.open(IMAGE_CACHE);
-  const cached = await cache.match(request);
-  const cachedAt = Number(cached?.headers.get("x-farm-pwa-cached-at") || 0);
-  const fresh = cached && Date.now() - cachedAt <= IMAGE_OPTIONS.ttlMs;
-  const update = fetchAndCacheImage(request, cache);
+    const cache = await caches.open(IMAGE_CACHE);
+    const cached = await cache.match(request);
+    const cachedAt = Number(cached?.headers.get("x-farm-pwa-cached-at") || 0);
+    const fresh = cached && Date.now() - cachedAt <= IMAGE_OPTIONS.ttlMs;
+    update = fetchAndCacheImage(request, cache);
 
-  if (fresh) {
-    event.waitUntil(update.catch(() => undefined));
-    return cached;
-  }
+    if (fresh) return cached;
 
-  try {
-    return await update;
-  } catch (error) {
-    if (cached) return cached;
-    throw error;
-  }
+    try {
+      return await update;
+    } catch (error) {
+      if (cached) return cached;
+      throw error;
+    }
+  })();
+  const lifetime = response
+    .then(
+      () => update,
+      () => update,
+    )
+    .then(
+      () => undefined,
+      () => undefined,
+    );
+  return { response, lifetime };
 }
 
 async function fetchAndCacheImage(request, cache) {


### PR DESCRIPTION
## Problem

The generated stale-while-revalidate image handler returns a fresh cached response immediately, but its background fetch is not attached to the service worker event lifetime. A browser may terminate the worker before the updated image reaches the cache.

## Root cause

The generated worker intentionally detached the update promise with `void` instead of passing it to `FetchEvent.waitUntil`.

## Change

Return separate response and lifetime promises from the image handler. Register both synchronously during the fetch event, so cache hits remain immediate while the browser keeps the background update alive. Background network failures remain non-fatal.

## Safety and compatibility

Only generated workers with image caching enabled are affected. Cache hits remain immediate, cache misses still await the network, and custom service workers are unchanged.

## Verification

- `pnpm --filter @farm.js/pwa test`
- `pnpm --filter @farm.js/pwa type-check`
- `pnpm --filter @farm.js/pwa build`
- `pnpm exec oxlint packages/farm-pwa/src/build.ts packages/farm-pwa/src/build.test.ts`

The behavioral regression test evaluates the generated worker, confirms `waitUntil` is registered during dispatch, confirms the cached response returns before the network update, and confirms the update completes within that lifetime. It fails before this change because no lifetime promise is registered.

## Documentation and release

None.