### PR TITLE
fix(server): preserve repeated Set-Cookie headers

### DIFF
--- a/packages/farm/src/__tests__/server-response.test.ts
+++ b/packages/farm/src/__tests__/server-response.test.ts
@@ -1,7 +1,27 @@
 import { describe, expect, it } from "vitest";
-import { sendWebResponse } from "../server/response";
+import { applyWebResponseHeaders, sendWebResponse } from "../server/response";
 
 describe("sendWebResponse", () => {
+  it("keeps repeated Set-Cookie fields separate in Node response adapters", () => {
+    const headers = new Map<string, string | string[]>();
+    const responseHeaders = new Headers();
+    responseHeaders.append("set-cookie", "session=abc; Path=/; HttpOnly");
+    responseHeaders.append("set-cookie", "csrf=xyz; Path=/");
+
+    applyWebResponseHeaders(
+      {
+        getHeader: (key) => headers.get(String(key)),
+        setHeader: (key, value) => headers.set(String(key), value as string | string[]),
+      } as any,
+      responseHeaders,
+    );
+
+    expect(headers.get("Set-Cookie")).toEqual([
+      "session=abc; Path=/; HttpOnly",
+      "csrf=xyz; Path=/",
+    ]);
+  });
+
   it("keeps comma-joined fallback cookies separate without splitting Expires", async () => {
     const headers = new Map<string, string | string[]>();
     const res = {

--- a/packages/farm/src/nitro/dev-server.ts
+++ b/packages/farm/src/nitro/dev-server.ts
@@ -3,6 +3,7 @@ import type { ViteDevServer } from "vite";
 import type { IncomingMessage, ServerResponse } from "http";
 import { H3Event, toNodeListener } from "h3";
 import { fromWebHandler } from "h3";
+import { sendWebResponse } from "../server/response";
 
 /**
  * Convert Node.js request to Web Standard Request
@@ -35,29 +36,7 @@ function nodeToWebRequest(req: IncomingMessage, baseUrl: string): Request {
  * Convert Web Standard Response to Node.js response
  */
 async function webToNodeResponse(res: ServerResponse, webRes: Response): Promise<void> {
-  // Set status
-  res.statusCode = webRes.status;
-
-  // Set headers
-  webRes.headers.forEach((value, key) => {
-    res.setHeader(key, value);
-  });
-
-  // Write body
-  if (webRes.body) {
-    const reader = webRes.body.getReader();
-    try {
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) break;
-        res.write(value);
-      }
-    } finally {
-      reader.releaseLock();
-    }
-  }
-
-  res.end();
+  await sendWebResponse(res, webRes);
 }
 
 /**

--- a/packages/farm/src/server.ts
+++ b/packages/farm/src/server.ts
@@ -10,6 +10,7 @@ export * from "./after";
 export * from "./server-query";
 export { createServer, DEFAULT_FARM_DEV_SERVER_PORT, startDevServer } from "./server/create-server";
 export { getCurrentRequest } from "./server/request";
+export { sendWebResponse } from "./server/response";
 export { getTheme, getThemeSnapshot } from "./theme/server";
 export * from "./server-action-security";
 export * from "./layers";

--- a/packages/farm/src/server/response.ts
+++ b/packages/farm/src/server/response.ts
@@ -104,36 +104,50 @@ function splitSetCookieHeader(value: string): string[] {
   return cookies.filter(Boolean);
 }
 
-export async function sendWebResponse(res: ServerResponse, response: Response): Promise<void> {
-  res.statusCode = response.status;
-
-  const appendSetCookies = (cookies: readonly string[]) => {
-    const existing = typeof res.getHeader === "function" ? res.getHeader("Set-Cookie") : undefined;
-    const existingCookies = Array.isArray(existing)
-      ? existing.map(String)
-      : existing === undefined
-        ? []
-        : [String(existing)];
-    res.setHeader("Set-Cookie", [...existingCookies, ...cookies]);
-  };
-
-  const responseHeaders = response.headers as Headers & {
+export function applyWebResponseHeaders(
+  res: Pick<ServerResponse, "setHeader"> & Partial<Pick<ServerResponse, "getHeader">>,
+  headers: Headers,
+  options: { appendSetCookie?: boolean } = {},
+): void {
+  const responseHeaders = headers as Headers & {
     getSetCookie?: () => string[];
     raw?: () => Record<string, string[]>;
   };
   const rawSetCookies = responseHeaders.raw?.()["set-cookie"];
   const setCookies = responseHeaders.getSetCookie?.() || rawSetCookies || [];
-  if (setCookies.length > 0) {
-    appendSetCookies(setCookies);
-  }
+  const existing =
+    options.appendSetCookie && typeof res.getHeader === "function"
+      ? res.getHeader("Set-Cookie")
+      : undefined;
+  const existingCookies = Array.isArray(existing)
+    ? existing.map(String)
+    : existing === undefined
+      ? []
+      : [String(existing)];
 
-  response.headers.forEach((value, key) => {
+  let fallbackSetCookie = "";
+  headers.forEach((value, key) => {
     if (key.toLowerCase() === "set-cookie") {
-      if (setCookies.length === 0) appendSetCookies(splitSetCookieHeader(value));
+      fallbackSetCookie = value;
       return;
     }
     res.setHeader(key, value);
   });
+
+  const cookies =
+    setCookies.length > 0
+      ? setCookies
+      : fallbackSetCookie
+        ? splitSetCookieHeader(fallbackSetCookie)
+        : [];
+  if (cookies.length > 0) {
+    res.setHeader("Set-Cookie", [...existingCookies, ...cookies]);
+  }
+}
+
+export async function sendWebResponse(res: ServerResponse, response: Response): Promise<void> {
+  res.statusCode = response.status;
+  applyWebResponseHeaders(res, response.headers, { appendSetCookie: true });
 
   if (!response.body) {
     res.end();

--- a/packages/farm/src/vite.ts
+++ b/packages/farm/src/vite.ts
@@ -25,7 +25,7 @@ import {
 import type { FarmDocsAPIHandler } from "./docs";
 import { createMarkdownMirrorResponse, resolveMarkdownMirrorTarget } from "./markdown";
 import { createFarmMarkdownSourceResponse, isFarmMarkdownPageFile } from "./app-markdown";
-import { sendWebResponse } from "./server/response";
+import { applyWebResponseHeaders, sendWebResponse } from "./server/response";
 import {
   getClientModuleMetadata,
   getIslandStrategyExport,
@@ -418,9 +418,7 @@ function applyWebResponseToNodeResponse(
   for (const name of res.getHeaderNames()) {
     res.removeHeader(name);
   }
-  response.headers.forEach((value, key) => {
-    res.setHeader(key, value);
-  });
+  applyWebResponseHeaders(res as any, response.headers);
 }
 
 function toNodeResponseBuffer(chunk: unknown, encoding?: unknown): Buffer | undefined {

--- a/packages/farmjs-plugin/src/api/index.ts
+++ b/packages/farmjs-plugin/src/api/index.ts
@@ -25,6 +25,7 @@
 import type { Plugin, ViteDevServer } from "vite";
 import { _withAfterNodeMiddleware } from "@farm.js/core/after";
 import { invokeAPIRouteEndpoint } from "@farm.js/core/api/runtime";
+import { sendWebResponse } from "@farm.js/core/server";
 
 export interface FarmApiOptions {
   /** Source directory containing the api folder (default: 'src') */
@@ -396,14 +397,7 @@ export default function farmApi(options: FarmApiOptions = {}): Plugin {
               const duration = Date.now() - startTime;
               logResponse(method, pathname, response.status, duration);
 
-              // Send response
-              res.statusCode = response.status;
-              response.headers.forEach((value, key) => {
-                res.setHeader(key, value);
-              });
-
-              const responseBody = await response.text();
-              res.end(responseBody);
+              await sendWebResponse(res, response);
             } catch (error: any) {
               const duration = Date.now() - startTime;
               logResponse(method, pathname, 500, duration);


### PR DESCRIPTION
## Problem

Several Web Response to Node adapters iterated `Headers` and called `setHeader()` for every value. Depending on the Fetch implementation, repeated `Set-Cookie` fields were either overwritten or exposed as a comma-joined value, which is not valid cookie forwarding.

## Root cause

Only the main `sendWebResponse()` path understood `Headers.getSetCookie()`, raw header arrays, and the legacy comma-joined fallback. The Vite runtime bridge, Nitro development server, and standalone API plugin each reimplemented a lossy adapter.

## Change

Extract the established repeated-cookie header logic into one shared helper. Use the shared response sender in Nitro development and the API plugin, and use its header portion when a Vite runtime response replaces Node response metadata.

## Safety and compatibility

Existing response cookies are still appended by `sendWebResponse()`. Fresh adapter responses replace their cookie field with the complete array. Ordinary headers, streamed bodies, binary bodies, status codes, and disconnect handling continue through the established sender.

## Verification

- `pnpm --filter @farm.js/core exec vitest run src/__tests__/server-response.test.ts src/__tests__/send-web-response.test.ts` (6/6)
- `pnpm --filter @farm.js/core type-check`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @farm.js/core build`
- `pnpm --filter @farm.js/plugin typecheck`
- `pnpm --filter @farm.js/plugin test` passed 55 tests; its unrelated isolated Nitro copy test could not complete because the machine had 173 MB free and reported `ENOSPC`.
- Focused oxlint and `git diff --check`

The repeated-cookie regression fails with the previous per-header adapter behavior.

## Documentation and release

None. This restores standard HTTP response semantics.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes repeated `Set-Cookie` headers being dropped or comma-joined in the Vite runtime bridge, Nitro dev server, and API plugin. These adapters now route through the shared response sender, so multiple cookies reach the Node response intact.

**Behavior**
- `sendWebResponse()` still appends cookies to any existing `Set-Cookie` value; the adapter paths replace the cookie field with the complete array.
- Streamed bodies, binary bodies, status codes, and disconnect handling are unchanged.

<sup>Written for commit f87db5f0ee354d7939803b54a53bf12fff2664e1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/916?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

