### PR TITLE
perf(react): compile multi-branch keyed maps

### DIFF
--- a/docs/src/app/docs/renderers/react/page.md
+++ b/docs/src/app/docs/renderers/react/page.md
@@ -1169,6 +1169,7 @@ setItems((current) =>
 );
 ```
 
+Each map may use a compiler-safe nested conditional to update several retained rows.
 Farm links mapped retained items back to their committed rows, creates the incoming suffix from its
 final mapped values, and prepares every changed binding and incoming row before the first live DOM
 write. Unchanged survivors keep their elements, focus, selection, scopes, and delegated-event
@@ -1383,6 +1384,26 @@ by comparing the input and final result of each consecutive map segment. The int
 need no separate full scan, and the final replacements still point directly to their committed
 source rows. The complete pipeline then needs one final keyed reconciliation rather than a growing
 chain of intermediate snapshots.
+
+One callback may select several rows with nested conditional expressions:
+
+```tsx
+setItems((current) =>
+  current.map((item) =>
+    item.id === reviewedId
+      ? { ...item, status: "reviewed" }
+      : item.id === escalatedId
+        ? { ...item, status: "escalated", priority: 1 }
+        : item,
+  ),
+);
+```
+
+The compiler recursively proves every condition and leaf. Each leaf must return the original item
+or a compiler-safe object spread of that item, with at least one unchanged and one replacement
+path. Calls, mutation, block bodies, and any other effectful or ambiguous branch keep complete keyed
+reconciliation. Runtime key validation remains atomic, so a replacement that changes its key falls
+back before the first DOM write.
 
 Before changing the DOM, the runtime verifies ordinary dense arrays, exact native methods, the
 committed collection token, equal lengths, a unique one-to-one source-item match, and the key of
@@ -2436,7 +2457,8 @@ The package and example test suites verify more than generated code:
   survivor bindings, preserve retained DOM identity, update delegated indexes, preserve controlled
   focus and selection, and cover changed mapped keys, unsafe evaluated bounds, reused or discarded
   intermediate keys, custom slices, mixed queued chains, collection-dependent rows, Strict Mode
-  hydration, React 18/19, and unmount cleanup;
+  hydration, React 18/19, and unmount cleanup; compiler tests accept recursively proven
+  multi-branch maps while rejecting effectful leaves and callbacks that replace every row;
 - 2,000 deterministic randomized keyed-array removals match normal React; targeted tests require
   zero surviving descriptor and binding reads, preserve DOM identity, and cover queued filters,
   unhinted-chain fallback, collection-reading rows, StrictMode hydration, and unmount cleanup;

--- a/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
+++ b/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
@@ -2,6 +2,39 @@
 
 Latest run: 2026-09-11
 
+## Multi-branch same-key maps — 2026-09-11
+
+One compiler-safe `map()` callback may now select several rows with a nested conditional chain.
+Every condition is proven recursively, and every leaf must return the original item or an object
+spread of that item. Effectful or ambiguous branches still use complete keyed reconciliation, and
+changed replacement keys still trigger the atomic runtime fallback.
+
+The maintained 10,000-row workload performs a 50-row roll, updates two different retained rows in
+one nested map, and performs another 50-row roll before React commits. Previously, the nested map
+was not eligible and broke the rolling-window chain. The block-bodied rolling control performs the
+same JavaScript and DOM result without compiler lineage.
+
+| Mode   | Two-branch mapped chain | Compiled fallback | vs React | vs fallback |
+| ------ | ----------------------: | ----------------: | -------: | ----------: |
+| Static |                 3.50 ms |          13.80 ms |   16.46x |       3.94x |
+| Hybrid |                 3.40 ms |          14.20 ms |   16.94x |       4.18x |
+
+Both modes passed the unchanged 2x React and 1.25x compiled-control floors. The bracketed React
+median was 57.60 ms. Every sample checked the final 10,000-row count, both retained DOM identities,
+both branch-specific label and amount changes, the final incoming suffix, browser errors, and zero
+compiled owner executions. The compiler report recorded two mapped rolling-chain steps and 34
+safe keyed maps in both compiled modes.
+
+Every existing correctness, performance, optimization-persistence, feature, and scalability gate
+passed. The established 10k/20k persistence speedups remained between 13.95x and 19.73x. The
+compiler runtime-size baselines are unchanged because recursive branch proof is build-time only;
+the complete example bundles were 31,682 bytes gzip in both compiler modes.
+
+Numbers are browser medians from the complete production-build command with 5 warmups, 10 measured
+samples per compiler action, 20 bracketed React samples, 60 dashboard samples of 10 updates, and 3
+scale cycles, using Chrome 153.0.8010.36 and Node.js 23.11.0 on Apple M1 macOS arm64. The aggregate
+command and every individual gate passed.
+
 ## Same-key maps through multiple rolling windows — 2026-09-11
 
 One synchronous setter segment can now retain committed-row lineage through more than one

--- a/examples/react-compiler-dashboard/README.md
+++ b/examples/react-compiler-dashboard/README.md
@@ -151,11 +151,11 @@ least 2x faster than React and 1.25x faster than that control. Every sample veri
 DOM identity, mapped value, exact row count, fresh suffix, and zero compiled owner executions.
 
 Mapped rolling-window chains have a separate gate so the single-window result cannot hide a chain
-regression. The 10,000-row workload runs one same-key map between two queued 50-row rolls. Its
-block-bodied control performs the same native work but cannot retain compiler lineage. Both
-compiler modes must remain at least 2x faster than React and 1.25x faster than that control, and the
-compiler report must contain both mapped rolling-chain steps. Every sample verifies the final
-retained identity and values plus the final incoming suffix.
+regression. The 10,000-row workload runs one nested, two-branch same-key map between two queued
+50-row rolls. Its block-bodied control performs the same native work but cannot retain compiler
+lineage. Both compiler modes must remain at least 2x faster than React and 1.25x faster than that
+control, and the compiler report must contain both mapped rolling-chain steps. Every sample verifies
+both retained identities and mapped values plus the final incoming suffix.
 
 Exact-position insertions, removals, and replacements have separate 10,000-row comparisons. Concise
 native `toSpliced(position, 0, item)`, `toSpliced(position, 0, ...items)`, `toSpliced(position, 1)`,

--- a/examples/react-compiler-dashboard/scripts/benchmark.mjs
+++ b/examples/react-compiler-dashboard/scripts/benchmark.mjs
@@ -641,24 +641,41 @@ async function measureTrial(browser, trial, compilerMode, port) {
 
         const measureMappedRollingWindowChain = async (action) => {
           const rows = table.querySelectorAll("tbody tr");
-          const firstSurvivor = rows[100];
-          const previousLabel = firstSurvivor?.querySelector("td:nth-child(2)")?.textContent;
-          const previousAmount = Number(
-            firstSurvivor?.querySelector("td:nth-child(4)")?.textContent?.slice(1),
+          const reviewedSurvivor = rows[100];
+          const escalatedSurvivor = rows[101];
+          const reviewedLabel = reviewedSurvivor?.querySelector("td:nth-child(2)")?.textContent;
+          const escalatedLabel = escalatedSurvivor?.querySelector("td:nth-child(2)")?.textContent;
+          const reviewedAmount = Number(
+            reviewedSurvivor?.querySelector("td:nth-child(4)")?.textContent?.slice(1),
+          );
+          const escalatedAmount = Number(
+            escalatedSurvivor?.querySelector("td:nth-child(4)")?.textContent?.slice(1),
           );
           const previousLast = rows[9_999]?.getAttribute("data-row-id");
-          if (!firstSurvivor || !previousLabel || !Number.isFinite(previousAmount)) {
+          if (
+            !reviewedSurvivor ||
+            !escalatedSurvivor ||
+            !reviewedLabel ||
+            !escalatedLabel ||
+            !Number.isFinite(reviewedAmount) ||
+            !Number.isFinite(escalatedAmount)
+          ) {
             throw new Error("Mapped rolling-chain source rows are invalid.");
           }
           await runTableAction(action, () => {
             const nextRows = table.querySelectorAll("tbody tr");
             return (
               rowCount() === 10_000 &&
-              nextRows[0] === firstSurvivor &&
-              firstSurvivor.querySelector("td:nth-child(2)")?.textContent ===
-                `${previousLabel} reviewed` &&
-              firstSurvivor.querySelector("td:nth-child(4)")?.textContent ===
-                `$${previousAmount + 1}` &&
+              nextRows[0] === reviewedSurvivor &&
+              nextRows[1] === escalatedSurvivor &&
+              reviewedSurvivor.querySelector("td:nth-child(2)")?.textContent ===
+                `${reviewedLabel} reviewed` &&
+              reviewedSurvivor.querySelector("td:nth-child(4)")?.textContent ===
+                `$${reviewedAmount + 1}` &&
+              escalatedSurvivor.querySelector("td:nth-child(2)")?.textContent ===
+                `${escalatedLabel} escalated` &&
+              escalatedSurvivor.querySelector("td:nth-child(4)")?.textContent ===
+                `$${escalatedAmount + 2}` &&
               nextRows[9_999]?.getAttribute("data-row-id") !== previousLast
             );
           });

--- a/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
+++ b/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
@@ -320,14 +320,17 @@ export function StandardTableBenchmark() {
             const secondSeed = seed + 2;
             const firstAdditions = buildRows(50, firstSeed);
             const secondAdditions = buildRows(50, secondSeed);
-            const targetId = rows[100].id;
+            const reviewedId = rows[100].id;
+            const escalatedId = rows[101].id;
             const trimCount = 50;
             setSeed(secondSeed);
             setRows((current) => [...current.slice(trimCount), ...firstAdditions]);
             setRows((current) =>
               current.map((row) =>
-                row.id === targetId
+                row.id === reviewedId
                   ? { ...row, amount: row.amount + 1, label: `${row.label} reviewed` }
+                  : row.id === escalatedId
+                    ? { ...row, amount: row.amount + 2, label: `${row.label} escalated` }
                   : row,
               ),
             );
@@ -346,7 +349,8 @@ export function StandardTableBenchmark() {
             const secondSeed = seed + 2;
             const firstAdditions = buildRows(50, firstSeed);
             const secondAdditions = buildRows(50, secondSeed);
-            const targetId = rows[100].id;
+            const reviewedId = rows[100].id;
+            const escalatedId = rows[101].id;
             const trimCount = 50;
             setSeed(secondSeed);
             setRows((current) => {
@@ -354,8 +358,10 @@ export function StandardTableBenchmark() {
             });
             setRows((current) =>
               current.map((row) =>
-                row.id === targetId
+                row.id === reviewedId
                   ? { ...row, amount: row.amount + 1, label: `${row.label} reviewed` }
+                  : row.id === escalatedId
+                    ? { ...row, amount: row.amount + 2, label: `${row.label} escalated` }
                   : row,
               ),
             );

--- a/packages/farm-react/README.md
+++ b/packages/farm-react/README.md
@@ -413,6 +413,7 @@ setItems((current) =>
 );
 ```
 
+Each map may use a compiler-safe nested conditional to update several retained rows.
 The compiler carries mapped survivor identity through the retained tail, creates incoming rows
 from their final mapped values, and patches only changed committed survivors. A single rolling
 setter uses the optional structural append/map runtime. Multiple rolling setters keep their
@@ -545,14 +546,33 @@ setItems((current) =>
 );
 ```
 
+One callback may select several rows through nested conditional expressions:
+
+```tsx
+setItems((current) =>
+  current.map((item) =>
+    item.id === reviewedId
+      ? { ...item, status: "reviewed" }
+      : item.id === escalatedId
+        ? { ...item, status: "escalated", priority: 1 }
+        : item,
+  ),
+);
+```
+
+Every condition must be compiler-safe, and every leaf must return the original item or a safe
+object spread of it, with at least one unchanged and one replacement path. Effectful calls,
+mutation, block bodies, and ambiguous leaves use complete keyed reconciliation. A runtime key
+change also falls back before any DOM write.
+
 Farm executes every native map and reorder call normally. For consecutive accepted maps, it checks
 each native call but compares only the input and final result of that map segment, avoiding a full
 lineage scan for every intermediate array. It verifies the committed token, dense-array shape, a
 one-to-one source-item match, and every final replacement key before touching the DOM, then runs one
 LIS and patches each changed row once. Unchanged rows need no second key or binding read. Queued
 supported map-and-reorder setters compose against the same committed rows. Every accepted map
-requires an inline synchronous conditional mapper that returns either the original item or an
-object-spread replacement, plus index-independent compiler-owned host rows. Changed keys,
+requires an inline synchronous conditional mapper whose leaves return either the original item or
+an object-spread replacement, plus index-independent compiler-owned host rows. Changed keys,
 referenced or block-bodied callbacks, unconditional replacements, `thisArg`, structural calls in
 the same chain, computed or custom methods, sparse or subclassed arrays, collection-reading
 bindings, nested or React-owned rows, and failed checks use complete keyed reconciliation. Reports

--- a/packages/farm-react/src/__tests__/compiler-keyed-array-rolling-window-hints.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-keyed-array-rolling-window-hints.test.ts
@@ -191,7 +191,7 @@ describe("React AOT keyed-array rolling-window hints", () => {
     expect(result.code).not.toContain("createCompilerKeyedArrayStructuralAppendMapPipeline");
   });
 
-  it("does not emit a rolling-window chain hint for an unsupported map callback", async () => {
+  it("retains a rolling-window chain through a safe multi-branch map callback", async () => {
     const result = await compile(`
       import { useState } from "react";
       export function Feed({ nextOne, nextTwo, firstId, secondId, nextLabel }) {
@@ -208,6 +208,35 @@ describe("React AOT keyed-array rolling-window hints", () => {
             ));
             setRows((current) => [...current.slice(1), nextTwo]);
           }}>Roll around unsupported map</button>
+          <ul>{rows.map((row) => <li key={row.id}>{row.label}</li>)}</ul>
+        </section>;
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Feed"]);
+    expect(result.optimizations.keyedArrayMappedRollingWindowChainHints).toBe(2);
+    expect(result.optimizations.keyedMapUpdateHints).toBe(1);
+    expect(result.code).toContain("createCompilerKeyedArrayRollingWindowMapPipeline");
+    expect(result.code).toContain("createCompilerKeyedArrayMappedRollingWindow");
+  });
+
+  it("does not emit a rolling-window chain hint when one nested map branch is effectful", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Feed({ nextOne, nextTwo, firstId, secondId, computeLabel }) {
+        const [rows, setRows] = useState([{ id: "a", label: "Alpha" }]);
+        return <section>
+          <button onClick={() => {
+            setRows((current) => [...current.slice(1), nextOne]);
+            setRows((current) => current.map((row) =>
+              row.id === firstId
+                ? { ...row, label: "First" }
+                : row.id === secondId
+                  ? { ...row, label: computeLabel(row) }
+                  : row
+            ));
+            setRows((current) => [...current.slice(1), nextTwo]);
+          }}>Roll around unsafe map</button>
           <ul>{rows.map((row) => <li key={row.id}>{row.label}</li>)}</ul>
         </section>;
       }

--- a/packages/farm-react/src/__tests__/compiler-keyed-update-hints.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-keyed-update-hints.test.ts
@@ -108,6 +108,44 @@ describe("React AOT keyed update hints", () => {
     });
   });
 
+  it("records one keyed update for a safe multi-branch map", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Inventory({ firstId, secondId, firstLabel, secondLabel }) {
+        const [items, setItems] = useState([
+          { id: "a", label: "Alpha", selected: false },
+          { id: "b", label: "Beta", selected: false },
+        ]);
+        return (
+          <section>
+            <button onClick={() => setItems((current) => current.map((row) =>
+              row.id === firstId
+                ? { ...row, label: firstLabel }
+                : row.id === secondId
+                  ? { ...row, label: secondLabel, selected: true }
+                  : row
+            ))}>Update two rows</button>
+            <ul>{items.map((item) => <li key={item.id}>{item.label}</li>)}</ul>
+          </section>
+        );
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Inventory"]);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.optimizations.keyedMapUpdateHints).toBe(1);
+    expect(result.code.match(/createCompilerKeyedMapUpdate\(/g)).toHaveLength(1);
+    expect(result.code).toContain("keyedRowsHintedRuntimeFeature");
+    await expect(
+      transformWithEsbuild(result.code, "/app/KeyedUpdateHints.tsx", {
+        loader: "tsx",
+        jsx: "automatic",
+      }),
+    ).resolves.toMatchObject({
+      code: expect.stringContaining("createCompilerKeyedMapUpdate"),
+    });
+  });
+
   it("supports direct-state public List rows without adding a public option", async () => {
     const result = await compile(`
       import { useState } from "react";
@@ -153,6 +191,13 @@ describe("React AOT keyed update hints", () => {
       collection: "items",
       update:
         'setItems((current) => current.map((row) => row.id === "a" ? { ...row, label: "First" } : row).map((row) => ({ ...row, label: "Updated" })))',
+    },
+    {
+      name: "a conditional mapper that replaces every row",
+      declaration: "",
+      collection: "items",
+      update:
+        'setItems((current) => current.map((row) => row.id === "a" ? { ...row, label: "First" } : { ...row, label: "Other" }))',
     },
     {
       name: "a potentially mutating mapper",

--- a/packages/farm-react/src/compiler.ts
+++ b/packages/farm-react/src/compiler.ts
@@ -1241,13 +1241,32 @@ function isSafeKeyedMapResult(
   item: t.Identifier,
   safeGlobals: ReadonlySet<string>,
 ): boolean {
+  type BranchProof = { replacement: boolean; unchanged: boolean };
+  const proveBranch = (branch: t.Expression): BranchProof | undefined => {
+    if (isUnchangedMapItem(branch, item)) return { replacement: false, unchanged: true };
+    if (isSafeKeyedMapReplacement(branch, item, safeGlobals)) {
+      return { replacement: true, unchanged: false };
+    }
+    if (!t.isConditionalExpression(branch)) return undefined;
+    if (validateDerivedExpression(branch.test, safeGlobals)) return undefined;
+    const consequent = proveBranch(branch.consequent);
+    const alternate = proveBranch(branch.alternate);
+    if (!consequent || !alternate) return undefined;
+    return {
+      replacement: consequent.replacement || alternate.replacement,
+      unchanged: consequent.unchanged || alternate.unchanged,
+    };
+  };
+
   if (!t.isConditionalExpression(expression)) return false;
   if (validateDerivedExpression(expression.test, safeGlobals)) return false;
-  return (
-    (isUnchangedMapItem(expression.consequent, item) &&
-      isSafeKeyedMapReplacement(expression.alternate, item, safeGlobals)) ||
-    (isUnchangedMapItem(expression.alternate, item) &&
-      isSafeKeyedMapReplacement(expression.consequent, item, safeGlobals))
+  const consequent = proveBranch(expression.consequent);
+  const alternate = proveBranch(expression.alternate);
+  return Boolean(
+    consequent &&
+    alternate &&
+    (consequent.replacement || alternate.replacement) &&
+    (consequent.unchanged || alternate.unchanged),
   );
 }
 


### PR DESCRIPTION
## Problem

The experimental React compiler could preserve keyed rows through a mapped rolling-window chain only when the map used a single conditional branch. A common update that changes either of two retained rows with a nested ternary was rejected, so the complete keyed React fallback ran even though every branch was statically safe.

## Root cause

The compiler's keyed-map proof recognized only one conditional expression whose leaves were the unchanged item or a safe object-spread replacement. It did not recursively prove nested conditional branches, so safe multi-branch selection maps were indistinguishable from ambiguous maps.

## Change

- recursively prove conditional keyed-map expressions
- require every condition to remain side-effect-free
- require every leaf to be either the unchanged row or a safe object-spread replacement of that row
- require the complete expression to contain both an unchanged path and a replacement path
- exercise two different retained-row updates in the rolling-chain dashboard benchmark
- document the supported syntax and fallback boundary

## Safety and compatibility

This changes compiler eligibility only; it adds no runtime implementation and does not change the runtime-size baseline. Block bodies, effectful conditions, ambiguous leaves, and expressions that replace every row continue to use the complete keyed React fallback. Runtime key validation remains atomic, React still owns unsupported structures, and the optimization stays behind the existing experimental React compiler flag.

React 18.3.1 and React 19.2.8 compatibility suites pass. DOM identity, hydration, cleanup, and fallback behavior remain covered by the existing package and browser suites.

## Verification

- `pnpm --filter @farm.js/react test` — 75 files; 832 passed, 14 skipped
- React stress suites — 8 files; 23 passed, 132 skipped
- `pnpm --filter @farm.js/react test:compat` — React 18.3.1 and 19.2.8 passed
- `pnpm --filter @farm.js/react test:runtime-size` — passed with unchanged baselines
- `pnpm --filter @farm.js/react type-check`
- `pnpm --filter @farm.js/react build`
- `pnpm --filter @farm.js/react-compiler-dashboard type-check`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @farm.js/core build`
- `pnpm docs:check-navigation` — 83 pages, 12 plugins
- `pnpm --dir docs exec farm generate --check`
- `pnpm docs:build` — Vercel/Nitro production build passed
- focused `oxfmt` and `oxlint` checks passed

Production Chromium benchmark, 10,000 keyed rows, median browser update latency:

- static mode: compiled 3.50 ms, forced fallback 13.80 ms, React 57.60 ms — 16.46x faster than React and 3.94x faster than fallback
- hybrid mode: compiled 3.40 ms, forced fallback 14.20 ms, React 57.60 ms — 16.94x faster than React and 4.18x faster than fallback
- all correctness, identity, fallback, cleanup, hydration, persistence, and performance gates passed
- compiler example bundle remained 31,682 gzip bytes in both modes

## Documentation and release

Updated the React renderer documentation, renderer README, dashboard README, benchmark methodology/results, and executable dashboard case. No release version changes.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extends the React compiler's keyed-map optimization to support multi-branch (nested conditional) map callbacks, so safe multi-branch updates no longer fall back to full keyed reconciliation.

- Recursively proves nested conditional expressions, requiring every condition to be side-effect-free and every leaf to be either the unchanged item or a safe object-spread replacement.
- Requires each proof to contain at least one unchanged and one replacement path.
- Updates the dashboard benchmark to exercise two retained-row updates and adds tests for accepted and rejected cases.
- Documents the supported syntax and fallback boundary in the renderer and package READMEs.

No runtime behavior changes; the optimization remains behind the existing experimental compiler flag. Unsafe branches (effectful conditions, block bodies, replacement-only callbacks) still use the complete keyed React fallback.

<sup>Written for commit d9b5526ec1a48ceb3a9e6096f180215e1ef8bce6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/937?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

