### PR TITLE
fix(agent-runtime): normalize decoded proxy response headers

### DIFF
--- a/packages/farm/src/__tests__/agent-runtime.test.ts
+++ b/packages/farm/src/__tests__/agent-runtime.test.ts
@@ -4,6 +4,7 @@ import { createServer } from "node:http";
 import { mkdtemp, mkdir, realpath, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { gzipSync } from "node:zlib";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   applyAgentRuntimeViteProxy,
@@ -183,6 +184,74 @@ describe("agent runtime proxy", () => {
     expect(response.headers.get("x-upstream-auth")).toBe("Bearer secret");
     expect(response.headers.get("x-forwarded-host")).toBe("farm.test");
     expect(await response.text()).toBe("POST:hello:done");
+  });
+
+  it("does not forward stale compression metadata after fetch decodes the body", async () => {
+    const payload = "decoded agent response";
+    const compressed = gzipSync(payload);
+    let acceptEncoding: string | undefined;
+    const server = createServer((request, response) => {
+      acceptEncoding = request.headers["accept-encoding"];
+      // Ignore identity to exercise the defensive response normalization too.
+      response.writeHead(200, {
+        "content-encoding": "gzip",
+        "content-length": compressed.byteLength,
+        "content-type": "text/plain",
+      });
+      response.end(compressed);
+    });
+    const origin = await listen(server);
+    cleanups.push(() => close(server));
+
+    const response = await proxyAgentRuntimeRequest(
+      new Request("http://farm.test/agents/compressed", {
+        headers: { "accept-encoding": "br, gzip" },
+      }),
+      origin,
+    );
+
+    expect(acceptEncoding).toBe("identity");
+    expect(response.headers.get("content-encoding")).toBeNull();
+    expect(response.headers.get("content-length")).toBeNull();
+    expect(await response.text()).toBe(payload);
+  });
+
+  it.each(["HEAD", "GET"])(
+    "preserves encoded representation metadata for bodyless %s responses",
+    async (method) => {
+      const server = createServer((_request, response) => {
+        response.writeHead(method === "HEAD" ? 200 : 304, {
+          "content-encoding": "gzip",
+          "content-length": "123",
+        });
+        response.end();
+      });
+      const origin = await listen(server);
+      cleanups.push(() => close(server));
+      const response = await proxyAgentRuntimeRequest(
+        new Request("http://farm.test/agents/metadata", { method }),
+        origin,
+      );
+      expect(response.body).toBeNull();
+      expect(response.headers.get("content-encoding")).toBe("gzip");
+      expect(response.headers.get("content-length")).toBe("123");
+    },
+  );
+
+  it("preserves metadata for content codings Fetch does not decode", async () => {
+    const server = createServer((_request, response) => {
+      response.writeHead(200, { "content-encoding": "custom", "content-length": "3" });
+      response.end("raw");
+    });
+    const origin = await listen(server);
+    cleanups.push(() => close(server));
+    const response = await proxyAgentRuntimeRequest(
+      new Request("http://farm.test/agents/raw"),
+      origin,
+    );
+    expect(response.headers.get("content-encoding")).toBe("custom");
+    expect(response.headers.get("content-length")).toBe("3");
+    expect(await response.text()).toBe("raw");
   });
 
   it("rewrites upstream redirects and sanitizes connection failures", async () => {

--- a/packages/farm/src/agent-runtime.ts
+++ b/packages/farm/src/agent-runtime.ts
@@ -260,6 +260,18 @@ export async function proxyAgentRuntimeRequest(
     const upstream = await (options.fetch || globalThis.fetch)(targetUrl, init);
     const responseHeaders = new Headers(upstream.headers);
     removeHopByHopHeaders(responseHeaders);
+    // Fetch decodes supported content codings before exposing the body while retaining
+    // the upstream metadata. Forwarding those headers would make the client
+    // try to decode an already-decoded stream and trust a stale byte length.
+    const contentCodings = responseHeaders.get("content-encoding")?.toLowerCase().split(",");
+    if (
+      upstream.body &&
+      contentCodings?.length &&
+      contentCodings.every((coding) => ["gzip", "x-gzip", "deflate", "br"].includes(coding.trim()))
+    ) {
+      responseHeaders.delete("content-encoding");
+      responseHeaders.delete("content-length");
+    }
     rewriteProxyLocation(responseHeaders, upstreamOrigin, incomingUrl.origin);
 
     return new Response(upstream.body, {
@@ -516,7 +528,9 @@ function createProxyRequestHeaders(input: Headers, incomingUrl: URL): Headers {
   removeHopByHopHeaders(headers);
   headers.delete("host");
   headers.delete("content-length");
-  headers.delete("accept-encoding");
+  // Node fetch supplies its own compression preference when this header is
+  // absent, then exposes a decoded body with the original encoding headers.
+  headers.set("accept-encoding", "identity");
   if (!headers.has("x-forwarded-host")) headers.set("x-forwarded-host", incomingUrl.host);
   if (!headers.has("x-forwarded-proto")) {
     headers.set("x-forwarded-proto", incomingUrl.protocol.replace(":", ""));


### PR DESCRIPTION
## Problem

A compressed upstream agent response reaches Farm with decoded bytes but its original Content-Encoding and Content-Length. Clients can try to decompress the body again or wait for the wrong byte count.

## Root cause

Node Fetch adds compression negotiation when Accept-Encoding is absent, and retains the original headers after decoding.

## Change

Request identity encoding and remove stale encoding/length metadata when Fetch exposes a body with supported decoded content codings.

## Safety and compatibility

Streaming is preserved. HEAD/304 representation metadata, unknown content codings, redirects, authentication, and hop-by-hop header filtering remain intact. Custom fetch implementations must follow Fetch decoding semantics.

## Verification

macOS, Node 23.11.0, pnpm 8.12.1.
- `pnpm --filter @farm.js/core test -- agent-runtime.test.ts` (13 passed)
- `pnpm --filter @farm.js/core type-check`
- Focused oxfmt/oxlint and git diff checks.
- The compression regression fails without the fix against a real local gzip server.
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @farm.js/core build` (passed, including declarations).

All seven fixes also merge cleanly in a local validation checkout: 193 focused core tests and the full 60-test RSC plugin suite pass together. `pnpm docs:check-navigation` and `NODE_OPTIONS=--max-old-space-size=8192 pnpm docs:build` also pass on the combined checkout (Vercel production output).

## Documentation and release

No public API, configuration, template, or version changes.
