### PR TITLE
fix(build): disable production discovery file watchers

### DIFF
--- a/docs/src/app/docs/configuration/page.md
+++ b/docs/src/app/docs/configuration/page.md
@@ -811,6 +811,8 @@ Prefer a CI release or commit identifier when a deployment runs on multiple serv
 
 ## Production notes
 
+- Production route discovery disables filesystem watching, including when `vite.server.watch`
+  is configured. That option still applies to development; a one-shot build does not need a live watcher.
 - Keep secrets in environment variables, not committed config.
 - Use `storage.driver` and `storage.mounts` for KV data read through `getStorage()`.
 - Use a raw object at `storage.client` only when schema-backed integrations need a database client; see [Database and ORM Clients](/docs/integrations/orm-storage).

--- a/packages/farm/src/__tests__/production-discovery-watcher.test.ts
+++ b/packages/farm/src/__tests__/production-discovery-watcher.test.ts
@@ -1,0 +1,83 @@
+// @vitest-environment node
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import type { ViteDevServer } from "vite";
+import { expect, it } from "vitest";
+import { build } from "../build";
+import { resolveConfig } from "../config";
+import { loadFarmProductionVite } from "../build/production-vite";
+
+it.each([false, true])(
+  "disables production discovery watching with custom Vite config: %s",
+  async (customVite) => {
+    const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+    const root = await fs.mkdtemp(path.join(packageRoot, ".tmp-discovery-watcher-"));
+    let discoveryServer: ViteDevServer | undefined;
+    let injectedServerCalls = 0;
+    try {
+      await fs.mkdir(path.join(root, "node_modules", "@farm.js"), { recursive: true });
+      await fs.symlink(
+        packageRoot,
+        path.join(root, "node_modules", "@farm.js", "core"),
+        "junction",
+      );
+      await fs.mkdir(path.join(root, "src", "app"), { recursive: true });
+      await fs.writeFile(path.join(root, "package.json"), JSON.stringify({ type: "module" }));
+      await fs.writeFile(path.join(root, "src", "app", "globals.css"), "body { margin: 0; }");
+      await fs.writeFile(
+        path.join(root, "src", "app", "page.tsx"),
+        "export default function Page() { return <main>watcher fixture</main>; }",
+      );
+      const config = await resolveConfig(
+        {
+          root,
+          srcDir: "src",
+          images: { provider: "none" },
+          ...(customVite
+            ? {
+                vite: {
+                  server: { watch: { usePolling: true } },
+                  plugins: [
+                    {
+                      name: "capture-discovery-server",
+                      configureServer(server: ViteDevServer) {
+                        discoveryServer = server;
+                      },
+                    },
+                  ],
+                },
+              }
+            : {}),
+        },
+        "production",
+      );
+      const runtime = await loadFarmProductionVite();
+      await build(config, {
+        root,
+        preset: "node-server",
+        productionVite: {
+          ...runtime,
+          createServer: async (inlineConfig) => {
+            injectedServerCalls++;
+            discoveryServer = await runtime.createServer(inlineConfig);
+            return discoveryServer;
+          },
+        },
+      });
+      expect(discoveryServer).toBeDefined();
+      expect(injectedServerCalls).toBe(customVite ? 0 : 1);
+      expect(discoveryServer!.config.server.hmr).toBe(false);
+      expect(discoveryServer!.config.server.watch).toBeNull();
+      expect(discoveryServer!.watcher.getWatched()).toEqual({});
+      expect(
+        await fs.readFile(path.join(root, ".farm", ".output", "server", "index.mjs"), "utf8"),
+      ).not.toBe("");
+      if (customVite) expect(config.vite?.server?.watch).toEqual({ usePolling: true });
+    } finally {
+      await discoveryServer?.close();
+      await fs.rm(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+    }
+  },
+  120_000,
+);

--- a/packages/farm/src/build/index.ts
+++ b/packages/farm/src/build/index.ts
@@ -333,6 +333,9 @@ async function createProjectModuleServer(
       ...viteConfig.server,
       middlewareMode: true,
       hmr: false,
+      // This server only loads modules for a single build. HMR alone does not
+      // disable filesystem watching, which can race with generated output.
+      watch: null,
     },
     optimizeDeps: {
       ...viteConfig.optimizeDeps,


### PR DESCRIPTION
## Problem

A one-shot production build starts a live filesystem watcher during route discovery. It can watch generated output while the build writes or removes it. A recent Windows CI run reported an unhandled `EBUSY` watch error for `.vercel/output/static/farm-client.js` even though its core assertions passed.

## Root cause

The discovery server sets `hmr: false`, which disables HMR but does not disable Vite's filesystem watcher.

## Change

Set `server.watch: null` after merging user Vite options for the production module-discovery server. This applies to both the production-Vite path and the custom-Vite compatibility path.

## Safety and compatibility

Development configuration and watching are unchanged. Production discovery still loads modules and runs plugin hooks, but does not keep a live watcher for a single build. No new option or dependency.

## Verification

macOS, Node 23.11.0, pnpm 8.12.1:

- `pnpm --filter @farm.js/core test production-discovery-watcher.test.ts production-middleware.test.ts build-configure-hook.test.ts`: 7 tests pass, including real Node and Vercel production builds.
- `pnpm --filter @farm.js/core type-check`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @farm.js/core build`
- Focused formatting, lint, and `git diff --check` pass.

Both new tests fail without the fix: default discovery has an undefined watch option, while custom Vite discovery retains `{ usePolling: true }`. With the fix, both use `null`, have an empty watched-path map, and emit runnable server output. The caller's development watch configuration remains unchanged.

The watcher behavior was reproduced locally. The intermittent Windows-specific `EBUSY` came from CI and was not reproduced on macOS; Windows CI is still needed for platform confirmation.

## Documentation and release

Updated the configuration guide's production notes. No version, template, or generated-route changes.

Combined validation with #932, #933, and #934: the four branches merge cleanly. Core/plugin builds and type checks pass, along with 76 plugin tests and 94 focused core tests. `pnpm docs:check-navigation`, `pnpm --dir docs exec farm generate --check`, and `pnpm docs:build` pass, including Vercel production output. GitHub CI is still running.
