### PR TITLE
fix(search): reject browser-unstable output paths

### DIFF
--- a/packages/farm-search/src/config.test.ts
+++ b/packages/farm-search/src/config.test.ts
@@ -45,6 +45,14 @@ describe("resolveSearchOptions", () => {
     expect(() => resolveSearchOptions({ output: "search\\index" })).toThrow(
       "inside the public output directory",
     );
+    for (const output of [
+      "%2e%2e/search",
+      "search/%2Findex",
+      "search/%5cindex",
+      "search/%00index",
+    ]) {
+      expect(() => resolveSearchOptions({ output })).toThrow("inside the public output directory");
+    }
     expect(() => resolveSearchOptions({ language: "english" })).toThrow("ISO 639-1");
     expect(() => resolveSearchOptions({ excerptLength: 0 })).toThrow("excerptLength");
     expect(() => resolveSearchOptions({ verbose: "yes" } as never)).toThrow(

--- a/packages/farm-search/src/config.ts
+++ b/packages/farm-search/src/config.ts
@@ -104,11 +104,31 @@ function normalizeOutput(value: string): string {
     value.includes("\\") ||
     value.includes("?") ||
     value.includes("#") ||
-    segments.some((segment) => segment === "." || segment === ".." || !segment)
+    segments.some((segment) => !isStableOutputSegment(segment))
   ) {
     throw new TypeError("Search output must stay inside the public output directory");
   }
   return normalized;
+}
+
+function isStableOutputSegment(segment: string): boolean {
+  if (!segment) return false;
+  let decoded = segment;
+  try {
+    decoded = decodeURIComponent(segment);
+  } catch {
+    // Malformed escapes remain literal in browser pathnames.
+  }
+  return (
+    decoded !== "." &&
+    decoded !== ".." &&
+    !decoded.includes("/") &&
+    !decoded.includes("\\") &&
+    !Array.from(decoded).some((character) => {
+      const code = character.charCodeAt(0);
+      return code <= 31 || (code >= 127 && code <= 159);
+    })
+  );
 }
 
 function normalizeLanguage(value: string | undefined): string | undefined {


### PR DESCRIPTION
## Problem

Search accepts encoded dot segments, separators, and control characters in its public output path. The filesystem output can be written under one name while browsers request a different canonical URL.

## Root cause

Output validation checked only the raw segment text.

## Change

Validate each output segment after one URL decode and reject browser-unstable values.

## Safety and compatibility

Ordinary nested output paths, Unicode, and malformed percent literals retain their current behavior. Only paths without a stable public URL are rejected.

## Verification

- `pnpm --filter @farm.js/search test`
- `pnpm --filter @farm.js/search type-check`
- `pnpm --filter @farm.js/search build`
- `pnpm exec oxlint packages/farm-search/src/config.ts packages/farm-search/src/config.test.ts`

The regression cases fail before the fix because `%2e%2e/search`, encoded separators, and encoded controls are accepted.

## Documentation and release

None.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects search output paths that browsers would resolve differently than the filesystem writes, so encoded dot segments, separators, and control characters no longer produce a broken public URL.

- Validates each output segment after one URL decode and rejects unstable values.
- Keeps current behavior for ordinary nested paths, Unicode, and malformed percent literals.
- Regression tests for `%2e%2e`, encoded separators, and encoded controls are included.

<sup>Written for commit 3447ddf1fa144f6de823037180c793a4bb6da50e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/907?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

