### PR TITLE
perf(react): retain mapped lineage through rolling windows

### DIFF
--- a/docs/src/app/docs/renderers/react/page.md
+++ b/docs/src/app/docs/renderers/react/page.md
@@ -1148,15 +1148,35 @@ preserves every retained element, and creates only that final incoming suffix. I
 checked against the complete committed window; reusing an expired key takes full keyed
 reconciliation so React key identity is preserved.
 
+Safe same-key maps may be immediately adjacent to either side of one rolling setter:
+
+```tsx
+setItems((current) =>
+  current.map((item) => (item.id === editedId ? { ...item, label: nextLabel } : item)),
+);
+setItems((current) => [...current.slice(trimCount), ...nextItems]);
+setItems((current) =>
+  current.map((item) => (item.id === selectedId ? { ...item, selected: true } : item)),
+);
+```
+
+Farm links mapped retained items back to their committed rows, creates the incoming suffix from its
+final mapped values, and prepares every changed binding and incoming row before the first live DOM
+write. Unchanged survivors keep their elements, focus, selection, scopes, and delegated-event
+indexes. The compiler lowers this composition through the existing structural append/map runtime,
+so it does not add another browser runtime feature.
+
 The proof remains intentionally narrow: one compiler-safe slice bound, compiler-owned host rows,
 and index-independent render and key callbacks. A second slice bound, literal zero, effectful bound
 expressions, block-bodied updates, custom slice behavior, sparse or subclassed arrays, queued
 chains containing a mixed or unhinted intermediate update, collection-reading bindings, index-aware
-rows, React-owned rows, nested host blocks, row conditionals, unrelated dirty dependencies, and
-failed runtime validation all keep complete keyed reconciliation. Runtime bounds that evaluate to
-a fractional, non-numeric, unsafe, or no-op value preserve native results and use that fallback. No
-new component or option is required. Reports expose emitted sites as
-`keyedArrayRollingWindowHints`; only modules with such a site retain the optional all-hint runtime.
+rows, React-owned rows, nested host blocks, row conditionals, more than one rolling setter in a
+mapped segment, a statement or unsupported setter between the map and rolling calls, unrelated
+dirty dependencies, changed mapped keys, and failed runtime validation all keep complete keyed
+reconciliation. Runtime bounds that evaluate to a fractional, non-numeric, unsafe, or no-op value
+preserve native results and use that fallback. No new component or option is required. Reports
+expose emitted sites as `keyedArrayRollingWindowHints`; unmapped rolling modules retain the smaller
+optional all-hint runtime.
 
 #### Keyed array known-position hints
 
@@ -2398,12 +2418,12 @@ The package and example test suites verify more than generated code:
   focused controlled-input identity and selection, update delegated event indexes, and cover native
   evaluation and coercion, unsafe evaluated bounds, queued slice/filter chains, Strict Mode
   hydration, unmount cleanup, custom methods, proxies, and conservative fallback;
-- 250 committed fixed-bound, 1,000 randomized runtime-bound, and 1,000 randomized queued keyed
-  rolling-window commits match normal React; targeted tests require work to equal only the final
-  incoming suffix, preserve retained DOM identity, update delegated indexes, preserve controlled
-  focus and selection, and cover unsafe evaluated bounds, reused or discarded intermediate keys,
-  custom slices, mixed queued chains, collection-dependent rows, Strict Mode hydration, and unmount
-  cleanup;
+- 250 committed fixed-bound, 1,000 randomized runtime-bound, 1,000 randomized queued, and 2,000
+  randomized mapped keyed rolling-window commits match normal React; targeted tests require work
+  to equal only the final incoming suffix plus changed survivor bindings, preserve retained DOM
+  identity, update delegated indexes, preserve controlled focus and selection, and cover changed
+  mapped keys, unsafe evaluated bounds, reused or discarded intermediate keys, custom slices,
+  mixed queued chains, collection-dependent rows, Strict Mode hydration, and unmount cleanup;
 - 2,000 deterministic randomized keyed-array removals match normal React; targeted tests require
   zero surviving descriptor and binding reads, preserve DOM identity, and cover queued filters,
   unhinted-chain fallback, collection-reading rows, StrictMode hydration, and unmount cleanup;

--- a/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
+++ b/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
@@ -2,6 +2,41 @@
 
 Latest run: 2026-09-11
 
+## Mapped updates through a rolling window — 2026-09-11
+
+Immediately adjacent, same-key `map()` setters can now retain committed-row lineage across one
+rolling-window update. The maintained workload updates retained data, expires a 1,000-row prefix,
+appends a 1,000-row suffix, and applies another map before React commits. Previously, the rolling
+step discarded the mapped lineage and the final update used complete keyed reconciliation. The new
+path validates the final array and keys before the first DOM write, patches changed survivors,
+preserves unchanged rows, and creates only the incoming suffix.
+
+| Mode   | Map + roll + map | Compiled fallback | vs React | vs fallback |
+| ------ | ---------------: | ----------------: | -------: | ----------: |
+| Static |         16.50 ms |          27.10 ms |    4.10x |       1.64x |
+| Hybrid |         16.30 ms |          29.10 ms |    4.15x |       1.79x |
+
+Both modes passed the 2x React and 1.25x compiled-control floors. The bracketed React median was
+67.70 ms. Every sample checked the final 10,000-row count, the changed retained value, preserved
+survivor DOM identity, a fresh suffix, browser errors, and zero compiled owner executions. The
+broad 10% no-regression gate and the 10k/20k optimization-persistence gate passed. Two unchanged
+hybrid reorder controls were noisy: structural reorder measured 1.2466x against its 1.25x control
+floor, and queued map-then-reorder measured 1.157x against its 1.20x control floor. Their React
+speedups remained 3.35x and 8.99x, respectively. No threshold was relaxed.
+
+Compiler coverage includes maps before, after, and on both sides of one rolling setter; mixed plain
+and mapped sites; and conservative fallback for multiple rolling setters or an intervening
+statement. Runtime coverage checks changed-key fallback before mutation, exact key, descriptor, and
+binding work, controlled-input focus and selection, delegated indexes, Strict Mode hydration,
+recoverable errors, unmount-before-flush cleanup, React 18.3.1 and 19.2.8, and 2,000 randomized
+transitions matched with normal React. The implementation reuses the existing optional structural
+append/map runtime; the runtime-size suite remains green with an 84.9% core-runtime gzip reduction.
+
+Numbers are browser medians from a complete production-build run with 5 warmups, 10 measured
+samples per compiler action, 20 bracketed React samples, and 3 scale cycles, using Chrome
+153.0.8010.36 and Node.js 23.11.0 on Apple M1 macOS arm64. Correctness and the new performance gate
+passed; the command reported the two isolated unchanged timing misses described above.
+
 ## Queued removal followed by prepend — 2026-09-11
 
 An index-independent keyed-row `filter()` or bounded `slice()` can now retain its committed-row

--- a/examples/react-compiler-dashboard/README.md
+++ b/examples/react-compiler-dashboard/README.md
@@ -143,6 +143,13 @@ React and 1.25x faster than their compiled controls. The report must contain a n
 proportional only to the final incoming suffix, randomized dynamic and queued updates, and complete
 fallback for unsafe evaluated bounds or broken chains.
 
+Mapped rolling windows have another independent 10,000-row gate. The workload updates retained
+row data, expires a 1,000-row prefix while appending 1,000 rows, and applies a second same-key map
+before the commit. The concise path is measured against React and an equivalent compiled control
+whose block-bodied rolling setter intentionally breaks lineage. Both compiler modes must remain at
+least 2x faster than React and 1.25x faster than that control. Every sample verifies the retained
+DOM identity, mapped value, exact row count, fresh suffix, and zero compiled owner executions.
+
 Exact-position insertions, removals, and replacements have separate 10,000-row comparisons. Concise
 native `toSpliced(position, 0, item)`, `toSpliced(position, 0, ...items)`, `toSpliced(position, 1)`,
 `toSpliced(position, 64)`, `toSpliced(position, 1, replacement)`, and

--- a/examples/react-compiler-dashboard/scripts/benchmark.mjs
+++ b/examples/react-compiler-dashboard/scripts/benchmark.mjs
@@ -591,6 +591,44 @@ async function measureTrial(browser, trial, compilerMode, port) {
           },
         );
 
+        const tableMappedRollingWindow = await measureTable(
+          async () => ensure10000(),
+          async () => {
+            const rows = table.querySelectorAll("tbody tr");
+            const firstSurvivor = rows[1_000];
+            const previousText = firstSurvivor?.textContent;
+            const previousLast = rows[9_999]?.getAttribute("data-row-id");
+            await runTableAction(
+              () => tableButton("table-roll-window-map").click(),
+              () =>
+                rowCount() === 10_000 &&
+                table.querySelector("tbody tr") === firstSurvivor &&
+                firstSurvivor?.textContent !== previousText &&
+                table.querySelector("tbody tr:last-child")?.getAttribute("data-row-id") !==
+                  previousLast,
+            );
+          },
+        );
+
+        const tableMappedRollingWindowSnapshot = await measureTable(
+          async () => ensure10000(),
+          async () => {
+            const rows = table.querySelectorAll("tbody tr");
+            const firstSurvivor = rows[1_000];
+            const previousText = firstSurvivor?.textContent;
+            const previousLast = rows[9_999]?.getAttribute("data-row-id");
+            await runTableAction(
+              () => tableButton("table-roll-window-map-snapshot").click(),
+              () =>
+                rowCount() === 10_000 &&
+                table.querySelector("tbody tr") === firstSurvivor &&
+                firstSurvivor?.textContent !== previousText &&
+                table.querySelector("tbody tr:last-child")?.getAttribute("data-row-id") !==
+                  previousLast,
+            );
+          },
+        );
+
         const tableRollingWindowQueued = await measureTable(
           async () => ensure10000(),
           async () => {
@@ -2275,6 +2313,8 @@ async function measureTrial(browser, trial, compilerMode, port) {
             remove: tableRemove,
             removeSnapshot: tableRemoveSnapshot,
             replace: tableReplace,
+            mappedRollingWindow: tableMappedRollingWindow,
+            mappedRollingWindowSnapshot: tableMappedRollingWindowSnapshot,
             rollingWindow: tableRollingWindow,
             rollingWindowQueued: tableRollingWindowQueued,
             rollingWindowQueuedSnapshot: tableRollingWindowQueuedSnapshot,
@@ -2461,6 +2501,8 @@ async function measureTrial(browser, trial, compilerMode, port) {
         remove: timingSummary(result.table.remove),
         removeSnapshot: timingSummary(result.table.removeSnapshot),
         replace: timingSummary(result.table.replace),
+        mappedRollingWindow: timingSummary(result.table.mappedRollingWindow),
+        mappedRollingWindowSnapshot: timingSummary(result.table.mappedRollingWindowSnapshot),
         rollingWindow: timingSummary(result.table.rollingWindow),
         rollingWindowQueued: timingSummary(result.table.rollingWindowQueued),
         rollingWindowQueuedSnapshot: timingSummary(result.table.rollingWindowQueuedSnapshot),
@@ -2632,6 +2674,8 @@ const tableMetrics = [
   "swap",
   "remove",
   "removeSnapshot",
+  "mappedRollingWindow",
+  "mappedRollingWindowSnapshot",
   "rollingWindow",
   "rollingWindowQueued",
   "rollingWindowQueuedSnapshot",
@@ -2881,6 +2925,29 @@ const keyedRollingWindowRegressions = keyedRollingWindowResults.filter(
     speedup < keyedRollingWindowMinimumSpeedup ||
     !Number.isFinite(snapshotSpeedup) ||
     snapshotSpeedup < keyedRollingWindowMinimumSnapshotSpeedup,
+);
+// A mapped rolling window should retain the same committed-row proof across safe maps on either
+// side of the boundary change. Protect both the React-relative win and the improvement over an
+// equivalent compiled control whose block-bodied rolling setter must reconcile the full list.
+const keyedMappedRollingWindowMinimumSpeedup = 2;
+const keyedMappedRollingWindowMinimumSnapshotSpeedup = 1.25;
+const keyedMappedRollingWindowResults = ["static", "hybrid"].map((mode) => {
+  const rollingMedianMs = comparisons.table.mappedRollingWindow[mode].medianMs;
+  const snapshotMedianMs = comparisons.table.mappedRollingWindowSnapshot[mode].medianMs;
+  return {
+    mode,
+    rollingMedianMs,
+    snapshotMedianMs,
+    snapshotSpeedup: snapshotMedianMs / rollingMedianMs,
+    speedup: comparisons.table.mappedRollingWindow[`${mode}VsBaseline`].speedup,
+  };
+});
+const keyedMappedRollingWindowRegressions = keyedMappedRollingWindowResults.filter(
+  ({ snapshotSpeedup, speedup }) =>
+    !Number.isFinite(speedup) ||
+    speedup < keyedMappedRollingWindowMinimumSpeedup ||
+    !Number.isFinite(snapshotSpeedup) ||
+    snapshotSpeedup < keyedMappedRollingWindowMinimumSnapshotSpeedup,
 );
 // Two queued rolling setters should collapse to the final retained committed suffix and incoming
 // rows. Keep the queued 10,000-row workload ahead of both React and an equivalent block-bodied
@@ -3797,6 +3864,7 @@ const passed =
   keyedPrependRegressions.length === 0 &&
   keyedSliceRegressions.length === 0 &&
   keyedRollingWindowRegressions.length === 0 &&
+  keyedMappedRollingWindowRegressions.length === 0 &&
   keyedQueuedRollingWindowRegressions.length === 0 &&
   keyedBatchInsertRegressions.length === 0 &&
   keyedWindowReplaceRegressions.length === 0 &&
@@ -3884,6 +3952,13 @@ const report = {
     regressions: keyedRollingWindowRegressions,
     results: keyedRollingWindowResults,
     status: keyedRollingWindowRegressions.length === 0 ? "PASS" : "FAIL",
+  },
+  keyedMappedRollingWindowHintGate: {
+    minimumSnapshotSpeedup: keyedMappedRollingWindowMinimumSnapshotSpeedup,
+    minimumSpeedup: keyedMappedRollingWindowMinimumSpeedup,
+    regressions: keyedMappedRollingWindowRegressions,
+    results: keyedMappedRollingWindowResults,
+    status: keyedMappedRollingWindowRegressions.length === 0 ? "PASS" : "FAIL",
   },
   keyedQueuedRollingWindowHintGate: {
     minimumSnapshotSpeedup: keyedQueuedRollingWindowMinimumSnapshotSpeedup,

--- a/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
+++ b/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
@@ -257,6 +257,62 @@ export function StandardTableBenchmark() {
           Roll runtime-count window (snapshot control)
         </button>
         <button
+          data-action="table-roll-window-map"
+          type="button"
+          onClick={() => {
+            const nextSeed = seed + 1;
+            const additions = buildRows(1_000, nextSeed);
+            const trimCount = 1_000;
+            setSeed(nextSeed);
+            setRows((current) =>
+              current.map((row) =>
+                row.id % 1_000 === 1
+                  ? { ...row, label: `${row.label} reviewed` }
+                  : row,
+              ),
+            );
+            setRows((current) => [...current.slice(trimCount), ...additions]);
+            setRows((current) =>
+              current.map((row) =>
+                row.id % 1_000 === 1 ? { ...row, amount: row.amount + 1 } : row,
+              ),
+            );
+            setOperation("map, roll, and map runtime-count window");
+            setRevision((value) => value + 1);
+          }}
+        >
+          Map + roll window + map
+        </button>
+        <button
+          data-action="table-roll-window-map-snapshot"
+          type="button"
+          onClick={() => {
+            const nextSeed = seed + 1;
+            const additions = buildRows(1_000, nextSeed);
+            const trimCount = 1_000;
+            setSeed(nextSeed);
+            setRows((current) =>
+              current.map((row) =>
+                row.id % 1_000 === 1
+                  ? { ...row, label: `${row.label} reviewed` }
+                  : row,
+              ),
+            );
+            setRows((current) => {
+              return [...current.slice(trimCount), ...additions];
+            });
+            setRows((current) =>
+              current.map((row) =>
+                row.id % 1_000 === 1 ? { ...row, amount: row.amount + 1 } : row,
+              ),
+            );
+            setOperation("map, roll, and map window (snapshot control)");
+            setRevision((value) => value + 1);
+          }}
+        >
+          Map + roll window + map (snapshot control)
+        </button>
+        <button
           data-action="table-roll-window-queued"
           type="button"
           onClick={() => {

--- a/packages/farm-react/README.md
+++ b/packages/farm-react/README.md
@@ -395,11 +395,30 @@ final incoming suffix. This form supports one
 safe-integer literal or compiler-safe runtime slice bound and compiler-owned, index-independent
 host rows. Identifiers, property reads, side-effect-free arithmetic and conditionals, and safe
 `Math` calls are supported while preserving native lookup, evaluation, results, and errors.
+
+Immediately adjacent safe same-key maps may run before, after, or on both sides of one rolling
+setter:
+
+```tsx
+setItems((current) =>
+  current.map((item) => (item.id === editedId ? { ...item, label: nextLabel } : item)),
+);
+setItems((current) => [...current.slice(trimCount), ...nextItems]);
+setItems((current) =>
+  current.map((item) => (item.id === selectedId ? { ...item, selected: true } : item)),
+);
+```
+
+The compiler carries mapped survivor identity through the retained tail, creates incoming rows
+from their final mapped values, and patches only changed survivors. It reuses the optional
+structural append/map runtime rather than adding another browser helper.
+
 Effectful expressions, reused keys, block-bodied updaters, custom slice behavior,
 collection-reading or index-aware rows, nested or React-owned rows, mixed or unhinted queued chains,
-unsafe or no-op evaluated bounds, and failed checks use complete keyed reconciliation. The
-optional all-hint runtime is selected only for modules that emit this optimization. Reports expose
-the site count as `keyedArrayRollingWindowHints`.
+more than one rolling setter in a mapped segment, non-adjacent maps, changed mapped keys, unsafe or
+no-op evaluated bounds, and failed checks use complete keyed reconciliation. Unmapped rolling
+modules retain the smaller optional all-hint runtime. Reports expose the site count as
+`keyedArrayRollingWindowHints`.
 
 Native known-position updates can avoid a complete keyed scan too:
 

--- a/packages/farm-react/scripts/test-react-version.mjs
+++ b/packages/farm-react/scripts/test-react-version.mjs
@@ -50,6 +50,7 @@ const testSource = String.raw`
     createCompilerKeyedArrayMapReorder,
     createCompilerKeyedArrayPositionUpdate,
     createCompilerKeyedArrayPrepend,
+    createCompilerKeyedArrayQueuedMapPipeline,
     createCompilerKeyedArrayReorder,
     createCompilerKeyedArraySort,
     createCompilerKeyedArraySlice,
@@ -58,6 +59,7 @@ const testSource = String.raw`
     createCompilerKeyedArrayStructuralPrepend,
     createCompilerKeyedArrayWindowReplace,
     createCompilerKeyedMapUpdate,
+    finalizeCompilerKeyedArrayMappedStructuralUpdate,
     keyedRowsStructuralAppendMapHintedRuntimeFeature,
   } = await import(
     "@farm.js/react/compiler-runtime"
@@ -2276,6 +2278,7 @@ const testSource = String.raw`
 
   let structuralAppendRows = () => undefined;
   let mappedStructuralAppendRows = () => undefined;
+  let mappedRollingRows = () => undefined;
   let structuralAppendExecutions = 0;
   const StructuralAppendRows = createCompiledComponentWithFeatures({
     displayName: "CompatibilityStructuralAppendRows",
@@ -2331,6 +2334,32 @@ const testSource = String.raw`
             ...previous,
             { id: "e", label: "Epsilon" },
           ]),
+        );
+      };
+      mappedRollingRows = () => {
+        state[0].set((previous) =>
+          createCompilerKeyedArrayQueuedMapPipeline(previous, (current, applyMap) =>
+            applyMap(current, current.map, (item) =>
+              item.id === "d" ? { ...item, label: "Delta mapped first" } : item,
+            ),
+          ),
+        );
+        state[0].set((previous) => {
+          const retained = createCompilerKeyedArraySlice(previous, previous.slice, 1);
+          const structural = finalizeCompilerKeyedArrayMappedStructuralUpdate(retained);
+          return createCompilerKeyedArrayMappedStructuralAppend(structural, [
+            ...retained,
+            { id: "f", label: "Phi" },
+          ]);
+        });
+        state[0].set((previous) =>
+          createCompilerKeyedArrayStructuralAppendMapPipeline(
+            previous,
+            (current, applyMap) =>
+              applyMap(current, current.map, (item) =>
+                item.id === "d" ? { ...item, label: "Delta mapped twice" } : item,
+              ),
+          ),
         );
       };
       return React.createElement(
@@ -2392,6 +2421,17 @@ const testSource = String.raw`
   );
   assert.equal(structuralAppendContainer.querySelector("[data-key='c']"), structuralGamma);
   assert.equal(structuralBeta.isConnected, false);
+  assert.equal(structuralAppendExecutions, 1);
+  const structuralDelta = structuralAppendContainer.querySelector("[data-key='d']");
+  mappedRollingRows();
+  await Promise.resolve();
+  await Promise.resolve();
+  assert.deepEqual(
+    [...structuralAppendContainer.querySelectorAll("li")].map((row) => row.textContent),
+    ["Delta mapped twice", "Epsilon", "Phi"],
+  );
+  assert.equal(structuralAppendContainer.querySelector("[data-key='d']"), structuralDelta);
+  assert.equal(structuralGamma.isConnected, false);
   assert.equal(structuralAppendExecutions, 1);
   flushSync(() => structuralAppendRoot.unmount());
 

--- a/packages/farm-react/src/__tests__/compiler-keyed-array-rolling-window-hints.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-keyed-array-rolling-window-hints.test.ts
@@ -69,6 +69,143 @@ describe("React AOT keyed-array rolling-window hints", () => {
     expect(result.code).toContain("trimCount");
   });
 
+  it("retains same-key maps on both sides of one rolling-window setter", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Feed({ next, editedId, nextLabel }) {
+        const [rows, setRows] = useState([{ id: "a", label: "Alpha" }]);
+        return <section>
+          <button onClick={() => {
+            setRows((current) => current.map((row) =>
+              row.id === editedId ? { ...row, label: nextLabel } : row
+            ));
+            setRows((current) => [...current.slice(1), next]);
+            setRows((current) => current.map((row) =>
+              row.id === next.id ? { ...row, selected: true } : row
+            ));
+          }}>Roll and edit</button>
+          <ul>{rows.map((row) => <li key={row.id}>{row.label}</li>)}</ul>
+        </section>;
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Feed"]);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.optimizations.keyedArrayRollingWindowHints).toBe(1);
+    expect(result.optimizations.keyedMapUpdateHints).toBe(2);
+    expect(result.code).toContain("createCompilerKeyedArrayQueuedMapPipeline");
+    expect(result.code).toContain("finalizeCompilerKeyedArrayMappedStructuralUpdate");
+    expect(result.code).toContain("createCompilerKeyedArrayMappedStructuralAppend");
+    expect(result.code).toContain("createCompilerKeyedArrayStructuralAppendMapPipeline");
+    expect(result.code).toContain("keyedRowsStructuralAppendMapHintedRuntimeFeature");
+    expect(result.code).not.toContain("createCompilerKeyedArrayRollingWindow");
+  });
+
+  it("lowers a rolling window followed by maps through the structural append runtime", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Feed({ next, editedId, nextLabel }) {
+        const [rows, setRows] = useState([{ id: "a", label: "Alpha" }]);
+        return <section>
+          <button onClick={() => {
+            setRows((current) => [...current.slice(1), next]);
+            setRows((current) => current.map((row) =>
+              row.id === editedId ? { ...row, label: nextLabel } : row
+            ));
+          }}>Roll and edit</button>
+          <ul>{rows.map((row) => <li key={row.id}>{row.label}</li>)}</ul>
+        </section>;
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Feed"]);
+    expect(result.optimizations.keyedArrayRollingWindowHints).toBe(1);
+    expect(result.optimizations.keyedMapUpdateHints).toBe(1);
+    expect(result.code).toContain("createCompilerKeyedArrayStructuralAppend");
+    expect(result.code).toContain("createCompilerKeyedArrayStructuralAppendMapPipeline");
+    expect(result.code).toContain("keyedRowsStructuralAppendMapHintedRuntimeFeature");
+    expect(result.code).not.toContain("createCompilerKeyedArrayRollingWindow");
+  });
+
+  it("keeps the dedicated rolling helper when mapped and plain sites share a module", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Feed({ next, editedId, nextLabel }) {
+        const [rows, setRows] = useState([{ id: "a", label: "Alpha" }]);
+        return <section>
+          <button onClick={() => {
+            setRows((current) => [...current.slice(1), next]);
+          }}>Roll</button>
+          <button onClick={() => {
+            setRows((current) => current.map((row) =>
+              row.id === editedId ? { ...row, label: nextLabel } : row
+            ));
+            setRows((current) => [...current.slice(1), next]);
+          }}>Map and roll</button>
+          <ul>{rows.map((row) => <li key={row.id}>{row.label}</li>)}</ul>
+        </section>;
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Feed"]);
+    expect(result.optimizations.keyedArrayRollingWindowHints).toBe(2);
+    expect(result.code).toContain("createCompilerKeyedArrayRollingWindow");
+    expect(result.code).toContain("createCompilerKeyedArrayMappedStructuralAppend");
+    expect(result.code).toContain("keyedRowsStructuralAppendMapHintedRuntimeFeature");
+  });
+
+  it("does not merge maps with a segment containing two rolling setters", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Feed({ next, editedId, nextLabel }) {
+        const [rows, setRows] = useState([{ id: "a", label: "Alpha" }]);
+        return <section>
+          <button onClick={() => {
+            setRows((current) => current.map((row) =>
+              row.id === editedId ? { ...row, label: nextLabel } : row
+            ));
+            setRows((current) => [...current.slice(1), next]);
+            setRows((current) => [...current.slice(1), next]);
+            setRows((current) => current.map((row) =>
+              row.id === next.id ? { ...row, selected: true } : row
+            ));
+          }}>Roll twice</button>
+          <ul>{rows.map((row) => <li key={row.id}>{row.label}</li>)}</ul>
+        </section>;
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Feed"]);
+    expect(result.optimizations.keyedArrayRollingWindowHints).toBe(2);
+    expect(result.code).toContain("createCompilerKeyedArrayRollingWindow");
+    expect(result.code).not.toContain("createCompilerKeyedArrayMappedStructuralAppend");
+    expect(result.code).not.toContain("createCompilerKeyedArrayStructuralAppendMapPipeline");
+  });
+
+  it("does not connect rolling-window maps across another statement", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Feed({ next, editedId, nextLabel }) {
+        const [rows, setRows] = useState([{ id: "a", label: "Alpha" }]);
+        return <section>
+          <button onClick={() => {
+            setRows((current) => [...current.slice(1), next]);
+            logRoll();
+            setRows((current) => current.map((row) =>
+              row.id === editedId ? { ...row, label: nextLabel } : row
+            ));
+          }}>Roll and edit</button>
+          <ul>{rows.map((row) => <li key={row.id}>{row.label}</li>)}</ul>
+        </section>;
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Feed"]);
+    expect(result.code).toContain("createCompilerKeyedArrayRollingWindow");
+    expect(result.code).not.toContain("createCompilerKeyedArrayStructuralAppendMapPipeline");
+    expect(result.code).not.toContain("keyedRowsStructuralAppendMapHintedRuntimeFeature");
+  });
+
   it.each([
     {
       name: "an index-dependent row",

--- a/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-rolling-window-hints.test.tsx
+++ b/packages/farm-react/src/__tests__/compiler-runtime-keyed-array-rolling-window-hints.test.tsx
@@ -5,8 +5,13 @@ import { renderToString } from "react-dom/server";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   createCompiledComponent,
+  createCompilerKeyedArrayMappedStructuralAppend,
+  createCompilerKeyedArrayQueuedMapPipeline,
   createCompilerKeyedArrayRollingWindow,
   createCompilerKeyedArraySlice,
+  createCompilerKeyedArrayStructuralAppend,
+  createCompilerKeyedArrayStructuralAppendMapPipeline,
+  finalizeCompilerKeyedArrayMappedStructuralUpdate,
   type CompilerKeyedRowElement,
 } from "../compiler-runtime";
 
@@ -20,6 +25,7 @@ interface Item {
 }
 
 const roots: Root[] = [];
+const stressIt = process.env.FARM_REACT_STRESS === "1" ? it : it.skip;
 
 beforeEach(() => {
   globalThis.IS_REACT_ACT_ENVIRONMENT = true;
@@ -45,6 +51,39 @@ function hintedRoll(previous: Item[], remove: number, incoming: readonly Item[])
   ]) as Item[];
 }
 
+function hintedQueuedMap(previous: Item[], mapper: (item: Item, index: number) => Item): Item[] {
+  return createCompilerKeyedArrayQueuedMapPipeline(previous, (current, applyMap) =>
+    applyMap(current, (current as Item[]).map, mapper),
+  ) as Item[];
+}
+
+function hintedStructuralRoll(
+  previous: Item[],
+  remove: number,
+  incoming: readonly Item[],
+  mapped: boolean,
+): Item[] {
+  const retained = createCompilerKeyedArraySlice(previous, previous.slice, remove) as Item[];
+  const structural = mapped
+    ? (finalizeCompilerKeyedArrayMappedStructuralUpdate(retained) as Item[])
+    : retained;
+  const value = [...retained, ...incoming];
+  return (
+    mapped
+      ? createCompilerKeyedArrayMappedStructuralAppend(structural, value)
+      : createCompilerKeyedArrayStructuralAppend(structural, value)
+  ) as Item[];
+}
+
+function hintedStructuralRollMap(
+  previous: Item[],
+  mapper: (item: Item, index: number) => Item,
+): Item[] {
+  return createCompilerKeyedArrayStructuralAppendMapPipeline(previous, (current, applyMap) =>
+    applyMap(current, (current as Item[]).map, mapper),
+  ) as Item[];
+}
+
 function rowDescriptor(item: Item, text = item.label): CompilerKeyedRowElement {
   return {
     kind: "element",
@@ -59,6 +98,12 @@ function createRollingHarness(initialItems: Item[], readsCollection = false) {
   const counters = { executions: 0, renders: 0, keys: 0, descriptors: 0, bindings: 0 };
   let roll: (remove: number, incoming: readonly Item[]) => void = () => undefined;
   let customRoll: (incoming: Item) => void = () => undefined;
+  let mappedRoll: (
+    remove: number,
+    incoming: readonly Item[],
+    before?: (item: Item, index: number) => Item,
+    after?: (item: Item, index: number) => Item,
+  ) => void = () => undefined;
   const Feed = createCompiledComponent({
     displayName: "RollingFeed",
     initialize: () => [initialItems],
@@ -79,6 +124,17 @@ function createRollingHarness(initialItems: Item[], readsCollection = false) {
             incoming,
           ]) as Item[];
         });
+      mappedRoll = (remove, incoming, before, after) => {
+        if (before) {
+          state[0].set((previous) => hintedQueuedMap(previous as Item[], before));
+        }
+        state[0].set((previous) =>
+          hintedStructuralRoll(previous as Item[], remove, incoming, before !== undefined),
+        );
+        if (after) {
+          state[0].set((previous) => hintedStructuralRollMap(previous as Item[], after));
+        }
+      };
       const text = (item: Item) =>
         readsCollection ? `${items().length}: ${item.label}` : item.label;
       return (
@@ -132,6 +188,12 @@ function createRollingHarness(initialItems: Item[], readsCollection = false) {
     Feed,
     counters,
     customRoll: (incoming: Item) => customRoll(incoming),
+    mappedRoll: (
+      remove: number,
+      incoming: readonly Item[],
+      before?: (item: Item, index: number) => Item,
+      after?: (item: Item, index: number) => Item,
+    ) => mappedRoll(remove, incoming, before, after),
     roll: (remove: number, incoming: readonly Item[]) => roll(remove, incoming),
   };
 }
@@ -171,6 +233,86 @@ describe("compiled keyed-array rolling-window hints", () => {
     expect(harness.counters.keys).toBe(2);
     expect(harness.counters.descriptors).toBe(2);
     expect(harness.counters.bindings).toBe(2);
+  });
+
+  it("patches mapped survivors and prepares only the incoming rolling suffix", async () => {
+    const initialItems = Array.from(
+      { length: 2_048 },
+      (_, index): Item => ({ id: `row-${index}`, label: `Row ${index}` }),
+    );
+    const harness = createRollingHarness(initialItems);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Feed />));
+    const survivor = container.querySelector('[data-key="row-1024"]');
+    const untouched = container.querySelector('[data-key="row-1536"]');
+    harness.counters.keys = 0;
+    harness.counters.descriptors = 0;
+    harness.counters.bindings = 0;
+
+    await act(async () => {
+      harness.mappedRoll(
+        2,
+        [
+          { id: "row-2048", label: "Row 2048" },
+          { id: "row-2049", label: "Row 2049" },
+        ],
+        (item) => (item.id === "row-1024" ? { ...item, label: "Mapped survivor" } : item),
+        (item) =>
+          item.id === "row-1024"
+            ? { ...item, label: "Mapped survivor twice" }
+            : item.id === "row-2049"
+              ? { ...item, label: "Mapped incoming" }
+              : item,
+      );
+      await flushCompilerUpdates();
+    });
+
+    expect(container.querySelector('[data-key="row-0"]')).toBeNull();
+    expect(container.querySelector('[data-key="row-1"]')).toBeNull();
+    expect(container.querySelector('[data-key="row-1024"]')).toBe(survivor);
+    expect(container.querySelector('[data-key="row-1536"]')).toBe(untouched);
+    expect(survivor?.textContent).toBe("Mapped survivor twice");
+    expect(container.querySelector("li:last-child")?.textContent).toBe("Mapped incoming");
+    expect(container.querySelectorAll("li")).toHaveLength(2_048);
+    expect(harness.counters.executions).toBe(1);
+    expect(harness.counters.renders).toBe(1);
+    expect(harness.counters.keys).toBe(3);
+    expect(harness.counters.descriptors).toBe(2);
+    expect(harness.counters.bindings).toBe(3);
+  });
+
+  it("falls back atomically when a mapped rolling survivor changes key", async () => {
+    const harness = createRollingHarness([
+      { id: "a", label: "Alpha" },
+      { id: "b", label: "Beta" },
+      { id: "c", label: "Gamma" },
+    ]);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => root.render(<harness.Feed />));
+    const gamma = container.querySelector('[data-key="c"]');
+
+    await act(async () => {
+      harness.mappedRoll(1, [{ id: "d", label: "Delta" }], (item) =>
+        item.id === "b" ? { ...item, id: "renamed-b", label: "Renamed" } : item,
+      );
+      await flushCompilerUpdates();
+    });
+
+    expect([...container.querySelectorAll("li")].map((row) => row.textContent)).toEqual([
+      "Renamed",
+      "Gamma",
+      "Delta",
+    ]);
+    expect(container.querySelector('[data-key="a"]')).toBeNull();
+    expect(container.querySelector('[data-key="b"]')).toBeNull();
+    expect(container.querySelector('[data-key="renamed-b"]')).not.toBeNull();
+    expect(container.querySelector('[data-key="c"]')).toBe(gamma);
   });
 
   it("composes queued rolling windows and creates only the final incoming suffix", async () => {
@@ -413,7 +555,7 @@ describe("compiled keyed-array rolling-window hints", () => {
     expect(harness.counters.keys).toBe(6);
   });
 
-  it("preserves controlled focus and updates delegated indexes after queued rolls", async () => {
+  it("preserves controlled focus and delegated indexes through a mapped rolling window", async () => {
     const initialItems = ["a", "b", "c", "d"].map((id) => ({
       id,
       label: id.toUpperCase().repeat(4),
@@ -427,10 +569,25 @@ describe("compiled keyed-array rolling-window hints", () => {
         const items = () => state[0].get() as Item[];
         queue = () => {
           state[0].set((previous) =>
-            hintedRoll(previous as Item[], 1, [{ id: "e", label: "EEEE" }]),
+            hintedQueuedMap(previous as Item[], (item) =>
+              item.id === "d" ? { ...item, label: "DDDD mapped" } : item,
+            ),
           );
           state[0].set((previous) =>
-            hintedRoll(previous as Item[], 1, [{ id: "f", label: "FFFF" }]),
+            hintedStructuralRoll(
+              previous as Item[],
+              2,
+              [
+                { id: "e", label: "EEEE" },
+                { id: "f", label: "FFFF" },
+              ],
+              true,
+            ),
+          );
+          state[0].set((previous) =>
+            hintedStructuralRollMap(previous as Item[], (item) =>
+              item.id === "d" ? { ...item, label: "DDDD mapped twice" } : item,
+            ),
           );
         };
         return (
@@ -706,6 +863,95 @@ describe("compiled keyed-array rolling-window hints", () => {
     expect(harness.counters.bindings).toBe(incomingCount);
   }, 30_000);
 
+  stressIt(
+    "matches React through 2,000 randomized mapped rolling-window updates",
+    async () => {
+      const initialItems = Array.from(
+        { length: 48 },
+        (_, index): Item => ({ id: `mapped-row-${index}`, label: `Mapped row ${index}` }),
+      );
+      const harness = createRollingHarness(initialItems);
+      let updateReact: (
+        remove: number,
+        incoming: readonly Item[],
+        editedId: string,
+        beforeLabel: string,
+        afterLabel: string,
+      ) => void = () => undefined;
+      let expected = initialItems;
+      let seed = 0x5a17ed;
+      let nextId = initialItems.length;
+      const random = () => {
+        seed = (Math.imul(seed, 1_664_525) + 1_013_904_223) >>> 0;
+        return seed;
+      };
+      function NormalFeed() {
+        const [items, setItems] = useState(initialItems);
+        updateReact = (remove, incoming, editedId, beforeLabel, afterLabel) => {
+          setItems((previous) =>
+            previous.map((item) => (item.id === editedId ? { ...item, label: beforeLabel } : item)),
+          );
+          setItems((previous) => [...previous.slice(remove), ...incoming]);
+          setItems((previous) =>
+            previous.map((item) => (item.id === editedId ? { ...item, label: afterLabel } : item)),
+          );
+        };
+        return (
+          <ol>
+            {items.map((item) => (
+              <li key={item.id}>{item.label}</li>
+            ))}
+          </ol>
+        );
+      }
+      const compiledContainer = document.createElement("div");
+      const reactContainer = document.createElement("div");
+      document.body.append(compiledContainer, reactContainer);
+      const compiledRoot = createRoot(compiledContainer);
+      const reactRoot = createRoot(reactContainer);
+      roots.push(compiledRoot, reactRoot);
+      await act(async () => {
+        compiledRoot.render(<harness.Feed />);
+        reactRoot.render(<NormalFeed />);
+      });
+
+      for (let update = 0; update < 2_000; update += 1) {
+        const remove = 1 + (random() % 4);
+        const incoming = Array.from({ length: remove }, (): Item => {
+          const id = nextId++;
+          return { id: `mapped-row-${id}`, label: `Mapped row ${id}` };
+        });
+        const editedIndex = remove + (random() % (expected.length - remove));
+        const editedId = expected[editedIndex].id;
+        const beforeLabel = `Before ${update}`;
+        const afterLabel = `After ${update}`;
+        const before = (item: Item) =>
+          item.id === editedId ? { ...item, label: beforeLabel } : item;
+        const after = (item: Item) =>
+          item.id === editedId ? { ...item, label: afterLabel } : item;
+
+        expected = expected.map(before);
+        expected = [...expected.slice(remove), ...incoming].map(after);
+        await act(async () => {
+          harness.mappedRoll(remove, incoming, before, after);
+          updateReact(remove, incoming, editedId, beforeLabel, afterLabel);
+          await flushCompilerUpdates();
+        });
+        if (update % 50 === 0) {
+          expect(compiledContainer.textContent).toBe(reactContainer.textContent);
+        }
+      }
+
+      expect(compiledContainer.textContent).toBe(reactContainer.textContent);
+      expect([...compiledContainer.querySelectorAll("li")].map((row) => row.textContent)).toEqual(
+        expected.map((item) => item.label),
+      );
+      expect(harness.counters.executions).toBe(1);
+      expect(harness.counters.renders).toBe(1);
+    },
+    30_000,
+  );
+
   it("hydrates in StrictMode and drops a queued rolling update after unmount", async () => {
     const harness = createRollingHarness([
       { id: "a", label: "Alpha" },
@@ -743,6 +989,56 @@ describe("compiled keyed-array rolling-window hints", () => {
     act(() => {
       harness.roll(1, [{ id: "e", label: "Epsilon" }]);
       harness.roll(1, [{ id: "f", label: "Phi" }]);
+      root.unmount();
+    });
+    await flushCompilerUpdates();
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("hydrates mapped rolling windows in StrictMode and ignores an abandoned flush", async () => {
+    const harness = createRollingHarness([
+      { id: "a", label: "Alpha" },
+      { id: "b", label: "Beta" },
+      { id: "c", label: "Gamma" },
+    ]);
+    const container = document.createElement("div");
+    container.innerHTML = renderToString(
+      <StrictMode>
+        <harness.Feed />
+      </StrictMode>,
+    );
+    document.body.append(container);
+    const recoverable: unknown[] = [];
+    let root!: Root;
+    await act(async () => {
+      root = hydrateRoot(
+        container,
+        <StrictMode>
+          <harness.Feed />
+        </StrictMode>,
+        { onRecoverableError: (error) => recoverable.push(error) },
+      );
+    });
+    roots.push(root);
+
+    await act(async () => {
+      harness.mappedRoll(
+        1,
+        [{ id: "d", label: "Delta" }],
+        (item) => (item.id === "c" ? { ...item, label: "Gamma mapped" } : item),
+        (item) => (item.id === "d" ? { ...item, label: "Delta mapped" } : item),
+      );
+      await flushCompilerUpdates();
+    });
+    expect(container.textContent).toBe("BetaGamma mappedDelta mapped");
+    expect(recoverable).toEqual([]);
+
+    roots.pop();
+    act(() => {
+      harness.mappedRoll(1, [{ id: "e", label: "Epsilon" }], (item) => ({
+        ...item,
+        label: `${item.label}!`,
+      }));
       root.unmount();
     });
     await flushCompilerUpdates();

--- a/packages/farm-react/src/compiler.ts
+++ b/packages/farm-react/src/compiler.ts
@@ -3000,6 +3000,194 @@ function rewriteQueuedKeyedArrayStructuralPrependMapHints(
   };
 }
 
+function rewriteQueuedKeyedArrayRollingWindowMapHints(
+  root: t.JSXElement,
+  statesBySetter: ReadonlyMap<string, StateBinding>,
+  mapUpdateIdentifier: t.Identifier,
+  mapPipelineIdentifier: t.Identifier,
+  queuedMapPipelineIdentifier: t.Identifier,
+  rollingWindowIdentifier: t.Identifier,
+  structuralAppendIdentifier: t.Identifier,
+  mappedStructuralAppendIdentifier: t.Identifier,
+  structuralAppendMapPipelineIdentifier: t.Identifier,
+  mappedStructuralIdentifier: t.Identifier,
+  allowed: boolean,
+): {
+  root: t.JSXElement;
+  leadingMapCount: number;
+  mappedRollingWindowCount: number;
+  rollingWindowCount: number;
+  structuralRollingWindowCount: number;
+  trailingMapCount: number;
+} {
+  if (!allowed) {
+    return {
+      root: t.cloneNode(root, true),
+      leadingMapCount: 0,
+      mappedRollingWindowCount: 0,
+      rollingWindowCount: 0,
+      structuralRollingWindowCount: 0,
+      trailingMapCount: 0,
+    };
+  }
+  const file = expressionFile(t.cloneNode(root, true));
+  let leadingMapCount = 0;
+  let mappedRollingWindowCount = 0;
+  let rollingWindowCount = 0;
+  let structuralRollingWindowCount = 0;
+  let trailingMapCount = 0;
+
+  type MapStep = {
+    count: number;
+    updater: t.ArrowFunctionExpression & { body: t.CallExpression };
+  };
+  type RollingStep = {
+    call: t.CallExpression;
+  };
+  type SegmentStep = { kind: "map"; value: MapStep } | { kind: "rolling"; value: RollingStep };
+
+  const mapStep = (updater: t.ArrowFunctionExpression): MapStep | undefined => {
+    if (!t.isCallExpression(updater.body)) return undefined;
+    const count =
+      countKeyedArrayMapPipeline(updater, mapUpdateIdentifier) ||
+      countKeyedArrayMapPipeline(updater, mapPipelineIdentifier);
+    return count > 0
+      ? {
+          count,
+          updater: updater as t.ArrowFunctionExpression & { body: t.CallExpression },
+        }
+      : undefined;
+  };
+  const rollingStep = (updater: t.ArrowFunctionExpression): RollingStep | undefined => {
+    if (!t.isBlockStatement(updater.body)) return undefined;
+    const statement = updater.body.body.at(-1);
+    if (
+      !t.isReturnStatement(statement) ||
+      !statement.argument ||
+      !t.isCallExpression(statement.argument) ||
+      !t.isIdentifier(statement.argument.callee, { name: rollingWindowIdentifier.name }) ||
+      statement.argument.arguments.length !== 3 ||
+      !t.isExpression(statement.argument.arguments[1]) ||
+      !t.isExpression(statement.argument.arguments[2])
+    ) {
+      return undefined;
+    }
+    return { call: statement.argument };
+  };
+
+  traverse(file, {
+    BlockStatement(path) {
+      let segment: SegmentStep[] = [];
+      let segmentState: number | undefined;
+      const flushSegment = (): void => {
+        const rollingIndices = segment.flatMap((step, index) =>
+          step.kind === "rolling" ? [index] : [],
+        );
+        if (rollingIndices.length !== 1 || segment.length < 2) {
+          segment = [];
+          segmentState = undefined;
+          return;
+        }
+        const rollingIndex = rollingIndices[0];
+        const leadingMaps = segment.slice(0, rollingIndex).filter((step) => step.kind === "map");
+        const trailingMaps = segment.slice(rollingIndex + 1).filter((step) => step.kind === "map");
+        if (leadingMaps.length === 0 && trailingMaps.length === 0) {
+          segment = [];
+          segmentState = undefined;
+          return;
+        }
+
+        const rolling = segment[rollingIndex];
+        if (rolling.kind !== "rolling") return;
+        const retained = rolling.value.call.arguments[1];
+        const value = rolling.value.call.arguments[2];
+        if (!t.isExpression(retained) || !t.isExpression(value)) return;
+        const hasLeadingMaps = leadingMaps.length > 0;
+        rolling.value.call.callee = t.cloneNode(
+          hasLeadingMaps ? mappedStructuralAppendIdentifier : structuralAppendIdentifier,
+        );
+        rolling.value.call.arguments = [
+          hasLeadingMaps
+            ? t.callExpression(t.cloneNode(mappedStructuralIdentifier), [
+                t.cloneNode(retained, true),
+              ])
+            : t.cloneNode(retained, true),
+          t.cloneNode(value, true),
+        ];
+        rollingWindowCount += 1;
+        if (hasLeadingMaps) {
+          mappedRollingWindowCount += 1;
+          for (const step of leadingMaps) {
+            if (step.kind !== "map") continue;
+            step.value.updater.body.callee = t.cloneNode(queuedMapPipelineIdentifier);
+            leadingMapCount += step.value.count;
+          }
+        } else {
+          structuralRollingWindowCount += 1;
+        }
+        for (const step of trailingMaps) {
+          if (step.kind !== "map") continue;
+          step.value.updater.body.callee = t.cloneNode(structuralAppendMapPipelineIdentifier);
+          trailingMapCount += step.value.count;
+        }
+        segment = [];
+        segmentState = undefined;
+      };
+
+      const statements = path.get("body") as NodePath<t.Statement>[];
+      for (const statementPath of statements) {
+        const statement = statementPath.node;
+        if (!t.isExpressionStatement(statement) || !t.isCallExpression(statement.expression)) {
+          flushSegment();
+          continue;
+        }
+        const setterCall = statement.expression;
+        if (
+          !t.isIdentifier(setterCall.callee) ||
+          statementPath.scope.hasBinding(setterCall.callee.name) ||
+          setterCall.arguments.length !== 1
+        ) {
+          flushSegment();
+          continue;
+        }
+        const state = statesBySetter.get(setterCall.callee.name);
+        const updater = setterCall.arguments[0];
+        if (
+          !state ||
+          !t.isArrowFunctionExpression(updater) ||
+          updater.async ||
+          updater.generator ||
+          updater.params.length !== 1 ||
+          !t.isIdentifier(updater.params[0])
+        ) {
+          flushSegment();
+          continue;
+        }
+        if (segmentState !== undefined && segmentState !== state.index) flushSegment();
+        const nextMap = mapStep(updater);
+        const nextRolling = rollingStep(updater);
+        if (!nextMap && !nextRolling) {
+          flushSegment();
+          continue;
+        }
+        segmentState = state.index;
+        segment.push(
+          nextMap ? { kind: "map", value: nextMap } : { kind: "rolling", value: nextRolling! },
+        );
+      }
+      flushSegment();
+    },
+  });
+  return {
+    root: (file.program.body[0] as t.ExpressionStatement).expression as t.JSXElement,
+    leadingMapCount,
+    mappedRollingWindowCount,
+    rollingWindowCount,
+    structuralRollingWindowCount,
+    trailingMapCount,
+  };
+}
+
 function rewriteQueuedKeyedArrayStructuralReorderHints(
   root: t.JSXElement,
   statesBySetter: ReadonlyMap<string, StateBinding>,
@@ -8370,11 +8558,13 @@ function compileCandidate(
     keyedArrayMapReorderHints: number;
     keyedArrayMapSortHints: number;
     keyedArrayMapUpdateHints: number;
+    keyedArrayMappedRollingWindowHints: number;
     keyedArrayMappedStructuralHints: number;
     keyedArrayMappedStructuralAppendHints: number;
     keyedArrayMappedStructuralPrependHints: number;
     keyedArrayQueuedMapUpdateHints: number;
     keyedArrayStructuralAppendMapHints: number;
+    keyedArrayStructuralRollingWindowHints: number;
     keyedArrayStructuralPrependMapHints: number;
     keyedArrayStructuralReorderHints: number;
     keyedArrayStructuralSortHints: number;
@@ -9225,6 +9415,60 @@ function compileCandidate(
         queuedStructuralPrependMapHintedRoot.structuralPrependMapCount;
     }
   }
+  const queuedRollingWindowMapHintedRoot = rewriteQueuedKeyedArrayRollingWindowMapHints(
+    expandedReactiveRoot,
+    statesBySetter,
+    keyedMapUpdateIdentifier,
+    keyedArrayMapPipelineIdentifier,
+    keyedArrayQueuedMapPipelineIdentifier,
+    keyedArrayRollingWindowIdentifier,
+    keyedArrayAppendIdentifier,
+    keyedArrayMappedStructuralAppendIdentifier,
+    keyedArrayStructuralAppendMapPipelineIdentifier,
+    keyedArrayMappedStructuralIdentifier,
+    allowKeyedArrayMapPipelines,
+  );
+  let appliedMappedRollingWindowHints = 0;
+  if (queuedRollingWindowMapHintedRoot.rollingWindowCount > 0) {
+    const hintedBlockAnalysis = analyzeComposableBlocks(
+      queuedRollingWindowMapHintedRoot.root,
+      reactiveByValue,
+      safeGlobals,
+      listNames,
+      allowedComponentNames,
+    );
+    const hintedAnalysis = analyzeHostTree(
+      queuedRollingWindowMapHintedRoot.root,
+      reactiveByValue,
+      safeGlobals,
+      hintedBlockAnalysis.conditionalExpressions || new Set<t.Expression>(),
+      hintedBlockAnalysis.keyedExpressions || new Set<t.Expression>(),
+      hintedBlockAnalysis.ownedElements || new Set<t.JSXElement>(),
+      hintedBlockAnalysis.componentElements || new Set<t.JSXElement>(),
+    );
+    if (!hintedBlockAnalysis.reason && !hintedAnalysis.reason) {
+      expandedReactiveRoot = queuedRollingWindowMapHintedRoot.root;
+      blockAnalysis = hintedBlockAnalysis;
+      analysis = hintedAnalysis;
+      appliedMappedRollingWindowHints = queuedRollingWindowMapHintedRoot.rollingWindowCount;
+      appliedQueuedStructuralAppendMapHints +=
+        queuedRollingWindowMapHintedRoot.mappedRollingWindowCount +
+        queuedRollingWindowMapHintedRoot.trailingMapCount;
+      compilerUsage.keyedArrayMapUpdateHints +=
+        queuedRollingWindowMapHintedRoot.leadingMapCount +
+        queuedRollingWindowMapHintedRoot.trailingMapCount;
+      compilerUsage.keyedArrayQueuedMapUpdateHints +=
+        queuedRollingWindowMapHintedRoot.leadingMapCount;
+      compilerUsage.keyedArrayStructuralAppendMapHints +=
+        queuedRollingWindowMapHintedRoot.trailingMapCount;
+      compilerUsage.keyedArrayMappedRollingWindowHints +=
+        queuedRollingWindowMapHintedRoot.mappedRollingWindowCount;
+      compilerUsage.keyedArrayMappedStructuralHints +=
+        queuedRollingWindowMapHintedRoot.mappedRollingWindowCount;
+      compilerUsage.keyedArrayStructuralRollingWindowHints +=
+        queuedRollingWindowMapHintedRoot.structuralRollingWindowCount;
+    }
+  }
   const queuedMapReorderHintedRoot = rewriteQueuedKeyedArrayMapReorderHints(
     expandedReactiveRoot,
     statesBySetter,
@@ -9427,8 +9671,9 @@ function compileCandidate(
     blockPlans,
     hasKeyedUpdateHints,
     hasKeyedArrayRemovalHints,
-    appliedKeyedArrayAppendHints > 0 &&
-      (appliedKeyedArrayFilterHints > 0 || appliedKeyedArraySliceHints > 0),
+    (appliedKeyedArrayAppendHints > 0 &&
+      (appliedKeyedArrayFilterHints > 0 || appliedKeyedArraySliceHints > 0)) ||
+      compilerUsage.keyedArrayStructuralRollingWindowHints > 0,
     appliedQueuedStructuralAppendMapHints > 0,
     appliedKeyedArrayPrependHints > 0,
     appliedKeyedArrayPrependHints > 0 && hasKeyedArrayRemovalHints,
@@ -9441,7 +9686,7 @@ function compileCandidate(
       appliedQueuedReorderMapHints > 0 ||
       appliedQueuedMappedStructuralHints > 0 ||
       appliedQueuedStructuralMapHints > 0,
-    appliedKeyedArrayRollingWindowHints > 0,
+    appliedKeyedArrayRollingWindowHints > appliedMappedRollingWindowHints,
   );
   markShortCircuitBindings(analysis.bindings || []);
   assignStableBindingTargets(analysis.bindings || []);
@@ -9655,11 +9900,13 @@ export async function compileReactModule(
     keyedArrayMapReorderHints: 0,
     keyedArrayMapSortHints: 0,
     keyedArrayMapUpdateHints: 0,
+    keyedArrayMappedRollingWindowHints: 0,
     keyedArrayMappedStructuralHints: 0,
     keyedArrayMappedStructuralAppendHints: 0,
     keyedArrayMappedStructuralPrependHints: 0,
     keyedArrayQueuedMapUpdateHints: 0,
     keyedArrayStructuralAppendMapHints: 0,
+    keyedArrayStructuralRollingWindowHints: 0,
     keyedArrayStructuralPrependMapHints: 0,
     keyedArrayStructuralReorderHints: 0,
     keyedArrayStructuralSortHints: 0,
@@ -9846,9 +10093,10 @@ export async function compileReactModule(
         const hasKeyedArrayMapReorderHints =
           compilerUsage.keyedArrayMapReorderHints + compilerUsage.keyedArrayMapSortHints > 0;
         const hasKeyedArrayStructuralAppendHints =
-          optimizationCounts.keyedArrayAppendHints > 0 &&
-          (optimizationCounts.keyedArrayFilterHints > 0 ||
-            optimizationCounts.keyedArraySliceHints > 0);
+          (optimizationCounts.keyedArrayAppendHints > 0 &&
+            (optimizationCounts.keyedArrayFilterHints > 0 ||
+              optimizationCounts.keyedArraySliceHints > 0)) ||
+          compilerUsage.keyedArrayStructuralRollingWindowHints > 0;
         const hasUnmappedKeyedArrayAppendHints =
           optimizationCounts.keyedArrayAppendHints >
           compilerUsage.keyedArrayMappedStructuralAppendHints;
@@ -9916,7 +10164,8 @@ export async function compileReactModule(
                       ),
                     ]
                   : []),
-                ...(compilerUsage.keyedArrayMappedStructuralAppendHints > 0
+                ...(compilerUsage.keyedArrayMappedStructuralAppendHints > 0 ||
+                compilerUsage.keyedArrayMappedRollingWindowHints > 0
                   ? [
                       t.importSpecifier(
                         keyedArrayMappedStructuralAppendIdentifier,
@@ -9940,7 +10189,8 @@ export async function compileReactModule(
                       ),
                     ]
                   : []),
-                ...(hasUnmappedKeyedArrayAppendHints
+                ...(hasUnmappedKeyedArrayAppendHints ||
+                compilerUsage.keyedArrayStructuralRollingWindowHints > 0
                   ? [
                       t.importSpecifier(
                         keyedArrayAppendIdentifier,
@@ -10033,7 +10283,9 @@ export async function compileReactModule(
                       ),
                     ]
                   : []),
-                ...(optimizationCounts.keyedArrayRollingWindowHints > 0
+                ...(optimizationCounts.keyedArrayRollingWindowHints >
+                compilerUsage.keyedArrayMappedRollingWindowHints +
+                  compilerUsage.keyedArrayStructuralRollingWindowHints
                   ? [
                       t.importSpecifier(
                         keyedArrayRollingWindowIdentifier,

--- a/packages/farm-react/vitest.stress.config.ts
+++ b/packages/farm-react/vitest.stress.config.ts
@@ -20,10 +20,11 @@ export default defineConfig({
       "src/__tests__/compiler-runtime-keyed-array-structural-reorder-hints.test.tsx",
       "src/__tests__/compiler-runtime-keyed-array-append-hints.test.tsx",
       "src/__tests__/compiler-runtime-keyed-array-prepend-hints.test.tsx",
+      "src/__tests__/compiler-runtime-keyed-array-rolling-window-hints.test.tsx",
     ],
     setupFiles: ["src/__tests__/stress.setup.ts"],
     testNamePattern:
-      /2,000 deterministic mapped reorder updates|2,000 deterministic mapped reversal parity updates|2,000 queued reverse, map, and reverse updates|2,000 reverse-or-sort then map updates|2,000 queued reorder then standalone map updates|2,000 queued map then reorder updates|2,000 queued map and consecutive reorder updates|2,000 mapped structural removals|2,000 randomized interleaved map and structural removals|2,000 randomized terminal structural-map row transitions|2,000 randomized mapped terminal-structural row transitions|2,000 randomized queued mapped structural transitions|2,000 randomized queued structural mapped transitions|2,000 randomized queued structural mapped reorders|2,000 randomized structural removals, appends, and maps|2,000 randomized removals, maps, and later appends|2,000 randomized structural prepend updates|2,000 randomized mapped structural prepends|3,000 deterministic recursive updates|4,096 rows/,
+      /2,000 deterministic mapped reorder updates|2,000 deterministic mapped reversal parity updates|2,000 queued reverse, map, and reverse updates|2,000 reverse-or-sort then map updates|2,000 queued reorder then standalone map updates|2,000 queued map then reorder updates|2,000 queued map and consecutive reorder updates|2,000 mapped structural removals|2,000 randomized interleaved map and structural removals|2,000 randomized terminal structural-map row transitions|2,000 randomized mapped terminal-structural row transitions|2,000 randomized queued mapped structural transitions|2,000 randomized queued structural mapped transitions|2,000 randomized queued structural mapped reorders|2,000 randomized structural removals, appends, and maps|2,000 randomized removals, maps, and later appends|2,000 randomized structural prepend updates|2,000 randomized mapped structural prepends|2,000 randomized mapped rolling-window updates|3,000 deterministic recursive updates|4,096 rows/,
     testTimeout: 30_000,
   },
 });


### PR DESCRIPTION
## Problem

The experimental React compiler can optimize safe keyed-row maps and rolling-window updates independently, but an adjacent sequence such as `map -> roll -> map` loses compiler-proven row lineage at the rolling step. React then performs complete keyed reconciliation even though survivor keys and the incoming suffix are already known.

This affects bounded feeds, log viewers, market tables, telemetry grids, and other UIs that patch retained rows while trimming an old prefix and appending fresh rows.

## Root cause

The compiler linked queued map pipelines and rolling-window setters through separate rewrites. Neither rewrite could describe the complete transition, so the rolling setter became a boundary between otherwise safe mapped updates.

## Change

- Link adjacent safe keyed-row maps across exactly one compiler-recognized rolling-window setter.
- Reuse the existing mapped structural-append pipeline and runtime validation instead of adding a new browser runtime helper.
- Support maps before the rolling update, after it, or on both sides.
- Keep mixed plain and mapped rolling sites on their correct existing helper paths.
- Add a 10,000-row `map -> roll 1,000 -> map` dashboard benchmark and a block-bodied React control that intentionally cannot retain compiler lineage.

## Safety and compatibility

- React remains the only affected renderer.
- There is no new public API, syntax, configuration, or runtime dependency.
- Disabled compiler builds receive no new runtime behavior or bundle cost.
- The transform requires contiguous setters for the same state and exactly one proven rolling-window update.
- Changed keys, unsafe syntax, custom behavior, ambiguous ownership, intervening statements, multiple rolling setters, or failed runtime validation use the complete React fallback.
- DOM identity, controlled input focus and selection, delegated events, hydration, Strict Mode, unmount cleanup, and queued update semantics are covered.
- React 18 and React 19 compatibility remains covered.

## Verification

- `pnpm --filter @farm.js/react exec vitest run src/__tests__/compiler-keyed-array-rolling-window-hints.test.ts`
- `pnpm --filter @farm.js/react exec vitest run src/__tests__/compiler-runtime-keyed-array-rolling-window-hints.test.tsx`
- `FARM_REACT_STRESS=1 pnpm --filter @farm.js/react exec vitest run --config vitest.stress.config.ts src/__tests__/compiler-runtime-keyed-array-rolling-window-hints.test.tsx -t "2,000 randomized mapped rolling-window updates"`
- `pnpm --filter @farm.js/react test:compat`
- `pnpm --filter @farm.js/react test:runtime-size`
- `pnpm --filter @farm.js/react type-check`
- `pnpm --filter @farm.js/react build`
- `pnpm docs:check-navigation`
- `pnpm --dir docs exec farm generate --check`
- Dashboard type check, production Nitro build, and production browser benchmark.

The new benchmark correctness and performance gates pass:

- Static: 16.50 ms compiled, 27.10 ms control, 67.70 ms React; 4.103x over React and 1.642x over control.
- Hybrid: 16.30 ms compiled, 29.10 ms control, 67.70 ms React; 4.153x over React and 1.785x over control.
- 10,000 rows, rolling 1,000 rows per update, 5 warmups, 10 measured samples, and 20 bracketed React baseline samples.
- Compiled dashboard and table owner execution counts remain zero.
- Existing benchmark thresholds were not reduced.

## Documentation and release

- Expanded the experimental React compiler documentation and package README with mapped rolling-window behavior, limits, and fallback rules.
- Updated the React compiler dashboard example, benchmark runner, and checked-in benchmark report.
- No template, generated artifact, version, or release-flow change.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retains compiler-proven keyed-row lineage through `map -> roll -> map` update sequences so the React compiler no longer falls back to complete keyed reconciliation at the rolling step.

- Links adjacent safe same-key maps across exactly one compiler-recognized rolling-window setter, before, after, or on both sides.
- Reuses the existing structural append/map runtime and validation; no new public API, config, or browser helper.
- Unchanged survivors keep DOM identity, focus, selection, and delegated-event indexes; only changed bindings and the incoming suffix are written.
- Falls back to complete React reconciliation for changed keys, multiple rolling setters, intervening statements, unsafe syntax, or failed runtime validation.

**Benchmark**
- Adds a 10,000-row `map -> roll 1,000 -> map` dashboard benchmark with a block-bodied compiled control.
- Compiled path is about 4.1x faster than React and 1.6-1.8x faster than the compiled control.

<sup>Written for commit 52a2c903d138625695d30babbd3d9f0a3464d825. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/924?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

