### PR TITLE
fix(docs): block symlink escapes from embedded content

### DIFF
--- a/packages/farm/src/__tests__/docs-handler.test.ts
+++ b/packages/farm/src/__tests__/docs-handler.test.ts
@@ -199,6 +199,19 @@ describe("createFarmDocsHandler", () => {
     expect(response == null || response.status === 404).toBe(true);
   });
 
+  it("does not serve docs files through symlinks outside the content directory", async () => {
+    const { root, docs, docsDir } = await createDocsFixture();
+    const privateDir = path.join(root, "private");
+    await fs.mkdir(privateDir);
+    await fs.writeFile(path.join(privateDir, "page.md"), "# Private\n\nTOP_SECRET_VALUE");
+    await fs.symlink(privateDir, path.join(docsDir, "leak"), "junction");
+
+    const handler = createFarmDocsHandler(docs, { root, srcDir: "src" });
+    const response = await handler(new Request("http://farm.test/docs/leak"));
+
+    expect(response == null || response.status === 404).toBe(true);
+  });
+
   it("serves docs markdown files as HTML", async () => {
     const { root, docs } = await createDocsFixture();
     const handler = createFarmDocsHandler(docs, { root, srcDir: "src" });

--- a/packages/farm/src/docs/handler.ts
+++ b/packages/farm/src/docs/handler.ts
@@ -1,4 +1,4 @@
-import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync, realpathSync, statSync } from "node:fs";
 import path from "node:path";
 import {
   buildDocsAgentDiscoverySpec,
@@ -174,6 +174,20 @@ function resolveInside(root: string, target: string): string | null {
   return null;
 }
 
+function resolveExistingFileInside(root: string, target: string): string | null {
+  const safePath = resolveInside(root, target);
+  if (!safePath) return null;
+
+  try {
+    const realRoot = realpathSync(root);
+    const realTarget = realpathSync(safePath);
+    const containedTarget = resolveInside(realRoot, realTarget);
+    return containedTarget && statSync(containedTarget).isFile() ? containedTarget : null;
+  } catch {
+    return null;
+  }
+}
+
 export function isFarmDocsRequest(docs: FarmDocsResolvedConfig | undefined, request: Request) {
   if (!docs?.enabled) return false;
   if (request.method !== "GET" && request.method !== "HEAD") return false;
@@ -245,8 +259,8 @@ function findDocsPageFile(contentDir: string, slug: string): string | null {
         ];
 
   for (const candidate of candidates) {
-    const safePath = resolveInside(contentDir, candidate);
-    if (safePath && existsSync(safePath) && statSync(safePath).isFile()) {
+    const safePath = resolveExistingFileInside(contentDir, candidate);
+    if (safePath) {
       return safePath;
     }
   }


### PR DESCRIPTION
## Problem

Embedded docs accepted a lexically contained page path even when a symlink redirected the final file outside the configured content directory. A docs request could therefore expose application files that were never intended to be public.

## Root cause

The page resolver checked `path.relative()` before calling `statSync()` and `readFileSync()`. Both filesystem operations follow symlinks, but the resolved target was never checked against the real content root.

## Change

Resolve both the content root and candidate page through `realpathSync()`, then enforce containment on the real paths before accepting a regular file. Missing files, dangling links, and targets outside the content root now behave as not found.

## Safety and compatibility

Ordinary Markdown and MDX pages are unchanged. Symlinks that resolve within the content directory remain valid. The regression uses a directory junction so the behavior is covered on Windows as well as Unix.

## Verification

- `pnpm --filter @farm.js/core exec vitest run src/__tests__/docs-handler.test.ts`
- `pnpm --filter @farm.js/core type-check`
- `pnpm exec oxlint packages/farm/src/docs/handler.ts packages/farm/src/__tests__/docs-handler.test.ts`
- `pnpm --filter @farm.js/core test` reached 1,739 passing tests with one unrelated development-server startup failure; rerunning `development-observability.test.ts` passed.

The new symlink regression returns the private page on the previous implementation and returns not found with this change.

## Documentation and release

None. This tightens the existing content-directory boundary without changing the public API.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the docs handler so embedded content cannot escape the content directory via symlinks and expose private application files. Previously the resolver checked lexical path containment only; now it resolves both the content root and candidate file to real paths and enforces containment there before serving.

- Missing files, dangling links, and symlink targets outside the content root now return 404.
- Symlinks that resolve within the content directory still serve normally.

<sup>Written for commit c6015a3397bbbdee718b4d1b4bb5c3d7c825024f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/912?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

