### PR TITLE
fix(routing): reject browser-unstable route paths

### DIFF
--- a/packages/farm/src/__tests__/programmatic-routes.test.ts
+++ b/packages/farm/src/__tests__/programmatic-routes.test.ts
@@ -71,6 +71,18 @@ describe("programmatic routes", () => {
     );
   });
 
+  it("rejects route declarations that browsers reinterpret", () => {
+    for (const routePath of [
+      "/docs/../admin",
+      "/docs/%2e%2e/admin",
+      "/docs/%2Fadmin",
+      "/docs/%5cadmin",
+      "/docs/%00admin",
+    ]) {
+      expect(() => parseProgrammaticRoutePath(routePath)).toThrow(/browser-unstable/);
+    }
+  });
+
   it("keeps programmatic route groups out of URL segments", () => {
     expect(parseProgrammaticRoutePath("/(marketing)/pricing")).toEqual({
       filePath: "(marketing)/pricing/page.tsx",

--- a/packages/farm/src/__tests__/utils.test.ts
+++ b/packages/farm/src/__tests__/utils.test.ts
@@ -160,6 +160,18 @@ describe("parseRoutePath", () => {
     );
   });
 
+  it("rejects file route segments that browsers reinterpret", () => {
+    for (const routePath of [
+      "docs/../admin/page.tsx",
+      "docs/%2e%2e/admin/page.tsx",
+      "docs/%2Fadmin/page.tsx",
+      "docs/%5cadmin/page.tsx",
+      "docs/%00admin/page.tsx",
+    ]) {
+      expect(() => parseRoutePath(routePath)).toThrow(/browser-unstable/);
+    }
+  });
+
   it("should parse root page", () => {
     const result = parseRoutePath("page.tsx");
     expect(result.segments).toEqual([]);

--- a/packages/farm/src/routes-shared.ts
+++ b/packages/farm/src/routes-shared.ts
@@ -1,5 +1,9 @@
 import type { ParsedRoute } from "./types";
-import { assertTerminalCatchAll, assertUniqueRouteParameters } from "./routing/specificity";
+import {
+  assertBrowserStableRoutePath,
+  assertTerminalCatchAll,
+  assertUniqueRouteParameters,
+} from "./routing/specificity";
 
 export const PROGRAMMATIC_ROUTE_FILE_NAMES = [
   "farm.route.ts",
@@ -124,6 +128,7 @@ export function normalizeProgrammaticRoutePath(routePath: string): string {
   }
   const withSlash = routePath.startsWith("/") ? routePath : `/${routePath}`;
   const withoutTrailing = withSlash.length > 1 ? withSlash.replace(/\/+$/, "") : withSlash;
+  assertBrowserStableRoutePath(withoutTrailing);
   return withoutTrailing || "/";
 }
 

--- a/packages/farm/src/routing/specificity.ts
+++ b/packages/farm/src/routing/specificity.ts
@@ -28,6 +28,13 @@ export class ReservedRouteParameterError extends AmbiguousRouteError {
   }
 }
 
+export class BrowserUnstableRouteError extends TypeError {
+  constructor(message: string) {
+    super(message);
+    this.name = "BrowserUnstableRouteError";
+  }
+}
+
 const SEGMENT_RANK: Record<RouteSegmentSpecificity, number> = {
   static: 4,
   dynamic: 3,
@@ -62,6 +69,48 @@ const PAGE_PARAMETER_PATTERN = /^(?:\[\[\.\.\.(.+)\]\]|\[\.\.\.(.+)\]|\[(.+)\])$
 const ROUTER_PARAMETER_PATTERN =
   /^(?:\[\[\.\.\.([A-Za-z0-9_$-]+)\]\]|\[\.\.\.([A-Za-z0-9_$-]+)\]|\[([A-Za-z0-9_$-]+)\]|:([A-Za-z0-9_$-]+)|\*([A-Za-z0-9_$-]+)\??)$/;
 const RESERVED_PARAMETER_NAMES = new Set(["__proto__", "constructor", "prototype"]);
+
+export function assertBrowserStableRoutePath(pattern: string): void {
+  if (pattern.includes("\\") || hasControlCharacter(pattern)) {
+    throw new BrowserUnstableRouteError(
+      `Route path "${pattern}" cannot contain backslashes or control characters.`,
+    );
+  }
+
+  for (const segment of pattern.split("/").filter(Boolean)) {
+    if (
+      (segment.startsWith("(") && segment.endsWith(")")) ||
+      (segment.startsWith("[") && segment.endsWith("]"))
+    ) {
+      continue;
+    }
+
+    let decoded = segment;
+    try {
+      decoded = decodeURIComponent(segment);
+    } catch {
+      // Malformed escapes stay literal in browser pathnames.
+    }
+    if (
+      decoded === "." ||
+      decoded === ".." ||
+      decoded.includes("/") ||
+      decoded.includes("\\") ||
+      hasControlCharacter(decoded)
+    ) {
+      throw new BrowserUnstableRouteError(
+        `Route path "${pattern}" contains browser-unstable segment "${segment}".`,
+      );
+    }
+  }
+}
+
+function hasControlCharacter(value: string): boolean {
+  return Array.from(value).some((character) => {
+    const code = character.charCodeAt(0);
+    return code <= 31 || (code >= 127 && code <= 159);
+  });
+}
 
 export function assertUniqueRouteParameters(
   pattern: string,

--- a/packages/farm/src/utils.ts
+++ b/packages/farm/src/utils.ts
@@ -1,6 +1,10 @@
 import type { RouteSegment, ParsedRoute } from "./types";
 import path from "path";
-import { assertTerminalCatchAll, assertUniqueRouteParameters } from "./routing/specificity";
+import {
+  assertBrowserStableRoutePath,
+  assertTerminalCatchAll,
+  assertUniqueRouteParameters,
+} from "./routing/specificity";
 import { searchParamsToObject } from "./search-params";
 import { decodeRouteSegment } from "./utils/decode";
 
@@ -11,8 +15,10 @@ export function parseRoutePath(filePath: string): ParsedRoute {
 
   const fileName = pathParts.pop() || "";
   const fileType = getRouteType(fileName);
-  assertTerminalCatchAll(`/${pathParts.join("/")}`);
-  assertUniqueRouteParameters(`/${pathParts.join("/")}`);
+  const routePath = `/${pathParts.join("/")}`;
+  assertBrowserStableRoutePath(routePath);
+  assertTerminalCatchAll(routePath);
+  assertUniqueRouteParameters(routePath);
 
   for (const part of pathParts) {
     // Route groups like `(marketing)` organize files without adding URL


### PR DESCRIPTION
## Problem

File and programmatic routes can declare static path segments that browsers reinterpret, such as literal or encoded parent segments and encoded separators. The declared URL can then resolve to a different pathname than Farm registered.

## Root cause

Route validation covered parameter ambiguity and catch-all placement, but did not validate static segments using browser path semantics.

## Change

Add one shared browser-stability check for file and programmatic route declarations. Reject dot segments, encoded separators, backslashes, and control characters while preserving route groups, dynamic parameters, Unicode, and literal percent-named files.

## Safety and compatibility

Valid static, dynamic, catch-all, grouped, and interception routes are unchanged. The rejected declarations do not have a stable browser URL matching the registered route.

## Verification

- `pnpm --filter @farm.js/core exec vitest run src/__tests__/programmatic-routes.test.ts src/__tests__/utils.test.ts`
- `pnpm --filter @farm.js/core type-check`
- `pnpm exec oxlint packages/farm/src/routing/specificity.ts packages/farm/src/routes-shared.ts packages/farm/src/utils.ts packages/farm/src/__tests__/programmatic-routes.test.ts packages/farm/src/__tests__/utils.test.ts`

The regression tests fail before the fix because values such as `/docs/%2e%2e/admin` are accepted even though a browser resolves that declaration as `/admin`.

## Documentation and release

None.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects route paths that browsers reinterpret, so declared URLs always match the registered route. Previously, static segments like `../` or `%2e%2e` were accepted even though the browser resolves them differently.

- Adds a shared browser-stability check for file and programmatic route declarations.
- Rejects dot segments, encoded separators, backslashes, and control characters; route groups, dynamic params, Unicode, and literal percent-named files are preserved.

<sup>Written for commit 6e5ba657c55bbd335fe9b6a52f32154849c446e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/906?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

