### PR TITLE
fix(rsc): honor configured API roots

### DIFF
--- a/docs/src/app/docs/configuration/page.md
+++ b/docs/src/app/docs/configuration/page.md
@@ -338,6 +338,11 @@ server mount and browser URL cannot resolve to different origins or paths.
 The option configures `createAPIClient()` automatically. An explicit per-client `baseURL` still
 takes precedence.
 
+This also applies to RSC builds and their Nitro servers, including apps configured with
+`defineConfig` from `@farm.js/plugin/rsc`. API requests at the custom prefix stay on the API
+pipeline rather than being decoded as server actions. The canonical `/api` routes remain available;
+an external API URL changes the client destination only, not the local server mount.
+
 ## Isolated client hydration
 
 React applications can keep using `"use client"` without enabling React Server Components. By

--- a/packages/farm/src/api/index.ts
+++ b/packages/farm/src/api/index.ts
@@ -2,5 +2,6 @@ export * from "./endpoint";
 export * from "./route-manager";
 export * from "./client";
 export * from "./config";
+export { resolveFarmAPIServerBasePath } from "./server-path";
 export * from "./transport";
 export * from "./vite-plugin";

--- a/packages/farmjs-plugin/src/rsc/core-external.test.ts
+++ b/packages/farmjs-plugin/src/rsc/core-external.test.ts
@@ -18,8 +18,9 @@ import { fileURLToPath } from "node:url";
 import viteRsc from "@vitejs/plugin-rsc";
 import { createBuilder } from "vite";
 import { describe, expect, it } from "vitest";
+import { resolveFarmAPIRequestURL } from "@farm.js/core/api";
 import { resolveRscBuildOutputPath } from "./build-paths.js";
-import farmRsc from "./index.js";
+import farmRsc, { defineConfig } from "./index.js";
 import { buildRscNitro } from "./nitro-build.js";
 
 const delay = (milliseconds: number) =>
@@ -55,6 +56,50 @@ async function stopProcess(child: ChildProcess): Promise<void> {
 }
 
 describe("RSC core runtime bundling", () => {
+  it("passes API configuration through the standalone config helper", () => {
+    const api = { basePath: async () => "/backend" };
+    expect((defineConfig({ api }) as any).api).toBe(api);
+  });
+
+  it.each(["serve", "build"] as const)(
+    "resolves async API configuration once for the %s client and generated entry",
+    async (command) => {
+      const root = mkdtempSync(path.join(tmpdir(), "farm-rsc-api-config-"));
+      try {
+        const plugin = farmRsc().find(
+          (candidate) => candidate.name === "@farm.js/plugin/rsc:config",
+        );
+        const configHook = plugin!.config as (
+          config: Record<string, unknown>,
+          env: { command: "serve" | "build"; mode: string },
+        ) => Promise<any>;
+        let calls = 0;
+        const resolved = await configHook(
+          {
+            root,
+            experimental: { serverComponents: true },
+            api: {
+              basePath: async ({ mode, root: apiRoot }: { mode: string; root: string }) => {
+                calls++;
+                expect(apiRoot).toBe(root);
+                return `/${mode}-api`;
+              },
+            },
+          },
+          { command, mode: command === "build" ? "production" : "development" },
+        );
+        const basePath = command === "build" ? "/production-api" : "/development-api";
+        expect(calls).toBe(1);
+        expect(resolved.define.__FARM_API_BASE_URL__).toBe(JSON.stringify(basePath));
+        expect(readFileSync(path.join(root, ".farm/rsc-entries/entry.rsc.tsx"), "utf8")).toContain(
+          `const farmApiBasePath = ${JSON.stringify(basePath)};`,
+        );
+      } finally {
+        rmSync(root, { recursive: true, force: true });
+      }
+    },
+  );
+
   it("does not prefix absolute Vite environment output paths with the project root", () => {
     const root = path.resolve("/workspace/app");
     const absoluteOutDir = path.join(root, ".nitro", "vite", "dist", "rsc");
@@ -190,62 +235,82 @@ export const schema = z.string();`;
     ).toThrow(/@farm.js\/core\/storage is not supported.*isolated server output/s);
   });
 
-  it("builds and boots a real RSC app with exact-root runtime imports outside the workspace", async () => {
-    const fixtureRoot = mkdtempSync(path.join(tmpdir(), "farm-rsc-root-runtime-"));
-    const isolatedRoot = mkdtempSync(path.join(tmpdir(), "farm-rsc-root-output-"));
-    const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
-    let child: ChildProcess | undefined;
+  it.each([
+    { name: "default", api: undefined, baseURL: "/api", mount: "/api" },
+    {
+      name: "custom",
+      api: {
+        basePath: async ({ mode }: { mode: string }) =>
+          mode === "production" ? "/backend" : "/dev-backend",
+      },
+      baseURL: "/backend",
+      mount: "/backend",
+    },
+    { name: "root", api: { basePath: "/" }, baseURL: "/", mount: "" },
+    {
+      name: "external",
+      api: { baseURL: "https://api.example.test/v1" },
+      baseURL: "https://api.example.test/v1",
+      mount: "/api",
+    },
+  ])(
+    "builds and boots an isolated RSC app with the $name API root",
+    async ({ api, baseURL, mount }) => {
+      const fixtureRoot = mkdtempSync(path.join(tmpdir(), "farm-rsc-root-runtime-"));
+      const isolatedRoot = mkdtempSync(path.join(tmpdir(), "farm-rsc-root-output-"));
+      const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+      let child: ChildProcess | undefined;
 
-    try {
-      const srcDir = path.join(fixtureRoot, "src");
-      mkdirSync(srcDir, { recursive: true });
-      writeFileSync(
-        path.join(fixtureRoot, "package.json"),
-        JSON.stringify({
-          name: "farm-rsc-root-runtime-fixture",
-          private: true,
-          type: "module",
-        }),
-      );
-      const fixtureModules = path.join(fixtureRoot, "node_modules");
-      for (const packageName of [
-        "@farm.js/core",
-        "@vitejs/plugin-rsc",
-        "better-call",
-        "react",
-        "react-dom",
-        "react-server-dom-webpack",
-        "rsc-html-stream",
-        "vite",
-      ]) {
-        const linkPath = path.join(fixtureModules, packageName);
-        const packagePath = [
-          path.join(packageRoot, "node_modules", packageName),
-          path.resolve(packageRoot, "../../examples/rsc-demo/node_modules", packageName),
-        ].find((candidate) => existsSync(candidate));
-        if (!packagePath) throw new Error(`Missing fixture dependency: ${packageName}`);
-        mkdirSync(path.dirname(linkPath), { recursive: true });
-        symlinkSync(
-          realpathSync(packagePath),
-          linkPath,
-          process.platform === "win32" ? "junction" : "dir",
+      try {
+        const srcDir = path.join(fixtureRoot, "src");
+        mkdirSync(srcDir, { recursive: true });
+        writeFileSync(
+          path.join(fixtureRoot, "package.json"),
+          JSON.stringify({
+            name: "farm-rsc-root-runtime-fixture",
+            private: true,
+            type: "module",
+          }),
         );
-      }
-      writeFileSync(
-        path.join(srcDir, "layout.tsx"),
-        `export default function Layout({ children }) {
+        const fixtureModules = path.join(fixtureRoot, "node_modules");
+        for (const packageName of [
+          "@farm.js/core",
+          "@vitejs/plugin-rsc",
+          "better-call",
+          "react",
+          "react-dom",
+          "react-server-dom-webpack",
+          "rsc-html-stream",
+          "vite",
+        ]) {
+          const linkPath = path.join(fixtureModules, packageName);
+          const packagePath = [
+            path.join(packageRoot, "node_modules", packageName),
+            path.resolve(packageRoot, "../../examples/rsc-demo/node_modules", packageName),
+          ].find((candidate) => existsSync(candidate));
+          if (!packagePath) throw new Error(`Missing fixture dependency: ${packageName}`);
+          mkdirSync(path.dirname(linkPath), { recursive: true });
+          symlinkSync(
+            realpathSync(packagePath),
+            linkPath,
+            process.platform === "win32" ? "junction" : "dir",
+          );
+        }
+        writeFileSync(
+          path.join(srcDir, "layout.tsx"),
+          `export default function Layout({ children }) {
   return <html><body>{children}</body></html>;
 }`,
-      );
-      writeFileSync(
-        path.join(srcDir, "page.tsx"),
-        `export default function Page() {
+        );
+        writeFileSync(
+          path.join(srcDir, "page.tsx"),
+          `export default function Page() {
   return <main>RSC root runtime fixture</main>;
 }`,
-      );
-      writeFileSync(
-        path.join(srcDir, "routes.ts"),
-        `import {
+        );
+        writeFileSync(
+          path.join(srcDir, "routes.ts"),
+          `import {
   createEndpoint,
   createRoute,
   getCurrentRequest,
@@ -304,117 +369,157 @@ export const rootRuntime = createEndpoint("/api/root-runtime", {
     notFound: recognizesNotFound(),
   };
 });
+
+export const echo = createEndpoint("/api/echo", { method: "POST" }, async ({ body }) => ({ body }));
 `,
-      );
+        );
 
-      const plugins = farmRsc({ routesDir: "" }).filter(
-        (plugin) => plugin.name !== "@farm.js/plugin/rsc:nitro-build",
-      );
-      plugins.push(
-        ...viteRsc({
-          serverHandler: false,
-          entries: {
-            rsc: "./.farm/rsc-entries/entry.rsc.tsx",
-            ssr: "./.farm/rsc-entries/entry.ssr.tsx",
-            client: "./.farm/rsc-entries/entry.browser.tsx",
-          },
-        }),
-      );
+        const plugins = farmRsc({ routesDir: "" }).filter(
+          (plugin) => plugin.name !== "@farm.js/plugin/rsc:nitro-build",
+        );
+        plugins.push(
+          ...viteRsc({
+            serverHandler: false,
+            entries: {
+              rsc: "./.farm/rsc-entries/entry.rsc.tsx",
+              ssr: "./.farm/rsc-entries/entry.ssr.tsx",
+              client: "./.farm/rsc-entries/entry.browser.tsx",
+            },
+          }),
+        );
 
-      const builder = await createBuilder({
-        root: fixtureRoot,
-        configFile: false,
-        logLevel: "silent",
-        srcDir: "src",
-        outDir: "dist",
-        experimental: { serverComponents: true, serverActions: false },
-        plugins,
-      } as never);
-      await builder.buildApp();
+        const builder = await createBuilder({
+          root: fixtureRoot,
+          configFile: false,
+          logLevel: "silent",
+          srcDir: "src",
+          outDir: "dist",
+          experimental: { serverComponents: true, serverActions: true },
+          api,
+          plugins,
+        } as never);
+        expect(builder.config.define?.__FARM_API_BASE_URL__).toBe(JSON.stringify(baseURL));
+        await builder.buildApp();
 
-      const rscPath = path.join(fixtureRoot, "dist", "rsc", "index.js");
-      const ssrPath = path.join(fixtureRoot, "dist", "ssr", "index.js");
-      const clientDir = path.join(fixtureRoot, "dist", "client");
-      const rscCode = readFileSync(rscPath, "utf-8");
-      expect(rscCode).not.toMatch(/from\s*["']@farm.js\/core["']/);
+        const rscPath = path.join(fixtureRoot, "dist", "rsc", "index.js");
+        const ssrPath = path.join(fixtureRoot, "dist", "ssr", "index.js");
+        const clientDir = path.join(fixtureRoot, "dist", "client");
+        const rscCode = readFileSync(rscPath, "utf-8");
+        expect(rscCode).not.toMatch(/from\s*["']@farm.js\/core["']/);
 
-      const outputDir = path.join(fixtureRoot, ".output");
-      await buildRscNitro({
-        root: fixtureRoot,
-        rendererPath: rscPath,
-        ssrPath,
-        publicDir: clientDir,
-        outputDir,
-        preset: "node-server",
-      });
+        const outputDir = path.join(fixtureRoot, ".output");
+        await buildRscNitro({
+          root: fixtureRoot,
+          rendererPath: rscPath,
+          ssrPath,
+          publicDir: clientDir,
+          outputDir,
+          preset: "node-server",
+        });
 
-      const outputPackage = JSON.parse(
-        readFileSync(path.join(outputDir, "server", "package.json"), "utf-8"),
-      ) as { dependencies?: Record<string, string> };
-      expect(outputPackage.dependencies).not.toHaveProperty("@farm.js/core");
-      for (const buildOnlyPackage of ["vite", "nitro", "rollup", "rolldown", "esbuild"]) {
-        expect(outputPackage.dependencies).not.toHaveProperty(buildOnlyPackage);
-        expect(existsSync(path.join(outputDir, "server", "node_modules", buildOnlyPackage))).toBe(
+        const outputPackage = JSON.parse(
+          readFileSync(path.join(outputDir, "server", "package.json"), "utf-8"),
+        ) as { dependencies?: Record<string, string> };
+        expect(outputPackage.dependencies).not.toHaveProperty("@farm.js/core");
+        for (const buildOnlyPackage of ["vite", "nitro", "rollup", "rolldown", "esbuild"]) {
+          expect(outputPackage.dependencies).not.toHaveProperty(buildOnlyPackage);
+          expect(existsSync(path.join(outputDir, "server", "node_modules", buildOnlyPackage))).toBe(
+            false,
+          );
+        }
+        expect(existsSync(path.join(outputDir, "server", "node_modules", "@farm.js", "core"))).toBe(
           false,
         );
-      }
-      expect(existsSync(path.join(outputDir, "server", "node_modules", "@farm.js", "core"))).toBe(
-        false,
-      );
 
-      const isolatedOutput = path.join(isolatedRoot, ".output");
-      cpSync(outputDir, isolatedOutput, { recursive: true });
-      rmSync(fixtureRoot, { recursive: true, force: true });
+        const isolatedOutput = path.join(isolatedRoot, ".output");
+        cpSync(outputDir, isolatedOutput, { recursive: true });
+        rmSync(fixtureRoot, { recursive: true, force: true });
 
-      const port = await availablePort();
-      let logs = "";
-      child = spawn(process.execPath, [path.join(isolatedOutput, "server", "index.mjs")], {
-        cwd: isolatedRoot,
-        env: {
-          ...process.env,
-          HOST: "127.0.0.1",
-          PORT: String(port),
-          NODE_ENV: "production",
-        },
-        stdio: ["ignore", "pipe", "pipe"],
-      });
-      child.stdout?.on("data", (chunk) => {
-        logs += chunk.toString();
-      });
-      child.stderr?.on("data", (chunk) => {
-        logs += chunk.toString();
-      });
+        const port = await availablePort();
+        let logs = "";
+        child = spawn(process.execPath, [path.join(isolatedOutput, "server", "index.mjs")], {
+          cwd: isolatedRoot,
+          env: {
+            ...process.env,
+            HOST: "127.0.0.1",
+            PORT: String(port),
+            NODE_ENV: "production",
+          },
+          stdio: ["ignore", "pipe", "pipe"],
+        });
+        child.stdout?.on("data", (chunk) => {
+          logs += chunk.toString();
+        });
+        child.stderr?.on("data", (chunk) => {
+          logs += chunk.toString();
+        });
 
-      let response: Response | undefined;
-      const deadline = Date.now() + 15_000;
-      while (Date.now() < deadline && child.exitCode === null) {
-        try {
-          response = await fetch(`http://127.0.0.1:${port}/api/root-runtime`, {
-            headers: { "x-root-runtime": "isolated" },
-          });
-          break;
-        } catch {
-          await delay(50);
+        let response: Response | undefined;
+        const deadline = Date.now() + 15_000;
+        while (Date.now() < deadline && child.exitCode === null) {
+          try {
+            response = await fetch(`http://127.0.0.1:${port}/api/root-runtime`, {
+              headers: { "x-root-runtime": "isolated" },
+            });
+            break;
+          } catch {
+            await delay(50);
+          }
         }
-      }
 
-      expect(response, logs).toBeDefined();
-      expect(response?.status, logs).toBe(200);
-      await expect(response?.json()).resolves.toEqual({
-        runtime: "bundled-root-facade",
-        marker: "isolated",
-        requestPath: "/api/root-runtime",
-        route: { kind: "page", path: "/root-public-api" },
-        cache: "root-cache-ok",
-        query: "query-ok",
-        workflow: { id: "root-runtime-workflow", kind: "farm-workflow" },
-        redirect: true,
-        notFound: true,
-      });
-    } finally {
-      if (child) await stopProcess(child);
-      rmSync(fixtureRoot, { recursive: true, force: true });
-      rmSync(isolatedRoot, { recursive: true, force: true });
-    }
-  }, 120_000);
+        expect(response, logs).toBeDefined();
+        expect(response?.status, logs).toBe(200);
+        await expect(response?.json()).resolves.toEqual({
+          runtime: "bundled-root-facade",
+          marker: "isolated",
+          requestPath: "/api/root-runtime",
+          route: { kind: "page", path: "/root-public-api" },
+          cache: "root-cache-ok",
+          query: "query-ok",
+          workflow: { id: "root-runtime-workflow", kind: "farm-workflow" },
+          redirect: true,
+          notFound: true,
+        });
+
+        const origin = `http://127.0.0.1:${port}`;
+        const aliasedResponse = await fetch(`${origin}${mount}/root-runtime`);
+        expect(aliasedResponse.status, logs).toBe(200);
+        expect((await aliasedResponse.json()).requestPath).toBe(`${mount}/root-runtime`);
+
+        // A custom API prefix is not a server-action URL, even with actions enabled.
+        const post = await fetch(`${origin}${mount}/echo`, {
+          method: "POST",
+          headers: { "content-type": "application/json", origin: "https://other.example" },
+          body: JSON.stringify({ message: "hello" }),
+        });
+        expect(post.status, logs).toBe(200);
+        expect(await post.json()).toEqual({ body: { message: "hello" } });
+        const pagePost = await fetch(origin + "/", {
+          method: "POST",
+          headers: { origin: "https://other.example" },
+          body: "not an action",
+        });
+        expect(pagePost.status).toBe(403);
+
+        const missing = await fetch(`${origin}${mount}/missing-api-route`);
+        expect(missing.status).toBe(404);
+        if (mount) expect((await missing.json()).error).toBe("API route not found");
+        if (baseURL.startsWith("/")) {
+          const clientURL = resolveFarmAPIRequestURL(
+            "/api/root-runtime",
+            JSON.parse(builder.config.define!.__FARM_API_BASE_URL__ as string),
+            origin,
+          );
+          expect((await fetch(clientURL)).status).toBe(200);
+        } else {
+          expect((await fetch(origin + "/v1/root-runtime")).status).toBe(404);
+        }
+      } finally {
+        if (child) await stopProcess(child);
+        rmSync(fixtureRoot, { recursive: true, force: true });
+        rmSync(isolatedRoot, { recursive: true, force: true });
+      }
+    },
+    120_000,
+  );
 });

--- a/packages/farmjs-plugin/src/rsc/entries/rsc.ts
+++ b/packages/farmjs-plugin/src/rsc/entries/rsc.ts
@@ -56,12 +56,14 @@ import {
 import {
   getAllowedAPIRouteMethods,
   invokeAPIRouteEndpoint,
-  matchAPIRoute,
+  isFarmAPIPathname,
+  matchAPIRouteAtBasePath,
 } from '@farm.js/core/api/runtime';
 import { _runWithAfterRequest } from '@farm.js/core/after';
 import { _runWithCurrentRequest, searchParamsToObject } from '@farm.js/core/internal/production-runtime';
 
 const farmDeploymentId = ${JSON.stringify(ctx.deploymentId)};
+const farmApiBasePath = ${JSON.stringify(ctx.apiBasePath ?? "/api")};
 `;
   if (ctx.actionsEnabled) {
     code += `import {
@@ -262,7 +264,7 @@ registerApiRouteSources(apiRouteModules, routeDefinitionModules, ${routeSourceRo
 
 async function handleAPIRequest(request) {
   const url = new URL(request.url);
-  const match = matchAPIRoute(apiRouteMap, url.pathname);
+  const match = matchAPIRouteAtBasePath(apiRouteMap, url.pathname, farmApiBasePath);
   if (!match) return null;
 
   const method = request.method.toUpperCase();
@@ -548,9 +550,9 @@ async function handleFarmRequest(request) {
     return createFarmDeploymentMismatchResponse(deploymentMismatch);
   }
 
-  const initialApiMatch = matchAPIRoute(apiRouteMap, url.pathname);
+  const initialApiMatch = matchAPIRouteAtBasePath(apiRouteMap, url.pathname, farmApiBasePath);
   const isInitialApiRequest = Boolean(initialApiMatch) ||
-    url.pathname === '/api' || url.pathname.startsWith('/api/');
+    isFarmAPIPathname(url.pathname, farmApiBasePath) || isFarmAPIPathname(url.pathname);
 
   ${
     ctx.actionsEnabled
@@ -603,7 +605,7 @@ async function handleFarmRequest(request) {
   if (apiResponse) {
     return applyProductionMiddlewareHeaders(apiResponse, middlewareHeaders);
   }
-  if (url.pathname === '/api' || url.pathname.startsWith('/api/')) {
+  if (isFarmAPIPathname(url.pathname, farmApiBasePath) || isFarmAPIPathname(url.pathname)) {
     return applyProductionMiddlewareHeaders(new Response(
       JSON.stringify({ error: 'API route not found', pathname: url.pathname }),
       { status: 404, headers: { 'Content-Type': 'application/json' } },

--- a/packages/farmjs-plugin/src/rsc/entries/security.test.ts
+++ b/packages/farmjs-plugin/src/rsc/entries/security.test.ts
@@ -3,7 +3,7 @@ import { transformWithEsbuild } from "vite";
 import {
   getAllowedAPIRouteMethods,
   invokeAPIRouteEndpoint,
-  matchAPIRoute,
+  matchAPIRouteAtBasePath,
 } from "@farm.js/core/api/runtime";
 import type { EntryContext } from "../types.js";
 import { generateClientEntry } from "./client.js";
@@ -134,7 +134,7 @@ describe("generated server action security", () => {
     expect(entry).toContain("if (request.method === 'POST' && !isInitialApiRequest)");
     expect(entry).toContain("applyProductionMiddlewareHeaders(apiResponse, middlewareHeaders)");
 
-    const apiClassification = entry.indexOf("const initialApiMatch = matchAPIRoute(");
+    const apiClassification = entry.indexOf("const initialApiMatch = matchAPIRouteAtBasePath(");
     const actionValidation = entry.indexOf("validateServerActionRequest(request");
     const middleware = entry.indexOf("const middlewareResult = await executeMiddleware(request");
     const apiDispatch = entry.indexOf(
@@ -200,16 +200,18 @@ describe("generated server action security", () => {
     const handlerEnd = entry.indexOf("\nconst farmMiddlewareRunner", handlerStart);
     const createHandler = new Function(
       "apiRouteMap",
-      "matchAPIRoute",
+      "matchAPIRouteAtBasePath",
       "getAllowedAPIRouteMethods",
       "invokeAPIRouteEndpoint",
+      "farmApiBasePath",
       `${entry.slice(handlerStart, handlerEnd)}; return handleAPIRequest;`,
     );
     const handleAPIRequest = createHandler(
       apiRouteMap,
-      matchAPIRoute,
+      matchAPIRouteAtBasePath,
       getAllowedAPIRouteMethods,
       invokeAPIRouteEndpoint,
+      "/api",
     ) as (request: Request) => Promise<Response | null>;
 
     const headResponse = await handleAPIRequest(

--- a/packages/farmjs-plugin/src/rsc/index.ts
+++ b/packages/farmjs-plugin/src/rsc/index.ts
@@ -26,6 +26,7 @@ import { parseAst, type ConfigEnv, type Plugin, type UserConfig } from "vite";
 import { init as initModuleLexer, parse as parseModuleImports } from "es-module-lexer";
 import type { FarmRscPluginOptions, EntryContext } from "./types.js";
 import type { FarmServerActionsConfig } from "@farm.js/core/server-action-security";
+import type { FarmAPIConfig } from "@farm.js/core/api";
 import type { FarmLayerEntry, ResolvedFarmLayer } from "@farm.js/core/server";
 import { farmEnvironmentFunctionsPlugin } from "@farm.js/core/environment/vite";
 import { generateRscEntry } from "./entries/rsc.js";
@@ -59,6 +60,10 @@ const { getFarmLayerAliases, getFarmSourceRoots, resolveFarmLayers } = require_(
 const { searchParamsToObject } = require_(
   "@farm.js/core/internal/production-runtime",
 ) as typeof import("@farm.js/core/internal/production-runtime");
+const { resolveFarmAPIConfig, resolveFarmAPIServerBasePath } = require_(
+  "@farm.js/core/api",
+) as typeof import("@farm.js/core/api");
+const { getResolvedEnv } = require_("@farm.js/core/env") as typeof import("@farm.js/core/env");
 
 export type { FarmRscPluginOptions, EntryContext };
 export { buildRscNitro, waitForRscManifest, waitForRscOutputs } from "./nitro-build.js";
@@ -74,6 +79,7 @@ export interface FarmRscConfig {
   layers?: readonly ResolvedFarmLayer[];
   outDir?: string;
   basePath?: string;
+  api?: FarmAPIConfig;
   port?: number;
   experimental?: {
     /**
@@ -131,6 +137,7 @@ export function defineConfig(config: FarmRscConfig = {}): UserConfig {
     layers: config.layers,
     outDir: config.outDir ?? "dist",
     basePath: config.basePath ?? "/",
+    api: config.api,
     serverActions: config.serverActions,
     deploymentId: config.deploymentId,
     generateBuildId: config.generateBuildId,
@@ -613,6 +620,7 @@ export default function farmRsc(options: FarmRscPluginOptions = {}): Plugin[] {
           srcDir?: string;
           outDir?: string;
           basePath?: string;
+          api?: FarmAPIConfig;
           root?: string;
           extends?: readonly FarmLayerEntry[];
           layers?: readonly ResolvedFarmLayer[];
@@ -658,6 +666,11 @@ export default function farmRsc(options: FarmRscPluginOptions = {}): Plugin[] {
         }
 
         // Read user's directory configuration
+        const api = await resolveFarmAPIConfig(c.api, {
+          root,
+          mode: env.command === "build" ? "production" : "development",
+          env: getResolvedEnv(),
+        });
         const srcDir = c.srcDir ?? "src";
         const outDir = c.outDir ?? "dist";
         const deploymentId = normalizeFarmDeploymentId(
@@ -700,6 +713,7 @@ export default function farmRsc(options: FarmRscPluginOptions = {}): Plugin[] {
           srcDir,
           outDir,
           basePath: c.basePath ?? "/",
+          apiBasePath: resolveFarmAPIServerBasePath(api),
           routesDir: options.routesDir,
           globalCssPath,
           routeRoots,
@@ -755,6 +769,9 @@ export default function farmRsc(options: FarmRscPluginOptions = {}): Plugin[] {
         return {
           appType: "custom" as const,
           builder: { sharedConfigBuild: true } as any,
+          define: {
+            __FARM_API_BASE_URL__: JSON.stringify(api.baseURL),
+          },
           ssr: {
             external: [
               "react",

--- a/packages/farmjs-plugin/src/rsc/types.ts
+++ b/packages/farmjs-plugin/src/rsc/types.ts
@@ -68,6 +68,9 @@ export interface EntryContext {
   /** Base URL path, e.g. '/' */
   basePath: string;
 
+  /** Resolved same-origin mount for canonical /api routes. */
+  apiBasePath?: string;
+
   /** Route files subdirectory within srcDir */
   routesDir?: string;
 


### PR DESCRIPTION
## Problem

An RSC app configured with `api: { basePath: "/backend" }` builds successfully, but its deployed `/backend/...` endpoints return 404 while `/api/...` works. The generated client also needs the same resolved API URL as the server.

## Root cause

The RSC entry never receives the API mount. Its route matcher and API versus server-action checks use only the canonical `/api` prefix.

## Change

- Resolve API configuration once in the RSC config hook, including async values and the correct build/serve mode.
- Pass the same-origin mount into the generated entry and the public URL into the client define.
- Reuse core's API alias matcher for dispatch and request classification.
- Preserve `api` in the standalone RSC `defineConfig` helper.

## Safety and compatibility

Canonical `/api` routes remain available. An external API URL changes the client destination without mounting that external path locally. A root API mount does not turn every page POST into an API request. Ordinary page POSTs still go through server-action origin validation.

No new option, dependency, or renderer contract. This fixes generated RSC routing; it does not redesign the existing standalone development request bridge.

## Verification

macOS, Node 23.11.0, pnpm 8.12.1:

- `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @farm.js/core build`
- `pnpm --filter @farm.js/core type-check`
- `pnpm --filter @farm.js/plugin typecheck`
- `pnpm --filter @farm.js/plugin build`
- `pnpm --filter @farm.js/plugin test`: 66 tests pass.
- `pnpm --filter @farm.js/core test api-config.test.ts api-route-manager.test.ts`: 39 tests pass.
- Focused formatting, lint, and `git diff --check` pass. Lint reports existing warnings in the RSC plugin.

The regression builds and boots isolated Nitro Node output for default, custom, root, and external API configurations. It exercises real GET/POST requests, generated client URLs, missing routes, and action-origin rejection. Removing the generated API mount makes the custom/root cases fail with 404 while the default/external controls pass.

## Documentation and release

Updated the configuration guide. No version, template, or generated-route changes.

Combined validation with #933, #934, and #935: the four branches merge cleanly. Core/plugin builds and type checks pass, along with 76 plugin tests and 94 focused core tests. `pnpm docs:check-navigation`, `pnpm --dir docs exec farm generate --check`, and `pnpm docs:build` pass, including Vercel production output. GitHub CI is still running.
