### PR TITLE
fix(integrations): reject non-terminal catch-all routes

### DIFF
--- a/packages/farm/src/__tests__/integrations.test.ts
+++ b/packages/farm/src/__tests__/integrations.test.ts
@@ -225,6 +225,23 @@ describe("integrations runtime", () => {
     expect(dynamic?.params).toEqual({ id: "%E0" });
   });
 
+  it("rejects integration catch-all parameters before later path segments", () => {
+    expect(() =>
+      defineIntegration({
+        category: "agent",
+        type: "invalid-catch-all",
+        instance: {},
+        routes: [
+          integrationRoute.get("/api/[...slug]/admin", {
+            handler: async () => new Response("unexpected"),
+          }),
+        ],
+      }),
+    ).toThrow(
+      'Catch-all segment "[...slug]" must be the final segment in route "/api/[...slug]/admin".',
+    );
+  });
+
   it("rejects duplicate plugin names from one integration", () => {
     const integration = defineIntegration({
       category: "custom",

--- a/packages/farm/src/integrations.ts
+++ b/packages/farm/src/integrations.ts
@@ -12,6 +12,7 @@ import type {
 import type { InferFarmIntegrationOrmClient } from "./integration-orm";
 import { setFarmPluginIntegrationContext } from "./plugin-integration-context";
 import { decodeRouteSegment } from "./utils/decode";
+import { assertTerminalCatchAll } from "./routing/specificity";
 import type {
   FarmPlugin,
   FarmPluginContext,
@@ -1113,6 +1114,10 @@ export function defineIntegration<
     routes?.length || endpointRoutes.length
       ? ([...(routes || []), ...endpointRoutes] as readonly FarmIntegrationRoute[])
       : undefined;
+
+  for (const route of allRoutes || []) {
+    assertTerminalCatchAll(route.path, "api");
+  }
 
   const derivedApi =
     integration.api ||


### PR DESCRIPTION
## Problem

An integration route could place a catch-all parameter before later path segments, for example `/api/[...slug]/admin`. The matcher consumes the remaining pathname as soon as it reaches the catch-all, so that route could incorrectly handle `/api/private`.

## Root cause

File-system, programmatic, and router routes enforce terminal catch-all parameters, but integration routes were not passed through the shared route invariant.

## Change

Validate every route and flattened endpoint contributed through `defineIntegration()` with the existing API-route terminal catch-all check.

## Safety and compatibility

Valid integration routes are unchanged. Invalid non-terminal catch-all routes now fail during integration definition with the same actionable error used by Farm's other route surfaces.

## Verification

- `pnpm --filter @farm.js/core exec vitest run src/__tests__/integrations.test.ts`
- `pnpm --filter @farm.js/core type-check`
- `pnpm exec oxlint packages/farm/src/integrations.ts packages/farm/src/__tests__/integrations.test.ts`
- `git diff --check`

The regression fails on the previous implementation because the invalid route is accepted.

## Documentation and release

None. This aligns integration routes with the existing route contract.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects integration routes that place a catch-all segment before later path segments, so `/api/[...slug]/admin` no longer matches unrelated paths like `/api/private`. Invalid routes now fail during `defineIntegration()` with the same terminal catch-all error used by Farm's other route surfaces; valid integration routes are unchanged.

<sup>Written for commit 977d590b9e8ae530b94caa9baf1bd43ab9b2da40. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/913?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

