### PR TITLE
fix(rsc): preserve negotiated response cache variants

### DIFF
--- a/docs/src/app/docs/server-rendering/page.md
+++ b/docs/src/app/docs/server-rendering/page.md
@@ -16,6 +16,11 @@ Svelte conventions and the features that remain React-specific.
 
 ## Rendering options
 
+RSC page URLs return HTML for document visits and a Flight payload for requests accepting
+`text/x-component`. Both representations include `Vary: Accept`. When you enable shared caching,
+configure the CDN or reverse proxy to honor `Vary`; do not cache these responses by URL alone.
+Farm preserves existing `Vary` fields, including `Origin` and Nitro's `Accept-Encoding`.
+
 | Mode    | How to opt in                                  | Best for                                |
 | ------- | ---------------------------------------------- | --------------------------------------- |
 | Dynamic | Default for request-bound pages                | Dashboards and personalized UI.         |

--- a/packages/farmjs-plugin/src/rsc/core-external.test.ts
+++ b/packages/farmjs-plugin/src/rsc/core-external.test.ts
@@ -237,6 +237,7 @@ export const schema = z.string();`;
 
   it.each([
     { name: "default", api: undefined, baseURL: "/api", mount: "/api" },
+    { name: "cache-variants", api: undefined, baseURL: "/api", mount: "/api" },
     {
       name: "custom",
       api: {
@@ -255,7 +256,7 @@ export const schema = z.string();`;
     },
   ])(
     "builds and boots an isolated RSC app with the $name API root",
-    async ({ api, baseURL, mount }) => {
+    async ({ name, api, baseURL, mount }) => {
       const fixtureRoot = mkdtempSync(path.join(tmpdir(), "farm-rsc-root-runtime-"));
       const isolatedRoot = mkdtempSync(path.join(tmpdir(), "farm-rsc-root-output-"));
       const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
@@ -272,6 +273,15 @@ export const schema = z.string();`;
             type: "module",
           }),
         );
+        if (name === "cache-variants") {
+          writeFileSync(
+            path.join(srcDir, "middleware.ts"),
+            `export function middleware(request, context) {
+            context.headers.set("cache-control", "public, max-age=60");
+            context.headers.set("vary", new URL(request.url).searchParams.has("wildcard") ? "*" : "Origin, aCcEpT");
+          }`,
+          );
+        }
         const fixtureModules = path.join(fixtureRoot, "node_modules");
         for (const packageName of [
           "@farm.js/core",
@@ -394,6 +404,7 @@ export const echo = createEndpoint("/api/echo", { method: "POST" }, async ({ bod
           logLevel: "silent",
           srcDir: "src",
           outDir: "dist",
+          esbuild: { jsxDev: false },
           experimental: { serverComponents: true, serverActions: true },
           api,
           plugins,
@@ -486,6 +497,27 @@ export const echo = createEndpoint("/api/echo", { method: "POST" }, async ({ bod
         expect(aliasedResponse.status, logs).toBe(200);
         expect((await aliasedResponse.json()).requestPath).toBe(`${mount}/root-runtime`);
 
+        if (name === "cache-variants") {
+          for (const accept of ["text/html", "text/x-component"]) {
+            const page = await fetch(origin + "/", {
+              headers: { accept },
+              signal: AbortSignal.timeout(10_000),
+            });
+            expect(page.status, logs).toBe(200);
+            expect(page.headers.get("content-type")).toContain(accept);
+            expect(await page.text(), logs).toContain("RSC root runtime fixture");
+            expect(page.headers.get("cache-control")).toBe("public, max-age=60");
+            const fields = page.headers.get("vary")?.toLowerCase().split(/,\s*/);
+            expect(fields).toEqual(expect.arrayContaining(["accept", "origin", "accept-encoding"]));
+            expect(fields?.filter((value) => value === "accept")).toHaveLength(1);
+            const wildcard = await fetch(origin + "/?wildcard", {
+              headers: { accept },
+              signal: AbortSignal.timeout(10_000),
+            });
+            expect(await wildcard.text(), logs).toContain("RSC root runtime fixture");
+            expect(wildcard.headers.get("vary")).toBe("*");
+          }
+        }
         // A custom API prefix is not a server-action URL, even with actions enabled.
         const post = await fetch(`${origin}${mount}/echo`, {
           method: "POST",

--- a/packages/farmjs-plugin/src/rsc/entries/rsc.ts
+++ b/packages/farmjs-plugin/src/rsc/entries/rsc.ts
@@ -88,6 +88,9 @@ function debug(...args) {
 }
 
 function applyActionResponseHeaders(headers, request) {
+  // The same page URL serves HTML or Flight depending on Accept.
+  const vary = (headers.get('vary') || '').split(',').map(value => value.trim().toLowerCase());
+  if (!vary.includes('*') && !vary.includes('accept')) headers.append('vary', 'Accept');
   headers.set('x-farm-deployment-id', farmDeploymentId);
   const accept = request.headers.get('accept') || '';
   if (request.method === 'GET' && !accept.includes('text/x-component')) {

--- a/packages/farmjs-plugin/src/rsc/entries/vary.test.ts
+++ b/packages/farmjs-plugin/src/rsc/entries/vary.test.ts
@@ -1,0 +1,46 @@
+import { expect, it } from "vitest";
+import { generateRscEntry } from "./rsc.js";
+
+const entry = generateRscEntry({
+  srcDir: "src",
+  outDir: "dist",
+  basePath: "/",
+  actionsEnabled: true,
+  serverActions: { allowedOrigins: [], bodySizeLimit: 1000 },
+  deploymentId: "test",
+  debug: false,
+});
+const start = entry.indexOf("function applyActionResponseHeaders(");
+const end = entry.indexOf("// Auto-discover all route modules", start);
+const apply = new Function(
+  "farmDeploymentId",
+  "createFarmDeploymentCookie",
+  `${entry.slice(start, end)}; return applyActionResponseHeaders;`,
+)("test", () => "deployment=test");
+
+it.each(["text/html", "text/x-component"])(
+  "varies %s pages by Accept without losing fields",
+  (accept) => {
+    const request = new Request("https://farm.test/", { headers: { accept } });
+    for (const [value, expected] of [
+      ["", "Accept"],
+      ["Origin", "Origin, Accept"],
+      ["aCcEpT, Origin", "aCcEpT, Origin"],
+      ["*", "*"],
+    ]) {
+      const headers = new Headers(value ? { vary: value } : {});
+      apply(headers, request);
+      expect(headers.get("vary")).toBe(expected);
+    }
+  },
+);
+
+it("keeps action responses non-cacheable", () => {
+  const headers = new Headers({ "cache-control": "public, max-age=60" });
+  apply(
+    headers,
+    new Request("https://farm.test/", { method: "POST", headers: { accept: "text/x-component" } }),
+  );
+  expect(headers.get("vary")).toBe("Accept");
+  expect(headers.get("cache-control")).toBe("no-store");
+});

--- a/packages/farmjs-plugin/src/rsc/nitro-build.ts
+++ b/packages/farmjs-plugin/src/rsc/nitro-build.ts
@@ -255,9 +255,20 @@ function createRscRequest(event) {
   return new Request(event.req, { signal: controller.signal });
 }
 
-export default defineEventHandler((event) => handler(createRscRequest(event), {
-  waitUntil: (promise) => event.waitUntil(promise),
-}));
+export default defineEventHandler(async (event) => {
+  const response = await handler(createRscRequest(event), {
+    waitUntil: (promise) => event.waitUntil(promise),
+  });
+  // H3's prepared headers override Response headers. Keep both the runtime's
+  // fields (e.g. Accept-Encoding from static middleware) and the app's fields.
+  const vary = [event.res.headers.get('vary'), response.headers.get('vary')]
+    .filter(Boolean).join(',').split(',').map(value => value.trim()).filter(Boolean);
+  if (vary.length) {
+    const fields = new Map(vary.map(value => [value.toLowerCase(), value]));
+    event.res.headers.set('vary', fields.has('*') ? '*' : [...fields.values()].join(', '));
+  }
+  return response;
+});
 `.trim();
   const entryPath = path.join(buildDir, "rsc-entry.mjs");
   mkdirSync(buildDir, { recursive: true });


### PR DESCRIPTION
## Problem

A cacheable RSC page serves HTML and Flight at the same URL without Vary: Accept. Nitro also drops an app-provided Vary field before the response reaches the client.

## Root cause

The page handler negotiates on Accept without declaring it. Nitro's static middleware prepares Vary: Accept-Encoding, and H3 later overwrites the handler's Vary with that prepared field.

## Change

Append Accept to negotiated page responses without duplicating existing fields or changing Vary: *. At the Nitro adapter boundary, merge the runtime and handler Vary fields before H3 applies prepared headers.

## Safety and compatibility

API dispatch and action validation are unchanged. Action responses remain no-store. The adapter preserves existing app cache-variation fields without changing other header precedence.

## Verification

macOS, Node 23.11.0, pnpm 8.12.1.

- `pnpm --filter @farm.js/plugin test vary.test.ts`: 3 passed.
- Isolated Nitro Node builds return complete HTML and Flight bodies with Accept, Origin, and Accept-Encoding preserved; wildcard variation remains *.
- Existing default/custom/root/external API-root build controls pass.
- Baseline production responses returned only Accept-Encoding.
- Plugin typecheck and focused formatting/lint passed.

## Documentation and release

Combined validation with the other four runtime fixes also passed: 104 plugin tests, 43 focused core tests, core/plugin builds and type checks, docs navigation and generated-type checks, and `pnpm docs:build` with the Vercel preset. The five branches apply together without conflicts. GitHub CI is still running or queued; these results are local verification, not a claim that every CI platform has finished.

Documented content negotiation and the need for caches to honor Vary. No version, template, or dependency changes.
