### PR TITLE
fix(integrations): honor wildcard route methods

### DIFF
--- a/docs/src/app/docs/integrations/custom/page.md
+++ b/docs/src/app/docs/integrations/custom/page.md
@@ -69,6 +69,10 @@ A plain object in `routes` or `endpoints` still mounts its handler. Only the typ
 `integrationRoute.*` and `endpoint.*` builders attach the operation metadata Farm needs to infer
 `api` and `apiClient` request and response types.
 
+Plain route objects accept every HTTP method when `method` and `methods` are omitted, or when
+`method: "ALL"` is specified. Use an explicit method list or `integrationRoute.get/post/...`
+to restrict which requests can reach a handler, especially webhooks and mutations.
+
 The three formats below are alternatives. Each example exports an integration named `billing` and
 uses the same registration and caller setup.
 

--- a/packages/farm/src/__tests__/integrations.test.ts
+++ b/packages/farm/src/__tests__/integrations.test.ts
@@ -180,52 +180,6 @@ describe("integrations runtime", () => {
     expect(globalIntegration).toBeUndefined();
   });
 
-  it("keeps static plugin arrays compatible and propagates server ownership", () => {
-    const contributedPlugin = {
-      name: "platform:contribution",
-    };
-    const integration = defineIntegration({
-      category: "agent",
-      type: "platform-plugins",
-      instance: {},
-      serverRuntime: false,
-      plugins: [contributedPlugin],
-    });
-
-    const plugins = resolveIntegrationPlugins({ agent: integration });
-
-    expect(plugins[1]).not.toBe(contributedPlugin);
-    expect(plugins[1].name).toBe(contributedPlugin.name);
-    expect(getFarmIntegrationPluginServerRuntime(plugins[1])).toBe(false);
-    expect(getFarmIntegrationPluginOwner(plugins[1])?.source).toBe("contribution");
-  });
-
-  it("matches routes with malformed percent-encoded segments instead of throwing", () => {
-    const integration = defineIntegration({
-      category: "agent",
-      type: "proxy",
-      instance: {},
-      routes: [
-        integrationRoute.get("/agents/[...path]", { handler: async () => new Response("ok") }),
-        integrationRoute.get("/items/[id]", { handler: async () => new Response("ok") }),
-      ],
-    });
-
-    // decodeURIComponent throws on these segments; matching must keep the
-    // raw value instead of throwing before any handler runs.
-    const catchAll = matchIntegrationRoute(
-      { agent: integration },
-      { pathname: "/agents/%E0/logs", method: "GET" },
-    );
-    expect(catchAll?.params).toEqual({ path: ["%E0", "logs"] });
-
-    const dynamic = matchIntegrationRoute(
-      { agent: integration },
-      { pathname: "/items/%E0", method: "GET" },
-    );
-    expect(dynamic?.params).toEqual({ id: "%E0" });
-  });
-
   it.each([undefined, "ALL", "all"] as const)(
     "dispatches integration routes with method %s for every request method",
     async (method) => {
@@ -275,6 +229,52 @@ describe("integrations runtime", () => {
       await manager.runHookParallel("shutdown", { reason: "test" });
     },
   );
+
+  it("keeps static plugin arrays compatible and propagates server ownership", () => {
+    const contributedPlugin = {
+      name: "platform:contribution",
+    };
+    const integration = defineIntegration({
+      category: "agent",
+      type: "platform-plugins",
+      instance: {},
+      serverRuntime: false,
+      plugins: [contributedPlugin],
+    });
+
+    const plugins = resolveIntegrationPlugins({ agent: integration });
+
+    expect(plugins[1]).not.toBe(contributedPlugin);
+    expect(plugins[1].name).toBe(contributedPlugin.name);
+    expect(getFarmIntegrationPluginServerRuntime(plugins[1])).toBe(false);
+    expect(getFarmIntegrationPluginOwner(plugins[1])?.source).toBe("contribution");
+  });
+
+  it("matches routes with malformed percent-encoded segments instead of throwing", () => {
+    const integration = defineIntegration({
+      category: "agent",
+      type: "proxy",
+      instance: {},
+      routes: [
+        integrationRoute.get("/agents/[...path]", { handler: async () => new Response("ok") }),
+        integrationRoute.get("/items/[id]", { handler: async () => new Response("ok") }),
+      ],
+    });
+
+    // decodeURIComponent throws on these segments; matching must keep the
+    // raw value instead of throwing before any handler runs.
+    const catchAll = matchIntegrationRoute(
+      { agent: integration },
+      { pathname: "/agents/%E0/logs", method: "GET" },
+    );
+    expect(catchAll?.params).toEqual({ path: ["%E0", "logs"] });
+
+    const dynamic = matchIntegrationRoute(
+      { agent: integration },
+      { pathname: "/items/%E0", method: "GET" },
+    );
+    expect(dynamic?.params).toEqual({ id: "%E0" });
+  });
 
   it("rejects integration catch-all parameters before later path segments", () => {
     expect(() =>

--- a/packages/farm/src/__tests__/integrations.test.ts
+++ b/packages/farm/src/__tests__/integrations.test.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from "events";
+import { Readable } from "node:stream";
 import { describe, expect, expectTypeOf, it, vi } from "vitest";
 import { z } from "zod";
 import { definePlugin, PluginManager, type FarmPluginIntegrationContext } from "../plugin";
@@ -224,6 +225,56 @@ describe("integrations runtime", () => {
     );
     expect(dynamic?.params).toEqual({ id: "%E0" });
   });
+
+  it.each([undefined, "ALL", "all"] as const)(
+    "dispatches integration routes with method %s for every request method",
+    async (method) => {
+      const integration = defineIntegration({
+        category: "custom",
+        type: "methodless-route",
+        instance: {},
+        routes: [
+          {
+            path: "/api/methodless",
+            method,
+            handler: async () => new Response("ok"),
+          },
+        ],
+      });
+
+      const manager = createManager();
+      manager.addPlugins(resolveIntegrationPlugins({ methodless: integration }));
+      await manager.runHookParallel("init");
+      const runtime = getRegisteredIntegrationRuntime("methodless")!;
+
+      for (const method of ["GET", "POST", "PATCH", "DELETE"]) {
+        const match = matchIntegrationRoute(
+          { methodless: integration },
+          { pathname: "/api/methodless", method },
+        );
+        expect(match?.route.methods).toEqual(["ALL"]);
+        const res = createResponse();
+        expect(
+          await manager.runHookParallel(
+            "beforeRequest",
+            Object.assign(Readable.from([]), {
+              url: "/api/methodless",
+              method,
+              headers: { host: "localhost" },
+            }) as any,
+            res as any,
+          ),
+        ).toBe(true);
+        expect(res.body.toString()).toBe("ok");
+        const response = await dispatchIntegrationRequest(
+          runtime,
+          new Request("http://localhost/api/methodless", { method }),
+        );
+        expect(await response?.text()).toBe("ok");
+      }
+      await manager.runHookParallel("shutdown", { reason: "test" });
+    },
+  );
 
   it("rejects integration catch-all parameters before later path segments", () => {
     expect(() =>

--- a/packages/farm/src/integrations.ts
+++ b/packages/farm/src/integrations.ts
@@ -3183,7 +3183,11 @@ function matchesMethod(methods: readonly string[], method: string | undefined): 
     return false;
   }
 
-  return methods.some((item) => item.toUpperCase() === method.toUpperCase());
+  const normalizedMethod = method.toUpperCase();
+  return methods.some((item) => {
+    const candidate = item.toUpperCase();
+    return candidate === "ALL" || candidate === normalizedMethod;
+  });
 }
 
 function matchesMatcher(


### PR DESCRIPTION
## Problem

A plain integration route without method/methods, or with method: "ALL", never receives requests.

## Root cause

Normalization produced ALL, but dispatch compared it literally with GET, POST, and other request methods.

## Change

Treat ALL as the wildcard already exposed by the integration route type.

## Safety and compatibility

Explicit method restrictions are preserved. The custom integration guide explains how to restrict sensitive handlers. No new API or default is introduced.

## Verification

macOS, Node 23.11.0, pnpm 8.12.1.
- `pnpm --filter @farm.js/core test -- integrations.test.ts` (33 passed)
- `pnpm --filter @farm.js/core type-check`
- Regression coverage exercises omitted, uppercase, and lowercase ALL through matching, Vite-style hooks, and server dispatch; all three fail without the fix.
- Focused formatting/lint passes with existing unused-helper warnings.
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @farm.js/core build` (passed, including declarations).

All seven fixes also merge cleanly in a local validation checkout: 193 focused core tests and the full 60-test RSC plugin suite pass together. `pnpm docs:check-navigation` and `NODE_OPTIONS=--max-old-space-size=8192 pnpm docs:build` also pass on the combined checkout (Vercel production output).

## Documentation and release

Clarify wildcard methods in the custom integration guide. No version or template changes.

## Preview status

Vercel preview deployment is blocked by the account's daily deployment quota (`api-deployments-free-per-day`). Vercel reports retrying in 24 hours; this is separate from the code and test results.
