### PR TITLE
fix(routing): validate configured endpoint paths

### DIFF
--- a/docs/src/app/docs/openapi/page.md
+++ b/docs/src/app/docs/openapi/page.md
@@ -27,6 +27,10 @@ export default defineConfig({
 
 The OpenAPI route can be included in generated route types so docs navigation and Link hrefs stay aware of the reference page.
 
+Use an absolute pathname, such as `/docs/reference`. Farm rejects query strings, fragments,
+backslashes, encoded separators, and dot segments such as `..` or `%2e%2e` that browsers
+would reinterpret. Integration route paths and `workflows.route` use the same validation.
+
 ## What gets documented
 
 Farm scans API route files and generates an OpenAPI 3.0.3 spec from the discovered routes, methods, route params, query schemas, body schemas, and response metadata it can infer.

--- a/packages/farm/src/__tests__/config.test.ts
+++ b/packages/farm/src/__tests__/config.test.ts
@@ -754,6 +754,17 @@ describe("resolveConfig", () => {
     }
   });
 
+  it("rejects OpenAPI routes that browsers reinterpret", async () => {
+    for (const route of [
+      "/docs/../reference",
+      "/docs/%2e%2e/reference",
+      "/docs/%2Freference",
+      "/docs\\reference",
+    ]) {
+      await expect(resolveConfig({ openapi: { route } }, "production")).rejects.toThrow();
+    }
+  });
+
   it("rejects route-rule keys that normalize to the same pathname", async () => {
     await expect(
       resolveConfig(

--- a/packages/farm/src/__tests__/integrations.test.ts
+++ b/packages/farm/src/__tests__/integrations.test.ts
@@ -242,6 +242,19 @@ describe("integrations runtime", () => {
     );
   });
 
+  it("rejects integration routes that browsers reinterpret", () => {
+    for (const path of ["/api/../admin", "/api/%2e%2e/admin", "/api/%2Fadmin", "/api\\admin"]) {
+      expect(() =>
+        defineIntegration({
+          category: "custom",
+          type: "unstable-route",
+          instance: {},
+          routes: [{ path, handler: async () => new Response("unexpected") }],
+        }),
+      ).toThrow();
+    }
+  });
+
   it("rejects duplicate plugin names from one integration", () => {
     const integration = defineIntegration({
       category: "custom",

--- a/packages/farm/src/__tests__/workflows.test.ts
+++ b/packages/farm/src/__tests__/workflows.test.ts
@@ -27,6 +27,17 @@ afterEach(() => {
 });
 
 describe("Farm workflows", () => {
+  it("rejects workflow routes that browsers reinterpret", () => {
+    for (const route of [
+      "/api/../workflows",
+      "/api/%2e%2e/workflows",
+      "/api/%2Fworkflows",
+      "/api\\workflows",
+    ]) {
+      expect(() => resolveWorkflowsConfig({ route })).toThrow();
+    }
+  });
+
   it("defines cron workflow modules with typed schedule metadata", () => {
     const cron = defineCron({
       id: "daily-digest",

--- a/packages/farm/src/config.ts
+++ b/packages/farm/src/config.ts
@@ -959,6 +959,16 @@ export async function resolveConfig(
       (mode === "production" ? await generateBuildId() : "development"),
   );
   const basePath = normalizeFarmConfigBasePath(userConfig.basePath);
+  const openapi = {
+    enabled: false,
+    route: "/docs/reference",
+    title: "API Documentation",
+    description: "Auto-generated API documentation",
+    version: "1.0.0",
+    servers: [{ url: "http://localhost:3000", description: "Development server" }],
+    ...userConfig.openapi,
+  };
+  if (openapi.route !== undefined) validateConfigRouteSource(openapi.route, "openapi.route");
 
   const resolved: ResolvedFarmConfig = {
     [FARM_RESOLVED_CUSTOM_CONTEXT]: typeof userConfig.context === "function",
@@ -1007,15 +1017,7 @@ export async function resolveConfig(
     theme: resolveFarmThemeConfig(userConfig.theme, basePath),
     publicDir: userConfig.publicDir || "public",
     i18n: resolveFarmI18nConfig(userConfig.i18n, { root, mode, basePath }),
-    openapi: {
-      enabled: false,
-      route: "/docs/reference",
-      title: "API Documentation",
-      description: "Auto-generated API documentation",
-      version: "1.0.0",
-      servers: [{ url: "http://localhost:3000", description: "Development server" }],
-      ...userConfig.openapi,
-    },
+    openapi,
     middleware: userConfig.middleware || {},
     notFound: userConfig.notFound || {},
     context: userConfig.context || (() => undefined),

--- a/packages/farm/src/integrations.ts
+++ b/packages/farm/src/integrations.ts
@@ -13,6 +13,7 @@ import type { InferFarmIntegrationOrmClient } from "./integration-orm";
 import { setFarmPluginIntegrationContext } from "./plugin-integration-context";
 import { decodeRouteSegment } from "./utils/decode";
 import { assertTerminalCatchAll } from "./routing/specificity";
+import { validateConfigRouteSource } from "./plugins/route-pattern";
 import type {
   FarmPlugin,
   FarmPluginContext,
@@ -1116,6 +1117,7 @@ export function defineIntegration<
       : undefined;
 
   for (const route of allRoutes || []) {
+    validateConfigRouteSource(route.path, `Integration route "${route.path}"`);
     assertTerminalCatchAll(route.path, "api");
   }
 

--- a/packages/farm/src/integrations.ts
+++ b/packages/farm/src/integrations.ts
@@ -1,3 +1,4 @@
+import { validateConfigRouteSource } from "./plugins/route-pattern";
 import type { ComponentType, ReactNode } from "react";
 import { api as integrationApi, defineIntegrationAPIOperation } from "./integration-api";
 import type {
@@ -13,7 +14,6 @@ import type { InferFarmIntegrationOrmClient } from "./integration-orm";
 import { setFarmPluginIntegrationContext } from "./plugin-integration-context";
 import { decodeRouteSegment } from "./utils/decode";
 import { assertTerminalCatchAll } from "./routing/specificity";
-import { validateConfigRouteSource } from "./plugins/route-pattern";
 import type {
   FarmPlugin,
   FarmPluginContext,

--- a/packages/farm/src/workflows.ts
+++ b/packages/farm/src/workflows.ts
@@ -8,6 +8,7 @@ import {
 import { searchParamsToObject } from "./search-params";
 import { decodeRouteSegment } from "./utils/decode";
 import { toPosixPath } from "./utils";
+import { validateConfigRouteSource } from "./plugins/route-pattern";
 import {
   isAbsolute as isAbsolutePath,
   normalize as normalizePath,
@@ -435,7 +436,9 @@ function normalizeWorkflowDir(value: string): string {
 function normalizeWorkflowRoute(route: string): string {
   const trimmed = route.trim();
   if (!trimmed || trimmed === "/") return DEFAULT_FARM_WORKFLOW_ROUTE;
-  return `/${trimSlashes(trimmed)}`;
+  const normalized = `/${trimSlashes(trimmed)}`;
+  validateConfigRouteSource(normalized, "workflows.route");
+  return normalized;
 }
 
 function normalizeWorkflowId(id: string): string {


### PR DESCRIPTION
## Problem

Integration, workflow, and OpenAPI endpoints accept paths such as /api/%2e%2e/admin that browsers normalize to a different URL.

## Root cause

These entry points bypassed Farm's existing configured-path validator.

## Change

Validate integration paths at definition time, workflow paths after their existing slash normalization, and configured OpenAPI routes during config resolution.

## Safety and compatibility

Reuse the existing validator for dot segments, encoded separators, backslashes, control characters, query strings, and fragments. Valid route patterns and optional OpenAPI configuration remain supported.

## Verification

macOS, Node 23.11.0, pnpm 8.12.1.
- `pnpm --filter @farm.js/core test -- integrations.test.ts workflows.test.ts config.test.ts` (126 passed)
- `pnpm --filter @farm.js/core type-check`
- All three new endpoint validation regressions fail without the fix.
- Focused formatting/lint passes with existing unused-helper warnings.
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @farm.js/core build` (passed, including declarations).

All seven fixes also merge cleanly in a local validation checkout: 193 focused core tests and the full 60-test RSC plugin suite pass together. `pnpm docs:check-navigation` and `NODE_OPTIONS=--max-old-space-size=8192 pnpm docs:build` also pass on the combined checkout (Vercel production output).

## Documentation and release

Clarify endpoint pathname constraints in the OpenAPI guide. No version or generated-route changes.

## Preview status

Vercel preview deployment is blocked by the account's daily deployment quota (`api-deployments-free-per-day`). Vercel reports retrying in 24 hours; this is separate from the code and test results.
