### PR TITLE
fix(vite): preserve runtime response bytes in development

### DIFF
--- a/packages/farm/src/__tests__/development-runtime-response.test.ts
+++ b/packages/farm/src/__tests__/development-runtime-response.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment node
 
 import fs from "node:fs/promises";
+import { createServer as createNodeServer } from "node:http";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -27,6 +28,17 @@ async function writeModule(root: string, relativePath: string, source: string): 
   await fs.writeFile(filePath, source);
 }
 
+async function getAvailablePort(): Promise<number> {
+  const server = createNodeServer();
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("Missing test server address");
+  await new Promise<void>((resolve, reject) =>
+    server.close((error) => (error ? reject(error) : resolve())),
+  );
+  return address.port;
+}
+
 describe("development runtime response bridge", () => {
   it("passes streamed binary short-circuit responses through runtime.after without corruption", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "farm-development-runtime-response-"));
@@ -47,6 +59,11 @@ describe("development runtime response bridge", () => {
     await fs.writeFile(
       path.join(root, "farm.config.ts"),
       `export default {
+  redirects: async () => [{ source: "/redirect", destination: "/" }],
+  headers: async () => [{
+    source: "/redirect",
+    headers: [{ key: "x-late-config-header", value: "must-not-run" }],
+  }],
   plugins: [{
     name: "binary-runtime-response",
     beforeRequest(req, res) {
@@ -82,7 +99,7 @@ export default function Page() { return <main>home</main>; }`,
 
     const server = await createServer({ root, images: { provider: "none" } });
     servers.add(server);
-    await server.listen(0);
+    await server.listen(await getAvailablePort());
     const address = server.httpServer?.address();
     if (!address || typeof address === "string") throw new Error("Missing dev server address");
 
@@ -92,6 +109,14 @@ export default function Page() { return <main>home</main>; }`,
     expect(response.status).toBe(200);
     expect(response.headers.get("x-runtime-body")).toBe("00ff018002");
     expect([...bytes]).toEqual([0, 255, 1, 128, 2]);
+
+    const redirectResponse = await fetch(`http://localhost:${address.port}/redirect`, {
+      redirect: "manual",
+    });
+    expect(redirectResponse.status).toBe(307);
+    expect(redirectResponse.headers.get("location")).toBe("/");
+    expect(redirectResponse.headers.get("x-late-config-header")).toBeNull();
+    expect(redirectResponse.headers.get("x-runtime-body")).toBe("");
 
     const pageResponse = await fetch(`http://localhost:${address.port}/`);
     expect(pageResponse.headers.get("x-runtime-body")).toMatch(/^[a-f0-9]+$/);

--- a/packages/farm/src/__tests__/development-runtime-response.test.ts
+++ b/packages/farm/src/__tests__/development-runtime-response.test.ts
@@ -1,0 +1,100 @@
+// @vitest-environment node
+
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+import type { ViteDevServer } from "vite";
+import { createServer } from "../server/create-server";
+
+const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const temporaryRoots = new Set<string>();
+const servers = new Set<ViteDevServer>();
+
+afterEach(async () => {
+  await Promise.all([...servers].map((server) => server.close()));
+  servers.clear();
+  await Promise.all(
+    [...temporaryRoots].map((root) => fs.rm(root, { recursive: true, force: true })),
+  );
+  temporaryRoots.clear();
+});
+
+async function writeModule(root: string, relativePath: string, source: string): Promise<void> {
+  const filePath = path.join(root, relativePath);
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, source);
+}
+
+describe("development runtime response bridge", () => {
+  it("passes streamed binary short-circuit responses through runtime.after without corruption", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "farm-development-runtime-response-"));
+    temporaryRoots.add(root);
+
+    await fs.mkdir(path.join(root, "node_modules"), { recursive: true });
+    await fs.symlink(
+      await fs.realpath(path.join(packageRoot, "node_modules", "react")),
+      path.join(root, "node_modules", "react"),
+      "junction",
+    );
+    await fs.symlink(
+      await fs.realpath(path.join(packageRoot, "node_modules", "react-dom")),
+      path.join(root, "node_modules", "react-dom"),
+      "junction",
+    );
+    await fs.writeFile(path.join(root, "package.json"), '{"private":true,"type":"module"}');
+    await fs.writeFile(
+      path.join(root, "farm.config.ts"),
+      `export default {
+  plugins: [{
+    name: "binary-runtime-response",
+    beforeRequest(req, res) {
+      if (req.url !== "/binary") return;
+      res.statusCode = 200;
+      res.setHeader("content-type", "application/octet-stream");
+      res.write(Buffer.from([0, 255, 1]));
+      res.end(Buffer.from([128, 2]));
+    },
+    runtime: {
+      async after({ response }) {
+        const bytes = Buffer.from(await response.arrayBuffer());
+        const headers = new Headers(response.headers);
+        headers.set("x-runtime-body", bytes.toString("hex"));
+        return new Response(bytes, { status: response.status, headers });
+      },
+    },
+  }],
+};`,
+    );
+    await writeModule(
+      root,
+      "src/app/layout.tsx",
+      `import React from "react";
+export default function Layout({ children }) { return <>{children}</>; }`,
+    );
+    await writeModule(
+      root,
+      "src/app/page.tsx",
+      `import React from "react";
+export default function Page() { return <main>home</main>; }`,
+    );
+
+    const server = await createServer({ root, images: { provider: "none" } });
+    servers.add(server);
+    await server.listen(0);
+    const address = server.httpServer?.address();
+    if (!address || typeof address === "string") throw new Error("Missing dev server address");
+
+    const response = await fetch(`http://localhost:${address.port}/binary`);
+    const bytes = Buffer.from(await response.arrayBuffer());
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("x-runtime-body")).toBe("00ff018002");
+    expect([...bytes]).toEqual([0, 255, 1, 128, 2]);
+
+    const pageResponse = await fetch(`http://localhost:${address.port}/`);
+    expect(pageResponse.headers.get("x-runtime-body")).toMatch(/^[a-f0-9]+$/);
+    await expect(pageResponse.text()).resolves.toContain("home");
+  }, 30_000);
+});

--- a/packages/farm/src/plugin.ts
+++ b/packages/farm/src/plugin.ts
@@ -13,6 +13,8 @@ import {
 import { getFarmPluginIntegrationContext } from "./plugin-integration-context";
 
 type MaybePromise<T> = T | Promise<T>;
+/** @internal Marks a Node response whose intercepted end is awaiting response hooks. */
+export const FARM_NODE_RESPONSE_END_PENDING = Symbol.for("farm.nodeResponseEndPending");
 declare const FARM_PLUGIN_INTEGRATION_INSTANCE: unique symbol;
 declare const FARM_PLUGIN_INTEGRATION_BOUND: unique symbol;
 
@@ -1363,7 +1365,7 @@ export class PluginManager {
           // Check if response is already sent (only for beforeRequest)
           if (hookName === "beforeRequest") {
             const res = args[1];
-            if (res && res.writableEnded) {
+            if (res && (res.writableEnded || res[FARM_NODE_RESPONSE_END_PENDING])) {
               return true;
             }
           }

--- a/packages/farm/src/vite.ts
+++ b/packages/farm/src/vite.ts
@@ -3,7 +3,12 @@ import type { FarmConfig, FarmRequest } from "./types";
 import { FarmApp } from "./app";
 import { logger, toPosixPath, toViteModuleId } from "./utils";
 import { defaultGlobalCSS } from "./default-styles";
-import type { FarmPlugin, FarmPluginRuntimeSession, PluginManager } from "./plugin";
+import {
+  FARM_NODE_RESPONSE_END_PENDING,
+  type FarmPlugin,
+  type FarmPluginRuntimeSession,
+  type PluginManager,
+} from "./plugin";
 import { generateFarmClientPluginEntryCode } from "./client-plugin-build";
 import { APIRouteManager } from "./api/route-manager";
 import { DEFAULT_FARM_API_BASE_PATH } from "./api/config";
@@ -428,6 +433,29 @@ function toNodeResponseBuffer(chunk: unknown, encoding?: unknown): Buffer | unde
   );
 }
 
+function applyNodeWriteHeadHeaders(res: any, headers: unknown): void {
+  if (Array.isArray(headers)) {
+    const grouped = new Map<string, { name: string; values: Array<string | number> }>();
+    for (let index = 0; index + 1 < headers.length; index += 2) {
+      const name = String(headers[index]);
+      const key = name.toLowerCase();
+      const entry = grouped.get(key) ?? { name, values: [] };
+      const value = headers[index + 1];
+      entry.values.push(...(Array.isArray(value) ? value : [value]).map(String));
+      grouped.set(key, entry);
+    }
+    for (const { name, values } of grouped.values()) {
+      res.setHeader(name, values.length === 1 ? values[0] : values);
+    }
+    return;
+  }
+
+  if (!headers || typeof headers !== "object") return;
+  for (const [name, value] of Object.entries(headers)) {
+    if (value !== undefined) res.setHeader(name, value);
+  }
+}
+
 function interceptFarmDevPageResponse(options: {
   req: any;
   res: any;
@@ -459,6 +487,8 @@ function interceptFarmDevPageResponse(options: {
   } = options;
   const originalWrite = res.write.bind(res);
   const originalEnd = res.end.bind(res);
+  const originalWriteHead = res.writeHead.bind(res);
+  const originalFlushHeaders = res.flushHeaders?.bind(res);
   let afterResponseCalled = false;
   let interceptedEnd = false;
   const htmlChunks: Buffer[] = [];
@@ -467,6 +497,31 @@ function interceptFarmDevPageResponse(options: {
   const bufferPluginResponse = Boolean(
     hasHTMLTransformHook || (runtimeSession && hasRuntimeAfterHook),
   );
+  const shouldBufferCurrentResponse = () => {
+    const contentTypeHeader = res.getHeader("content-type") || res.getHeader("Content-Type");
+    const contentType = typeof contentTypeHeader === "string" ? contentTypeHeader : "";
+    return contentType.includes("text/html")
+      ? bufferPluginResponse
+      : Boolean(runtimeSession && hasRuntimeAfterHook);
+  };
+
+  res.writeHead = ((statusCode: number, ...args: unknown[]) => {
+    const statusMessage = typeof args[0] === "string" ? args[0] : undefined;
+    const headers = statusMessage === undefined ? args[0] : args[1];
+    res.statusCode = statusCode;
+    if (statusMessage !== undefined) res.statusMessage = statusMessage;
+    applyNodeWriteHeadHeaders(res, headers);
+
+    if (shouldBufferCurrentResponse()) return res;
+    return statusMessage === undefined
+      ? originalWriteHead(statusCode)
+      : originalWriteHead(statusCode, statusMessage);
+  }) as any;
+
+  if (originalFlushHeaders) {
+    res.flushHeaders = (() =>
+      shouldBufferCurrentResponse() ? undefined : originalFlushHeaders()) as any;
+  }
 
   res.write = ((chunk: unknown, ...args: unknown[]) => {
     const contentTypeHeader = res.getHeader("content-type") || res.getHeader("Content-Type");
@@ -497,7 +552,8 @@ function interceptFarmDevPageResponse(options: {
 
   res.end = ((...args: unknown[]) => {
     interceptedEnd = true;
-    if (afterResponseCalled) return originalEnd(...args);
+    res[FARM_NODE_RESPONSE_END_PENDING] = true;
+    if (afterResponseCalled) return res;
 
     afterResponseCalled = true;
     options.logResponse(method, urlPath, res.statusCode || 200, Date.now() - startTime, "PAGE");
@@ -571,7 +627,14 @@ function interceptFarmDevPageResponse(options: {
       .then(() =>
         hasAfterResponseHook ? pm.runHookParallel("afterResponse", req, res) : undefined,
       )
-      .then(() => originalEnd(...originalEndArgs))
+      .then(() => {
+        res.write = originalWrite;
+        res.end = originalEnd;
+        res.writeHead = originalWriteHead;
+        if (originalFlushHeaders) res.flushHeaders = originalFlushHeaders;
+        delete res[FARM_NODE_RESPONSE_END_PENDING];
+        originalEnd(...originalEndArgs);
+      })
       .catch((error) => {
         void options.emitError(error);
         console.error("Error in afterResponse hook:", error);
@@ -580,8 +643,18 @@ function interceptFarmDevPageResponse(options: {
           : Boolean(runtimeSession && hasRuntimeAfterHook);
         if (shouldBufferResponse) {
           const body = Buffer.concat(isHtmlResponse ? htmlChunks : responseChunks);
+          res.write = originalWrite;
+          res.end = originalEnd;
+          res.writeHead = originalWriteHead;
+          if (originalFlushHeaders) res.flushHeaders = originalFlushHeaders;
+          delete res[FARM_NODE_RESPONSE_END_PENDING];
           originalEnd(body, callback);
         } else {
+          res.write = originalWrite;
+          res.end = originalEnd;
+          res.writeHead = originalWriteHead;
+          if (originalFlushHeaders) res.flushHeaders = originalFlushHeaders;
+          delete res[FARM_NODE_RESPONSE_END_PENDING];
           originalEnd(...originalEndArgs);
         }
       });

--- a/packages/farm/src/vite.ts
+++ b/packages/farm/src/vite.ts
@@ -418,6 +418,182 @@ function applyWebResponseToNodeResponse(
   });
 }
 
+function toNodeResponseBuffer(chunk: unknown, encoding?: unknown): Buffer | undefined {
+  if (chunk === undefined || chunk === null || typeof chunk === "function") return undefined;
+  if (Buffer.isBuffer(chunk)) return chunk;
+  if (chunk instanceof Uint8Array) return Buffer.from(chunk);
+  return Buffer.from(
+    String(chunk),
+    typeof encoding === "string" ? (encoding as BufferEncoding) : "utf8",
+  );
+}
+
+function interceptFarmDevPageResponse(options: {
+  req: any;
+  res: any;
+  pm: PluginManager;
+  runtimeSession?: FarmPluginRuntimeSession;
+  hasRuntimeAfterHook: boolean;
+  hasAfterResponseHook: boolean;
+  hasHTMLTransformHook: boolean;
+  renderPayload: Record<string, unknown>;
+  method: string;
+  urlPath: string;
+  pathname: string;
+  startTime: number;
+  logResponse(method: string, path: string, status: number, durationMs: number, type: "PAGE"): void;
+  emitError(error: unknown): Promise<void>;
+}): { isEnded(): boolean } {
+  const {
+    req,
+    res,
+    pm,
+    runtimeSession,
+    hasRuntimeAfterHook,
+    hasAfterResponseHook,
+    hasHTMLTransformHook,
+    renderPayload,
+    method,
+    urlPath,
+    startTime,
+  } = options;
+  const originalWrite = res.write.bind(res);
+  const originalEnd = res.end.bind(res);
+  let afterResponseCalled = false;
+  let interceptedEnd = false;
+  const htmlChunks: Buffer[] = [];
+  const responseChunks: Buffer[] = [];
+  let didStreamHtml = false;
+  const bufferPluginResponse = Boolean(
+    hasHTMLTransformHook || (runtimeSession && hasRuntimeAfterHook),
+  );
+
+  res.write = ((chunk: unknown, ...args: unknown[]) => {
+    const contentTypeHeader = res.getHeader("content-type") || res.getHeader("Content-Type");
+    const contentType = typeof contentTypeHeader === "string" ? contentTypeHeader : "";
+    const isHtmlResponse = contentType.includes("text/html");
+    const bufferChunk = toNodeResponseBuffer(chunk, args[0]);
+
+    if (isHtmlResponse && bufferChunk) {
+      htmlChunks.push(bufferChunk);
+      didStreamHtml = true;
+    } else if (runtimeSession && hasRuntimeAfterHook && bufferChunk) {
+      responseChunks.push(bufferChunk);
+    }
+
+    const shouldBufferResponse = isHtmlResponse
+      ? bufferPluginResponse
+      : Boolean(runtimeSession && hasRuntimeAfterHook);
+    if (shouldBufferResponse) {
+      const callback = args.find((arg) => typeof arg === "function") as (() => void) | undefined;
+      callback?.();
+      return true;
+    }
+
+    const writeResult = originalWrite(chunk, ...args);
+    if (isHtmlResponse && typeof res.flush === "function") res.flush();
+    return writeResult;
+  }) as any;
+
+  res.end = ((...args: unknown[]) => {
+    interceptedEnd = true;
+    if (afterResponseCalled) return originalEnd(...args);
+
+    afterResponseCalled = true;
+    options.logResponse(method, urlPath, res.statusCode || 200, Date.now() - startTime, "PAGE");
+    const originalEndArgs = [...args];
+    const callback =
+      typeof originalEndArgs[originalEndArgs.length - 1] === "function"
+        ? (originalEndArgs[originalEndArgs.length - 1] as () => void)
+        : undefined;
+    const contentTypeHeader = res.getHeader("content-type") || res.getHeader("Content-Type");
+    const contentType = typeof contentTypeHeader === "string" ? contentTypeHeader : "";
+    const isHtmlResponse = contentType.includes("text/html");
+    const finalChunk = toNodeResponseBuffer(args[0], args[1]);
+    if (finalChunk) {
+      if (isHtmlResponse) htmlChunks.push(finalChunk);
+      else if (runtimeSession && hasRuntimeAfterHook) responseChunks.push(finalChunk);
+    }
+
+    Promise.resolve()
+      .then(async () => {
+        if (isHtmlResponse) {
+          const fullHtml = Buffer.concat(htmlChunks).toString("utf8");
+          if (!didStreamHtml || bufferPluginResponse) {
+            let html = await pm.runHookSerial("transformHTML", fullHtml);
+            html = await pm.runHookSerial("afterRender", html, renderPayload);
+            originalEndArgs.length = 0;
+            originalEndArgs.push(html);
+            if (callback) originalEndArgs.push(callback);
+          } else {
+            await pm.runHookSerial("transformHTML", fullHtml);
+            await pm.runHookSerial("afterRender", fullHtml, renderPayload);
+          }
+        }
+
+        if (runtimeSession) {
+          pm.copyRequestContext(req, runtimeSession.request);
+          const status = res.statusCode || 200;
+          const canHaveBody =
+            method !== "HEAD" && status !== 204 && status !== 205 && status !== 304;
+          const firstArg = originalEndArgs[0];
+          const responseBody = canHaveBody
+            ? isHtmlResponse
+              ? didStreamHtml && !bufferPluginResponse
+                ? Buffer.concat(htmlChunks)
+                : toNodeResponseBuffer(firstArg, originalEndArgs[1])
+              : hasRuntimeAfterHook
+                ? Buffer.concat(responseChunks)
+                : toNodeResponseBuffer(firstArg, originalEndArgs[1])
+            : null;
+          const runtimeResponse = await pm.endRuntimeRequest(
+            runtimeSession,
+            new Response(responseBody ? toRequestBody(responseBody) : responseBody, {
+              status,
+              headers: createHeadersFromNodeResponse(res),
+            }),
+          );
+          applyWebResponseToNodeResponse(runtimeResponse, res);
+
+          const canReplaceOutput = isHtmlResponse
+            ? !didStreamHtml || bufferPluginResponse
+            : hasRuntimeAfterHook;
+          if (canReplaceOutput) {
+            const body = runtimeResponse.body
+              ? Buffer.from(await runtimeResponse.arrayBuffer())
+              : undefined;
+            originalEndArgs.length = 0;
+            if (body) originalEndArgs.push(body);
+            if (callback) originalEndArgs.push(callback);
+          }
+        }
+      })
+      .then(() =>
+        hasAfterResponseHook ? pm.runHookParallel("afterResponse", req, res) : undefined,
+      )
+      .then(() => originalEnd(...originalEndArgs))
+      .catch((error) => {
+        void options.emitError(error);
+        console.error("Error in afterResponse hook:", error);
+        const shouldBufferResponse = isHtmlResponse
+          ? bufferPluginResponse
+          : Boolean(runtimeSession && hasRuntimeAfterHook);
+        if (shouldBufferResponse) {
+          const body = Buffer.concat(isHtmlResponse ? htmlChunks : responseChunks);
+          originalEnd(body, callback);
+        } else {
+          originalEnd(...originalEndArgs);
+        }
+      });
+
+    return res;
+  }) as any;
+
+  return {
+    isEnded: () => interceptedEnd || res.writableEnded,
+  };
+}
+
 function getFullEnvDefine(config: FarmVitePluginOptions): {
   server: Record<string, unknown>;
   public: Record<string, unknown>;
@@ -2356,6 +2532,34 @@ window.__FARM_MANIFEST__ = ${inlineValue({
             }
           }
 
+          // Runtime response transforms need the complete byte stream, including
+          // responses completed by middleware or beforeRequest hooks.
+          const shouldInterceptResponse = Boolean(
+            pm &&
+            (hasAfterResponseHook ||
+              hasHTMLTransformHook ||
+              (runtimeSession && hasRuntimeAfterHook)),
+          );
+          const responseInterceptor =
+            pm && shouldInterceptResponse
+              ? interceptFarmDevPageResponse({
+                  req,
+                  res,
+                  pm,
+                  runtimeSession,
+                  hasRuntimeAfterHook,
+                  hasAfterResponseHook,
+                  hasHTMLTransformHook,
+                  renderPayload,
+                  method,
+                  urlPath,
+                  pathname,
+                  startTime,
+                  logResponse,
+                  emitError: (error) => emitPluginError("response-end", error, { pathname }),
+                })
+              : undefined;
+
           try {
             if (middlewareManager?.hasMiddleware()) {
               const middlewareRequest = createRequestFromNodeRequest(req, new URL(fullUrl));
@@ -2365,18 +2569,10 @@ window.__FARM_MANIFEST__ = ${inlineValue({
                   middlewareManager!.execute(req, res),
                 );
               if (handled) {
-                if (pm && runtimeSession) {
-                  pm.copyRequestContext(req, runtimeSession.request);
-                  await pm.endRuntimeRequest(
-                    runtimeSession,
-                    new Response(null, {
-                      status: res.statusCode || 200,
-                      headers: createHeadersFromNodeResponse(res),
-                    }),
-                  );
+                if (!responseInterceptor?.isEnded()) {
+                  const duration = Date.now() - startTime;
+                  logResponse(method, urlPath, res.statusCode || 200, duration, "PAGE");
                 }
-                const duration = Date.now() - startTime;
-                logResponse(method, urlPath, res.statusCode || 200, duration, "PAGE");
                 return; // Middleware handled the response
               }
             }
@@ -2396,169 +2592,12 @@ window.__FARM_MANIFEST__ = ${inlineValue({
               );
             }
 
-            if (res.writableEnded) {
-              if (pm && runtimeSession) {
-                pm.copyRequestContext(req, runtimeSession.request);
-                await pm.endRuntimeRequest(
-                  runtimeSession,
-                  new Response(null, {
-                    status: res.statusCode || 200,
-                    headers: createHeadersFromNodeResponse(res),
-                  }),
-                );
+            if (res.writableEnded || responseInterceptor?.isEnded()) {
+              if (!responseInterceptor?.isEnded()) {
+                const duration = Date.now() - startTime;
+                logResponse(method, urlPath, res.statusCode || 200, duration, "PAGE");
               }
-              // Log response if already ended
-              const duration = Date.now() - startTime;
-              logResponse(method, urlPath, res.statusCode || 200, duration, "PAGE");
               return;
-            }
-
-            // Only intercept streamed output when an installed plugin can
-            // observe or replace the response. The default dev path can write
-            // directly to Node without buffering and replaying the whole HTML.
-            const shouldInterceptResponse = Boolean(
-              pm &&
-              (hasAfterResponseHook ||
-                hasHTMLTransformHook ||
-                (runtimeSession && hasRuntimeAfterHook)),
-            );
-            if (pm && shouldInterceptResponse) {
-              const originalWrite = res.write.bind(res);
-              const originalEnd = res.end.bind(res);
-              let afterResponseCalled = false;
-              const htmlChunks: Buffer[] = [];
-              let didStreamHtml = false;
-              const bufferPluginResponse = Boolean(
-                hasHTMLTransformHook || (runtimeSession && hasRuntimeAfterHook),
-              );
-
-              res.write = ((chunk: any, ...args: any[]) => {
-                const contentTypeHeader =
-                  res.getHeader("content-type") || res.getHeader("Content-Type");
-                const contentType = typeof contentTypeHeader === "string" ? contentTypeHeader : "";
-                const isHtmlResponse = contentType.includes("text/html");
-
-                if (isHtmlResponse && chunk !== undefined && chunk !== null) {
-                  const bufferChunk = Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk));
-                  htmlChunks.push(bufferChunk);
-                  didStreamHtml = true;
-                  if (bufferPluginResponse) {
-                    const callback = args.find((arg) => typeof arg === "function");
-                    callback?.();
-                    return true;
-                  }
-                  const writeResult = originalWrite(chunk, ...args);
-                  if (typeof (res as any).flush === "function") {
-                    (res as any).flush();
-                  }
-                  return writeResult;
-                }
-
-                return originalWrite(chunk, ...args);
-              }) as any;
-
-              res.end = ((...args: any[]) => {
-                if (!afterResponseCalled && pm) {
-                  afterResponseCalled = true;
-                  const duration = Date.now() - startTime;
-                  logResponse(method, urlPath, res.statusCode || 200, duration, "PAGE");
-                  const originalEndArgs = [...args];
-                  Promise.resolve()
-                    .then(async () => {
-                      const contentTypeHeader =
-                        res.getHeader("content-type") || res.getHeader("Content-Type");
-                      const contentType =
-                        typeof contentTypeHeader === "string" ? contentTypeHeader : "";
-                      const isHtmlResponse = contentType.includes("text/html");
-                      if (isHtmlResponse) {
-                        const firstArg = args[0];
-                        if (typeof firstArg === "string" || Buffer.isBuffer(firstArg)) {
-                          const bufferChunk = Buffer.isBuffer(firstArg)
-                            ? firstArg
-                            : Buffer.from(firstArg, "utf-8");
-                          htmlChunks.push(bufferChunk);
-                        }
-
-                        const fullHtml = Buffer.concat(htmlChunks).toString("utf-8");
-                        let html = fullHtml;
-                        if (!didStreamHtml || bufferPluginResponse) {
-                          html = await pm.runHookSerial("transformHTML", html);
-                          html = await pm.runHookSerial("afterRender", html, renderPayload);
-                          const callback =
-                            typeof originalEndArgs[originalEndArgs.length - 1] === "function"
-                              ? originalEndArgs[originalEndArgs.length - 1]
-                              : undefined;
-                          originalEndArgs.length = 0;
-                          originalEndArgs.push(html);
-                          if (callback) originalEndArgs.push(callback);
-                        } else {
-                          await pm.runHookSerial("transformHTML", fullHtml);
-                          await pm.runHookSerial("afterRender", fullHtml, renderPayload);
-                        }
-                      }
-
-                      if (runtimeSession) {
-                        pm.copyRequestContext(req, runtimeSession.request);
-                        const status = res.statusCode || 200;
-                        const canHaveBody =
-                          method !== "HEAD" && status !== 204 && status !== 205 && status !== 304;
-                        const firstArg = originalEndArgs[0];
-                        const responseBody = canHaveBody
-                          ? isHtmlResponse
-                            ? didStreamHtml && !bufferPluginResponse
-                              ? Buffer.concat(htmlChunks)
-                              : typeof firstArg === "string" || Buffer.isBuffer(firstArg)
-                                ? firstArg
-                                : undefined
-                            : typeof firstArg === "string" || Buffer.isBuffer(firstArg)
-                              ? firstArg
-                              : undefined
-                          : null;
-                        const runtimeResponse = await pm.endRuntimeRequest(
-                          runtimeSession,
-                          new Response(
-                            Buffer.isBuffer(responseBody)
-                              ? responseBody.toString("utf8")
-                              : responseBody,
-                            {
-                              status,
-                              headers: createHeadersFromNodeResponse(res),
-                            },
-                          ),
-                        );
-                        applyWebResponseToNodeResponse(runtimeResponse, res);
-
-                        if (!didStreamHtml || bufferPluginResponse) {
-                          const callback =
-                            typeof originalEndArgs[originalEndArgs.length - 1] === "function"
-                              ? originalEndArgs[originalEndArgs.length - 1]
-                              : undefined;
-                          const body = runtimeResponse.body
-                            ? Buffer.from(await runtimeResponse.arrayBuffer())
-                            : undefined;
-                          originalEndArgs.length = 0;
-                          if (body) originalEndArgs.push(body);
-                          if (callback) originalEndArgs.push(callback);
-                        }
-                      }
-                    })
-                    .then(() =>
-                      hasAfterResponseHook
-                        ? pm.runHookParallel("afterResponse", req, res)
-                        : undefined,
-                    )
-                    .then(() => {
-                      originalEnd(...originalEndArgs);
-                    })
-                    .catch((err) => {
-                      emitPluginError("response-end", err, { pathname }).catch(() => {});
-                      console.error("Error in afterResponse hook:", err);
-                      originalEnd(...originalEndArgs);
-                    });
-                } else {
-                  originalEnd(...args);
-                }
-              }) as any;
             }
 
             // Note: __FARM_PROPS__ is set by the renderer with actual page props (params, searchParams)


### PR DESCRIPTION
## Problem

The Vite response bridge could corrupt binary bodies through UTF-8 conversion. Responses completed by middleware or `beforeRequest` also reached `runtime.after` with an empty body and ignored transformed output.

## Root cause

Development buffered only rendered HTML, installed interception after early request hooks, and could commit `writeHead` before asynchronous response hooks completed. Production already carries a complete Web Response through this pipeline.

## Change

Install interception before middleware and request hooks, retain arbitrary chunks as bytes, and defer headers and `end` only when response hooks need the complete response. Runtime transforms can now replace status, headers, and body before Node commits them.

## Safety and compatibility

The no-plugin path remains direct and unbuffered. HTML continues streaming unless a transform requires buffering. Redirect short-circuits stop later request hooks, and HEAD plus bodyless status semantics remain intact.

## Verification

- `pnpm --filter @farm.js/core test` (200 files, 1,740 passed, 1 skipped)
- focused bridge, rewrite, and lifecycle tests (15 passed)
- `pnpm --filter @farm.js/core type-check`
- focused Oxlint and `git diff --check`

The regression streams `[0, 255, 1, 128, 2]`, checks an early redirect with deferred headers, and verifies ordinary rendered HTML.

## Documentation and release

None. This aligns development runtime semantics with production.