### PR TITLE
fix(rsc): validate API route shapes and layer overrides

### DIFF
--- a/docs/src/app/docs/api-routes/page.md
+++ b/docs/src/app/docs/api-routes/page.md
@@ -12,6 +12,12 @@ Expose HTTP handlers from src/app/api and validate input with schemas before han
 
 API route modules export HTTP methods. Farm discovers them, runs the route pipeline, and can generate typed client callers from the route shape.
 
+Routes in one app source must have distinct URL shapes. For example, `/api/users/[id]` and
+`/api/users/[slug]` conflict even though their parameter names differ. Parameters must have unique,
+non-reserved names, and catch-alls must be the final segment. These checks also run in RSC builds.
+If a project overrides a layer's equivalent dynamic shape, the project route replaces it completely,
+so handlers do not receive parameters named by the lower-priority route.
+
 **src/app/api/hello/route.ts**
 
 ```ts

--- a/packages/farm/src/api/route-manager.ts
+++ b/packages/farm/src/api/route-manager.ts
@@ -14,18 +14,15 @@ import { _runWithFarmI18nRequest, type FarmI18nRuntime } from "../i18n/server";
 import {
   getAllowedAPIRouteMethods,
   invokeAPIRouteEndpoint,
+  registerAPIRouteShape,
+  type APIRouteShapeSource,
   matchAPIRouteAtBasePath,
   matchAPIRoute,
   resolveAPIRouteEndpoint,
   type APIRouteMatch,
 } from "./runtime";
 import { isFarmAPIRouteFileName } from "./route-files";
-import {
-  AmbiguousRouteError,
-  assertUniqueRouteParameters,
-  getRoutePatternShape,
-  NonTerminalCatchAllRouteError,
-} from "../routing/specificity";
+import { AmbiguousRouteError, NonTerminalCatchAllRouteError } from "../routing/specificity";
 
 export interface APIRoute extends FarmRouteRuntimeConfig {
   path: string;
@@ -71,7 +68,7 @@ export class APIRouteManager {
   private routes: Map<string, APIRoute> = new Map();
   private endpointSources: Map<string, Map<string, { appDir: string; filePath: string }>> =
     new Map();
-  private routeShapes = new Map<string, { routePath: string; appDir: string; filePath: string }>();
+  private routeShapes = new Map<string, APIRouteShapeSource<string>>();
   private viteServer?: ViteDevServer;
   private appDirs: string[];
   private throwOnLoadError: boolean;
@@ -375,21 +372,11 @@ export class APIRouteManager {
   }
 
   private registerRouteShape(routePath: string, filePath: string, appDir: string): void {
-    assertUniqueRouteParameters(routePath, "api");
-    const shape = getRoutePatternShape(routePath, "api");
-    const existing = this.routeShapes.get(shape);
-
-    if (existing && existing.routePath !== routePath) {
-      if (existing.appDir === appDir) {
-        throw new AmbiguousRouteError(
-          `Ambiguous API routes "${existing.routePath}" and "${routePath}" match the same URLs. Found ${existing.filePath} and ${filePath}. Keep only one route for this URL shape.`,
-        );
-      }
-      this.routes.delete(existing.routePath);
-      this.endpointSources.delete(existing.routePath);
+    const replacedPath = registerAPIRouteShape(this.routeShapes, routePath, filePath, appDir);
+    if (replacedPath) {
+      this.routes.delete(replacedPath);
+      this.endpointSources.delete(replacedPath);
     }
-
-    this.routeShapes.set(shape, { routePath, appDir, filePath });
   }
 
   /**

--- a/packages/farm/src/api/route-shape.ts
+++ b/packages/farm/src/api/route-shape.ts
@@ -1,0 +1,33 @@
+import {
+  AmbiguousRouteError,
+  assertUniqueRouteParameters,
+  getRoutePatternShape,
+} from "../routing/specificity";
+
+export interface APIRouteShapeSource<TSource> {
+  routePath: string;
+  source: TSource;
+  filePath: string;
+}
+
+/** Validate API URL shapes and return the lower-priority route replaced by this source. */
+export function registerAPIRouteShape<TSource>(
+  shapes: Map<string, APIRouteShapeSource<TSource>>,
+  routePath: string,
+  filePath: string,
+  source: TSource,
+): string | undefined {
+  assertUniqueRouteParameters(routePath, "api");
+  const shape = getRoutePatternShape(routePath, "api");
+  const existing = shapes.get(shape);
+  const replacesPath = existing && existing.routePath !== routePath;
+
+  if (replacesPath && existing.source === source) {
+    throw new AmbiguousRouteError(
+      `Ambiguous API routes "${existing.routePath}" and "${routePath}" match the same URLs. Found ${existing.filePath} and ${filePath}. Keep only one route for this URL shape.`,
+    );
+  }
+
+  shapes.set(shape, { routePath, source, filePath });
+  return replacesPath ? existing.routePath : undefined;
+}

--- a/packages/farm/src/api/runtime.ts
+++ b/packages/farm/src/api/runtime.ts
@@ -15,6 +15,8 @@ import { resolveFarmAPICanonicalPathname } from "./server-path";
 import { compareRouteSpecificity, type RouteSegmentSpecificity } from "../routing/specificity";
 import { omitFarmResponseBody } from "../response-body";
 
+export { registerAPIRouteShape, type APIRouteShapeSource } from "./route-shape";
+
 export type APIRouteParamValue = string | string[];
 export type APIRouteParams = Record<string, APIRouteParamValue>;
 

--- a/packages/farmjs-plugin/src/rsc/entries/api-route-shapes.test.ts
+++ b/packages/farmjs-plugin/src/rsc/entries/api-route-shapes.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import { matchAPIRoute, registerAPIRouteShape } from "@farm.js/core/api/runtime";
+import { generateRscEntry } from "./rsc.js";
+
+function createRegistry() {
+  const entry = generateRscEntry({
+    srcDir: "src",
+    outDir: "dist",
+    basePath: "/",
+    routesDir: "app",
+    actionsEnabled: false,
+    serverActions: { allowedOrigins: [], bodySizeLimit: 500_000 },
+    deploymentId: "route-shapes",
+    debug: false,
+  });
+  const start = entry.indexOf("const apiRouteMethods =");
+  const end = entry.indexOf("\n\nregisterApiRouteSources(apiRouteModules", start);
+  return new Function(
+    "registerAPIRouteShape",
+    `${entry.slice(start, end)};
+    return { apiRouteMap, registerApiEndpoint, registerApiRouteSources };`,
+  )(registerAPIRouteShape);
+}
+
+describe("generated RSC API route shapes", () => {
+  it.each(["/api/users/[slug]", "/api/users/[id]/"])(
+    "rejects ambiguous path %s within one source",
+    (path) => {
+      const { registerApiEndpoint } = createRegistry();
+      registerApiEndpoint("/api/users/[id]", "first.ts", "GET", () => {}, 0);
+      expect(() => registerApiEndpoint(path, "second.ts", "POST", () => {}, 0)).toThrow(
+        /Ambiguous API routes.*first.ts.*second.ts/,
+      );
+    },
+  );
+
+  it.each([
+    ["/api/teams/[id]/users/[id]", /Duplicate route parameter/],
+    ["/api/users/[__proto__]", /reserved/],
+    ["/api/users/[...__proto__]", /reserved/],
+    ["/api/users/[[...constructor]]", /reserved/],
+    ["/api/docs/[...slug]/edit", /final segment/],
+  ])("rejects invalid parameter definitions in %s", (path, message) => {
+    const { registerApiEndpoint, apiRouteMap } = createRegistry();
+    expect(() => registerApiEndpoint(path, "invalid.ts", "GET", () => {}, 0)).toThrow(message);
+    expect(apiRouteMap.size).toBe(0);
+  });
+
+  it("replaces a layer's entire dynamic shape with the project route", () => {
+    const { registerApiEndpoint, apiRouteMap } = createRegistry();
+    const project = () => new Response("project");
+    registerApiEndpoint("/api/users/[id]", "layer.ts", "GET", () => {}, 0);
+    registerApiEndpoint("/api/users/[id]", "layer.ts", "POST", () => {}, 0);
+    registerApiEndpoint("/api/users/[slug]", "project.ts", "GET", project, 1);
+    const match = matchAPIRoute(apiRouteMap, "/api/users/alice") as any;
+    expect(match.route.path).toBe("/api/users/[slug]");
+    expect(match.route.handlers.GET).toBe(project);
+    expect(match.route.methods).toEqual(["GET"]);
+    expect(match.params).toEqual({ slug: "alice" });
+    expect(apiRouteMap.has("/api/users/[id]")).toBe(false);
+  });
+
+  it("applies shape checks across file, explicit endpoint, and programmatic definitions", () => {
+    for (const programmatic of [false, true]) {
+      const { registerApiRouteSources } = createRegistry();
+      const endpoint = Object.assign(() => {}, { __path: "/api/users/[slug]", __method: "GET" });
+      const module = programmatic
+        ? {
+            routes: {
+              __farmRoutes: true,
+              routes: [{ kind: "api", path: "/api/users/[slug]", methods: { GET: () => {} } }],
+            },
+          }
+        : { endpoint };
+      expect(() =>
+        registerApiRouteSources(
+          [
+            {
+              sourceIndex: 0,
+              relativePath: "/api/users/[id]/route.ts",
+              filePath: "file.ts",
+              module: { GET: () => {} },
+            },
+          ],
+          [{ sourceIndex: 0, filePath: "definitions.ts", module }],
+          1,
+        ),
+      ).toThrow(/Ambiguous API routes/);
+    }
+  });
+
+  it("keeps static, dynamic, required and optional catch-all routes distinct", () => {
+    const { registerApiEndpoint, apiRouteMap } = createRegistry();
+    for (const path of [
+      "/api/users/[[...rest]]",
+      "/api/users/[...rest]",
+      "/api/users/[id]",
+      "/api/users/new",
+      "/api/users",
+    ]) {
+      registerApiEndpoint(path, path + "/route.ts", "GET", () => {}, 0);
+    }
+    expect(matchAPIRoute(apiRouteMap, "/api/users")?.route.path).toBe("/api/users");
+    expect(matchAPIRoute(apiRouteMap, "/api/users/new")?.route.path).toBe("/api/users/new");
+    expect(matchAPIRoute(apiRouteMap, "/api/users/alice")?.route.path).toBe("/api/users/[id]");
+    expect(matchAPIRoute(apiRouteMap, "/api/users/alice/posts")?.route.path).toBe(
+      "/api/users/[...rest]",
+    );
+  });
+});

--- a/packages/farmjs-plugin/src/rsc/entries/rsc.ts
+++ b/packages/farmjs-plugin/src/rsc/entries/rsc.ts
@@ -29,6 +29,7 @@ export function generateRscEntry(ctx: EntryContext): string {
   const debugLog = `// Debug disabled`;
   let code = `
 import React from 'react';
+import { registerAPIRouteShape } from '@farm.js/core/api/runtime';
 import {
   renderToReadableStream,
 `;
@@ -189,9 +190,12 @@ const routeDefinitionModules = collectRouteModuleEntries([${routeSourceRoots
 
 const apiRouteMethods = ['GET', 'HEAD', 'QUERY', 'POST', 'PUT', 'DELETE', 'PATCH', 'OPTIONS'];
 const apiRouteMap = new Map();
+const apiRouteShapes = new Map();
 
 function registerApiEndpoint(routePath, filePath, method, endpoint, sourceIndex) {
   if (!routePath || typeof endpoint !== 'function') return;
+  const replacedPath = registerAPIRouteShape(apiRouteShapes, routePath, filePath, sourceIndex);
+  if (replacedPath) apiRouteMap.delete(replacedPath);
   const normalizedMethod = String(method || 'GET').toUpperCase();
   let route = apiRouteMap.get(routePath);
   if (!route) {

--- a/packages/farmjs-plugin/src/rsc/entries/security.test.ts
+++ b/packages/farmjs-plugin/src/rsc/entries/security.test.ts
@@ -1,3 +1,4 @@
+import { registerAPIRouteShape } from "@farm.js/core/api/runtime";
 import { describe, expect, it } from "vitest";
 import { transformWithEsbuild } from "vite";
 import {
@@ -153,8 +154,9 @@ describe("generated server action security", () => {
     const registryStart = entry.indexOf("const apiRouteMethods =");
     const registryEnd = entry.indexOf("\n\nregisterApiRouteSources(apiRouteModules", registryStart);
     const { apiRouteMap, registerApiRouteSources } = new Function(
+      "registerAPIRouteShape",
       `${entry.slice(registryStart, registryEnd)}; return { apiRouteMap, registerApiRouteSources };`,
-    )() as {
+    )(registerAPIRouteShape) as {
       apiRouteMap: Map<
         string,
         { path: string; methods: string[]; handlers: Record<string, Function> }
@@ -441,8 +443,9 @@ describe("generated server action security", () => {
     const registryStart = entry.indexOf("const apiRouteMethods =");
     const registryEnd = entry.indexOf("\n\nregisterApiRouteSources(apiRouteModules", registryStart);
     const { apiRouteMap, registerApiRouteSources } = new Function(
+      "registerAPIRouteShape",
       `${entry.slice(registryStart, registryEnd)}; return { apiRouteMap, registerApiRouteSources };`,
-    )() as {
+    )(registerAPIRouteShape) as {
       apiRouteMap: Map<string, { handlers: Record<string, Function> }>;
       registerApiRouteSources: (
         fileModules: unknown[],
@@ -464,8 +467,9 @@ describe("generated server action security", () => {
     const registryStart = entry.indexOf("const apiRouteMethods =");
     const registryEnd = entry.indexOf("\n\nregisterApiRouteSources(apiRouteModules", registryStart);
     const { registerApiRouteSources } = new Function(
+      "registerAPIRouteShape",
       `${entry.slice(registryStart, registryEnd)}; return { registerApiRouteSources };`,
-    )() as {
+    )(registerAPIRouteShape) as {
       registerApiRouteSources: (
         fileModules: unknown[],
         definitionModules: Array<{
@@ -519,8 +523,9 @@ describe("generated server action security", () => {
     const registryStart = entry.indexOf("const apiRouteMethods =");
     const registryEnd = entry.indexOf("\n\nregisterApiRouteSources(apiRouteModules", registryStart);
     const { apiRouteMap, registerApiRouteSources } = new Function(
+      "registerAPIRouteShape",
       `${entry.slice(registryStart, registryEnd)}; return { apiRouteMap, registerApiRouteSources };`,
-    )() as {
+    )(registerAPIRouteShape) as {
       apiRouteMap: Map<string, { handlers: Record<string, Function> }>;
       registerApiRouteSources: (
         fileModules: Array<{


### PR DESCRIPTION
## Problem

RSC accepts `/api/users/[id]` and `/api/users/[slug]` from the same source even though they match the same URLs. A layer's `[id]` route can also win over a project's `[slug]` override, sending the wrong parameter name to the handler.

## Root cause

The generated RSC registry checks exact duplicate path/method pairs but omits the URL-shape validation and layer replacement already used by the core route manager.

## Change

Extract the existing shape registration into a small, filesystem-free core helper and use it in both registries. It rejects same-source ambiguous shapes, duplicate/reserved parameter names, and nonterminal catch-alls. A higher-priority source with a renamed dynamic parameter replaces the lower-priority shape completely.

## Safety and compatibility

Exact-path method merging and duplicate-method errors keep their existing behavior. Static, dynamic, required catch-all, and optional catch-all routes remain distinct. The generated runtime imports only the shared helper, not the filesystem route manager.

## Verification

macOS, Node 23.11.0, pnpm 8.12.1:

- `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @farm.js/core build`
- `pnpm --filter @farm.js/core type-check`
- `pnpm --filter @farm.js/plugin typecheck`
- `pnpm --filter @farm.js/plugin build`
- `pnpm --filter @farm.js/plugin test`: 70 tests pass, including the real isolated Nitro build/boot test.
- `pnpm --filter @farm.js/core test api-route-manager.test.ts`: 30 tests pass.
- Focused formatting, lint, and `git diff --check` pass.

The new suite executes the actual generated registry across file, explicit endpoint, and programmatic definitions. Removing its helper calls makes 9 of the 10 regression cases fail; the ordinary route-specificity control still passes.

## Documentation and release

Updated the API routes guide. No version, template, or generated-route changes.

Combined validation with #932, #934, and #935: the four branches merge cleanly. Core/plugin builds and type checks pass, along with 76 plugin tests and 94 focused core tests. `pnpm docs:check-navigation`, `pnpm --dir docs exec farm generate --check`, and `pnpm docs:build` pass, including Vercel production output. GitHub CI is still running.
