### PR TITLE
fix(preview): preserve compressed request encoding

### DIFF
--- a/packages/farm-preview-gateway/src/index.ts
+++ b/packages/farm-preview-gateway/src/index.ts
@@ -88,7 +88,6 @@ const DEFAULT_MAX_RESPONSE_BODY_BYTES = 1024 * 1024 * 5;
 const DEFAULT_POLL_REQUEST_LIMIT = 50;
 const HOP_BY_HOP_HEADERS = new Set([
   "connection",
-  "content-encoding",
   "content-length",
   "keep-alive",
   "proxy-authenticate",
@@ -680,7 +679,7 @@ async function proxyPublicRequest(
   const responseHopByHopHeaders = getHopByHopHeaderNames(response.headers || {});
   for (const [key, value] of Object.entries(response.headers || {})) {
     const normalized = key.toLowerCase();
-    if (responseHopByHopHeaders.has(normalized)) {
+    if (responseHopByHopHeaders.has(normalized) || normalized === "content-encoding") {
       continue;
     }
     // Append multi-valued headers (Set-Cookie) so every value reaches the

--- a/packages/farm-preview-gateway/test/gateway.test.mjs
+++ b/packages/farm-preview-gateway/test/gateway.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { createServer, request as createRequest } from "node:http";
 import { setTimeout as delay } from "node:timers/promises";
 import test from "node:test";
+import { gunzipSync, gzipSync } from "node:zlib";
 import { createNodePreviewGatewayHandler, MemoryPreviewGatewayStore } from "../dist/index.js";
 
 test("proxies a public preview request through the gateway queue", async () => {
@@ -217,6 +218,50 @@ test("removes headers nominated by Connection in both polling proxy directions",
     const response = await publicRequest;
     assert.equal(response.status, 200);
     assert.equal(response.headers["x-response-hop"], undefined);
+  } finally {
+    await gateway.close();
+  }
+});
+
+test("preserves Content-Encoding for compressed public request bodies", async () => {
+  const store = new MemoryPreviewGatewayStore();
+  const gateway = await createGatewayServer(store);
+
+  try {
+    const session = await fetch(`${gateway.url}/api/sessions`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name: "encoding-check", localUrl: "http://localhost:4321" }),
+    }).then((response) => response.json());
+    const compressedBody = gzipSync(JSON.stringify({ message: "compressed" }));
+
+    const publicRequest = fetch(`${gateway.url}/__preview/encoding-check/messages`, {
+      method: "POST",
+      headers: {
+        "content-encoding": "gzip",
+        "content-type": "application/json",
+      },
+      body: compressedBody,
+    });
+    const poll = await fetch(
+      `${gateway.url}/api/sessions/${session.id}/requests?token=${session.token}&wait=1000`,
+    ).then((response) => response.json());
+    const queued = poll.requests[0];
+
+    assert.equal(queued.headers["content-encoding"], "gzip");
+    assert.deepEqual(JSON.parse(gunzipSync(Buffer.from(queued.body, "base64")).toString("utf8")), {
+      message: "compressed",
+    });
+
+    await fetch(
+      `${gateway.url}/api/sessions/${session.id}/responses/${queued.id}?token=${session.token}`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ status: 204 }),
+      },
+    );
+    assert.equal((await publicRequest).status, 204);
   } finally {
     await gateway.close();
   }


### PR DESCRIPTION
## Problem

The hosted preview gateway forwarded compressed request bytes but removed `Content-Encoding`. A local app receiving a gzip or Brotli request therefore tried to interpret compressed bytes as the declared content type.

## Root cause

The gateway used one excluded-header set for both request and response directions. That set intentionally removed response `Content-Encoding` after the preview agent decoded a fetch response, but it also removed the end-to-end header from untouched public request bodies.

## Change

Preserve `Content-Encoding` while serializing public requests. Continue stripping it from uploaded preview responses, where the body has already been decoded by the agent.

## Safety and compatibility

Connection-specific headers and nominated headers remain filtered. `Content-Length` is still recalculated rather than forwarded because the queue serializes bodies as base64.

## Verification

- `pnpm --filter @farm.js/preview-gateway test` (10/10)
- `pnpm --filter @farm.js/preview-gateway type-check`
- `pnpm exec oxlint packages/farm-preview-gateway/src/index.ts packages/farm-preview-gateway/test/gateway.test.mjs`
- `git diff --check`

The regression sends a real gzipped HTTP request through the Node gateway, verifies the queued encoding header and bytes, and fails on the previous implementation.

## Documentation and release

None. This restores standard HTTP request semantics.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the preview gateway so compressed public requests keep their `Content-Encoding` header, preventing local apps from misreading gzipped or Brotli bodies as plain content. Previously the gateway stripped the header in both directions, which worked for decoded preview responses but broke untouched request bodies.

- Restores compression headers only for queued public requests; responses are still forwarded without `Content-Encoding` since the agent already decodes them.
- Adds a regression test that sends a real gzipped request and verifies the queued encoding header and body bytes.

<sup>Written for commit 76c4d8201bddb13c8710d8c10e038ea55de378a6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/914?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

