### PR TITLE
fix(cf-agent): reject outside deployment config symlinks

### DIFF
--- a/packages/farm-cf-agent/src/__tests__/cf-agent.test.ts
+++ b/packages/farm-cf-agent/src/__tests__/cf-agent.test.ts
@@ -1,4 +1,4 @@
-import { access, mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { access, mkdir, mkdtemp, readFile, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
@@ -64,6 +64,29 @@ describe("Cloudflare Agents integration", () => {
 });
 
 describe("Cloudflare Agents build output", () => {
+  it("rejects a Wrangler config that resolves outside the project", async () => {
+    const temporaryRoot = await mkdtemp(join(tmpdir(), "farm-cf-agent-symlink-"));
+    const root = join(temporaryRoot, "project");
+    const externalDirectory = join(temporaryRoot, "external");
+    await mkdir(root);
+    await mkdir(externalDirectory);
+    await writeFile(join(externalDirectory, "wrangler.jsonc"), '{"main":"agent.mjs"}\n');
+    await symlink(externalDirectory, join(root, "cloudflare"), "junction");
+
+    await expect(
+      writeCloudflareAgentOutput({
+        root,
+        outputDir: ".output",
+        config: "cloudflare/wrangler.jsonc",
+        routePrefix: "/agents",
+      }),
+    ).rejects.toThrow("including through symlinks");
+
+    await expect(
+      access(join(externalDirectory, ".farm-cf-agent.wrangler.jsonc")),
+    ).rejects.toThrow();
+  });
+
   it("composes agent and Farm handlers without changing the user's config", async () => {
     const root = await mkdtemp(join(tmpdir(), "farm-cf-agent-"));
     const outputDir = join(root, ".output");

--- a/packages/farm-cf-agent/src/output.ts
+++ b/packages/farm-cf-agent/src/output.ts
@@ -1,4 +1,4 @@
-import { access, mkdir, readFile, stat, writeFile } from "node:fs/promises";
+import { access, mkdir, readFile, realpath, stat, writeFile } from "node:fs/promises";
 import { basename, dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import { parse, printParseErrorCode, type ParseError } from "jsonc-parser";
 import { normalizeAgentRoutePrefix } from "@farm.js/core/agent-runtime";
@@ -36,6 +36,7 @@ export async function writeCloudflareAgentOutput(
   const outputDir = resolve(root, options.outputDir);
   const configPath = resolve(root, options.config);
   assertInsideRoot(root, configPath, "Wrangler config");
+  await assertRealPathInsideRoot(root, configPath, "Wrangler config");
 
   const configDirectory = dirname(configPath);
   const config = await readWranglerConfig(configPath);
@@ -253,6 +254,19 @@ function assertInsideRoot(root: string, target: string, label: string): void {
   const pathFromRoot = relative(root, target);
   if (pathFromRoot === ".." || pathFromRoot.startsWith(`..${sep}`) || isAbsolute(pathFromRoot)) {
     throw new Error(`${label} must be inside the Farm project root.`);
+  }
+}
+
+async function assertRealPathInsideRoot(
+  root: string,
+  target: string,
+  label: string,
+): Promise<void> {
+  const realRoot = await realpath(root);
+  const realTarget = await realpath(target);
+  const pathFromRoot = relative(realRoot, realTarget);
+  if (pathFromRoot === ".." || pathFromRoot.startsWith(`..${sep}`) || isAbsolute(pathFromRoot)) {
+    throw new Error(`${label} must be inside the Farm project root, including through symlinks.`);
   }
 }
 

--- a/packages/farm-cf-agent/src/output.ts
+++ b/packages/farm-cf-agent/src/output.ts
@@ -262,8 +262,16 @@ async function assertRealPathInsideRoot(
   target: string,
   label: string,
 ): Promise<void> {
-  const realRoot = await realpath(root);
-  const realTarget = await realpath(target);
+  let realRoot: string;
+  let realTarget: string;
+  try {
+    [realRoot, realTarget] = await Promise.all([realpath(root), realpath(target)]);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      throw new Error(`${label} was not found at ${target}.`);
+    }
+    throw error;
+  }
   const pathFromRoot = relative(realRoot, realTarget);
   if (pathFromRoot === ".." || pathFromRoot.startsWith(`..${sep}`) || isAbsolute(pathFromRoot)) {
     throw new Error(`${label} must be inside the Farm project root, including through symlinks.`);

--- a/packages/farm-cli/src/deploy.ts
+++ b/packages/farm-cli/src/deploy.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from "child_process";
-import { existsSync, readFileSync } from "fs";
+import { existsSync, readFileSync, realpathSync } from "fs";
 import path from "path";
 import {
   getDeployTargetForPreset,
@@ -600,6 +600,7 @@ export function resolveCloudflareAgentDeployPlan(
   if (!existsSync(configPath)) {
     throw new Error(`Cloudflare Agents deployment config was not found at ${configPath}.`);
   }
+  assertRealPathInsideProject(projectRoot, configPath, "Cloudflare Agents deployment config");
 
   const environment = metadata.environment;
   if (environment !== undefined && (typeof environment !== "string" || !environment.trim())) {
@@ -652,6 +653,12 @@ function assertPathInsideProject(projectRoot: string, candidate: string, label: 
   ) {
     throw new Error(`${label} must stay inside the Farm project root.`);
   }
+}
+
+function assertRealPathInsideProject(projectRoot: string, candidate: string, label: string): void {
+  const realProjectRoot = realpathSync(projectRoot);
+  const realCandidate = realpathSync(candidate);
+  assertPathInsideProject(realProjectRoot, realCandidate, label);
 }
 
 function assertWranglerInstalled(root: string): void {

--- a/packages/farm-cli/src/deploy.ts
+++ b/packages/farm-cli/src/deploy.ts
@@ -632,6 +632,9 @@ function resolveConfiguredCloudflareAgentDeployPlan(
   const projectRoot = path.resolve(root);
   const sourceConfigPath = path.resolve(projectRoot, configuredPath);
   assertPathInsideProject(projectRoot, sourceConfigPath, "Cloudflare Agents source config");
+  if (existsSync(sourceConfigPath)) {
+    assertRealPathInsideProject(projectRoot, sourceConfigPath, "Cloudflare Agents source config");
+  }
   const configPath = path.join(path.dirname(sourceConfigPath), ".farm-cf-agent.wrangler.jsonc");
   const environment = integration.instance.environment;
 

--- a/packages/farm-cli/test/deploy.test.mjs
+++ b/packages/farm-cli/test/deploy.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -100,6 +100,35 @@ test("keeps generated deployment configs inside the Farm root", async () => {
     );
   } finally {
     if (root) await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("rejects a Cloudflare Agent config that resolves outside the Farm root", async () => {
+  let temporaryRoot;
+
+  try {
+    temporaryRoot = await mkdtemp(path.join(tmpdir(), "farm-cli-cf-agent-symlink-"));
+    const root = path.join(temporaryRoot, "project");
+    const externalDirectory = path.join(temporaryRoot, "external");
+    await mkdir(path.join(root, ".farm", "cf-agent"), { recursive: true });
+    await mkdir(externalDirectory);
+    await writeFile(path.join(externalDirectory, "wrangler.jsonc"), "{}\n");
+    await symlink(externalDirectory, path.join(root, "cloudflare"), "junction");
+    await writeFile(
+      path.join(root, ".farm", "cf-agent", "deploy.json"),
+      JSON.stringify({
+        version: 1,
+        provider: "cloudflare-agents",
+        config: "cloudflare/wrangler.jsonc",
+      }),
+    );
+
+    assert.throws(
+      () => resolveCloudflareAgentDeployPlan(root),
+      /must stay inside the Farm project root/,
+    );
+  } finally {
+    if (temporaryRoot) await rm(temporaryRoot, { recursive: true, force: true });
   }
 });
 

--- a/packages/farm-cli/test/deploy.test.mjs
+++ b/packages/farm-cli/test/deploy.test.mjs
@@ -173,6 +173,45 @@ test("plans the generated Cloudflare Agent config before the first build", async
   }
 });
 
+test("rejects a configured Cloudflare Agent source config through an outside symlink", async () => {
+  let temporaryRoot;
+
+  try {
+    temporaryRoot = await mkdtemp(path.join(tmpdir(), "farm-cli-cf-agent-source-symlink-"));
+    const root = path.join(temporaryRoot, "project");
+    const externalDirectory = path.join(temporaryRoot, "external");
+    await mkdir(root);
+    await mkdir(externalDirectory);
+    await writeFile(path.join(externalDirectory, "wrangler.jsonc"), "{}\n");
+    await symlink(externalDirectory, path.join(root, "cloudflare"), "junction");
+    await writeFile(
+      path.join(root, "farm.config.mjs"),
+      [
+        "export default {",
+        "  deploy: { target: 'cloudflare', preset: 'cloudflare-module' },",
+        "  integrations: {",
+        "    agent: {",
+        "      kind: 'farm-integration',",
+        "      category: 'agent',",
+        "      type: 'cloudflare',",
+        "      serverRuntime: false,",
+        "      instance: { config: 'cloudflare/wrangler.jsonc' },",
+        "    },",
+        "  },",
+        "};",
+        "",
+      ].join("\n"),
+    );
+
+    await assert.rejects(
+      () => createFarmDeployPlan({ root }),
+      /Cloudflare Agents source config must stay inside the Farm project root/,
+    );
+  } finally {
+    if (temporaryRoot) await rm(temporaryRoot, { recursive: true, force: true });
+  }
+});
+
 test("reports Netlify deploys as production operations", async () => {
   let root;
 


### PR DESCRIPTION
## Problem

A Cloudflare Agents deployment handoff can name a config that is lexically inside the Farm project while a symlinked path component resolves the Wrangler config outside it.

## Root cause

Deployment validates the normalized path but does not compare the existing config real path with the project real path before passing it to Wrangler.

## Change

Resolve both filesystem locations and reject an existing Cloudflare Agents deployment config whose real path is outside the project.

## Safety and compatibility

Ordinary in-project configs and projects reached through a symlink remain supported. The change only rejects deployment configs that cross the project boundary through symlinks.

## Verification

- `pnpm --filter @farm.js/cli type-check`
- `pnpm --filter @farm.js/cli build`
- `node --test packages/farm-cli/test/deploy.test.mjs` (12 passed)
- `pnpm exec oxlint packages/farm-cli/src/deploy.ts packages/farm-cli/test/deploy.test.mjs`
- `git diff --check`

The regression test places `wrangler.jsonc` below a symlinked directory and confirms the deploy handoff is rejected.

## Documentation and release

None.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a path containment issue in Cloudflare Agents deployment validation: a config that is lexically inside the project but resolves outside it through a symlink is now rejected.

This applies to both the deploy handoff config and the configured source config, while ordinary in-project configs and projects reached via symlink still work.

**Bug Fixes**
- Rejects the handoff config and configured source config when their real path lies outside the project root.
- Reports a clear "was not found" error when the config is missing instead of a generic realpath failure.
- Adds regression tests covering an outside-resolving symlinked config for both paths.

<sup>Written for commit 9bd14ed2d18f5579c72172552c7934439cc0c13c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/919?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

