### PR TITLE
fix(integrations): reject unsafe route parameter names

### DIFF
--- a/docs/src/app/docs/integrations/custom/page.md
+++ b/docs/src/app/docs/integrations/custom/page.md
@@ -563,6 +563,11 @@ Within an integration, static paths take precedence over dynamic parameters, fol
 catch-all paths. For example, `/api/items/new` wins over `/api/items/[id]` regardless of
 declaration order. Routes with equal specificity keep their declaration order.
 
+Parameter names must be unique within a route. Use `/api/teams/[teamId]/members/[memberId]`,
+not two `[id]` segments, so both identifiers reach the handler. Farm rejects `__proto__`,
+`constructor`, and `prototype` as parameter names, including catch-all parameters. Validation
+applies to plain routes, typed builders, grouped endpoints, and raw integration objects.
+
 `integrationRoute` is the route factory. It supports `get`, `post`, `put`, `patch`, `delete`, `options`, and `head`.
 
 ```ts

--- a/packages/farm/src/__tests__/integration-route-parameters.test.ts
+++ b/packages/farm/src/__tests__/integration-route-parameters.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  defineIntegration,
+  dispatchIntegrationRequest,
+  integrationRoute,
+  matchIntegrationRoute,
+  resolveIntegrationPlugins,
+} from "../integrations";
+
+const base = { category: "custom", type: "route-parameters", instance: {} } as const;
+const invalidPaths = [
+  "/api/teams/[id]/members/[id]",
+  "/api/teams/[id]/[...id]",
+  "/api/users/[__proto__]",
+  "/api/users/[...__proto__]",
+  "/api/users/[constructor]",
+  "/api/users/[prototype]",
+];
+
+describe("integration route parameter validation", () => {
+  it.each(invalidPaths)("rejects %s in plain, typed, and grouped route definitions", (path) => {
+    const handler = vi.fn(() => new Response("unexpected"));
+    expect(() => defineIntegration({ ...base, routes: [{ path, handler }] })).toThrow(
+      /Duplicate route parameter|reserved/,
+    );
+    expect(() =>
+      defineIntegration({ ...base, routes: [integrationRoute.get(path, { handler })] }),
+    ).toThrow(/Duplicate route parameter|reserved/);
+    expect(() =>
+      defineIntegration({
+        ...base,
+        endpoints: ({ endpoint }) => ({ nested: { item: endpoint.get(path, { handler }) } }),
+      }),
+    ).toThrow(/Duplicate route parameter|reserved/);
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it.each(invalidPaths)("also guards raw integration objects containing %s", async (path) => {
+    const handler = vi.fn(() => new Response("unexpected"));
+    const integration = { ...base, kind: "farm-integration" as const, routes: [{ path, handler }] };
+    expect(() => resolveIntegrationPlugins({ custom: integration })).toThrow(
+      /Duplicate route parameter|reserved/,
+    );
+    expect(() =>
+      matchIntegrationRoute({ custom: integration }, { pathname: "/api/users/a", method: "GET" }),
+    ).toThrow(/Duplicate route parameter|reserved/);
+    await expect(
+      dispatchIntegrationRequest(
+        { integration, config: {}, isDev: false, isProd: true },
+        new Request("https://farm.test/api/users/a"),
+      ),
+    ).rejects.toThrow(/Duplicate route parameter|reserved/);
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("preserves distinct decoded values and catch-all arrays", async () => {
+    const integration = defineIntegration({
+      ...base,
+      routes: [
+        integrationRoute.get("/api/teams/[teamId]/members/[memberId]", {
+          handler: (_request, { params }) => Response.json(params),
+        }),
+        integrationRoute.get("/api/files/[...parts]", {
+          handler: (_request, { params }) => Response.json(params),
+        }),
+      ],
+    });
+    for (const [pathname, params] of [
+      ["/api/teams/team-a/members/member%20b", { teamId: "team-a", memberId: "member b" }],
+      ["/api/files/folder/my%20file", { parts: ["folder", "my file"] }],
+    ] as const) {
+      const match = matchIntegrationRoute({ custom: integration }, { pathname, method: "GET" });
+      expect(match?.params).toEqual(params);
+      expect(Object.getPrototypeOf(match!.params)).toBe(Object.prototype);
+      const response = await dispatchIntegrationRequest(
+        { integration, config: {}, isDev: false, isProd: true },
+        new Request("https://farm.test" + pathname),
+      );
+      expect(await response?.json()).toEqual(params);
+    }
+  });
+});

--- a/packages/farm/src/integrations.ts
+++ b/packages/farm/src/integrations.ts
@@ -15,6 +15,7 @@ import { setFarmPluginIntegrationContext } from "./plugin-integration-context";
 import { decodeRouteSegment } from "./utils/decode";
 import {
   assertTerminalCatchAll,
+  assertUniqueRouteParameters,
   compareRouteSpecificity,
   getRoutePatternSpecificity,
 } from "./routing/specificity";
@@ -1121,6 +1122,7 @@ export function defineIntegration<
       : undefined;
 
   for (const route of allRoutes || []) {
+    assertUniqueRouteParameters(route.path, "api");
     validateConfigRouteSource(route.path, `Integration route "${route.path}"`);
     assertTerminalCatchAll(route.path, "api");
   }
@@ -2242,15 +2244,19 @@ function normalizeIntegrationRoutes(
   routes: readonly FarmIntegrationRoute[],
 ): NormalizedIntegrationRoute[] {
   return routes
-    .map((route, index) => ({
-      index,
-      route: {
-        ...route,
-        methods: normalizeIntegrationRouteMethods(route),
-        input: normalizeIntegrationRouteInputSchemas(route),
-      },
-      specificity: getRoutePatternSpecificity(route.path, "api"),
-    }))
+    .map((route, index) => {
+      // Raw FarmIntegration objects and direct dispatch also pass through here.
+      assertUniqueRouteParameters(route.path, "api");
+      return {
+        index,
+        route: {
+          ...route,
+          methods: normalizeIntegrationRouteMethods(route),
+          input: normalizeIntegrationRouteInputSchemas(route),
+        },
+        specificity: getRoutePatternSpecificity(route.path, "api"),
+      };
+    })
     .sort(
       (left, right) =>
         compareRouteSpecificity(left.specificity, right.specificity) || left.index - right.index,


### PR DESCRIPTION
## Problem

An integration route such as `/api/teams/[id]/members/[id]` silently loses the team identifier. A catch-all named `__proto__` can change the matched params object's prototype instead of creating an own property.

This requires an app or integration to declare the unsafe route. A request cannot choose parameter names on an otherwise safe route, and this is not global prototype pollution.

## Root cause

Integration route validation checks path stability and catch-all placement but does not use core's existing duplicate/reserved parameter-name guard.

## Change

Run the shared guard when defining an integration and when normalizing its routes. This covers plain routes, typed builders, grouped endpoints, and raw integration objects used through plugin resolution, matching, or direct dispatch.

## Safety and compatibility

Valid bracket parameters, decoded identifiers, and catch-all arrays keep their current behavior. Invalid definitions fail before a handler runs. There is no new configuration or dependency, and the validation is renderer-neutral.

## Verification

macOS, Node 23.11.0, pnpm 8.12.1:

- `pnpm --filter @farm.js/core test integration-route-parameters.test.ts integrations.test.ts`: 48 tests pass.
- `pnpm --filter @farm.js/core type-check`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @farm.js/core build`
- Focused formatting, lint, and `git diff --check` pass. Lint reports two existing unused-function warnings.

Removing both guards makes all 12 rejection cases fail; the valid decoded-parameter and catch-all dispatch control still passes.

## Documentation and release

Updated the custom integrations guide with valid parameter naming and the rejected names. No version, template, or generated-route changes.

Combined validation with #932, #933, and #935: the four branches merge cleanly. Core/plugin builds and type checks pass, along with 76 plugin tests and 94 focused core tests. `pnpm docs:check-navigation`, `pnpm --dir docs exec farm generate --check`, and `pnpm docs:build` pass, including Vercel production output. GitHub CI is still running.
