### PR TITLE
fix(react): contain compiler reports through symlinks

### DIFF
--- a/packages/farm-react/src/__tests__/compiler-report.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-report.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment node
 
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -147,5 +147,23 @@ describe("React compiler coverage report", () => {
     expect(outputPath).toBe(join(projectRoot, ".farm", "react-compiler.json"));
     expect(report.version).toBe(1);
     expect(report.summary.compiled).toBe(2);
+  });
+
+  it("does not write a report outside the project through a symlinked parent", async () => {
+    const temporaryRoot = await mkdtemp(join(tmpdir(), "farm-react-report-"));
+    temporaryDirectories.push(temporaryRoot);
+    const projectRoot = join(temporaryRoot, "project");
+    const externalDirectory = join(temporaryRoot, "external");
+    const externalReport = join(externalDirectory, "compiler.json");
+    await mkdir(projectRoot);
+    await mkdir(externalDirectory);
+    await writeFile(externalReport, "keep me");
+    await symlink(externalDirectory, join(projectRoot, "reports"), "junction");
+
+    await expect(
+      writeReactCompilerReport(projectRoot, "reports/compiler.json", observations(projectRoot)),
+    ).rejects.toThrow("including through symlinks");
+
+    await expect(readFile(externalReport, "utf8")).resolves.toBe("keep me");
   });
 });

--- a/packages/farm-react/src/__tests__/compiler-report.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-report.test.ts
@@ -166,4 +166,19 @@ describe("React compiler coverage report", () => {
 
     await expect(readFile(externalReport, "utf8")).resolves.toBe("keep me");
   });
+
+  it("rejects a dangling symlink in the report path", async () => {
+    const temporaryRoot = await mkdtemp(join(tmpdir(), "farm-react-report-"));
+    temporaryDirectories.push(temporaryRoot);
+    const projectRoot = join(temporaryRoot, "project");
+    const externalDirectory = join(temporaryRoot, "external");
+    await mkdir(projectRoot);
+    await mkdir(externalDirectory);
+    await symlink(externalDirectory, join(projectRoot, "reports"), "junction");
+    await rm(externalDirectory, { recursive: true });
+
+    await expect(
+      writeReactCompilerReport(projectRoot, "reports/compiler.json", observations(projectRoot)),
+    ).rejects.toThrow("including through symlinks");
+  });
 });

--- a/packages/farm-react/src/compiler-report.ts
+++ b/packages/farm-react/src/compiler-report.ts
@@ -1,5 +1,5 @@
-import { mkdir, writeFile } from "node:fs/promises";
-import { dirname, relative, resolve } from "node:path";
+import { mkdir, realpath, writeFile } from "node:fs/promises";
+import { dirname, isAbsolute, relative, resolve, sep } from "node:path";
 import type { CompileReactModuleResult, CompilerDiagnostic } from "./compiler";
 
 export interface ReactCompilerModuleObservation {
@@ -152,8 +152,36 @@ export async function writeReactCompilerReport(
   observations: Iterable<ReactCompilerModuleObservation>,
 ): Promise<string> {
   const outputPath = resolve(projectRoot, reportFile);
+  await assertReportPathInsideProject(projectRoot, outputPath);
   const report = createReactCompilerReport(projectRoot, observations);
   await mkdir(dirname(outputPath), { recursive: true });
   await writeFile(outputPath, `${JSON.stringify(report, null, 2)}\n`, "utf8");
   return outputPath;
+}
+
+async function assertReportPathInsideProject(
+  projectRoot: string,
+  outputPath: string,
+): Promise<void> {
+  const realProjectRoot = await realpath(projectRoot);
+  let existingAncestor = outputPath;
+
+  while (true) {
+    try {
+      existingAncestor = await realpath(existingAncestor);
+      break;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+      const parent = dirname(existingAncestor);
+      if (parent === existingAncestor) throw error;
+      existingAncestor = parent;
+    }
+  }
+
+  const relativePath = relative(realProjectRoot, existingAncestor);
+  if (relativePath === ".." || relativePath.startsWith(`..${sep}`) || isAbsolute(relativePath)) {
+    throw new Error(
+      "The React compiler report file must stay inside the project root, including through symlinks.",
+    );
+  }
 }

--- a/packages/farm-react/src/compiler-report.ts
+++ b/packages/farm-react/src/compiler-report.ts
@@ -1,4 +1,4 @@
-import { mkdir, realpath, writeFile } from "node:fs/promises";
+import { lstat, mkdir, realpath, writeFile } from "node:fs/promises";
 import { dirname, isAbsolute, relative, resolve, sep } from "node:path";
 import type { CompileReactModuleResult, CompilerDiagnostic } from "./compiler";
 
@@ -172,6 +172,18 @@ async function assertReportPathInsideProject(
       break;
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+      let existingEntry = false;
+      try {
+        await lstat(existingAncestor);
+        existingEntry = true;
+      } catch (statError) {
+        if ((statError as NodeJS.ErrnoException).code !== "ENOENT") throw statError;
+      }
+      if (existingEntry) {
+        throw new Error(
+          "The React compiler report file must stay inside the project root, including through symlinks.",
+        );
+      }
       const parent = dirname(existingAncestor);
       if (parent === existingAncestor) throw error;
       existingAncestor = parent;


### PR DESCRIPTION
## Problem

A project-relative React compiler report path can escape the project when an existing parent is a symlink to an outside location.

## Root cause

Option normalization rejects absolute paths and ordinary traversal, but the report writer previously used only the lexical destination.

## Change

Resolve the project root and closest existing report ancestor through the filesystem. Reject both outside-resolving and dangling symlinks before creating or overwriting the report.

## Safety and compatibility

The default report, normal custom locations, and projects reached through a symlink remain supported. Only unsafe output chains fail closed.

## Verification

- `pnpm --filter @farm.js/react exec vitest run` (75 files, 805 passed, 11 skipped)
- focused report tests (4 passed)
- `pnpm --filter @farm.js/react type-check`
- focused Oxlint and `git diff --check`

The regressions preserve an external report and explicitly cover a dangling link.

## Documentation and release

None.