### PR TITLE
fix(pwa): contain service worker output through symlinks

### DIFF
--- a/packages/farm-pwa/src/build.test.ts
+++ b/packages/farm-pwa/src/build.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, mkdir, readFile, writeFile } from "node:fs/promises";
+import { mkdtemp, mkdir, readFile, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { runInNewContext } from "node:vm";
@@ -174,6 +174,26 @@ describe("writePwaBuildArtifacts", () => {
         options: resolvePwaOptions({ offline: "/missing" }),
       }),
     ).rejects.toThrow("was not emitted as a static page");
+  });
+
+  it("does not write a service worker outside publicDir through a symlinked parent", async () => {
+    const { root, publicDir } = await createOutput("node-server");
+    const externalDirectory = path.join(root, "external");
+    const externalWorker = path.join(externalDirectory, "sw.js");
+    await mkdir(externalDirectory);
+    await writeFile(externalWorker, "keep me");
+    await symlink(externalDirectory, path.join(publicDir, "app"), "junction");
+
+    await expect(
+      writePwaBuildArtifacts({
+        outputDir: root,
+        preset: "node-server",
+        basePath: "/app",
+        options: resolvePwaOptions(),
+      }),
+    ).rejects.toThrow("including through symlinks");
+
+    await expect(readFile(externalWorker, "utf8")).resolves.toBe("keep me");
   });
 });
 

--- a/packages/farm-pwa/src/build.test.ts
+++ b/packages/farm-pwa/src/build.test.ts
@@ -114,6 +114,25 @@ describe("writePwaBuildArtifacts", () => {
     expect(await readFile(path.join(publicDir, "app", "sw.js"), "utf8")).toBe(customWorker);
   });
 
+  it("creates a missing public directory for a custom service worker", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "farm-pwa-empty-output-"));
+    temporaryDirectories.push(root);
+    const customWorker = "self.skipWaiting();\n";
+    await writeFile(path.join(root, "custom-worker.js"), customWorker);
+
+    const result = await writePwaBuildArtifacts({
+      root,
+      outputDir: root,
+      preset: "node-server",
+      basePath: "/",
+      options: resolvePwaOptions({
+        serviceWorker: { source: "custom-worker.js", type: "module" },
+      }),
+    });
+
+    await expect(readFile(result.workerPath, "utf8")).resolves.toBe(customWorker);
+  });
+
   it("prefixes every logical static route without requiring basePath folders on disk", async () => {
     const { root } = await createOutput("node-server");
     const result = await writePwaBuildArtifacts({

--- a/packages/farm-pwa/src/build.test.ts
+++ b/packages/farm-pwa/src/build.test.ts
@@ -214,6 +214,25 @@ describe("writePwaBuildArtifacts", () => {
 
     await expect(readFile(externalWorker, "utf8")).resolves.toBe("keep me");
   });
+
+  it("rejects a dangling service worker symlink before creating its external target", async () => {
+    const { root, publicDir } = await createOutput("node-server");
+    const externalWorker = path.join(root, "external-worker.js");
+    const workerDirectory = path.join(publicDir, "app");
+    await mkdir(workerDirectory);
+    await symlink(externalWorker, path.join(workerDirectory, "sw.js"), "file");
+
+    await expect(
+      writePwaBuildArtifacts({
+        outputDir: root,
+        preset: "node-server",
+        basePath: "/app",
+        options: resolvePwaOptions(),
+      }),
+    ).rejects.toThrow("including through symlinks");
+
+    await expect(readFile(externalWorker)).rejects.toThrow();
+  });
 });
 
 describe("generateServiceWorker", () => {

--- a/packages/farm-pwa/src/build.ts
+++ b/packages/farm-pwa/src/build.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { mkdir, readdir, readFile, writeFile } from "node:fs/promises";
+import { mkdir, readdir, readFile, realpath, writeFile } from "node:fs/promises";
 import path from "node:path";
 import type { ResolvedPwaOptions } from "./config.js";
 
@@ -38,6 +38,7 @@ export async function writePwaBuildArtifacts(input: PwaBuildInput): Promise<PwaB
   const basePath = normalizeBasePath(input.basePath);
   const workerRelativePath = path.posix.join(basePath.replace(/^\//, ""), "sw.js");
   const workerPath = path.join(publicDir, ...workerRelativePath.split("/"));
+  await assertWorkerPathInsidePublicDir(publicDir, workerPath);
 
   if (input.options.serviceWorker) {
     const sourcePath = path.resolve(
@@ -325,6 +326,37 @@ export function resolvePwaPublicDir(outputDir: string, preset: string): string {
     outputDir,
     preset === "vercel" || preset === "vercel-edge" ? "static" : "public",
   );
+}
+
+async function assertWorkerPathInsidePublicDir(
+  publicDir: string,
+  workerPath: string,
+): Promise<void> {
+  const realPublicDir = await realpath(publicDir);
+  let existingAncestor = workerPath;
+
+  while (true) {
+    try {
+      existingAncestor = await realpath(existingAncestor);
+      break;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+      const parent = path.dirname(existingAncestor);
+      if (parent === existingAncestor) throw error;
+      existingAncestor = parent;
+    }
+  }
+
+  const relativePath = path.relative(realPublicDir, existingAncestor);
+  if (
+    relativePath === ".." ||
+    relativePath.startsWith(`..${path.sep}`) ||
+    path.isAbsolute(relativePath)
+  ) {
+    throw new Error(
+      "[farm:pwa] Service worker output must stay inside the public output directory, including through symlinks.",
+    );
+  }
 }
 
 export function normalizeBasePath(value: string | undefined): string {

--- a/packages/farm-pwa/src/build.ts
+++ b/packages/farm-pwa/src/build.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { mkdir, readdir, readFile, realpath, writeFile } from "node:fs/promises";
+import { lstat, mkdir, readdir, readFile, realpath, writeFile } from "node:fs/promises";
 import path from "node:path";
 import type { ResolvedPwaOptions } from "./config.js";
 
@@ -355,6 +355,18 @@ async function resolveProspectiveRealPath(candidate: string): Promise<string> {
       return path.join(await realpath(existingAncestor), ...missingSegments);
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+      let existingEntry = false;
+      try {
+        await lstat(existingAncestor);
+        existingEntry = true;
+      } catch (statError) {
+        if ((statError as NodeJS.ErrnoException).code !== "ENOENT") throw statError;
+      }
+      if (existingEntry) {
+        throw new Error(
+          "[farm:pwa] Service worker output must stay inside the public output directory, including through symlinks.",
+        );
+      }
       const parent = path.dirname(existingAncestor);
       if (parent === existingAncestor) throw error;
       missingSegments.unshift(path.basename(existingAncestor));

--- a/packages/farm-pwa/src/build.ts
+++ b/packages/farm-pwa/src/build.ts
@@ -332,22 +332,9 @@ async function assertWorkerPathInsidePublicDir(
   publicDir: string,
   workerPath: string,
 ): Promise<void> {
-  const realPublicDir = await realpath(publicDir);
-  let existingAncestor = workerPath;
-
-  while (true) {
-    try {
-      existingAncestor = await realpath(existingAncestor);
-      break;
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
-      const parent = path.dirname(existingAncestor);
-      if (parent === existingAncestor) throw error;
-      existingAncestor = parent;
-    }
-  }
-
-  const relativePath = path.relative(realPublicDir, existingAncestor);
+  const prospectivePublicDir = await resolveProspectiveRealPath(publicDir);
+  const prospectiveWorkerPath = await resolveProspectiveRealPath(workerPath);
+  const relativePath = path.relative(prospectivePublicDir, prospectiveWorkerPath);
   if (
     relativePath === ".." ||
     relativePath.startsWith(`..${path.sep}`) ||
@@ -356,6 +343,23 @@ async function assertWorkerPathInsidePublicDir(
     throw new Error(
       "[farm:pwa] Service worker output must stay inside the public output directory, including through symlinks.",
     );
+  }
+}
+
+async function resolveProspectiveRealPath(candidate: string): Promise<string> {
+  const missingSegments: string[] = [];
+  let existingAncestor = path.resolve(candidate);
+
+  while (true) {
+    try {
+      return path.join(await realpath(existingAncestor), ...missingSegments);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+      const parent = path.dirname(existingAncestor);
+      if (parent === existingAncestor) throw error;
+      missingSegments.unshift(path.basename(existingAncestor));
+      existingAncestor = parent;
+    }
   }
 }
 


### PR DESCRIPTION
## Problem

A base path can place a generated or custom PWA service worker below a symlinked public-directory child, causing the worker to be written outside deployment output.

## Root cause

The PWA build computed only a lexical worker path before creating directories and writing the file.

## Change

Resolve prospective public and worker locations using their closest existing ancestors. Reject outside-resolving and dangling symlinks before reading inputs or writing output.

## Safety and compatibility

Generated workers, custom workers, base paths, symlinked project roots, and not-yet-created public directories remain supported when output is contained.

## Verification

- `pnpm --filter @farm.js/pwa test` (26 passed)
- `pnpm --filter @farm.js/pwa type-check`
- `pnpm --filter @farm.js/pwa build`
- focused Oxlint and `git diff --check`

The regressions protect an outside worker, reject a dangling link, and retain custom-worker creation when `publicDir` does not yet exist.

## Documentation and release

None.