### PR TITLE
fix(analyzer): keep reports inside project root

### DIFF
--- a/packages/farm-analyzer/src/index.test.ts
+++ b/packages/farm-analyzer/src/index.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
@@ -48,6 +48,41 @@ describe("analyzer", () => {
         {} as never,
       ),
     ).rejects.toThrow("size limit exceeded");
+  });
+
+  it("does not write reports through a directory symlink outside the project", async () => {
+    const root = await createMinimalOutput();
+    const outside = await mkdtemp(path.join(os.tmpdir(), "farm-analyzer-outside-"));
+    await symlink(
+      outside,
+      path.join(root, "reports"),
+      process.platform === "win32" ? "junction" : "dir",
+    );
+    const plugin = analyzer({ output: "reports/build.html", json: false });
+
+    try {
+      await expect(
+        plugin.build?.after?.(
+          {
+            root,
+            preset: "node-server",
+            universal: true,
+            distDir: ".farm",
+            outputDir: path.join(root, ".farm/.output"),
+            success: true,
+          },
+          {} as never,
+        ),
+      ).rejects.toThrow("after resolving symbolic links");
+      await expect(readFile(path.join(outside, "build.html"), "utf8")).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+    } finally {
+      await Promise.all([
+        rm(root, { recursive: true, force: true }),
+        rm(outside, { recursive: true, force: true }),
+      ]);
+    }
   });
 });
 

--- a/packages/farm-analyzer/src/index.ts
+++ b/packages/farm-analyzer/src/index.ts
@@ -1,4 +1,4 @@
-import { mkdir, writeFile } from "node:fs/promises";
+import { lstat, mkdir, realpath, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { definePlugin } from "@farm.js/core/plugin";
 import { analyzeBuild, evaluateLimits, formatBytes } from "./analyze.js";
@@ -100,10 +100,64 @@ export function analyzer(options: AnalyzerOptions = {}) {
 }
 
 async function writeOutput(root: string, output: string, contents: string): Promise<string> {
-  const file = path.resolve(root, output);
-  await mkdir(path.dirname(file), { recursive: true });
+  const resolvedRoot = await realpath(root);
+  const relative = path.relative(resolvedRoot, path.resolve(resolvedRoot, output));
+  if (!relative || isOutsideRoot(relative)) {
+    throw new TypeError("Analyzer output must stay inside the project root");
+  }
+
+  const parts = relative.split(path.sep);
+  const filename = parts.pop()!;
+  let directory = resolvedRoot;
+  for (const part of parts) {
+    const candidate = path.join(directory, part);
+    const entry = await getPathEntry(candidate);
+    if (entry) {
+      if (!entry.isDirectory() && !entry.isSymbolicLink()) {
+        throw new TypeError(`Analyzer output parent is not a directory: ${candidate}`);
+      }
+      directory = entry.isSymbolicLink() ? await realpath(candidate) : candidate;
+      assertInsideRoot(resolvedRoot, directory);
+    } else {
+      await mkdir(candidate);
+      directory = candidate;
+    }
+  }
+
+  let file = path.join(directory, filename);
+  const entry = await getPathEntry(file);
+  if (entry?.isSymbolicLink()) {
+    file = await realpath(file);
+    assertInsideRoot(resolvedRoot, file);
+  }
   await writeFile(file, contents, "utf8");
   return file;
+}
+
+function assertInsideRoot(root: string, candidate: string): void {
+  const relative = path.relative(root, candidate);
+  if (isOutsideRoot(relative)) {
+    throw new TypeError(
+      "Analyzer output must stay inside the project root after resolving symbolic links",
+    );
+  }
+}
+
+function isOutsideRoot(relative: string): boolean {
+  return relative === ".." || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative);
+}
+
+function isMissingFileError(error: unknown): error is NodeJS.ErrnoException {
+  return (error as NodeJS.ErrnoException)?.code === "ENOENT";
+}
+
+async function getPathEntry(file: string) {
+  try {
+    return await lstat(file);
+  } catch (error) {
+    if (isMissingFileError(error)) return undefined;
+    throw error;
+  }
 }
 
 function formatViolations(


### PR DESCRIPTION
## Problem

Analyzer output paths are lexically constrained to the project, but an existing parent or destination symlink can redirect the report write outside the project root.

## Root cause

The writer resolved the configured string and then used recursive directory creation and `writeFile`, both of which follow filesystem symlinks.

## Change

Resolve the real project root, walk output parents one component at a time, and verify every resolved symlink remains inside that root before creating directories or writing. Apply the same containment check to an existing destination symlink.

## Safety and compatibility

Normal report paths and symlinks that remain inside the project continue to work. No output is written when a path resolves outside the project.

## Verification

- `pnpm --filter @farm.js/analyzer test`
- `pnpm --filter @farm.js/analyzer type-check`
- `pnpm --filter @farm.js/analyzer build`
- `pnpm exec oxlint packages/farm-analyzer/src/index.ts packages/farm-analyzer/src/index.test.ts`

The regression test creates an output-directory symlink to a separate temporary directory. It fails before the fix because `build.html` is written outside the project.

## Documentation and release

None.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the analyzer from writing reports outside the project root through symlinks. Previously, output paths were constrained only as strings, so a symlinked parent directory or destination file could redirect the report outside the project; now every path component is resolved and verified against the real project root, and any write that would escape the root is rejected with an error. Normal report paths and symlinks that stay inside the project continue to work.

**Verification**
- Regression test symlinks the output directory to an external temp dir and asserts the report write fails and no file is created.
- Ran `pnpm --filter @farm.js/analyzer test`, `type-check`, `build`, and `oxlint`.

<sup>Written for commit 1674f32d06fe8091419b3cd2e6745a0690097141. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/910?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

