### PR TITLE
fix(rsc): preserve cookies and respect response backpressure

### DIFF
--- a/packages/farmjs-plugin/src/rsc/dev-response.test.ts
+++ b/packages/farmjs-plugin/src/rsc/dev-response.test.ts
@@ -1,0 +1,86 @@
+import { EventEmitter } from "node:events";
+import { setImmediate } from "node:timers/promises";
+import { describe, expect, it, vi } from "vitest";
+import { sendRscDevelopmentResponse } from "./dev-response.js";
+
+describe("sendRscDevelopmentResponse", () => {
+  it("waits for drain and cancels the stream after a disconnect", async () => {
+    let notifyWrite!: () => void;
+    const written = new Promise<void>((resolve) => {
+      notifyWrite = resolve;
+    });
+    const cancel = vi.fn();
+    let value = 0;
+    const stream = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        controller.enqueue(new Uint8Array([value++]));
+      },
+      cancel,
+    });
+    const res = Object.assign(new EventEmitter(), {
+      statusCode: 0,
+      destroyed: false,
+      writableEnded: false,
+      setHeader: vi.fn(),
+      getHeader: vi.fn(),
+      write: vi.fn(() => {
+        notifyWrite();
+        return false;
+      }),
+      end: vi.fn(),
+    });
+    const sending = sendRscDevelopmentResponse(res as any, new Response(stream));
+    await written;
+    await setImmediate();
+    expect(res.write).toHaveBeenCalledTimes(1);
+    res.destroyed = true;
+    res.emit("close");
+    await sending;
+    expect(cancel).toHaveBeenCalledTimes(1);
+    expect(stream.locked).toBe(false);
+    expect(res.eventNames()).toEqual([]);
+    expect(res.end).not.toHaveBeenCalled();
+  });
+
+  it("preserves repeated cookies and omits transfer encoding", async () => {
+    const responseHeaders = new Headers();
+    responseHeaders.append("set-cookie", "session=one; Path=/; HttpOnly");
+    responseHeaders.append("set-cookie", "theme=dark; Path=/");
+    responseHeaders.set("transfer-encoding", "chunked");
+
+    const headers = new Map<string, string | string[]>();
+    let body = Buffer.alloc(0);
+    const res = {
+      statusCode: 0,
+      setHeader(name: string, value: string | string[]) {
+        headers.set(name.toLowerCase(), value);
+      },
+      getHeader(name: string) {
+        return headers.get(name.toLowerCase());
+      },
+      write(chunk: Uint8Array) {
+        body = Buffer.concat([body, Buffer.from(chunk)]);
+        return true;
+      },
+      end(chunk?: Uint8Array) {
+        if (chunk) body = Buffer.from(chunk);
+      },
+    };
+
+    await sendRscDevelopmentResponse(
+      res as any,
+      new Response("hello", {
+        status: 201,
+        headers: responseHeaders,
+      }),
+    );
+
+    expect(res.statusCode).toBe(201);
+    expect(headers.get("set-cookie")).toEqual([
+      "session=one; Path=/; HttpOnly",
+      "theme=dark; Path=/",
+    ]);
+    expect(headers.has("transfer-encoding")).toBe(false);
+    expect(body.toString()).toBe("hello");
+  });
+});

--- a/packages/farmjs-plugin/src/rsc/dev-response.ts
+++ b/packages/farmjs-plugin/src/rsc/dev-response.ts
@@ -1,0 +1,19 @@
+import type { ServerResponse } from "node:http";
+import { sendWebResponse } from "@farm.js/core/server";
+
+export async function sendRscDevelopmentResponse(
+  res: ServerResponse,
+  response: Response,
+): Promise<void> {
+  const headers = new Headers(response.headers);
+  headers.delete("transfer-encoding");
+
+  await sendWebResponse(
+    res,
+    new Response(response.body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers,
+    }),
+  );
+}

--- a/packages/farmjs-plugin/src/rsc/index.ts
+++ b/packages/farmjs-plugin/src/rsc/index.ts
@@ -36,6 +36,7 @@ import { transformFarmServerFns } from "./server-fn-transform.js";
 import { transformAutomaticOptimizedBoundaries } from "./automatic-optimized-boundary.js";
 import { resolveRscBuildOutputPath } from "./build-paths.js";
 import { assertRscPackageCompatibility } from "./compatibility.js";
+import { sendRscDevelopmentResponse } from "./dev-response.js";
 import fs from "fs/promises";
 import path from "path";
 import { devServableFileExists } from "../dev-static.js";
@@ -1268,28 +1269,17 @@ if (document.readyState === 'loading') {
                 throw new Error("[Farm.js] Could not load RSC entry in rsc environment");
               const response = await rscEntry.default.fetch(request);
 
-              res.statusCode = response.status;
-              response.headers.forEach((value: string, key: string) => {
-                if (key.toLowerCase() !== "transfer-encoding") res.setHeader(key, value);
-              });
-              if (response.body) {
-                const reader = response.body.getReader();
-                const pump = async () => {
-                  while (true) {
-                    const { done, value } = await reader.read();
-                    if (done) break;
-                    res.write(Buffer.from(value));
-                  }
-                  res.end();
-                };
-                await pump();
-              } else {
-                res.end();
-              }
+              await sendRscDevelopmentResponse(res, response);
               const duration = Date.now() - startTime;
               logResponse(method, pathname, response.status, duration);
               return;
             } catch (rscError: any) {
+              if (res.headersSent || res.writableEnded || res.destroyed) {
+                console.error("[Farm.js] RSC dev response error:", rscError);
+                if (!res.destroyed)
+                  res.destroy(rscError instanceof Error ? rscError : new Error(String(rscError)));
+                return;
+              }
               // RSC pipeline failed; fall back to legacy SSR for GET only
               if (method !== "GET") {
                 const duration = Date.now() - startTime;


### PR DESCRIPTION
## Problem

The RSC development bridge overwrites repeated Set-Cookie headers and keeps reading streamed responses when the client cannot accept more data.

## Root cause

It used a manual header loop and stream pump instead of Farm's shared Node response writer.

## Change

Use sendWebResponse through a small internal adapter that retains transfer-encoding filtering. Avoid attempting legacy SSR after a response has started or its socket has closed.

## Safety and compatibility

Preserve status, binary stream chunks, repeated cookies, backpressure, disconnect cancellation, and reader cleanup. Production behavior is unchanged.

## Verification

macOS, Node 23.11.0, pnpm 8.12.1.
- `pnpm --filter @farm.js/plugin test -- route-action-transform.test.ts dev-response.test.ts` (7 passed); the full plugin suite also passes with all seven fixes combined (60 tests).
- `pnpm --filter @farm.js/plugin typecheck`
- `pnpm --filter @farm.js/plugin build`
- The cookie regression fails with the original header loop. Stream coverage verifies backpressure, cancellation, and listener/reader cleanup.
- Focused formatting/lint passes with existing warnings in the RSC plugin.

All seven fixes also merge cleanly in a local validation checkout: 193 focused core tests and the full 60-test RSC plugin suite pass together. `pnpm docs:check-navigation` and `NODE_OPTIONS=--max-old-space-size=8192 pnpm docs:build` also pass on the combined checkout (Vercel production output).

## Documentation and release

No public API, configuration, template, or version changes.

## Preview status

Vercel preview deployment is blocked by the account's daily deployment quota (`api-deployments-free-per-day`). Vercel reports retrying in 24 hours; this is separate from the code and test results.
