### PR TITLE
fix(partytown): contain copied assets through symlinks

### DIFF
--- a/packages/farm-partytown/src/build.test.ts
+++ b/packages/farm-partytown/src/build.test.ts
@@ -1,4 +1,4 @@
-import { access, mkdtemp, readFile, rm } from "node:fs/promises";
+import { access, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -66,6 +66,30 @@ describe("Partytown assets", () => {
     await expect(
       access(path.join(result.assetsDir, "debug", "partytown-sw.js")),
     ).resolves.toBeUndefined();
+  });
+
+  it("does not copy assets outside publicDir through a symlinked parent", async () => {
+    const outputDir = await mkdtemp(path.join(tmpdir(), "farm-partytown-symlink-"));
+    temporaryDirectories.push(outputDir);
+    const publicDir = path.join(outputDir, "public");
+    const externalDirectory = path.join(outputDir, "external");
+    const sentinelPath = path.join(externalDirectory, "sentinel.txt");
+    await mkdir(publicDir);
+    await mkdir(externalDirectory);
+    await writeFile(sentinelPath, "keep me");
+    await symlink(externalDirectory, path.join(publicDir, "dashboard"), "junction");
+
+    await expect(
+      writePartytownBuildArtifacts({
+        outputDir,
+        preset: "node-server",
+        basePath: "/dashboard",
+        options: resolvePartytownOptions({}),
+      }),
+    ).rejects.toThrow("including through symlinks");
+
+    await expect(readFile(sentinelPath, "utf8")).resolves.toBe("keep me");
+    await expect(access(path.join(externalDirectory, "~partytown"))).rejects.toThrow();
   });
 
   it("serves only library files below the configured development path", async () => {

--- a/packages/farm-partytown/src/build.test.ts
+++ b/packages/farm-partytown/src/build.test.ts
@@ -1,4 +1,13 @@
-import { access, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import {
+  access,
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  rm,
+  symlink,
+  writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -90,6 +99,29 @@ describe("Partytown assets", () => {
 
     await expect(readFile(sentinelPath, "utf8")).resolves.toBe("keep me");
     await expect(access(path.join(externalDirectory, "~partytown"))).rejects.toThrow();
+  });
+
+  it("replaces nested output symlinks before copying library files", async () => {
+    const outputDir = await mkdtemp(path.join(tmpdir(), "farm-partytown-nested-symlink-"));
+    temporaryDirectories.push(outputDir);
+    const assetsDir = path.join(outputDir, "public", "dashboard", "~partytown");
+    const externalDirectory = path.join(outputDir, "external");
+    await mkdir(assetsDir, { recursive: true });
+    await mkdir(externalDirectory);
+    await writeFile(path.join(externalDirectory, "sentinel.txt"), "keep me");
+    await symlink(externalDirectory, path.join(assetsDir, "debug"), "junction");
+
+    const result = await writePartytownBuildArtifacts({
+      outputDir,
+      preset: "node-server",
+      basePath: "/dashboard",
+      options: resolvePartytownOptions({ debug: true }),
+    });
+
+    await expect(readdir(externalDirectory)).resolves.toEqual(["sentinel.txt"]);
+    await expect(
+      access(path.join(result.assetsDir, "debug", "partytown.js")),
+    ).resolves.toBeUndefined();
   });
 
   it("serves only library files below the configured development path", async () => {

--- a/packages/farm-partytown/src/build.ts
+++ b/packages/farm-partytown/src/build.ts
@@ -1,4 +1,4 @@
-import { readFile, writeFile } from "node:fs/promises";
+import { readFile, realpath, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { partytownSnippet, type PartytownConfig } from "@qwik.dev/partytown/integration";
 import { copyLibFiles, libDirPath } from "@qwik.dev/partytown/utils";
@@ -29,6 +29,7 @@ export async function writePartytownBuildArtifacts(
   const relativeAssetsDir = path.posix.join(basePath.slice(1), PARTYTOWN_DIRECTORY);
   const assetsDir = path.join(publicDir, ...relativeAssetsDir.split("/"));
   const debug = input.options.debug ?? false;
+  await assertAssetsPathInsidePublicDir(publicDir, assetsDir);
 
   await copyLibFiles(assetsDir, { debugDir: debug });
   const bootstrapPath = path.join(assetsDir, PARTYTOWN_BOOTSTRAP);
@@ -138,6 +139,41 @@ export function partytownAssetUrl(file: string, basePath: string): string {
 
 export function resolvePartytownPublicDir(outputDir: string, preset: string): string {
   return path.join(outputDir, preset.startsWith("vercel") ? "static" : "public");
+}
+
+async function assertAssetsPathInsidePublicDir(
+  publicDir: string,
+  assetsDir: string,
+): Promise<void> {
+  const prospectivePublicDir = await resolveProspectiveRealPath(publicDir);
+  const prospectiveAssetsDir = await resolveProspectiveRealPath(assetsDir);
+  const relativePath = path.relative(prospectivePublicDir, prospectiveAssetsDir);
+  if (
+    relativePath === ".." ||
+    relativePath.startsWith(`..${path.sep}`) ||
+    path.isAbsolute(relativePath)
+  ) {
+    throw new Error(
+      "[farm:partytown] Asset output must stay inside the public output directory, including through symlinks.",
+    );
+  }
+}
+
+async function resolveProspectiveRealPath(candidate: string): Promise<string> {
+  const missingSegments: string[] = [];
+  let existingAncestor = path.resolve(candidate);
+
+  while (true) {
+    try {
+      return path.join(await realpath(existingAncestor), ...missingSegments);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+      const parent = path.dirname(existingAncestor);
+      if (parent === existingAncestor) throw error;
+      missingSegments.unshift(path.basename(existingAncestor));
+      existingAncestor = parent;
+    }
+  }
 }
 
 function contentTypeFor(file: string): string {

--- a/packages/farm-partytown/src/build.ts
+++ b/packages/farm-partytown/src/build.ts
@@ -1,4 +1,4 @@
-import { readFile, realpath, writeFile } from "node:fs/promises";
+import { lstat, readFile, realpath, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { partytownSnippet, type PartytownConfig } from "@qwik.dev/partytown/integration";
 import { copyLibFiles, libDirPath } from "@qwik.dev/partytown/utils";
@@ -31,6 +31,9 @@ export async function writePartytownBuildArtifacts(
   const debug = input.options.debug ?? false;
   await assertAssetsPathInsidePublicDir(publicDir, assetsDir);
 
+  // This directory is entirely plugin-owned. Recreate it so stale files and
+  // nested symlinks cannot redirect copyFile outside the verified destination.
+  await rm(assetsDir, { recursive: true, force: true });
   await copyLibFiles(assetsDir, { debugDir: debug });
   const bootstrapPath = path.join(assetsDir, PARTYTOWN_BOOTSTRAP);
   await writeFile(bootstrapPath, createPartytownBootstrap(input.options, basePath, false), "utf8");
@@ -168,6 +171,18 @@ async function resolveProspectiveRealPath(candidate: string): Promise<string> {
       return path.join(await realpath(existingAncestor), ...missingSegments);
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+      let existingEntry = false;
+      try {
+        await lstat(existingAncestor);
+        existingEntry = true;
+      } catch (statError) {
+        if ((statError as NodeJS.ErrnoException).code !== "ENOENT") throw statError;
+      }
+      if (existingEntry) {
+        throw new Error(
+          "[farm:partytown] Asset output must stay inside the public output directory, including through symlinks.",
+        );
+      }
       const parent = path.dirname(existingAncestor);
       if (parent === existingAncestor) throw error;
       missingSegments.unshift(path.basename(existingAncestor));


### PR DESCRIPTION
## Problem

A symlinked path component can redirect Partytown library and bootstrap writes outside the public deployment output. A nested symlink inside an existing plugin asset directory can redirect individual copied files too.

## Root cause

The destination was assembled lexically and an existing plugin-owned asset tree was reused before `copyLibFiles`.

## Change

Resolve prospective public and asset locations, reject outside or dangling links, then safely recreate the plugin-owned asset directory before copying.

## Safety and compatibility

Node and Vercel outputs, base paths, debug assets, and not-yet-created public directories remain supported. Recreating only the dedicated `~partytown` directory also clears stale plugin assets.

## Verification

- `pnpm --filter @farm.js/partytown test` (24 passed)
- `pnpm --filter @farm.js/partytown type-check`
- `pnpm --filter @farm.js/partytown build`
- focused Oxlint and `git diff --check`

The regressions cover an outside base-path parent and a nested `debug` symlink while preserving the external sentinel.

## Documentation and release

None.