### PR TITLE
fix(federation): reject browser-unstable paths

### DIFF
--- a/packages/farm-federation/src/config.test.ts
+++ b/packages/farm-federation/src/config.test.ts
@@ -96,6 +96,16 @@ describe("resolveFederationOptions", () => {
     expect(() =>
       resolveFederationOptions({ name: "remote", filename: "../remoteEntry.js" }, reactRenderer),
     ).toThrow("safe relative");
+    for (const filename of [
+      "%2e%2e/remoteEntry.js",
+      "assets/%2FremoteEntry.js",
+      "assets/%5cremoteEntry.js",
+      "assets/%00remoteEntry.js",
+    ]) {
+      expect(() => resolveFederationOptions({ name: "remote", filename }, reactRenderer)).toThrow(
+        "safe relative",
+      );
+    }
     expect(() =>
       resolveFederationOptions(
         {
@@ -111,6 +121,10 @@ describe("resolveFederationOptions", () => {
       "//checkout.example.com/remoteEntry.js",
       "/\\checkout.example.com/remoteEntry.js",
       "checkout@file:///tmp/remoteEntry.js",
+      "/assets/%2e%2e/remoteEntry.js",
+      "/assets/%2FremoteEntry.js",
+      "/assets/%5cremoteEntry.js",
+      "/assets/%00remoteEntry.js",
     ]) {
       expect(() =>
         resolveFederationOptions({ name: "host", remotes: { checkout: entry } }, reactRenderer),
@@ -120,6 +134,10 @@ describe("resolveFederationOptions", () => {
       "//cdn.example.com/assets/",
       "/\\cdn.example.com/assets/",
       "https:\\cdn.example.com\\assets\\",
+      "/assets/%2e%2e/federation/",
+      "/assets/%2Ffederation/",
+      "/assets/%5cfederation/",
+      "/assets/%00federation/",
     ]) {
       expect(() => resolveFederationOptions({ name: "host", publicPath }, reactRenderer)).toThrow();
     }

--- a/packages/farm-federation/src/config.ts
+++ b/packages/farm-federation/src/config.ts
@@ -222,7 +222,7 @@ function normalizeRemoteAlias(value: string): string {
 function normalizeRemoteEntry(value: string, alias: string): string {
   const entry = nonEmptyString(value, `Federation remote ${alias} entry`);
   if (entry.startsWith("/")) {
-    if (entry.startsWith("//") || entry.includes("\\")) {
+    if (entry.startsWith("//") || entry.includes("\\") || !hasBrowserStablePathname(entry)) {
       throw new TypeError(
         `Federation remote ${alias} entry must be a root-relative URL, not a network-path URL`,
       );
@@ -283,7 +283,7 @@ function normalizeOutputFile(value: string): string {
     value.includes("\\") ||
     value.includes("?") ||
     value.includes("#") ||
-    segments.some((segment) => !segment || segment === "." || segment === "..") ||
+    segments.some((segment) => !isBrowserStablePathSegment(segment)) ||
     !/\.m?js$/i.test(filename)
   ) {
     throw new TypeError("Federation filename must be a safe relative .js or .mjs path");
@@ -296,7 +296,11 @@ function optionalPublicPath(value: string | undefined): string | undefined {
   const publicPath = nonEmptyString(value, "Federation publicPath");
   if (publicPath === "auto") return publicPath;
   if (publicPath.startsWith("/")) {
-    if (publicPath.startsWith("//") || publicPath.includes("\\")) {
+    if (
+      publicPath.startsWith("//") ||
+      publicPath.includes("\\") ||
+      !hasBrowserStablePathname(publicPath)
+    ) {
       throw new TypeError(
         "Federation publicPath must be a root-relative URL, not a network-path URL",
       );
@@ -320,6 +324,28 @@ function optionalPublicPath(value: string | undefined): string | undefined {
     throw new TypeError("Federation publicPath must use HTTP without URL credentials");
   }
   return parsed.href;
+}
+
+function hasBrowserStablePathname(value: string): boolean {
+  const pathname = value.split(/[?#]/, 1)[0] || "/";
+  return pathname.split("/").every((segment) => !segment || isBrowserStablePathSegment(segment));
+}
+
+function isBrowserStablePathSegment(segment: string): boolean {
+  if (!segment) return false;
+  let decoded = segment;
+  try {
+    decoded = decodeURIComponent(segment);
+  } catch {
+    // Malformed escapes remain literal in browser pathnames.
+  }
+  return (
+    decoded !== "." &&
+    decoded !== ".." &&
+    !decoded.includes("/") &&
+    !decoded.includes("\\") &&
+    !hasControlCharacter(decoded)
+  );
 }
 
 function booleanOption(value: boolean | undefined, label: string): boolean | undefined {


### PR DESCRIPTION
## Problem

Federation accepts encoded dot segments, separators, and controls in root-relative entries, output filenames, and public paths. Browsers can reinterpret those paths after Farm has validated or prefixed them.

## Root cause

The configuration checks covered raw traversal, backslashes, protocols, and credentials but did not inspect percent-encoded path segments.

## Change

Apply one decoded-segment stability check to all three federation path surfaces.

## Safety and compatibility

Normal root-relative and absolute HTTP(S) remote URLs, output filenames, public paths, query strings, fragments, and `auto` public paths remain supported. Only browser-unstable pathname segments are rejected.

## Verification

- `pnpm --filter @farm.js/federation test`
- `pnpm --filter @farm.js/federation type-check`
- `pnpm --filter @farm.js/federation build`
- `pnpm exec oxlint packages/farm-federation/src/config.ts packages/farm-federation/src/config.test.ts`

The regression cases fail before the fix because encoded parent segments, separators, and controls pass all three configuration boundaries.

## Documentation and release

None.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Federation previously accepted percent-encoded dot segments, separators, and control characters in root-relative remote entries, output filenames, and public paths. These are now rejected because browsers can decode and reinterpret them after validation.

**Bug Fixes**
- Decodes each path segment before checking it for traversal, separators, and control characters.
- Malformed percent-escapes remain literal and are still accepted.
- Regression tests cover encoded `..`, `/`, `\`, and null characters across all three path surfaces.

<sup>Written for commit 10e27cb79771efa3942dcadf5a99391f6c76259e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/909?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

