### PR TITLE
fix(scripts): reject unstable root-relative sources

### DIFF
--- a/packages/farm-scripts/src/config.test.ts
+++ b/packages/farm-scripts/src/config.test.ts
@@ -65,6 +65,14 @@ describe("resolveScriptsOptions", () => {
     expect(() => defineScript({ name: "x", src: "/vendor/unsafe\nscript.js" })).toThrow(
       "control characters",
     );
+    for (const [index, src] of [
+      "/%2e%2e/vendor.js",
+      "/vendor/%2Fscript.js",
+      "/vendor/%5cscript.js",
+      "/vendor/%00script.js",
+    ].entries()) {
+      expect(() => defineScript({ name: `unstable-${index}`, src })).toThrow("browser-unstable");
+    }
     expect(() =>
       defineScript({ name: "x", src: "/vendor.js", global: "window.__proto__.x" }),
     ).toThrow("relative to window");

--- a/packages/farm-scripts/src/shared.ts
+++ b/packages/farm-scripts/src/shared.ts
@@ -265,6 +265,10 @@ function normalizeScriptSource(value: unknown): string {
         "script root-relative src cannot contain backslashes or control characters",
       );
     }
+    const pathname = src.split(/[?#]/, 1)[0] || "/";
+    if (pathname.split("/").some((segment) => !isStableRootRelativeSegment(segment))) {
+      throw new TypeError("script root-relative src contains a browser-unstable path segment");
+    }
     return src;
   }
   if (!/^https?:\/\//i.test(src)) {
@@ -283,6 +287,26 @@ function normalizeScriptSource(value: unknown): string {
     throw new TypeError("script src cannot contain URL credentials");
   }
   return src;
+}
+
+function isStableRootRelativeSegment(segment: string): boolean {
+  if (!segment) return true;
+  let decoded = segment;
+  try {
+    decoded = decodeURIComponent(segment);
+  } catch {
+    // Malformed escapes remain literal in browser pathnames.
+  }
+  return (
+    decoded !== "." &&
+    decoded !== ".." &&
+    !decoded.includes("/") &&
+    !decoded.includes("\\") &&
+    !Array.from(decoded).some((character) => {
+      const code = character.charCodeAt(0);
+      return code <= 31 || (code >= 127 && code <= 159);
+    })
+  );
 }
 
 function normalizeDataAttributes(value: ScriptDefinition["attributes"]): Record<string, string> {


### PR DESCRIPTION
## Problem

A root-relative third-party script source can contain encoded dot segments, separators, or controls. After Farm applies `basePath`, the browser can canonicalize that source to a different path and escape the intended mount.

## Root cause

Script validation rejected raw backslashes and controls but did not inspect encoded path segments.

## Change

Validate the pathname portion of root-relative sources after one URL decode and reject browser-unstable segments. Query strings and fragments remain outside that path check.

## Safety and compatibility

Valid root-relative scripts, absolute HTTP(S) scripts, query strings, fragments, and malformed percent literals retain their existing behavior.

## Verification

- `pnpm --filter @farm.js/scripts test`
- `pnpm --filter @farm.js/scripts type-check`
- `pnpm --filter @farm.js/scripts build`
- `pnpm exec oxlint packages/farm-scripts/src/shared.ts packages/farm-scripts/src/config.test.ts`

The regression cases fail before the fix because encoded parent segments, separators, and controls are accepted as root-relative script sources.

## Documentation and release

None.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects root-relative script sources that contain browser-unstable path segments (like encoded dot segments, separators, or controls) which could escape the intended base path after canonicalization. Previously such sources were accepted; now they throw a `TypeError`. Query strings, fragments, absolute HTTP(S) URLs, and malformed percent escapes still work as before.

<sup>Written for commit 34b84d756820ee3c2fd52ea857894d492da296df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/908?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

