### PR TITLE
fix(rsc): reject duplicate API route registrations

### DIFF
--- a/docs/src/app/docs/api-routes/page.md
+++ b/docs/src/app/docs/api-routes/page.md
@@ -66,6 +66,10 @@ src/app/api/files/[...path]/route.ts -> /api/files/*
 Static route directory names may contain Unicode. Browsers percent-encode those path segments;
 Farm decodes both the discovered route and request segment before matching them.
 
+Defining the same method and path twice within one app source is an error, including in
+production RSC builds. The error names both files. Project routes may still override matching
+methods from a layer; other methods on the layer route remain available.
+
 Use `createEndpoint` when you want input validation and typed client generation. Use plain `GET`, `POST`, `PATCH`, and friends when you want to handle the raw `Request`.
 Plain handlers always receive that `Request`; parameter names such as `request`, `context`, or `ctx`
 do not change the calling convention. Use `createEndpoint` for the parsed `{ body, query, headers }`

--- a/packages/farmjs-plugin/src/rsc/entries/rsc.ts
+++ b/packages/farmjs-plugin/src/rsc/entries/rsc.ts
@@ -186,17 +186,24 @@ const routeDefinitionModules = collectRouteModuleEntries([${routeSourceRoots
 const apiRouteMethods = ['GET', 'HEAD', 'POST', 'PUT', 'DELETE', 'PATCH', 'OPTIONS'];
 const apiRouteMap = new Map();
 
-function registerApiEndpoint(routePath, filePath, method, endpoint) {
+function registerApiEndpoint(routePath, filePath, method, endpoint, sourceIndex) {
   if (!routePath || typeof endpoint !== 'function') return;
   const normalizedMethod = String(method || 'GET').toUpperCase();
   let route = apiRouteMap.get(routePath);
   if (!route) {
-    route = { path: routePath, methods: [], handlers: {}, files: {} };
+    route = { path: routePath, methods: [], handlers: {}, files: {}, sources: {} };
     apiRouteMap.set(routePath, route);
+  }
+  if (route.sources[normalizedMethod] === sourceIndex) {
+    throw new Error(
+      'Duplicate API route for ' + normalizedMethod + ' ' + routePath + ': ' +
+      route.files[normalizedMethod] + ' conflicts with ' + filePath
+    );
   }
   if (!route.methods.includes(normalizedMethod)) route.methods.push(normalizedMethod);
   route.handlers[normalizedMethod] = endpoint;
   route.files[normalizedMethod] = filePath;
+  route.sources[normalizedMethod] = sourceIndex;
 }
 
 function getProgrammaticApiRoutes(routeModule) {
@@ -224,7 +231,7 @@ function registerApiRouteSources(fileModules, definitionModules, sourceCount) {
       const routePath = relativePath.replace(/\\/route\\.[tj]sx?$/i, '') || '/api';
       for (const method of apiRouteMethods) {
         if (typeof routeModule?.[method] === 'function') {
-          registerApiEndpoint(routePath, filePath, method, routeModule[method]);
+          registerApiEndpoint(routePath, filePath, method, routeModule[method], sourceIndex);
         }
       }
     }
@@ -234,13 +241,13 @@ function registerApiRouteSources(fileModules, definitionModules, sourceCount) {
       const { filePath, module: routeModule } = entry;
       for (const endpoint of Object.values(routeModule)) {
         if (typeof endpoint === 'function' && endpoint.__path) {
-          registerApiEndpoint(endpoint.__path, filePath, endpoint.__method || 'GET', endpoint);
+          registerApiEndpoint(endpoint.__path, filePath, endpoint.__method || 'GET', endpoint, sourceIndex);
         }
       }
 
       for (const route of getProgrammaticApiRoutes(routeModule)) {
         for (const [method, endpoint] of Object.entries(route.methods || {})) {
-          registerApiEndpoint(route.path, filePath, method, endpoint);
+          registerApiEndpoint(route.path, filePath, method, endpoint, sourceIndex);
         }
       }
     }

--- a/packages/farmjs-plugin/src/rsc/entries/security.test.ts
+++ b/packages/farmjs-plugin/src/rsc/entries/security.test.ts
@@ -358,6 +358,46 @@ describe("generated server action security", () => {
     expect(apiRouteMap.get("/api/shared")?.handlers.POST).toBe(projectSharedPost);
   });
 
+  it("rejects duplicate API methods within one route source", () => {
+    const entry = generateRscEntry(context);
+    const registryStart = entry.indexOf("const apiRouteMethods =");
+    const registryEnd = entry.indexOf("\n\nregisterApiRouteSources(apiRouteModules", registryStart);
+    const { registerApiRouteSources } = new Function(
+      `${entry.slice(registryStart, registryEnd)}; return { registerApiRouteSources };`,
+    )() as {
+      registerApiRouteSources: (
+        fileModules: unknown[],
+        definitionModules: Array<{
+          sourceIndex: number;
+          filePath: string;
+          module: Record<string, Function>;
+        }>,
+        sourceCount: number,
+      ) => void;
+    };
+    const first = Object.assign(() => "first", {
+      __path: "/api/shared",
+      __method: "GET",
+    });
+    const second = Object.assign(() => "second", {
+      __path: "/api/shared",
+      __method: "GET",
+    });
+
+    expect(() =>
+      registerApiRouteSources(
+        [],
+        [
+          { sourceIndex: 0, filePath: "/src/routes-a.ts", module: { first } },
+          { sourceIndex: 0, filePath: "/src/routes-b.ts", module: { second } },
+        ],
+        1,
+      ),
+    ).toThrow(
+      "Duplicate API route for GET /api/shared: /src/routes-a.ts conflicts with /src/routes-b.ts",
+    );
+  });
+
   it("keeps project precedence when layer and project APIs use different discovery styles", () => {
     const entry = generateRscEntry({
       ...context,


### PR DESCRIPTION
## Problem

Two API declarations for the same method/path in one app source silently overwrite each other in production RSC.

## Root cause

The generated registry assigned handlers without tracking which layer or project source owned each method.

## Change

Track the source index per method and reject duplicate registrations from that source, naming both files.

## Safety and compatibility

Later project sources may still override a layer's matching method. Unrelated routes and other methods remain available. This addresses identical method/path registrations.

## Verification

macOS, Node 23.11.0, pnpm 8.12.1.
- `pnpm --filter @farm.js/plugin test -- security.test.ts` (13 passed)
- `pnpm --filter @farm.js/plugin typecheck`
- `pnpm --filter @farm.js/plugin build`
- The duplicate-registration regression fails without the fix. Existing tests preserve layer/project precedence across discovery styles.
- Focused formatting and lint pass.

All seven fixes also merge cleanly in a local validation checkout: 193 focused core tests and the full 60-test RSC plugin suite pass together. `pnpm docs:check-navigation` and `NODE_OPTIONS=--max-old-space-size=8192 pnpm docs:build` also pass on the combined checkout (Vercel production output).

## Documentation and release

Document duplicate registration behavior in the API routes guide. No version changes.

## Preview status

Vercel preview deployment is blocked by the account's daily deployment quota (`api-deployments-free-per-day`). Vercel reports retrying in 24 hours; this is separate from the code and test results.
