### PR TITLE
fix(rsc): preserve UTF-8 bytes during streamed HTML injection

### DIFF
--- a/docs/src/app/docs/server-rendering/page.md
+++ b/docs/src/app/docs/server-rendering/page.md
@@ -57,6 +57,10 @@ export default function BlogPage() {
 
 Use dynamic rendering for request-specific pages such as dashboards, account settings, and pages that depend on cookies, headers, or per-user data.
 
+With experimental React Server Components enabled, Farm streams HTML while inserting the styles,
+hydration payload, and client script. HTML injection preserves UTF-8 bytes across stream chunks,
+including emoji and non-ASCII content, without buffering the entire page.
+
 **src/app/dashboard/page.tsx**
 
 ```tsx

--- a/packages/farmjs-plugin/src/rsc/entries/ssr-stream.test.ts
+++ b/packages/farmjs-plugin/src/rsc/entries/ssr-stream.test.ts
@@ -1,0 +1,85 @@
+import { expect, it, vi } from "vitest";
+import { generateSsrEntry } from "./ssr.js";
+
+const entry = generateSsrEntry({
+  srcDir: "src",
+  outDir: "dist",
+  basePath: "/",
+  actionsEnabled: false,
+  serverActions: { allowedOrigins: [], bodySizeLimit: 500_000 },
+  deploymentId: "test",
+  debug: false,
+});
+// Execute the emitted implementation, not a second copy of the algorithm.
+const start = entry.indexOf("function injectBeforeStream(");
+const end = entry.indexOf("/** Collect Node stream", start);
+const inject = new Function(`${entry.slice(start, end)}; return injectBeforeStream;`)() as (
+  marker: string,
+  tag: string,
+) => TransformStream<Uint8Array | string, Uint8Array>;
+const encoder = new TextEncoder();
+
+async function run(chunks: Array<Uint8Array | string>, marker: string, tag: string) {
+  const source = new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(chunk);
+      controller.close();
+    },
+  });
+  return new Uint8Array(await new Response(source.pipeThrough(inject(marker, tag))).arrayBuffer());
+}
+
+it.each(["</head>", "</body></html>"])("preserves every byte split around %s", async (marker) => {
+  const input = `🍀<html><head>café 漢字</head><body>🍀 café 漢字</body></html>🍀`;
+  const bytes = encoder.encode(input);
+  const expected = encoder.encode(input.replace(marker, `<insert>é🍀</insert>${marker}`));
+  for (let i = 0; i <= bytes.length; i++) {
+    expect(
+      await run(
+        [bytes.slice(0, i), new Uint8Array(), bytes.slice(i)],
+        marker,
+        "<insert>é🍀</insert>",
+      ),
+    ).toEqual(expected);
+  }
+  expect(
+    await run(
+      Array.from(bytes, (byte) => new Uint8Array([byte])),
+      marker,
+      "<insert>é🍀</insert>",
+    ),
+  ).toEqual(expected);
+});
+
+it("preserves bytes when disabled or the marker is absent, including invalid UTF-8", async () => {
+  const bytes = new Uint8Array([0xef, 0xbb, 0xbf, 0xff, 0xf0, 0x80]);
+  expect(await run([bytes], "</head>", "x")).toEqual(bytes);
+  expect(await run([bytes], "</head>", "")).toEqual(bytes);
+  expect(await run([], "</head>", "x")).toEqual(new Uint8Array());
+});
+
+it("injects only once and handles marker-only and string chunks", async () => {
+  expect(await run(["</head>", "🍀</head>"], "</head>", "x")).toEqual(
+    encoder.encode("x</head>🍀</head>"),
+  );
+});
+
+it("emits a bounded prefix before EOF and propagates cancellation", async () => {
+  const cancel = vi.fn();
+  const source = new ReadableStream({
+    start(controller) {
+      controller.enqueue(encoder.encode("x".repeat(1024)));
+    },
+    cancel,
+  });
+  const reader = source.pipeThrough(inject("</head>", "x")).getReader();
+  const first = await reader.read();
+  expect(first.value?.length).toBe(1018);
+  await reader.cancel("navigation cancelled");
+  await vi.waitFor(() => expect(cancel).toHaveBeenCalledWith("navigation cancelled"));
+});
+
+it("uses the same byte-safe injector for streaming and legacy client scripts", () => {
+  expect(entry.match(/injectBeforeStream\('<\/body><\/html>', clientScriptTag\)/g)).toHaveLength(2);
+  expect(entry).toContain("injectBeforeStream('</head>', tag)");
+});

--- a/packages/farmjs-plugin/src/rsc/entries/ssr.ts
+++ b/packages/farmjs-plugin/src/rsc/entries/ssr.ts
@@ -43,41 +43,55 @@ const cssLinkTag = resolvedCssHref
   ? '<link rel="stylesheet" href="' + escapeHtmlAttribute(resolvedCssHref) + '" as="style" data-precedence="default">'
   : '';
 
-function injectIntoHeadStream(tag) {
+// Work on bytes: chunk boundaries need not align with UTF-8 code points.
+function injectBeforeStream(markerText, tag) {
   const encoder = new TextEncoder();
-  const decoder = new TextDecoder();
-  const marker = '</head>';
-  let buffer = '';
+  const marker = encoder.encode(markerText);
+  const insertion = encoder.encode(tag);
+  let buffer = new Uint8Array(0);
   let injected = false;
 
   return new TransformStream({
     transform(chunk, controller) {
-      const str = typeof chunk === "string" ? chunk : decoder.decode(chunk);
+      const bytes = typeof chunk === 'string' ? encoder.encode(chunk) : chunk;
       if (injected || !tag) {
-        controller.enqueue(typeof chunk === "string" ? encoder.encode(str) : chunk);
+        controller.enqueue(bytes);
         return;
       }
 
-      buffer += str;
-      const index = buffer.indexOf(marker);
+      const pending = new Uint8Array(buffer.length + bytes.length);
+      pending.set(buffer);
+      pending.set(bytes, buffer.length);
+      let index = -1;
+      outer: for (let i = 0; i <= pending.length - marker.length; i++) {
+        for (let j = 0; j < marker.length; j++) {
+          if (pending[i + j] !== marker[j]) continue outer;
+        }
+        index = i;
+        break;
+      }
       if (index >= 0) {
-        const before = buffer.slice(0, index);
-        const after = buffer.slice(index + marker.length);
-        controller.enqueue(encoder.encode(before + tag + marker + after));
-        buffer = '';
+        if (index) controller.enqueue(pending.subarray(0, index));
+        controller.enqueue(insertion);
+        controller.enqueue(pending.subarray(index));
+        buffer = new Uint8Array(0);
         injected = true;
         return;
       }
 
-      if (buffer.length > marker.length) {
-        controller.enqueue(encoder.encode(buffer.slice(0, buffer.length - marker.length)));
-        buffer = buffer.slice(-marker.length);
-      }
+      // Retain only a possible marker prefix, never the whole response.
+      const emitLength = Math.max(0, pending.length - marker.length + 1);
+      if (emitLength) controller.enqueue(pending.subarray(0, emitLength));
+      buffer = pending.slice(emitLength);
     },
     flush(controller) {
-      if (buffer) controller.enqueue(encoder.encode(buffer));
+      if (buffer.length) controller.enqueue(buffer);
     },
   });
+}
+
+function injectIntoHeadStream(tag) {
+  return injectBeforeStream('</head>', tag);
 }
 
 /** Collect Node stream (from renderToPipeableStream) into a single string. Supports Suspense. */
@@ -144,34 +158,7 @@ export async function renderHTML(firstArg, options = {}) {
   if (hasPayload) {
     // Stream HTML to the client while preserving the RSC payload for hydration.
     debug('Streaming HTML (loading fallback then content)');
-    const BODY_HTML_END = '</body></html>';
-    const TAG_LEN = BODY_HTML_END.length;
-    const encoder = new TextEncoder();
-    let streamBuf = '';
-    const streamingClientScriptInjector = new TransformStream({
-      transform(chunk, controller) {
-        const str = typeof chunk === "string" ? chunk : new TextDecoder().decode(chunk);
-        if (!injectClientScriptInStream || !clientScriptTag) {
-          controller.enqueue(typeof chunk === "string" ? encoder.encode(str) : chunk);
-          return;
-        }
-        streamBuf += str;
-        while (streamBuf.length > TAG_LEN) {
-          const tail = streamBuf.slice(-TAG_LEN);
-          if (tail === BODY_HTML_END) {
-            const before = streamBuf.slice(0, streamBuf.length - TAG_LEN);
-            controller.enqueue(encoder.encode(before + clientScriptTag + BODY_HTML_END));
-            streamBuf = '';
-            return;
-          }
-          controller.enqueue(encoder.encode(streamBuf.slice(0, streamBuf.length - TAG_LEN)));
-          streamBuf = streamBuf.slice(-TAG_LEN);
-        }
-      },
-      flush(controller) {
-        if (streamBuf) controller.enqueue(encoder.encode(streamBuf));
-      }
-    });
+    const streamingClientScriptInjector = injectBeforeStream('</body></html>', clientScriptTag);
     const webStream = typeof Readable.toWeb === 'function'
       ? Readable.toWeb(passThrough)
       : new ReadableStream({
@@ -212,30 +199,7 @@ export async function renderHTML(firstArg, options = {}) {
       controller.close();
     }
   });
-  let clientBuffer = "";
-  let clientScriptInjected = false;
-  const injectClientScriptStream = new TransformStream({
-    transform(chunk, controller) {
-      const str = typeof chunk === "string" ? chunk : new TextDecoder().decode(chunk);
-      if (!injectClientScriptInStream || clientScriptInjected) {
-        controller.enqueue(chunk);
-        return;
-      }
-      clientBuffer += str;
-      if (clientBuffer.includes("</body></html>")) {
-        const href = (typeof CLIENT_ENTRY_HREF === "string" && CLIENT_ENTRY_HREF.length > 0 && CLIENT_ENTRY_HREF.indexOf(PLACEHOLDER_STR) < 0) ? CLIENT_ENTRY_HREF : "";
-        const out = href ? clientBuffer.replace("</body></html>", '<script type="module" src="' + href + '"></script></body></html>') : clientBuffer;
-        controller.enqueue(new TextEncoder().encode(out));
-        clientBuffer = "";
-        clientScriptInjected = true;
-      }
-    },
-    flush(controller) {
-      if (clientBuffer) {
-        controller.enqueue(new TextEncoder().encode(clientBuffer));
-      }
-    }
-  });
+  const injectClientScriptStream = injectBeforeStream('</body></html>', clientScriptTag);
 
   let out = streamFromHtml.pipeThrough(injectRSCPayload(s2));
   out = out.pipeThrough(injectClientScriptStream);


### PR DESCRIPTION
## Problem

RSC HTML injection can turn emoji and non-ASCII text into replacement characters when a UTF-8 character spans stream chunks.

## Root cause

The head and client-script injectors decode each chunk independently, treating incomplete code points as invalid. The legacy script injector has the same issue.

## Change

Use one byte-oriented insertion transform for styles and both script-injection paths. It retains only a possible closing-marker prefix and passes the remaining bytes through without decoding.

## Safety and compatibility

No public API change. Injection still happens once, does not buffer the entire response, and propagates cancellation. Empty/absent markers, invalid input bytes, and post-insertion chunks are preserved.

## Verification

macOS, Node 23.11.0, pnpm 8.12.1.

- `pnpm --filter @farm.js/plugin test ssr-stream.test.ts`: 6 passed.
- The original emitted head/script transforms corrupt a split emoji; unsplit controls pass.
- Regression coverage executes the generated transform at every byte split, including one-byte chunks, accents/CJK/emoji, marker-only chunks, absent markers, disabled injection, invalid bytes, bounded output before EOF, and cancellation.
- Focused formatting and lint passed.

## Documentation and release

Combined validation with the other four runtime fixes also passed: 104 plugin tests, 43 focused core tests, core/plugin builds and type checks, docs navigation and generated-type checks, and `pnpm docs:build` with the Vercel preset. The five branches apply together without conflicts. GitHub CI is still running or queued; these results are local verification, not a claim that every CI platform has finished.

Clarified streamed UTF-8 handling in the rendering guide. No version, template, or dependency changes.
