### PR TITLE
fix(search): contain index output through symlinks

### DIFF
--- a/packages/farm-search/src/build.test.ts
+++ b/packages/farm-search/src/build.test.ts
@@ -1,4 +1,4 @@
-import { access, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { access, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -73,6 +73,30 @@ describe.sequential("writeSearchIndex", () => {
         options: resolveSearchOptions({ include: ["/docs/**"] }),
       }),
     ).rejects.toThrow("No static HTML pages matched");
+  });
+
+  it("does not delete or write outside publicDir through a symlinked output parent", async () => {
+    const { root, outputDir, publicDir } = await createOutput();
+    const externalDir = path.join(root, "external");
+    const externalSearchDir = path.join(externalDir, "_farm", "search");
+    const sentinelPath = path.join(externalSearchDir, "sentinel.txt");
+    await mkdir(externalSearchDir, { recursive: true });
+    await writeFile(sentinelPath, "keep me");
+    await writeFile(path.join(publicDir, "index.html"), page("Home", "Farm home"));
+    await symlink(externalDir, path.join(publicDir, "app"), "junction");
+
+    await expect(
+      writeSearchIndex({
+        outputDir,
+        publicDir,
+        preset: "node-server",
+        basePath: "/app",
+        options: resolveSearchOptions(),
+      }),
+    ).rejects.toThrow("including through symlinks");
+
+    await expect(readFile(sentinelPath, "utf8")).resolves.toBe("keep me");
+    await expect(access(path.join(externalSearchDir, "pagefind.js"))).rejects.toThrow();
   });
 });
 

--- a/packages/farm-search/src/build.test.ts
+++ b/packages/farm-search/src/build.test.ts
@@ -98,6 +98,25 @@ describe.sequential("writeSearchIndex", () => {
     await expect(readFile(sentinelPath, "utf8")).resolves.toBe("keep me");
     await expect(access(path.join(externalSearchDir, "pagefind.js"))).rejects.toThrow();
   });
+
+  it("rejects a dangling symlink in the output path", async () => {
+    const { root, outputDir, publicDir } = await createOutput();
+    const externalDir = path.join(root, "missing-external");
+    await writeFile(path.join(publicDir, "index.html"), page("Home", "Farm home"));
+    await symlink(externalDir, path.join(publicDir, "app"), "junction");
+
+    await expect(
+      writeSearchIndex({
+        outputDir,
+        publicDir,
+        preset: "node-server",
+        basePath: "/app",
+        options: resolveSearchOptions(),
+      }),
+    ).rejects.toThrow("including through symlinks");
+
+    await expect(access(externalDir)).rejects.toThrow();
+  });
 });
 
 describe("search route matching", () => {

--- a/packages/farm-search/src/build.ts
+++ b/packages/farm-search/src/build.ts
@@ -192,7 +192,12 @@ async function collectHtmlFiles(root: string, ignoredDirectory: string): Promise
 function resolveOutputPath(publicDir: string, bundlePath: string): string {
   const outputPath = path.resolve(publicDir, `.${bundlePath}`);
   const relative = path.relative(publicDir, outputPath);
-  if (!relative || relative.startsWith("..") || path.isAbsolute(relative)) {
+  if (
+    !relative ||
+    relative === ".." ||
+    relative.startsWith(`..${path.sep}`) ||
+    path.isAbsolute(relative)
+  ) {
     throw new Error("[farm:search] Search output must stay inside the public output directory");
   }
   return outputPath;
@@ -215,7 +220,7 @@ async function assertOutputPathInside(publicDir: string, outputPath: string): Pr
   }
 
   const relative = path.relative(realPublicDir, existingAncestor);
-  if (relative.startsWith("..") || path.isAbsolute(relative)) {
+  if (relative === ".." || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) {
     throw new Error(
       "[farm:search] Search output must stay inside the public output directory, including through symlinks",
     );

--- a/packages/farm-search/src/build.ts
+++ b/packages/farm-search/src/build.ts
@@ -1,4 +1,4 @@
-import { mkdir, readFile, readdir, rm } from "node:fs/promises";
+import { mkdir, readFile, readdir, realpath, rm } from "node:fs/promises";
 import path from "node:path";
 import * as pagefind from "pagefind";
 import type { ResolvedSearchOptions } from "./config.js";
@@ -25,6 +25,7 @@ export async function writeSearchIndex(input: SearchBuildInput): Promise<SearchB
   const basePath = normalizeBasePath(input.basePath);
   const bundlePath = withBasePath(`/${input.options.output}`, basePath);
   const outputPath = resolveOutputPath(publicDir, bundlePath);
+  await assertOutputPathInside(publicDir, outputPath);
   const htmlFiles = await collectHtmlFiles(publicDir, outputPath);
   const routes = htmlFiles
     .map((file) => ({
@@ -195,6 +196,30 @@ function resolveOutputPath(publicDir: string, bundlePath: string): string {
     throw new Error("[farm:search] Search output must stay inside the public output directory");
   }
   return outputPath;
+}
+
+async function assertOutputPathInside(publicDir: string, outputPath: string): Promise<void> {
+  const realPublicDir = await realpath(publicDir);
+  let existingAncestor = outputPath;
+
+  while (true) {
+    try {
+      existingAncestor = await realpath(existingAncestor);
+      break;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+      const parent = path.dirname(existingAncestor);
+      if (parent === existingAncestor) throw error;
+      existingAncestor = parent;
+    }
+  }
+
+  const relative = path.relative(realPublicDir, existingAncestor);
+  if (relative.startsWith("..") || path.isAbsolute(relative)) {
+    throw new Error(
+      "[farm:search] Search output must stay inside the public output directory, including through symlinks",
+    );
+  }
 }
 
 function pagefindError(action: string, errors: string[]): Error {

--- a/packages/farm-search/src/build.ts
+++ b/packages/farm-search/src/build.ts
@@ -1,4 +1,4 @@
-import { mkdir, readFile, readdir, realpath, rm } from "node:fs/promises";
+import { lstat, mkdir, readFile, readdir, realpath, rm } from "node:fs/promises";
 import path from "node:path";
 import * as pagefind from "pagefind";
 import type { ResolvedSearchOptions } from "./config.js";
@@ -213,6 +213,14 @@ async function assertOutputPathInside(publicDir: string, outputPath: string): Pr
       break;
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+      try {
+        await lstat(existingAncestor);
+        throw new Error(
+          "[farm:search] Search output must stay inside the public output directory, including through symlinks",
+        );
+      } catch (statError) {
+        if ((statError as NodeJS.ErrnoException).code !== "ENOENT") throw statError;
+      }
       const parent = path.dirname(existingAncestor);
       if (parent === existingAncestor) throw error;
       existingAncestor = parent;


### PR DESCRIPTION
## Problem

The search plugin checks its Pagefind output path lexically, but a symlinked parent under the public directory can resolve outside the application. Generating search output can then delete existing files and write Pagefind assets outside the project.

## Root cause

`resolveOutputPath` compared unresolved paths and did not validate the filesystem location of the closest existing output ancestor before `rm`, `mkdir`, and Pagefind writes.

## Change

Resolve the public directory and nearest existing output ancestor through the filesystem. Reject output that resolves outside the public directory, including dangling symlinks in the output chain.

## Safety and compatibility

Normal output paths and genuinely missing output directories remain supported. Escaping or dangling symlinks fail before destructive or write operations begin.

## Verification

- `pnpm --filter @farm.js/search test` (19 passed)
- `pnpm --filter @farm.js/search type-check`
- focused Oxlint and `git diff --check`

The regressions preserve an external sentinel during an outside-link attempt and verify that a dangling output symlink fails closed.

## Documentation and release

None.