### PR TITLE
fix(integrations): match routes by specificity

### DIFF
--- a/docs/src/app/docs/integrations/custom/page.md
+++ b/docs/src/app/docs/integrations/custom/page.md
@@ -555,6 +555,10 @@ export const acme = defineIntegration({
 
 ## Typed routes
 
+Within an integration, static paths take precedence over dynamic parameters, followed by
+catch-all paths. For example, `/api/items/new` wins over `/api/items/[id]` regardless of
+declaration order. Routes with equal specificity keep their declaration order.
+
 `integrationRoute` is the route factory. It supports `get`, `post`, `put`, `patch`, `delete`, `options`, and `head`.
 
 ```ts

--- a/packages/farm/src/__tests__/integrations.test.ts
+++ b/packages/farm/src/__tests__/integrations.test.ts
@@ -225,6 +225,55 @@ describe("integrations runtime", () => {
     expect(dynamic?.params).toEqual({ id: "%E0" });
   });
 
+  it("matches the most specific integration route regardless of declaration order", async () => {
+    const integration = defineIntegration({
+      category: "agent",
+      type: "specific-routes",
+      instance: {},
+      routes: [
+        integrationRoute.get("/api/[...path]", {
+          handler: async () => new Response("catch-all"),
+        }),
+        integrationRoute.get("/api/items/[id]", {
+          handler: async () => new Response("dynamic"),
+        }),
+        integrationRoute.get("/api/items/new", {
+          handler: async () => new Response("static"),
+        }),
+      ],
+    });
+
+    expect(
+      matchIntegrationRoute({ agent: integration }, { pathname: "/api/items/new", method: "GET" })
+        ?.route.path,
+    ).toBe("/api/items/new");
+    expect(
+      matchIntegrationRoute({ agent: integration }, { pathname: "/api/items/123", method: "GET" })
+        ?.route.path,
+    ).toBe("/api/items/[id]");
+    const manager = createManager();
+    manager.addPlugins(resolveIntegrationPlugins({ specific: integration }));
+    await manager.runHookParallel("init");
+    const runtime = getRegisteredIntegrationRuntime("specific")!;
+    for (const [pathname, expected] of [
+      ["/api/items/new", "static"],
+      ["/api/items/123", "dynamic"],
+      ["/api/other/deep", "catch-all"],
+    ]) {
+      const res = createResponse();
+      expect(
+        await manager.runHookParallel("beforeRequest", createRequest(pathname) as any, res as any),
+      ).toBe(true);
+      expect(res.body.toString()).toBe(expected);
+      const response = await dispatchIntegrationRequest(
+        runtime,
+        new Request(`http://localhost${pathname}`),
+      );
+      expect(await response?.text()).toBe(expected);
+    }
+    await manager.runHookParallel("shutdown", { reason: "test" });
+  });
+
   it("rejects integration catch-all parameters before later path segments", () => {
     expect(() =>
       defineIntegration({

--- a/packages/farm/src/integrations.ts
+++ b/packages/farm/src/integrations.ts
@@ -12,7 +12,11 @@ import type {
 import type { InferFarmIntegrationOrmClient } from "./integration-orm";
 import { setFarmPluginIntegrationContext } from "./plugin-integration-context";
 import { decodeRouteSegment } from "./utils/decode";
-import { assertTerminalCatchAll } from "./routing/specificity";
+import {
+  assertTerminalCatchAll,
+  compareRouteSpecificity,
+  getRoutePatternSpecificity,
+} from "./routing/specificity";
 import type {
   FarmPlugin,
   FarmPluginContext,
@@ -2235,11 +2239,21 @@ type NormalizedIntegrationRoute = Omit<FarmIntegrationRoute, "method" | "methods
 function normalizeIntegrationRoutes(
   routes: readonly FarmIntegrationRoute[],
 ): NormalizedIntegrationRoute[] {
-  return routes.map((route) => ({
-    ...route,
-    methods: normalizeIntegrationRouteMethods(route),
-    input: normalizeIntegrationRouteInputSchemas(route),
-  }));
+  return routes
+    .map((route, index) => ({
+      index,
+      route: {
+        ...route,
+        methods: normalizeIntegrationRouteMethods(route),
+        input: normalizeIntegrationRouteInputSchemas(route),
+      },
+      specificity: getRoutePatternSpecificity(route.path, "api"),
+    }))
+    .sort(
+      (left, right) =>
+        compareRouteSpecificity(left.specificity, right.specificity) || left.index - right.index,
+    )
+    .map(({ route }) => route);
 }
 
 function normalizeIntegrationRouteMethods(route: Pick<FarmIntegrationRoute, "method" | "methods">) {

--- a/packages/farm/src/routing/specificity.ts
+++ b/packages/farm/src/routing/specificity.ts
@@ -167,26 +167,8 @@ export function assertTerminalCatchAll(pattern: string, syntax: RoutePatternSynt
 export function getRoutePatternShape(pattern: string, syntax: RoutePatternSyntax = "page"): string {
   assertTerminalCatchAll(pattern, syntax);
   const segments = splitRoutePattern(pattern, syntax).map((segment) => {
-    const parameterName = syntax === "router" ? ROUTER_PARAMETER_NAME : ".+";
-    const supportsColonAndStar = syntax === "router";
-    if (
-      new RegExp(`^\\[\\[\\.\\.\\.${parameterName}\\]\\]$`).test(segment) ||
-      (supportsColonAndStar && new RegExp(`^\\*${parameterName}\\?$`).test(segment))
-    ) {
-      return "optional-catch-all";
-    }
-    if (
-      new RegExp(`^\\[\\.\\.\\.${parameterName}\\]$`).test(segment) ||
-      (supportsColonAndStar && new RegExp(`^\\*${parameterName}$`).test(segment))
-    ) {
-      return "catch-all";
-    }
-    if (
-      new RegExp(`^\\[${parameterName}\\]$`).test(segment) ||
-      (supportsColonAndStar && new RegExp(`^:${parameterName}$`).test(segment))
-    ) {
-      return "dynamic";
-    }
+    const specificity = getPatternSegmentSpecificity(segment, syntax);
+    if (specificity !== "static") return specificity;
 
     try {
       return `static:${decodeURIComponent(segment)}`;
@@ -196,4 +178,43 @@ export function getRoutePatternShape(pattern: string, syntax: RoutePatternSyntax
   });
 
   return segments.length === 0 ? "/" : JSON.stringify(segments);
+}
+
+/** Return the specificity of every URL-consuming segment in a route pattern. */
+export function getRoutePatternSpecificity(
+  pattern: string,
+  syntax: RoutePatternSyntax = "page",
+): RouteSegmentSpecificity[] {
+  assertTerminalCatchAll(pattern, syntax);
+  return splitRoutePattern(pattern, syntax).map((segment) =>
+    getPatternSegmentSpecificity(segment, syntax),
+  );
+}
+
+function getPatternSegmentSpecificity(
+  segment: string,
+  syntax: RoutePatternSyntax,
+): RouteSegmentSpecificity {
+  const parameterName = syntax === "router" ? ROUTER_PARAMETER_NAME : ".+";
+  const supportsColonAndStar = syntax === "router";
+  if (
+    new RegExp(`^\\[\\[\\.\\.\\.${parameterName}\\]\\]$`).test(segment) ||
+    (supportsColonAndStar && new RegExp(`^\\*${parameterName}\\?$`).test(segment))
+  ) {
+    return "optional-catch-all";
+  }
+  if (
+    new RegExp(`^\\[\\.\\.\\.${parameterName}\\]$`).test(segment) ||
+    (supportsColonAndStar && new RegExp(`^\\*${parameterName}$`).test(segment))
+  ) {
+    return "catch-all";
+  }
+  if (
+    new RegExp(`^\\[${parameterName}\\]$`).test(segment) ||
+    (supportsColonAndStar && new RegExp(`^:${parameterName}$`).test(segment))
+  ) {
+    return "dynamic";
+  }
+
+  return "static";
 }


### PR DESCRIPTION
## Problem

With a catch-all declared before /api/items/new, requests for the static endpoint reach the catch-all handler instead.

## Root cause

Integration routing used declaration order, unlike the core route matcher.

## Change

Sort normalized integration routes with Farm's shared segment-specificity comparator. Static segments win over dynamic segments and catch-alls; ties retain declaration order.

## Safety and compatibility

The matcher, Vite-style request hooks, and server dispatch use the same ordering. Integration registration order and explicit method matching are preserved.

## Verification

macOS, Node 23.11.0, pnpm 8.12.1.
- `pnpm --filter @farm.js/core test -- integrations.test.ts router.test.ts api-route-manager.test.ts`
- `pnpm --filter @farm.js/core type-check`
- The new regression fails without the fix and passes through matching and both dispatch paths.
- Focused formatting/lint passes with existing unused-helper warnings.
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @farm.js/core build` (passed, including declarations).

All seven fixes also merge cleanly in a local validation checkout: 193 focused core tests and the full 60-test RSC plugin suite pass together. `pnpm docs:check-navigation` and `NODE_OPTIONS=--max-old-space-size=8192 pnpm docs:build` also pass on the combined checkout (Vercel production output).

## Documentation and release

Document route precedence in the custom integration guide. No release or generated-artifact changes.
