### PR TITLE
fix(server): cancel response producers when downstream writes fail

### DIFF
--- a/docs/src/app/docs/api-routes/page.md
+++ b/docs/src/app/docs/api-routes/page.md
@@ -193,6 +193,10 @@ soon as the source yields it, respects response backpressure, cancels the source
 disconnects, and defaults to `Cache-Control: no-store`. Use ordinary `Response` objects for binary
 downloads or protocols that are not JSON event streams.
 
+When Farm bridges a streamed `Response` to Node, a failed response write also cancels the
+upstream body. Put producer cleanup in the stream's `cancel()` callback. Farm preserves the
+original write error and does not wait indefinitely for that cleanup to finish.
+
 ## Endpoint middleware
 
 Put plain async functions in `middleware`. There is no middleware factory and no `next()` callback. Functions run in declaration order after endpoint input validation.

--- a/packages/farm/src/__tests__/response-write-failure.test.ts
+++ b/packages/farm/src/__tests__/response-write-failure.test.ts
@@ -1,0 +1,65 @@
+// @vitest-environment node
+import { expect, it, vi } from "vitest";
+import { IncomingMessage, ServerResponse } from "node:http";
+import { Socket } from "node:net";
+import { sendWebResponse } from "../server/response";
+
+it.each(["normal", "rejecting", "pending"])(
+  "cancels a %s producer without masking or delaying the downstream write error",
+  async (mode) => {
+    const failure = new Error("downstream write failed");
+    const cancel = vi.fn(() => {
+      if (mode === "rejecting") return Promise.reject(new Error("cancel failed"));
+      if (mode === "pending") return new Promise<void>(() => {});
+    });
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array([1, 2, 3]));
+      },
+      cancel,
+    });
+    const response = {
+      setHeader: vi.fn(),
+      getHeader: vi.fn(),
+      write() {
+        throw failure;
+      },
+      end: vi.fn(),
+      destroy: vi.fn(),
+    };
+    await expect(
+      sendWebResponse(response as unknown as ServerResponse, new Response(stream)),
+    ).rejects.toBe(failure);
+    expect(response.destroy).toHaveBeenCalledWith(failure);
+    expect(stream.locked).toBe(false);
+    expect(cancel).toHaveBeenCalledExactlyOnceWith(failure);
+  },
+);
+
+it("cancels after a real Node strict Content-Length write error", async () => {
+  const request = new IncomingMessage(new Socket());
+  request.method = "GET";
+  const response = new ServerResponse(request);
+  response.strictContentLength = true;
+  response.setHeader("content-length", "2");
+  response.flushHeaders();
+  const cancel = vi.fn();
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(new Uint8Array([1, 2, 3]));
+    },
+    cancel,
+  });
+  try {
+    await expect(sendWebResponse(response, new Response(stream))).rejects.toMatchObject({
+      code: "ERR_HTTP_CONTENT_LENGTH_MISMATCH",
+    });
+    expect(cancel).toHaveBeenCalledTimes(1);
+    expect(cancel.mock.calls[0][0]).toMatchObject({ code: "ERR_HTTP_CONTENT_LENGTH_MISMATCH" });
+    expect(stream.locked).toBe(false);
+  } finally {
+    request.destroy();
+    response.destroy();
+    if (!stream.locked) void stream.cancel().catch(() => {});
+  }
+});

--- a/packages/farm/src/server/response.ts
+++ b/packages/farm/src/server/response.ts
@@ -206,6 +206,10 @@ export async function sendWebResponse(res: ServerResponse, response: Response): 
 
     res.end();
   } catch (error) {
+    // Releasing the lock does not stop the producer. Cancel it when the
+    // downstream write fails, without waiting on app-owned cleanup or letting
+    // a cancellation failure replace the original error.
+    void reader.cancel(error).catch(() => {});
     if (!res.writableEnded) {
       const responseError = error instanceof Error ? error : new Error(String(error));
       if (typeof res.destroy === "function") {


### PR DESCRIPTION
## Problem

A failed Node response write rejects the request but leaves the upstream Web stream running. A real strict Content-Length mismatch reproduces this.

## Root cause

The error path releases the reader lock without cancelling the producer. Releasing a lock does not run the stream's cleanup.

## Change

Cancel the reader with the original write error before destroying the downstream response. Cancellation is fire-and-forget with rejection handling, so app cleanup cannot replace the original error or hold the request open indefinitely.

## Safety and compatibility

No API change. The shared Node response bridge remains renderer-neutral. Successful writes and existing disconnect handling are unchanged.

## Verification

macOS, Node 23.11.0, pnpm 8.12.1.

- `pnpm --filter @farm.js/core test response-write-failure.test.ts send-web-response.test.ts server-response.test.ts development-runtime-response.test.ts`: 11 passed.
- The four new cases fail without the fix and pass with it: ordinary, rejecting, and never-settling cancel callbacks, plus a real Node ServerResponse strict Content-Length failure.
- Focused formatting and lint passed.

## Documentation and release

Combined validation with the other four runtime fixes also passed: 104 plugin tests, 43 focused core tests, core/plugin builds and type checks, docs navigation and generated-type checks, and `pnpm docs:build` with the Vercel preset. The five branches apply together without conflicts. GitHub CI is still running or queued; these results are local verification, not a claim that every CI platform has finished.

Documented producer cleanup in the API routes guide. No version, template, or dependency changes.
