### PR TITLE
fix(rsc): preserve and bound development request bodies

### DIFF
--- a/docs/src/app/docs/configuration/page.md
+++ b/docs/src/app/docs/configuration/page.md
@@ -544,6 +544,10 @@ export default defineConfig({
 
 Farm checks `Content-Length` when present and also counts the received bytes, so chunked requests cannot bypass `bodySizeLimit`. Oversized requests receive `413 Payload Too Large` before the route or integration handler runs. Server Actions keep their separate, tighter `serverActions.bodySizeLimit` setting.
 
+The RSC development bridge applies these limits too. `POST`, `PUT`, `PATCH`, `DELETE`, and `QUERY`
+bodies keep their original bytes, including multipart uploads and binary data. `GET` and `HEAD`
+remain bodyless. Action origin validation runs before buffering an action body.
+
 `trustProxy` defaults to `false`. Enable it only when the app is behind a trusted reverse proxy that removes client-supplied forwarding headers and writes its own `X-Forwarded-For`, `X-Forwarded-Host`, and `X-Forwarded-Proto` values. Farm uses those headers for the client address and public request URL only when the proxy is trusted. A directly exposed Farm server must leave it disabled so a client cannot spoof the address or authority used by rate limits, redirects, authentication callbacks, logs, or access policy.
 
 Workflow runner secrets are accepted only through `Authorization: Bearer <secret>` or `X-Farm-Workflow-Secret`. Farm does not accept secrets in query strings because URLs are commonly retained in logs, browser history, and referrer data.

--- a/packages/farm/src/nitro/production-runtime.ts
+++ b/packages/farm/src/nitro/production-runtime.ts
@@ -1,9 +1,11 @@
 export { _runWithAfterRequest } from "../after";
+export type { FarmServerConfig } from "../server-http";
 export {
   bufferFarmRequestBody,
   createFarmRequestBodyErrorResponse,
   matchesFarmIfNoneMatch,
   readFarmRequestBody,
+  readNodeRequestBody,
   resolveFarmServerConfig,
 } from "../server-http";
 export { createFarmProductionLifecycle } from "../production-lifecycle";

--- a/packages/farmjs-plugin/src/rsc/__tests__/rsc-entry-searchparams.test.ts
+++ b/packages/farmjs-plugin/src/rsc/__tests__/rsc-entry-searchparams.test.ts
@@ -28,7 +28,7 @@ describe("RSC entry search params", () => {
   });
 
   it("keeps repeated values in the legacy development fallback", () => {
-    expect(fallbackSource).toContain("const { searchParamsToObject } = require_(");
+    expect(fallbackSource).toMatch(/const \{[^}]*searchParamsToObject[^}]*\} = require_\(/);
     expect(fallbackSource).toContain('"@farm.js/core/internal/production-runtime"');
     expect(fallbackSource).toContain("const searchParams = searchParamsToObject(");
     expect(fallbackSource).not.toContain(

--- a/packages/farmjs-plugin/src/rsc/dev-request-body.test.ts
+++ b/packages/farmjs-plugin/src/rsc/dev-request-body.test.ts
@@ -1,0 +1,159 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { Readable } from "node:stream";
+import { expect, it, vi } from "vitest";
+import farmRsc from "./index.js";
+
+const scenarios = [
+  ...["POST", "PUT", "PATCH", "DELETE", "QUERY", "GET", "HEAD"].map((method) => ({
+    name: method,
+    method,
+  })),
+  { name: "binary", method: "PUT", payload: Buffer.from([0, 255, 240, 128, 10]) },
+  {
+    name: "multipart",
+    method: "PATCH",
+    payload: Buffer.from(
+      '--test\r\nContent-Disposition: form-data; name="name"\r\n\r\n🍀\r\n--test--\r\n',
+    ),
+    contentType: "multipart/form-data; boundary=test",
+  },
+  { name: "chunked limit", method: "PUT", limit: 2, status: 413 },
+  {
+    name: "declared limit",
+    method: "PUT",
+    limit: 2,
+    headers: { "content-length": "30" },
+    status: 413,
+  },
+  {
+    name: "invalid length",
+    method: "QUERY",
+    headers: { "content-length": "invalid" },
+    status: 400,
+  },
+  {
+    name: "action limit",
+    method: "POST",
+    url: "/form",
+    actionLimit: 2,
+    headers: { origin: "http://farm.test" },
+    status: 413,
+  },
+  {
+    name: "untrusted action",
+    method: "POST",
+    url: "/form",
+    headers: { origin: "https://untrusted.test" },
+    status: 403,
+  },
+  { name: "API is not an action", method: "POST", actionLimit: 2 },
+  {
+    name: "accepted action",
+    method: "POST",
+    url: "/form",
+    headers: { origin: "http://farm.test" },
+  },
+];
+
+it.each(scenarios)("preserves bytes and enforces policy: $name", async (scenario) => {
+  const {
+    method,
+    payload = Buffer.from(JSON.stringify({ message: "keep 🍀" })),
+    contentType = "application/json",
+    limit = 1000,
+    actionLimit = 1000,
+    headers = {},
+    status = 200,
+    url = "/backend/echo",
+  } = scenario as {
+    method: string;
+    payload?: Buffer;
+    contentType?: string;
+    limit?: number;
+    actionLimit?: number;
+    headers?: Record<string, string>;
+    status?: number;
+    url?: string;
+  };
+  const expectedBody = method === "GET" || method === "HEAD" ? Buffer.alloc(0) : payload;
+  const root = mkdtempSync(path.join(tmpdir(), "farm-dev-body-"));
+  const previousSSRLoader = (globalThis as any).__VITE_RSC_LOAD_SSR__;
+  const previousBootstrap = (globalThis as any).__FARM_VITE_RSC_LOAD_BOOTSTRAP__;
+  const log = vi.spyOn(console, "log").mockImplementation(() => {});
+  try {
+    const plugins = farmRsc();
+    const configure = plugins.find((plugin) => plugin.name === "@farm.js/plugin/rsc:config")!
+      .config as Function;
+    await configure(
+      {
+        root,
+        api: { basePath: "/backend" },
+        server: { bodySizeLimit: limit },
+        serverActions: { bodySizeLimit: actionLimit },
+        experimental: { serverComponents: true, serverActions: true },
+      },
+      { command: "serve", mode: "development" },
+    );
+    let middleware!: Function;
+    let receivedBody: Buffer | undefined;
+    const fetch = vi.fn(async (request: Request) => {
+      receivedBody = Buffer.from(await request.arrayBuffer());
+      if (method === "GET" || method === "HEAD") expect(request.body).toBeNull();
+      return new Response("ok");
+    });
+    const server = {
+      config: { root, publicDir: path.join(root, "public") },
+      middlewares: {
+        use(handler: Function) {
+          middleware = handler;
+        },
+      },
+      environments: {
+        rsc: {
+          pluginContainer: { resolveId: async () => ({ id: "test-entry" }) },
+          runner: { import: async () => ({ default: { fetch } }) },
+        },
+      },
+    };
+    const configureServer = plugins.find(
+      (plugin) => plugin.name === "@farm.js/plugin/rsc:dev-server",
+    )!.configureServer as Function;
+    configureServer(server)();
+    const request = Object.assign(
+      Readable.from([expectedBody.subarray(0, 1), expectedBody.subarray(1)]),
+      {
+        method,
+        url,
+        headers: { host: "farm.test", "content-type": contentType, ...headers },
+      },
+    );
+    const response = {
+      statusCode: 200,
+      setHeader: vi.fn(),
+      getHeader: vi.fn(),
+      write: vi.fn(() => true),
+      end: vi.fn(),
+    };
+    await middleware(request, response, vi.fn());
+    expect(response.statusCode).toBe(status);
+    if (status === 200) {
+      expect(fetch).toHaveBeenCalledTimes(1);
+      expect(receivedBody).toEqual(expectedBody);
+    } else {
+      expect(fetch).not.toHaveBeenCalled();
+      expect(response.setHeader).toHaveBeenCalledWith("cache-control", "no-store");
+    }
+    expect(request.listenerCount("data")).toBe(0);
+    expect(request.listenerCount("end")).toBe(0);
+  } finally {
+    log.mockRestore();
+    if (previousSSRLoader === undefined) delete (globalThis as any).__VITE_RSC_LOAD_SSR__;
+    else (globalThis as any).__VITE_RSC_LOAD_SSR__ = previousSSRLoader;
+    if (previousBootstrap === undefined)
+      delete (globalThis as any).__FARM_VITE_RSC_LOAD_BOOTSTRAP__;
+    else (globalThis as any).__FARM_VITE_RSC_LOAD_BOOTSTRAP__ = previousBootstrap;
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/packages/farmjs-plugin/src/rsc/farm-core.d.ts
+++ b/packages/farmjs-plugin/src/rsc/farm-core.d.ts
@@ -1,5 +1,9 @@
 declare module "@farm.js/core" {
   import type { Plugin } from "vite";
-  export const farmApiPlugin: (options?: { srcDir?: string; debug?: boolean }) => Plugin;
+  export const farmApiPlugin: (options?: {
+    srcDir?: string;
+    debug?: boolean;
+    bodySizeLimit?: number | string;
+  }) => Plugin;
   export const farmMiddlewarePlugin: (options?: { srcDir?: string; debug?: boolean }) => Plugin;
 }

--- a/packages/farmjs-plugin/src/rsc/index.ts
+++ b/packages/farmjs-plugin/src/rsc/index.ts
@@ -27,6 +27,7 @@ import { init as initModuleLexer, parse as parseModuleImports } from "es-module-
 import type { FarmRscPluginOptions, EntryContext } from "./types.js";
 import type { FarmServerActionsConfig } from "@farm.js/core/server-action-security";
 import type { FarmAPIConfig } from "@farm.js/core/api";
+import type { FarmServerConfig } from "@farm.js/core/internal/production-runtime";
 import type { FarmLayerEntry, ResolvedFarmLayer } from "@farm.js/core/server";
 import { farmEnvironmentFunctionsPlugin } from "@farm.js/core/environment/vite";
 import { generateRscEntry } from "./entries/rsc.js";
@@ -48,7 +49,11 @@ const require_ = createRequire(import.meta.url);
 const { farmApiPlugin, farmMiddlewarePlugin } = require_(
   "@farm.js/core",
 ) as typeof import("@farm.js/core");
-const { resolveServerActionsConfig } = require_(
+const {
+  resolveServerActionsConfig,
+  validateServerActionRequest,
+  createServerActionRequestErrorResponse,
+} = require_(
   "@farm.js/core/server-action-security",
 ) as typeof import("@farm.js/core/server-action-security");
 const { normalizeFarmDeploymentId } = require_(
@@ -57,9 +62,17 @@ const { normalizeFarmDeploymentId } = require_(
 const { getFarmLayerAliases, getFarmSourceRoots, resolveFarmLayers } = require_(
   "@farm.js/core/server",
 ) as typeof import("@farm.js/core/server");
-const { searchParamsToObject } = require_(
+const {
+  searchParamsToObject,
+  readNodeRequestBody,
+  resolveFarmServerConfig,
+  createFarmRequestBodyErrorResponse,
+} = require_(
   "@farm.js/core/internal/production-runtime",
 ) as typeof import("@farm.js/core/internal/production-runtime");
+const { isFarmAPIPathname } = require_(
+  "@farm.js/core/api/runtime",
+) as typeof import("@farm.js/core/api/runtime");
 const { resolveFarmAPIConfig, resolveFarmAPIServerBasePath } = require_(
   "@farm.js/core/api",
 ) as typeof import("@farm.js/core/api");
@@ -80,6 +93,7 @@ export interface FarmRscConfig {
   outDir?: string;
   basePath?: string;
   api?: FarmAPIConfig;
+  server?: FarmServerConfig;
   port?: number;
   experimental?: {
     /**
@@ -144,6 +158,7 @@ export function defineConfig(config: FarmRscConfig = {}): UserConfig {
 
     // Vite server configuration
     server: {
+      ...config.server,
       port,
       strictPort: false,
     },
@@ -159,7 +174,11 @@ export function defineConfig(config: FarmRscConfig = {}): UserConfig {
 
     plugins: [
       farmMiddlewarePlugin({ srcDir: config.srcDir ?? "src", debug }),
-      farmApiPlugin({ srcDir: config.srcDir ?? "src", debug }),
+      farmApiPlugin({
+        srcDir: config.srcDir ?? "src",
+        debug,
+        bodySizeLimit: config.server?.bodySizeLimit,
+      }),
       farmRsc({
         debug,
         encryptActions: config.encryptActions,
@@ -499,6 +518,7 @@ export default function farmRsc(options: FarmRscPluginOptions = {}): Plugin[] {
   let rscEnabled = false;
   let actionsEnabled = false;
   let optimizedBoundaryEnabled = false;
+  let bodySizeLimit = resolveFarmServerConfig(undefined).bodySizeLimit;
 
   // Context passed to entry generators
   let entryContext: EntryContext;
@@ -621,6 +641,7 @@ export default function farmRsc(options: FarmRscPluginOptions = {}): Plugin[] {
           outDir?: string;
           basePath?: string;
           api?: FarmAPIConfig;
+          server?: UserConfig["server"] & FarmServerConfig;
           root?: string;
           extends?: readonly FarmLayerEntry[];
           layers?: readonly ResolvedFarmLayer[];
@@ -631,6 +652,7 @@ export default function farmRsc(options: FarmRscPluginOptions = {}): Plugin[] {
         // Check if user enabled RSC in their config
         rscEnabled = c.experimental?.serverComponents === true;
         actionsEnabled = c.experimental?.serverActions === true;
+        bodySizeLimit = resolveFarmServerConfig(c.server).bodySizeLimit;
         optimizedBoundaryEnabled = c.experimental?.optimizedBoundary === true;
 
         logInfo(`RSC enabled: ${rscEnabled}`);
@@ -1232,19 +1254,37 @@ if (document.readyState === 'loading') {
                 `import("/@react-refresh").then(m=>{m.default.injectIntoGlobalHook(window);window.$RefreshReg$=()=>{};window.$RefreshSig$=()=>type=>type;window.__vite_plugin_react_preamble_installed__=true;return import("/@vite/client");}).then(()=>import(${JSON.stringify(clientEntryUrl)}));`;
 
               const base = `http://${req.headers.host || "localhost:3000"}`;
-              let body: Buffer | undefined;
-              if (method === "POST") {
-                const chunks: Buffer[] = [];
-                for await (const chunk of req) chunks.push(chunk as Buffer);
-                body = Buffer.concat(chunks);
-                // Keep as buffer so request.formData() / request.text() in RSC handler work (multipart must not be UTF-8 decoded)
+              const requestUrl = new URL(url, base);
+              const isAction =
+                actionsEnabled &&
+                method === "POST" &&
+                !isFarmAPIPathname(requestUrl.pathname, entryContext.apiBasePath) &&
+                !isFarmAPIPathname(requestUrl.pathname);
+              if (isAction) {
+                validateServerActionRequest(
+                  new Request(requestUrl, {
+                    method,
+                    headers: req.headers as HeadersInit,
+                  }),
+                  entryContext.serverActions,
+                );
               }
-              const request = new Request(new URL(url, base), {
+              let body: Buffer | undefined;
+              if (method !== "GET" && method !== "HEAD") {
+                body = await readNodeRequestBody(
+                  req,
+                  isAction ? entryContext.serverActions.bodySizeLimit : bodySizeLimit,
+                );
+              }
+              const request = new Request(requestUrl, {
                 method,
                 headers: req.headers as HeadersInit,
                 body:
-                  method === "POST" && body && body.length > 0
-                    ? (body as unknown as BodyInit)
+                  body && body.length > 0
+                    ? (body.buffer.slice(
+                        body.byteOffset,
+                        body.byteOffset + body.byteLength,
+                      ) as ArrayBuffer)
                     : undefined,
               });
 
@@ -1291,6 +1331,13 @@ if (document.readyState === 'loading') {
               logResponse(method, pathname, response.status, duration);
               return;
             } catch (rscError: any) {
+              const rejection =
+                createFarmRequestBodyErrorResponse(rscError) ??
+                createServerActionRequestErrorResponse(rscError);
+              if (rejection && !res.headersSent && !res.writableEnded && !res.destroyed) {
+                await sendRscDevelopmentResponse(res, rejection);
+                return;
+              }
               if (res.headersSent || res.writableEnded || res.destroyed) {
                 console.error("[Farm.js] RSC dev response error:", rscError);
                 if (!res.destroyed)


### PR DESCRIPTION
## Problem

PUT, PATCH, DELETE, and QUERY requests reaching the RSC development bridge lose their bodies. A custom /backend API prefix is one concrete reproduction. POST was also buffered without a bound.

## Root cause

The bridge reads and attaches a body only for POST, using an unbounded chunk collector.

## Change

Reuse core's bounded Node body reader for every method except GET/HEAD. Preserve binary and multipart bytes, use the existing server body limit, and validate action origins before buffering with the separate action limit. Return the shared 400/413/403 responses without invoking the handler.

The standalone RSC config forwards the existing server body-size option to its API plugin as well.

## Safety and compatibility

No new enablement flag. GET/HEAD remain bodyless. API POSTs are not treated as actions. The generated action handler retains its own validation after middleware rewrites. The new core export is internal, not a new public client entry point.

## Verification

macOS, Node 23.11.0, pnpm 8.12.1.

- `pnpm --filter @farm.js/plugin exec vitest run src/rsc/dev-request-body.test.ts src/rsc/dev-response.test.ts src/rsc/__tests__/rsc-entry-searchparams.test.ts`: passed.
- 16 request-policy cases cover the five body methods, GET/HEAD, binary/multipart bytes, declared/chunked limits, invalid length, trusted/untrusted actions, and API/action separation.
- Restoring the old bridge makes the regression suite fail.
- `pnpm --filter @farm.js/core test server-http.test.ts`: 9 passed.
- Core build/type-check and plugin build/typecheck passed.
- Focused formatting and lint passed with existing unrelated warnings.

## Documentation and release

Combined validation with the other four runtime fixes also passed: 104 plugin tests, 43 focused core tests, core/plugin builds and type checks, docs navigation and generated-type checks, and `pnpm docs:build` with the Vercel preset. The five branches apply together without conflicts. GitHub CI is still running or queued; these results are local verification, not a claim that every CI platform has finished.

Updated configuration guidance for the development bridge. No version, template, or dependency changes.
