### PR TITLE
fix(rsc): preserve API method semantics in production

### DIFF
--- a/docs/src/app/docs/api-routes/page.md
+++ b/docs/src/app/docs/api-routes/page.md
@@ -74,6 +74,9 @@ context.
 `HEAD` follows normal HTTP semantics. A route can export a dedicated `HEAD` handler, otherwise Farm
 uses its `GET` handler and returns the same status and headers without a response body.
 
+This also applies to production RSC builds. They support `QUERY` exports, prefer an explicit
+`HEAD` handler, and return `405` with an `Allow` header for unsupported methods.
+
 ## Body and query input
 
 ```ts

--- a/packages/farmjs-plugin/src/rsc/entries/rsc.ts
+++ b/packages/farmjs-plugin/src/rsc/entries/rsc.ts
@@ -53,7 +53,11 @@ import {
   applyProductionMiddlewareHeaders,
   createProductionMiddlewareRunner,
 } from '@farm.js/core/middleware';
-import { invokeAPIRouteEndpoint, matchAPIRoute } from '@farm.js/core/api/runtime';
+import {
+  getAllowedAPIRouteMethods,
+  invokeAPIRouteEndpoint,
+  matchAPIRoute,
+} from '@farm.js/core/api/runtime';
 import { _runWithAfterRequest } from '@farm.js/core/after';
 import { _runWithCurrentRequest, searchParamsToObject } from '@farm.js/core/internal/production-runtime';
 
@@ -183,7 +187,7 @@ const routeDefinitionModules = collectRouteModuleEntries([${routeSourceRoots
     )
     .join(", ")}]);
 
-const apiRouteMethods = ['GET', 'HEAD', 'POST', 'PUT', 'DELETE', 'PATCH', 'OPTIONS'];
+const apiRouteMethods = ['GET', 'HEAD', 'QUERY', 'POST', 'PUT', 'DELETE', 'PATCH', 'OPTIONS'];
 const apiRouteMap = new Map();
 
 function registerApiEndpoint(routePath, filePath, method, endpoint) {
@@ -255,11 +259,15 @@ async function handleAPIRequest(request) {
   if (!match) return null;
 
   const method = request.method.toUpperCase();
-  const endpoint = match.route.handlers[method];
+  const endpoint = match.route.handlers[method] ??
+    (method === 'HEAD' ? match.route.handlers.GET : undefined);
   if (!endpoint) {
     return new Response(JSON.stringify({ error: 'Method Not Allowed' }), {
       status: 405,
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Allow': getAllowedAPIRouteMethods(match.route).join(', '),
+        'Content-Type': 'application/json',
+      },
     });
   }
 

--- a/packages/farmjs-plugin/src/rsc/entries/security.test.ts
+++ b/packages/farmjs-plugin/src/rsc/entries/security.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
 import { transformWithEsbuild } from "vite";
+import {
+  getAllowedAPIRouteMethods,
+  invokeAPIRouteEndpoint,
+  matchAPIRoute,
+} from "@farm.js/core/api/runtime";
 import type { EntryContext } from "../types.js";
 import { generateClientEntry } from "./client.js";
 import { generateRscEntry } from "./rsc.js";
@@ -120,6 +125,9 @@ describe("generated server action security", () => {
     );
     expect(entry).toContain("getProgrammaticApiRoutes(routeModule)");
     expect(entry).toContain("from '@farm.js/core/api/runtime'");
+    expect(entry).toContain("'GET', 'HEAD', 'QUERY', 'POST'");
+    expect(entry).toContain("method === 'HEAD' ? match.route.handlers.GET : undefined");
+    expect(entry).toContain("getAllowedAPIRouteMethods(match.route).join(', ')");
     expect(entry).toContain("invokeAPIRouteEndpoint(endpoint, request, match.params)");
     expect(entry).toContain("error: 'Internal Server Error'");
     expect(entry).not.toContain("error?.message || 'Internal Server Error'");
@@ -138,6 +146,99 @@ describe("generated server action security", () => {
     expect(actionValidation).toBeLessThan(middleware);
     expect(middleware).toBeLessThan(apiDispatch);
     expect(apiDispatch).toBeLessThan(actionDecode);
+  });
+
+  it("keeps QUERY and implicit HEAD behavior in the generated API runtime", async () => {
+    const entry = generateRscEntry(context);
+    const registryStart = entry.indexOf("const apiRouteMethods =");
+    const registryEnd = entry.indexOf("\n\nregisterApiRouteSources(apiRouteModules", registryStart);
+    const { apiRouteMap, registerApiRouteSources } = new Function(
+      `${entry.slice(registryStart, registryEnd)}; return { apiRouteMap, registerApiRouteSources };`,
+    )() as {
+      apiRouteMap: Map<
+        string,
+        { path: string; methods: string[]; handlers: Record<string, Function> }
+      >;
+      registerApiRouteSources: (
+        fileModules: Array<{
+          sourceIndex: number;
+          filePath: string;
+          relativePath: string;
+          module: Record<string, Function>;
+        }>,
+        definitionModules: unknown[],
+        sourceCount: number,
+      ) => void;
+    };
+    const get = () => new Response("get", { headers: { "x-handler": "get" } });
+    const query = async (request: Request) => Response.json({ query: await request.json() });
+    registerApiRouteSources(
+      [
+        {
+          sourceIndex: 0,
+          filePath: "/src/app/api/items/route.ts",
+          relativePath: "/api/items/route.ts",
+          module: { GET: get, QUERY: query },
+        },
+        {
+          sourceIndex: 0,
+          filePath: "/src/app/api/explicit/route.ts",
+          relativePath: "/api/explicit/route.ts",
+          module: {
+            GET: get,
+            HEAD: () => new Response("head", { headers: { "x-handler": "head" } }),
+          },
+        },
+      ],
+      [],
+      1,
+    );
+
+    expect(apiRouteMap.get("/api/items")?.handlers.QUERY).toBe(query);
+
+    const handlerStart = entry.indexOf("async function handleAPIRequest(request)");
+    const handlerEnd = entry.indexOf("\nconst farmMiddlewareRunner", handlerStart);
+    const createHandler = new Function(
+      "apiRouteMap",
+      "matchAPIRoute",
+      "getAllowedAPIRouteMethods",
+      "invokeAPIRouteEndpoint",
+      `${entry.slice(handlerStart, handlerEnd)}; return handleAPIRequest;`,
+    );
+    const handleAPIRequest = createHandler(
+      apiRouteMap,
+      matchAPIRoute,
+      getAllowedAPIRouteMethods,
+      invokeAPIRouteEndpoint,
+    ) as (request: Request) => Promise<Response | null>;
+
+    const headResponse = await handleAPIRequest(
+      new Request("https://farm.test/api/items", { method: "HEAD" }),
+    );
+    expect(headResponse?.status).toBe(200);
+    expect(headResponse?.headers.get("x-handler")).toBe("get");
+    expect(await headResponse?.text()).toBe("");
+
+    const explicitHead = await handleAPIRequest(
+      new Request("https://farm.test/api/explicit", { method: "HEAD" }),
+    );
+    expect(explicitHead?.headers.get("x-handler")).toBe("head");
+    expect(await explicitHead?.text()).toBe("");
+    const queryResponse = await handleAPIRequest(
+      new Request("https://farm.test/api/items", {
+        method: "QUERY",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ term: "farm" }),
+      }),
+    );
+    expect(queryResponse?.status).toBe(200);
+    expect(await queryResponse?.json()).toEqual({ query: { term: "farm" } });
+
+    const rejected = await handleAPIRequest(
+      new Request("https://farm.test/api/items", { method: "POST" }),
+    );
+    expect(rejected?.status).toBe(405);
+    expect(rejected?.headers.get("allow")).toBe("GET, HEAD, QUERY");
   });
 
   it("merges layout/page metadata and clears stale document metadata during navigation", () => {


### PR DESCRIPTION
## Problem

Production RSC API discovery skips QUERY exports, rejects implicit HEAD requests, and returns 405 without Allow.

## Root cause

The generated API dispatcher kept a narrower method list and performed exact handler lookup.

## Change

Discover QUERY exports, prefer an explicit HEAD handler with GET fallback, and use the shared allowed-method helper for 405 responses. The shared invocation helper strips HEAD bodies.

## Safety and compatibility

Server-action validation and API dispatch boundaries are unchanged. The behavior matches ordinary Farm API routes.

## Verification

macOS, Node 23.11.0, pnpm 8.12.1.
- `pnpm --filter @farm.js/plugin test -- security.test.ts` (13 passed)
- `pnpm --filter @farm.js/plugin typecheck`
- `pnpm --filter @farm.js/plugin build`
- Execute the generated registry and dispatcher for QUERY JSON input, implicit/explicit HEAD, and 405 Allow. The regression fails without the fix.
- Focused formatting and lint pass.

All seven fixes also merge cleanly in a local validation checkout: 193 focused core tests and the full 60-test RSC plugin suite pass together. `pnpm docs:check-navigation` and `NODE_OPTIONS=--max-old-space-size=8192 pnpm docs:build` also pass on the combined checkout (Vercel production output).

## Documentation and release

Clarify production RSC method behavior in the API routes guide. No version changes.

## Preview status

Vercel preview deployment is blocked by the account's daily deployment quota (`api-deployments-free-per-day`). Vercel reports retrying in 24 hours; this is separate from the code and test results.
