### PR TITLE
fix(rsc): render server failures through route error boundaries

### DIFF
--- a/docs/src/app/docs/routing/page.md
+++ b/docs/src/app/docs/routing/page.md
@@ -1029,6 +1029,17 @@ export default function DashboardError({ error, reset }: ErrorProps) {
 
 `error.tsx` receives `error`, `reset`, `params`, `path`, `search`, `searchParams`, middleware data, and plugin context. The closest route error boundary handles normal render/data failures. Redirects and `notFound()` still escape to Farm's redirect and not-found handling.
 
+With experimental RSC enabled, failures before the HTML shell is sent render the nearest
+`error.tsx` through RSC and SSR with status `500` and `Cache-Control: private, no-store`.
+This fallback uses a standalone document shell, outside the failed page/layout tree, so a broken
+layout cannot prevent the error UI from rendering. Client boundaries receive a client-owned
+`reset()` that reloads the current URL. Production responses show a generic error message;
+the original exception stays in server logs. Development responses can show the error message.
+
+If no boundary exists, or the boundary itself fails during SSR, Farm returns a generic non-cacheable
+500 response. Failures after streaming starts cannot change the already-sent status code and remain
+subject to React's streaming recovery behavior.
+
 Place `not-found.*` at the app root to customize unmatched URLs. When the component lives elsewhere,
 set its project-relative path explicitly; Farm uses the same file in development and production and
 fails startup or build when the path is missing or incompatible with the selected renderer:

--- a/packages/farmjs-plugin/src/rsc/core-external.test.ts
+++ b/packages/farmjs-plugin/src/rsc/core-external.test.ts
@@ -255,7 +255,7 @@ export const schema = z.string();`;
     },
   ])(
     "builds and boots an isolated RSC app with the $name API root",
-    async ({ api, baseURL, mount }) => {
+    async ({ name, api, baseURL, mount }) => {
       const fixtureRoot = mkdtempSync(path.join(tmpdir(), "farm-rsc-root-runtime-"));
       const isolatedRoot = mkdtempSync(path.join(tmpdir(), "farm-rsc-root-output-"));
       const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
@@ -264,6 +264,68 @@ export const schema = z.string();`;
       try {
         const srcDir = path.join(fixtureRoot, "src");
         mkdirSync(srcDir, { recursive: true });
+        if (name === "default" || name === "custom") {
+          const writeRoute = (file: string, source: string) => {
+            const target = path.join(srcDir, file);
+            mkdirSync(path.dirname(target), { recursive: true });
+            writeFileSync(target, source);
+          };
+          writeRoute(
+            "broken/page.tsx",
+            `export default async function Page() { throw new Error("private page failure"); }`,
+          );
+          writeRoute(
+            "layout-failure/page.tsx",
+            `export default function Page() { return <p>page</p>; }`,
+          );
+          writeRoute(
+            "layout-failure/layout.tsx",
+            `export default async function Layout() { throw new Error("private layout failure"); }`,
+          );
+          writeRoute(
+            "sync-failure/page.tsx",
+            `export default function Page() { throw new Error("private sync failure"); }`,
+          );
+          writeRoute(
+            "middleware.ts",
+            `export function middleware(request, context) {
+            if (new URL(request.url).pathname === "/middleware-failure") throw new Error("private middleware failure");
+            context.headers.set("cache-control", "public, max-age=60");
+          }`,
+          );
+          writeRoute(
+            "go/page.tsx",
+            `import { redirect } from "@farm.js/core/navigation"; export default async function Page() { redirect("/", 307); }`,
+          );
+          writeRoute(
+            "missing/page.tsx",
+            `import { notFound } from "@farm.js/core/navigation"; export default async function Page() { notFound(); }`,
+          );
+          if (name === "default") {
+            writeRoute(
+              "error.tsx",
+              `"use client"; export default function ErrorPage({ error, reset, path, searchParams }) {
+              return <main>Route error rendered <p>{error.message}</p><p>{path}</p><p>{JSON.stringify(searchParams)}</p><button onClick={reset}>Reset</button></main>;
+            }`,
+            );
+            writeRoute(
+              "bad-boundary/page.tsx",
+              `export default async function Page() { throw new Error("private original failure"); }`,
+            );
+            writeRoute(
+              "bad-boundary/error.tsx",
+              `"use client"; export default function ErrorPage() { throw new Error("private boundary failure"); }`,
+            );
+            writeRoute(
+              "server-boundary/page.tsx",
+              `export default async function Page() { throw new Error("private server failure"); }`,
+            );
+            writeRoute(
+              "server-boundary/error.tsx",
+              `export default function ErrorPage({ error }) { return <main>Server error rendered {error.message}</main>; }`,
+            );
+          }
+        }
         writeFileSync(
           path.join(fixtureRoot, "package.json"),
           JSON.stringify({
@@ -394,6 +456,7 @@ export const echo = createEndpoint("/api/echo", { method: "POST" }, async ({ bod
           logLevel: "silent",
           srcDir: "src",
           outDir: "dist",
+          esbuild: { jsxDev: false },
           experimental: { serverComponents: true, serverActions: true },
           api,
           plugins,
@@ -482,6 +545,64 @@ export const echo = createEndpoint("/api/echo", { method: "POST" }, async ({ bod
         });
 
         const origin = `http://127.0.0.1:${port}`;
+        if (name === "default" || name === "custom") {
+          for (const route of ["broken", "layout-failure", "sync-failure", "middleware-failure"]) {
+            const error = await fetch(origin + "/" + route + "?tag=a&tag=b", {
+              signal: AbortSignal.timeout(10_000),
+            });
+            const body = await error.text();
+            expect(error.status, logs).toBe(500);
+            expect(error.headers.get("cache-control")).toBe("private, no-store");
+            expect(body).not.toContain("private page failure");
+            expect(body).not.toContain("private layout failure");
+            expect(body).not.toContain("private sync failure");
+            expect(body).not.toContain("private middleware failure");
+            if (name === "default") {
+              expect(error.headers.get("content-type")).toContain("text/html");
+              expect(body, logs).toContain("Route error rendered");
+              expect(body).toContain("Internal Server Error");
+              expect(body).toContain("Reset");
+              expect(body).toContain("/" + route);
+              expect(body).toContain("&quot;tag&quot;:[&quot;a&quot;,&quot;b&quot;]");
+            } else {
+              expect(JSON.parse(body).message).toBe("Internal Server Error");
+            }
+          }
+          expect(logs).not.toContain("glob is not defined");
+          expect(logs).toContain("private page failure");
+          const go = await fetch(origin + "/go", { redirect: "manual" });
+          expect(go.status).toBe(307);
+          expect(go.headers.get("location")).toBe("/");
+          expect((await fetch(origin + "/missing")).status).toBe(404);
+          const postFailure = await fetch(origin + "/middleware-failure", {
+            method: "POST",
+            headers: { origin },
+            body: "x",
+          });
+          expect(postFailure.status).toBe(500);
+          expect(await postFailure.text()).toBe("Server function failed");
+          if (name === "default") {
+            const flight = await fetch(origin + "/broken", {
+              headers: { accept: "text/x-component" },
+              signal: AbortSignal.timeout(10_000),
+            });
+            expect(flight.status).toBe(500);
+            expect(flight.headers.get("content-type")).toContain("text/x-component");
+            const body = await flight.text();
+            expect(body).toContain("rootContent");
+            expect(body).not.toContain("private page failure");
+            const serverBoundary = await fetch(origin + "/server-boundary", {
+              signal: AbortSignal.timeout(10_000),
+            });
+            expect(serverBoundary.status).toBe(500);
+            expect(await serverBoundary.text(), logs).toContain("Server error rendered");
+            const badBoundary = await fetch(origin + "/bad-boundary", {
+              signal: AbortSignal.timeout(10_000),
+            });
+            expect(badBoundary.status).toBe(500);
+            expect(await badBoundary.json()).toMatchObject({ message: "Internal Server Error" });
+          }
+        }
         const aliasedResponse = await fetch(`${origin}${mount}/root-runtime`);
         expect(aliasedResponse.status, logs).toBe(200);
         expect((await aliasedResponse.json()).requestPath).toBe(`${mount}/root-runtime`);

--- a/packages/farmjs-plugin/src/rsc/entries/error-fallback.test.ts
+++ b/packages/farmjs-plugin/src/rsc/entries/error-fallback.test.ts
@@ -1,0 +1,47 @@
+import React from "react";
+import { afterEach, expect, it, vi } from "vitest";
+import { generateErrorFallbackEntry } from "./error-fallback.js";
+import { generateRscEntry } from "./rsc.js";
+
+afterEach(() => vi.unstubAllGlobals());
+
+it("creates Error and reset in client code, preserving route props", () => {
+  const entry = generateErrorFallbackEntry();
+  expect(entry).toMatch(/^"use client"/);
+  const factory = new Function(
+    "React",
+    entry
+      .replace("import React from 'react';", "")
+      .replace("export default function", "return function"),
+  )(React);
+  const reload = vi.fn();
+  vi.stubGlobal("window", { location: { reload } });
+  const Fallback = () => null;
+  const element = factory({
+    Fallback,
+    message: "Internal Server Error",
+    fallbackProps: { path: "/broken", searchParams: { tag: ["a", "b"] } },
+  });
+  expect(element.type).toBe(Fallback);
+  expect(element.props.error).toBeInstanceOf(Error);
+  expect(element.props.error.message).toBe("Internal Server Error");
+  expect(element.props.searchParams).toEqual({ tag: ["a", "b"] });
+  element.props.reset();
+  expect(reload).toHaveBeenCalledOnce();
+});
+
+it("only exposes original error messages for the serve command", () => {
+  const context = {
+    srcDir: "src",
+    outDir: "dist",
+    basePath: "/",
+    actionsEnabled: false,
+    serverActions: { allowedOrigins: [], bodySizeLimit: 1000 },
+    deploymentId: "test",
+    debug: false,
+  };
+  expect(generateRscEntry(context)).toContain("const message = false && err instanceof Error");
+  expect(generateRscEntry({ ...context, development: true })).toContain(
+    "const message = true && err instanceof Error",
+  );
+});

--- a/packages/farmjs-plugin/src/rsc/entries/error-fallback.ts
+++ b/packages/farmjs-plugin/src/rsc/entries/error-fallback.ts
@@ -1,0 +1,12 @@
+/** Client-owned reset callbacks must not be serialized from the RSC server. */
+export function generateErrorFallbackEntry(): string {
+  return `"use client";
+import React from 'react';
+
+export default function ServerErrorFallback({ Fallback, message, fallbackProps }) {
+  const error = new Error(message);
+  const reset = () => window.location.reload();
+  return React.createElement(Fallback, { ...fallbackProps, error, reset });
+}
+`;
+}

--- a/packages/farmjs-plugin/src/rsc/entries/rsc.ts
+++ b/packages/farmjs-plugin/src/rsc/entries/rsc.ts
@@ -29,6 +29,7 @@ export function generateRscEntry(ctx: EntryContext): string {
   const debugLog = `// Debug disabled`;
   let code = `
 import React from 'react';
+import ServerErrorFallback from '/.farm/rsc-entries/error-fallback.tsx';
 import { registerAPIRouteShape } from '@farm.js/core/api/runtime';
 import {
   renderToReadableStream,
@@ -62,6 +63,7 @@ import {
 } from '@farm.js/core/api/runtime';
 import { _runWithAfterRequest } from '@farm.js/core/after';
 import { _runWithCurrentRequest, searchParamsToObject } from '@farm.js/core/internal/production-runtime';
+import { getFarmRedirectError, isFarmNotFoundError } from '@farm.js/core/internal/production-runtime';
 
 const farmDeploymentId = ${JSON.stringify(ctx.deploymentId)};
 const farmApiBasePath = ${JSON.stringify(ctx.apiBasePath ?? "/api")};
@@ -546,6 +548,9 @@ function getLayoutModules(pageFilePath) {
  */
 async function handleFarmRequest(request) {
   let url = new URL(request.url);
+  let errorData = new Map();
+  let errorContext = new Map();
+  let errorHeaders = new Headers();
   try {
   debug('Handling request:', request.method, url.pathname);
 
@@ -594,6 +599,9 @@ async function handleFarmRequest(request) {
   const middlewareData = Object.fromEntries(middlewareResult.data);
   const middlewareContext = middlewareResult.context;
   const middlewareHeaders = new Headers(middlewareResult.headers);
+  errorData = middlewareResult.data;
+  errorContext = middlewareContext;
+  errorHeaders = middlewareHeaders;
   if (middlewareResult.data.size || middlewareContext.size) {
     middlewareHeaders.set('cache-control', 'private, no-store');
   }
@@ -906,6 +914,9 @@ async function handleFarmRequest(request) {
     )
   );
   } catch (err) {
+    const redirect = getFarmRedirectError(err);
+    if (redirect) return new Response(null, { status: redirect.status, headers: { location: redirect.url, 'cache-control': 'no-store' } });
+    if (isFarmNotFoundError(err)) return new Response('Not Found', { status: 404, headers: { 'cache-control': 'no-store' } });
     console.error('[RSC] Handler error:', err);
     if (request.method === 'POST') {
       if (request.signal.aborted) {
@@ -920,50 +931,72 @@ async function handleFarmRequest(request) {
         },
       });
     }
-    // If route has error.tsx, render it (Next.js-style: SSR error goes to route error boundary)
+    // Render outside the failed page/layout tree, but retain request context.
     const pathname = url.pathname.replace(/\\/$/, '') || '/';
-    const ErrorComponent = getMatchingError(pathname, glob);
+    const ErrorComponent = getMatchingError(pathname, '');
     if (ErrorComponent) {
       try {
-        const matched = matchRoute(pathname);
-        const layoutPattern = matched ? matched.pattern : null;
-        const LayoutModules = matched ? getLayoutModules(layoutPattern) : [];
-        const Layout = LayoutModules[LayoutModules.length - 1]?.default;
-        const LayoutComp = Layout || (function PassThrough({ children }) { return children; });
-        const errParams = matched ? matched.params : {};
-        const errSearchParams = searchParamsToObject(url.searchParams);
-        const errorElement = h(ErrorComponent, {
-          error: err,
-          reset: () => {},
-          params: errParams,
-          path: pathname,
-          searchParams: errSearchParams,
-        });
-        const layoutContent = LayoutComp.constructor.name === 'AsyncFunction' || LayoutComp.toString().includes('async')
-          ? await LayoutComp({ children: errorElement })
-          : h(LayoutComp, null, errorElement);
-        const rootInner = h('div', { 'data-farm-root': 'true' }, layoutContent);
-        const doc = h('html', null,
-          h('head', null,
-            h('meta', { charSet: 'utf-8' }),
-            h('meta', { name: 'viewport', content: 'width=device-width, initial-scale=1' }),
-            h('link', { rel: 'icon', href: 'data:,' }),
-            h('title', null, 'Error'),
-            h('link', { rel: 'stylesheet', href: globalsCssPath, as: 'style', precedence: 'default' })
-          ),
-          h('body', null, h('div', { id: 'root' }, rootInner))
+        return await _runWithCurrentRequest(request, () =>
+          _runWithMiddlewareData(errorData, () =>
+            _runWithMiddlewareContext(errorContext, async () => {
+              const h = React.createElement;
+              const matched = matchRoute(pathname);
+              const errSearchParams = searchParamsToObject(url.searchParams);
+              const fallbackProps = {
+                params: matched?.params || {},
+                path: pathname,
+                search: url.search,
+                searchParams: errSearchParams,
+                middlewareData: Object.fromEntries(errorData),
+              };
+              // Preserve the original failure in logs, not production payloads.
+              const message = ${ctx.development === true ? "true" : "false"} && err instanceof Error
+                ? err.message : 'Internal Server Error';
+              const isClientBoundary = ErrorComponent.$$typeof === Symbol.for('react.client.reference');
+              const errorElement = isClientBoundary
+                ? h(ServerErrorFallback, { Fallback: ErrorComponent, message, fallbackProps })
+                : h(ErrorComponent, { ...fallbackProps, error: new Error(message), reset: () => {} });
+              const rootInner = h('div', { 'data-farm-root': 'true' }, errorElement);
+              const payload = {
+                root: h('html', null,
+                  h('head', null, h('meta', { charSet: 'utf-8' }), h('title', null, 'Error')),
+                  h('body', null, h('div', { id: 'root' }, rootInner))),
+                rootContent: rootInner,
+                metadata: { title: 'Error' },
+              };
+              const rscStream = renderToReadableStream(payload);
+              const headers = new Headers(errorHeaders);
+              headers.set('cache-control', 'private, no-store');
+              headers.set('x-content-type-options', 'nosniff');
+              applyActionResponseHeaders(headers, request);
+              if ((request.headers.get('accept') || '').includes('text/x-component')) {
+                headers.set('content-type', 'text/x-component');
+                return new Response(rscStream, { status: 500, headers });
+              }
+              let ssr;
+              if (typeof import.meta.viteRsc?.loadModule === 'function') {
+                ssr = await import.meta.viteRsc.loadModule('ssr', 'index');
+              } else if (typeof globalThis.__VITE_RSC_LOAD_SSR__ === 'function') {
+                ssr = await globalThis.__VITE_RSC_LOAD_SSR__();
+              }
+              if (!ssr) {
+                void rscStream.cancel().catch(() => {});
+                throw new Error('SSR environment unavailable');
+              }
+              const html = await ssr.renderHTML({ payload, rscStream });
+              headers.set('content-type', 'text/html; charset=utf-8');
+              return new Response(html, { status: 500, headers });
+            })
+          )
         );
-        const renderToString = (await import('react-dom/server')).renderToString;
-        const html = '<!DOCTYPE html>' + renderToString(doc);
-        return new Response(html, { status: 500, headers: { 'Content-Type': 'text/html; charset=utf-8' } });
-      } catch (e) {
-        console.error('[RSC] Error boundary render failed:', e);
+      } catch (fallbackError) {
+        console.error('[RSC] Error boundary render failed:', fallbackError);
       }
     }
     const message = 'Internal Server Error';
     return new Response(JSON.stringify({ error: true, url: request.url, status: 500, message }), {
       status: 500,
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', 'Cache-Control': 'private, no-store' },
     });
   }
 }

--- a/packages/farmjs-plugin/src/rsc/entries/ssr.ts
+++ b/packages/farmjs-plugin/src/rsc/entries/ssr.ts
@@ -128,13 +128,19 @@ export async function renderHTML(firstArg, options = {}) {
   if (!bootstrap && PROD_BOOTSTRAP !== "__FARM_BOOTSTRAP_SCRIPT__") bootstrap = PROD_BOOTSTRAP;
   
   // Use renderToPipeableStream so Suspense streams: fallback (loading.tsx) first, then resolved content.
-  const { pipe } = renderToPipeableStream(React.createElement(Root), {
-    ...(bootstrap && { bootstrapScriptContent: bootstrap }),
-    formState: options.formState,
-  });
   const { PassThrough, Readable } = await import('stream');
   const passThrough = new PassThrough();
-  pipe(passThrough);
+  // Do not commit an empty response when the shell cannot render. Reject back
+  // to the request handler so it can render error.tsx through RSC and SSR.
+  await new Promise((resolve, reject) => {
+    const { pipe } = renderToPipeableStream(React.createElement(Root), {
+      ...(bootstrap && { bootstrapScriptContent: bootstrap }),
+      formState: options.formState,
+      onShellReady() { pipe(passThrough); resolve(); },
+      onShellError: reject,
+      onError(error) { console.error('[RSC] SSR render error:', error); },
+    });
+  });
 
   const CLIENT_ENTRY_HREF = "__FARM_CLIENT_ENTRY_HREF__";
   const PLACEHOLDER_STR = "__FARM_CLIENT_ENTRY_HREF__";

--- a/packages/farmjs-plugin/src/rsc/index.ts
+++ b/packages/farmjs-plugin/src/rsc/index.ts
@@ -31,6 +31,7 @@ import type { FarmLayerEntry, ResolvedFarmLayer } from "@farm.js/core/server";
 import { farmEnvironmentFunctionsPlugin } from "@farm.js/core/environment/vite";
 import { generateRscEntry } from "./entries/rsc.js";
 import { generateSsrEntry } from "./entries/ssr.js";
+import { generateErrorFallbackEntry } from "./entries/error-fallback.js";
 import { generateClientEntry, serverFnTransportErrorClientRuntime } from "./entries/client.js";
 import { transformFarmRouteActionClients } from "./route-action-transform.js";
 import { transformFarmServerFns } from "./server-fn-transform.js";
@@ -726,6 +727,7 @@ export default function farmRsc(options: FarmRscPluginOptions = {}): Plugin[] {
           }),
           deploymentId,
           debug,
+          development: env.command === "serve",
         };
 
         logInfo(`srcDir: ${entryContext.srcDir}, outDir: ${entryContext.outDir}`);
@@ -738,6 +740,10 @@ export default function farmRsc(options: FarmRscPluginOptions = {}): Plugin[] {
         await fs.writeFile(entryRscPath, generateRscEntry(entryContext));
         await fs.writeFile(entrySsrPath, generateSsrEntry(entryContext));
         await fs.writeFile(entryClientPath, generateClientEntry(entryContext));
+        await fs.writeFile(
+          path.join(entriesDir, "error-fallback.tsx"),
+          generateErrorFallbackEntry(),
+        );
         logInfo(`Wrote RSC entries to ${entriesDir}`);
 
         // User must add rsc({ entries: { rsc, ssr, client } }) to config.plugins so the RSC plugin

--- a/packages/farmjs-plugin/src/rsc/types.ts
+++ b/packages/farmjs-plugin/src/rsc/types.ts
@@ -95,6 +95,9 @@ export interface EntryContext {
 
   /** Whether debug mode is enabled */
   debug: boolean;
+
+  /** True only for the Vite serve command, never for a production build. */
+  development?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Problem

A server page failure bypasses error.tsx and triggers a second exception, "glob is not defined". Client error components also cannot be rendered directly in the RSC environment, and an SSR shell failure can leave a response waiting indefinitely.

## Root cause

The outer fallback references helpers declared inside a nested request callback and uses react-dom/server directly on client references. The SSR bridge returns before checking whether its shell can render.

## Change

Render the nearest error boundary through the RSC-to-SSR pipeline, outside the failed page/layout tree, while retaining request context. A generated client adapter owns Error construction and reset(), so callbacks are not serialized across the server boundary. reset() reloads the current URL.

Wait for shell readiness and propagate shell failures to the fallback. Missing or broken boundaries produce a generic non-cacheable 500. Preserve POST sanitization and distinguish redirect/not-found control flow.

## Safety and compatibility

Error responses are private, no-store. Production builds redact original messages regardless of NODE_ENV; original exceptions remain in server logs. The development command can show messages. Responses that already started streaming retain React's existing recovery behavior and cannot change their status afterward.

## Verification

macOS, Node 23.11.0, pnpm 8.12.1.

- `pnpm --filter @farm.js/plugin test`: 78 passed on this branch.
- Built and booted isolated Nitro Node output outside the project dependency tree.
- Covered async page, synchronous render, layout, and middleware failures; client/server boundaries; missing and broken boundaries; HTML/Flight; repeated search params; reset callback; production redaction; POST failure sanitization; redirects and notFound.
- Restoring the old generated handler makes the production regression fail.
- Plugin build/typecheck and focused formatting/lint passed with existing unrelated warnings.

## Documentation and release

Combined validation with the other four runtime fixes also passed: 104 plugin tests, 43 focused core tests, core/plugin builds and type checks, docs navigation and generated-type checks, and `pnpm docs:build` with the Vercel preset. The five branches apply together without conflicts. GitHub CI is still running or queued; these results are local verification, not a claim that every CI platform has finished.

Documented the RSC error-shell contract, reset behavior, redaction, and streaming limits. No version, template, or dependency changes.
