### PR TITLE
fix(routing): reject browser-unstable configured paths

### DIFF
--- a/packages/farm/src/__tests__/config-route-plugins.test.ts
+++ b/packages/farm/src/__tests__/config-route-plugins.test.ts
@@ -48,6 +48,20 @@ describe("config route plugins", () => {
     ).toThrow('Redirect "/old" statusCode must be one of 301, 302, 303, 307, or 308');
   });
 
+  it("rejects route sources that browsers normalize differently", () => {
+    for (const source of [
+      "/docs/../admin",
+      "/docs/%2e%2e/admin",
+      "/docs/%2Fadmin",
+      "/docs/%5Cadmin",
+      "/docs\\admin",
+    ]) {
+      expect(() => createRedirectsPlugin([{ source, destination: "/safe" }])).toThrow(
+        /browser-unstable|backslashes/,
+      );
+    }
+  });
+
   it("falls back safely when a request carries a malformed Host header", async () => {
     const redirectRequest = createRequest("/old");
     redirectRequest.headers.host = "%";

--- a/packages/farm/src/__tests__/server-http.test.ts
+++ b/packages/farm/src/__tests__/server-http.test.ts
@@ -100,6 +100,22 @@ describe("Farm server HTTP policy", () => {
     expect(resolveFarmServerConfig({ health: false }).health.enabled).toBe(false);
   });
 
+  it("rejects health paths that browsers normalize to a different endpoint", () => {
+    for (const livenessPath of [
+      "/health/../private",
+      "/health/%2e%2e/private",
+      "/health/%2Fprivate",
+      "/health/%5Cprivate",
+      "/health\\private",
+    ]) {
+      expect(() =>
+        resolveFarmServerConfig({
+          health: { livenessPath, readinessPath: "/health/ready" },
+        }),
+      ).toThrow(/browser-unstable|backslashes/);
+    }
+  });
+
   it("rejects streamed Web request bodies above the limit", async () => {
     const request = new Request("https://example.com/upload", {
       method: "POST",

--- a/packages/farm/src/plugins/route-pattern.ts
+++ b/packages/farm/src/plugins/route-pattern.ts
@@ -1,5 +1,6 @@
 import { localizeFarmHref, resolveFarmLocalePath } from "../i18n/routing";
 import type { ResolvedFarmI18nConfig } from "../i18n/types";
+import { assertBrowserStableRoutePath } from "../routing/specificity";
 
 type ConfigRoutePatternToken =
   | { kind: "param"; name: string; captureIndex: number; catchAll: boolean }
@@ -32,6 +33,7 @@ export function validateConfigRouteSource(source: string, field = "Config route 
   ) {
     throw new Error(`${field} cannot contain backslashes or control characters.`);
   }
+  assertBrowserStableRoutePath(source);
   return source;
 }
 

--- a/packages/farm/src/server-http.ts
+++ b/packages/farm/src/server-http.ts
@@ -1,3 +1,5 @@
+import { assertBrowserStableRoutePath } from "./routing/specificity";
+
 export const DEFAULT_FARM_SERVER_BODY_SIZE_LIMIT = 10_000_000;
 export const DEFAULT_FARM_SERVER_HEADERS_TIMEOUT = 60_000;
 export const DEFAULT_FARM_SERVER_REQUEST_TIMEOUT = 300_000;
@@ -229,7 +231,9 @@ function normalizeHealthPath(value: string, optionName: string): string {
   if (!path.startsWith("/") || path.includes("?") || path.includes("#") || path.includes("*")) {
     throw new TypeError(`${optionName} must be an absolute pathname without a query or wildcard`);
   }
-  return path.length > 1 ? path.replace(/\/+$/, "") || "/" : path;
+  const normalized = path.length > 1 ? path.replace(/\/+$/, "") || "/" : path;
+  assertBrowserStableRoutePath(normalized);
+  return normalized;
 }
 
 export function parseBodySizeLimit(value: number | string, optionName = "bodySizeLimit"): number {


### PR DESCRIPTION
## Problem

Health endpoints and configuration-backed redirect, rewrite, header, and route-rule sources accept path spellings that browsers normalize before sending. Encoded dot segments, encoded separators, and backslashes can therefore make an endpoint unreachable or make the server match a different path than the browser requested.

## Root cause

These configuration paths only receive surface syntax checks. They do not use the browser-stability validation already applied to file and programmatic page routes.

## Change

Apply the shared browser-stable route assertion to normalized health endpoints and configuration route sources.

## Safety and compatibility

Normal static, named-parameter, wildcard, Unicode, and percent-encoded content paths remain supported. Only backslashes, control characters, decoded dot segments, and encoded path separators are rejected.

## Verification

- `pnpm --filter @farm.js/core exec vitest run src/__tests__/server-http.test.ts src/__tests__/config-route-plugins.test.ts src/__tests__/config.test.ts` (81 passed)
- `pnpm --filter @farm.js/core type-check`
- `pnpm exec oxlint packages/farm/src/server-http.ts packages/farm/src/plugins/route-pattern.ts packages/farm/src/__tests__/server-http.test.ts packages/farm/src/__tests__/config-route-plugins.test.ts`
- `git diff --check`

Regression coverage includes literal and encoded dot segments, encoded slash and backslash segments, and raw backslashes for both health and plugin-backed routes.

## Documentation and release

None.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes browser-unstable configured paths so health endpoints and config-backed redirect/rewrite/header/route-rule sources now reject path spellings that browsers normalize, such as encoded dot segments and backslashes. Previously these paths only got surface syntax checks, which could make endpoints unreachable or cause the server to match a different path than the browser requested.

- Uses the same browser-stable route assertion already applied to file and programmatic page routes.
- Only backslashes, control characters, decoded dot segments, and encoded path separators are rejected; static, parameter, wildcard, Unicode, and percent-encoded paths remain supported.

<sup>Written for commit 85da77103fe38f72657284fcfa5ba64e0cd4f0ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/922?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

