### PR TITLE
perf(react): compile structured keyed map callbacks

### DIFF
--- a/docs/src/app/docs/renderers/react/page.md
+++ b/docs/src/app/docs/renderers/react/page.md
@@ -917,9 +917,10 @@ setItems((current) =>
 
 This needs no option or component primitive. At build time, Farm recognizes a functional setter on
 the direct `useState` collection used by a compiled keyed map or `List`. The setter may contain one
-or more consecutive `map()` calls. Every mapper must be a concise arrow expression with a
-conditional result: one branch returns the original item and the other returns a new object that
-spreads that item. The conditions and replacement values must use the compiler's safe expression
+or more consecutive `map()` calls. Every mapper must be an inline arrow whose returning paths are
+conditional: at least one path returns the original item and another returns a new object that
+spreads that item. This may be a concise expression or a structured block made only from `if` and
+`return` statements. The conditions and replacement values must use the compiler's safe expression
 subset. The hint runtime is retained only in modules where at least one such call is emitted;
 direct-only and ordinary keyed builds do not import that capability.
 
@@ -935,10 +936,10 @@ Farm preserves each source property lookup and call. It records metadata only af
 array, unsupported mapper anywhere in the chain, changed key, insert, removal, reorder, relevant
 second dependency, or failed runtime check uses the existing complete keyed reconciliation and LIS
 path. Native results and thrown mapper or method errors are preserved. Derived collections,
-non-functional setters, block-bodied mappers, mutating replacements, and other unproven shapes also
-keep that existing path. This is an optimization hint, not a new correctness contract or a way to
-bypass React fallback behavior. The compiler report exposes the number of prepared map calls as
-`keyedMapUpdateHints`.
+non-functional setters, referenced callbacks, block bodies with intermediate statements or
+fallthrough, mutating replacements, and other unproven shapes also keep that existing path. This is
+an optimization hint, not a new correctness contract or a way to bypass React fallback behavior.
+The compiler report exposes the number of prepared map calls as `keyedMapUpdateHints`.
 
 #### Keyed array append hints
 
@@ -1385,23 +1386,24 @@ need no separate full scan, and the final replacements still point directly to t
 source rows. The complete pipeline then needs one final keyed reconciliation rather than a growing
 chain of intermediate snapshots.
 
-One callback may select several rows with nested conditional expressions:
+One callback may select several rows with nested expressions or structured early returns:
 
 ```tsx
 setItems((current) =>
-  current.map((item) =>
-    item.id === reviewedId
-      ? { ...item, status: "reviewed" }
-      : item.id === escalatedId
-        ? { ...item, status: "escalated", priority: 1 }
-        : item,
-  ),
+  current.map((item) => {
+    if (item.id === reviewedId) return { ...item, status: "reviewed" };
+    if (item.id === escalatedId) {
+      return { ...item, status: "escalated", priority: 1 };
+    }
+    return item;
+  }),
 );
 ```
 
 The compiler recursively proves every condition and leaf. Each leaf must return the original item
 or a compiler-safe object spread of that item, with at least one unchanged and one replacement
-path. Calls, mutation, block bodies, and any other effectful or ambiguous branch keep complete keyed
+path. Block bodies may contain only fully returning `if`/`return` paths; declarations, loops,
+mutation, calls, fallthrough, and any other effectful or ambiguous control flow keep complete keyed
 reconciliation. Runtime key validation remains atomic, so a replacement that changes its key falls
 back before the first DOM write.
 
@@ -1578,12 +1580,14 @@ changed row in committed order without moving DOM rows or constructing the gener
 sort or any other order ambiguity keeps the general permutation path.
 
 The proof requires every map callback to be inline, synchronous, compiler-safe, and to return the
-original item on one conditional branch and an object-spread replacement on the other. It requires
-compiler-owned host rows whose render and key do not observe the index. Referenced or block-bodied
-callbacks, unconditional replacements, changed or duplicate keys, `thisArg`, maps after structural
-steps, computed or custom methods, sparse or subclassed arrays, collection-reading
-bindings, React-owned rows, nested host blocks, row conditionals, unrelated dirty dependencies, or
-failed runtime validation use complete keyed reconciliation before any fast-path DOM write.
+original item on one conditional path and an object-spread replacement on another. Concise
+expressions and structured blocks containing only `if`/`return` paths are accepted. It requires
+compiler-owned host rows whose render and key do not observe the index. Referenced callbacks,
+intermediate statements, fallthrough, unconditional replacements, changed or duplicate keys,
+`thisArg`, maps after structural steps, computed or custom methods, sparse or subclassed arrays,
+collection-reading bindings, React-owned rows, nested host blocks, row conditionals, unrelated dirty
+dependencies, or failed runtime validation use complete keyed reconciliation before any fast-path
+DOM write.
 
 No API or option is added. Reports count the prepared map and reorder calls through the existing
 `keyedMapUpdateHints`, `keyedArraySortHints`, and `keyedArrayReorderHints` fields. Modules that do

--- a/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
+++ b/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
@@ -1,6 +1,42 @@
 # Complex dashboard and 21,000-row peak result
 
-Latest run: 2026-09-11
+Latest run: 2026-09-12
+
+## Structured block-bodied same-key maps — 2026-09-12
+
+Compiler-safe keyed `map()` callbacks may now use structured blocks made only from fully returning
+`if`/`return` paths. The compiler proves every condition and return value before emitting an
+existing same-key hint. A declaration, loop, call, mutation, ambiguous return, or fallthrough keeps
+complete keyed reconciliation. This is a build-time eligibility change; it adds no runtime helper,
+option, or bundle-size baseline.
+
+The maintained 10,000-row mapped rolling-chain workload now uses two early-return branches between
+two queued 50-row rolls. It updates two different retained rows and checks both DOM identities,
+branch-specific labels and amounts, the exact incoming suffix, browser errors, and zero compiled
+owner executions. The control performs the same result with unsupported block-bodied rolling
+setters.
+
+| Mode   | Block-bodied mapped chain | Compiled fallback | vs React | vs fallback |
+| ------ | -------------------------: | ----------------: | -------: | ----------: |
+| Static |                    3.40 ms |          14.90 ms |   19.62x |       4.38x |
+| Hybrid |                    4.10 ms |          16.30 ms |   16.27x |       3.98x |
+
+Both modes passed the unchanged 2x React and 1.25x compiled-control floors. The bracketed React
+median was 66.70 ms. A second complete run under heavier concurrent machine load also passed this
+target gate at 12.65x/10.67x versus React and 3.63x/4.04x versus the control. In both runs the broad
+performance, optimization-persistence, and scalability gates passed, the compiler report retained
+two mapped rolling-chain steps and 34 keyed map hints, and the compiler example bundle remained
+31,682 bytes gzip in both compiler modes.
+
+Compiler coverage includes concise nested expressions, early-return chains, single-return block
+wrappers, map-and-sort pipelines, effectful conditions, intermediate statements, fallthrough, and
+atomic runtime fallback. The focused compiler tests, full runtime suite with timeout-only cases
+rerun serially, React 18.3.1/19.2.8 compatibility, and runtime-size checks preserve the existing
+behavior and fallback boundaries.
+
+Numbers are browser medians from the complete production-build command with 5 warmups, 10 measured
+samples per compiler action, 20 bracketed React samples, 60 dashboard samples of 10 updates, and 3
+scale cycles, using Chrome 153.0.8010.36 and Node.js 23.11.0 on Apple M1 macOS arm64.
 
 ## Multi-branch same-key maps — 2026-09-11
 

--- a/examples/react-compiler-dashboard/README.md
+++ b/examples/react-compiler-dashboard/README.md
@@ -151,11 +151,12 @@ least 2x faster than React and 1.25x faster than that control. Every sample veri
 DOM identity, mapped value, exact row count, fresh suffix, and zero compiled owner executions.
 
 Mapped rolling-window chains have a separate gate so the single-window result cannot hide a chain
-regression. The 10,000-row workload runs one nested, two-branch same-key map between two queued
-50-row rolls. Its block-bodied control performs the same native work but cannot retain compiler
-lineage. Both compiler modes must remain at least 2x faster than React and 1.25x faster than that
-control, and the compiler report must contain both mapped rolling-chain steps. Every sample verifies
-both retained identities and mapped values plus the final incoming suffix.
+regression. The 10,000-row workload runs one structured block-bodied, two-branch same-key map
+between two queued 50-row rolls. Its control uses unsupported block-bodied rolling setters, so it
+performs the same native work without retaining compiler lineage. Both compiler modes must remain
+at least 2x faster than React and 1.25x faster than that control, and the compiler report must
+contain both mapped rolling-chain steps. Every sample verifies both retained identities and mapped
+values plus the final incoming suffix.
 
 Exact-position insertions, removals, and replacements have separate 10,000-row comparisons. Concise
 native `toSpliced(position, 0, item)`, `toSpliced(position, 0, ...items)`, `toSpliced(position, 1)`,

--- a/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
+++ b/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
@@ -326,13 +326,15 @@ export function StandardTableBenchmark() {
             setSeed(secondSeed);
             setRows((current) => [...current.slice(trimCount), ...firstAdditions]);
             setRows((current) =>
-              current.map((row) =>
-                row.id === reviewedId
-                  ? { ...row, amount: row.amount + 1, label: `${row.label} reviewed` }
-                  : row.id === escalatedId
-                    ? { ...row, amount: row.amount + 2, label: `${row.label} escalated` }
-                  : row,
-              ),
+              current.map((row) => {
+                if (row.id === reviewedId) {
+                  return { ...row, amount: row.amount + 1, label: `${row.label} reviewed` };
+                }
+                if (row.id === escalatedId) {
+                  return { ...row, amount: row.amount + 2, label: `${row.label} escalated` };
+                }
+                return row;
+              }),
             );
             setRows((current) => [...current.slice(trimCount), ...secondAdditions]);
             setOperation("map through two queued rolling windows");

--- a/packages/farm-react/README.md
+++ b/packages/farm-react/README.md
@@ -232,15 +232,16 @@ once; intermediate arrays never receive DOM work. Every user `map()` remains O(n
 keyed runtime's second full key-and-binding scan. Queued hints compose. The source method lookup,
 native result, callback order, and thrown errors are preserved.
 
-Each stage requires an inline synchronous conditional mapper that returns the original item or an
-object-spread replacement. An unsupported mapper anywhere in the chain disables the complete
-setter hint. Custom methods still execute but record no metadata. Key changes, structural edits,
-sparse or subclassed arrays, relevant mixed dependencies, and failed runtime checks use the
-existing complete reconciliation and LIS path. Non-functional setters, derived collections,
-block-bodied or mutating mappers, and other unproven forms are simply not hinted. No new option is
-required. A compiler report counts prepared map calls as `keyedMapUpdateHints`. The separate hint
-runtime capability is imported only when that count is nonzero, so direct-only and ordinary keyed
-builds do not retain it.
+Each stage requires an inline synchronous conditional mapper that returns the original item on at
+least one path and an object-spread replacement on another. The callback may be a concise expression
+or a structured block containing only fully returning `if`/`return` paths. An unsupported mapper
+anywhere in the chain disables the complete setter hint. Custom methods still execute but record no
+metadata. Key changes, structural edits, sparse or subclassed arrays, relevant mixed dependencies,
+and failed runtime checks use the existing complete reconciliation and LIS path. Non-functional
+setters, derived collections, referenced callbacks, intermediate statements, fallthrough, mutating
+mappers, and other unproven forms are simply not hinted. No new option is required. A compiler
+report counts prepared map calls as `keyedMapUpdateHints`. The separate hint runtime capability is
+imported only when that count is nonzero, so direct-only and ordinary keyed builds do not retain it.
 
 The same optional runtime recognizes conservative immutable appends on a direct keyed array:
 
@@ -546,24 +547,25 @@ setItems((current) =>
 );
 ```
 
-One callback may select several rows through nested conditional expressions:
+One callback may select several rows through nested expressions or structured early returns:
 
 ```tsx
 setItems((current) =>
-  current.map((item) =>
-    item.id === reviewedId
-      ? { ...item, status: "reviewed" }
-      : item.id === escalatedId
-        ? { ...item, status: "escalated", priority: 1 }
-        : item,
-  ),
+  current.map((item) => {
+    if (item.id === reviewedId) return { ...item, status: "reviewed" };
+    if (item.id === escalatedId) {
+      return { ...item, status: "escalated", priority: 1 };
+    }
+    return item;
+  }),
 );
 ```
 
 Every condition must be compiler-safe, and every leaf must return the original item or a safe
-object spread of it, with at least one unchanged and one replacement path. Effectful calls,
-mutation, block bodies, and ambiguous leaves use complete keyed reconciliation. A runtime key
-change also falls back before any DOM write.
+object spread of it, with at least one unchanged and one replacement path. Concise expressions and
+blocks made only from fully returning `if`/`return` paths are accepted. Effectful calls, mutation,
+intermediate statements, fallthrough, and ambiguous leaves use complete keyed reconciliation. A
+runtime key change also falls back before any DOM write.
 
 Farm executes every native map and reorder call normally. For consecutive accepted maps, it checks
 each native call but compares only the input and final result of that map segment, avoiding a full
@@ -572,12 +574,12 @@ one-to-one source-item match, and every final replacement key before touching th
 LIS and patches each changed row once. Unchanged rows need no second key or binding read. Queued
 supported map-and-reorder setters compose against the same committed rows. Every accepted map
 requires an inline synchronous conditional mapper whose leaves return either the original item or
-an object-spread replacement, plus index-independent compiler-owned host rows. Changed keys,
-referenced or block-bodied callbacks, unconditional replacements, `thisArg`, structural calls in
-the same chain, computed or custom methods, sparse or subclassed arrays, collection-reading
-bindings, nested or React-owned rows, and failed checks use complete keyed reconciliation. Reports
-use the existing map, sort, and reorder hint counters, and unrelated modules do not retain this
-optional runtime.
+an object-spread replacement, plus index-independent compiler-owned host rows. Concise expressions
+and structured `if`/`return` blocks are supported. Changed keys, referenced callbacks, intermediate
+statements or fallthrough, unconditional replacements, `thisArg`, structural calls in the same
+chain, computed or custom methods, sparse or subclassed arrays, collection-reading bindings, nested
+or React-owned rows, and failed checks use complete keyed reconciliation. Reports use the existing
+map, sort, and reorder hint counters, and unrelated modules do not retain this optional runtime.
 
 The maps may also finish the concise pipeline:
 

--- a/packages/farm-react/src/__tests__/compiler-keyed-array-rolling-window-hints.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-keyed-array-rolling-window-hints.test.ts
@@ -199,15 +199,13 @@ describe("React AOT keyed-array rolling-window hints", () => {
         return <section>
           <button onClick={() => {
             setRows((current) => [...current.slice(1), nextOne]);
-            setRows((current) => current.map((row) =>
-              row.id === firstId
-                ? { ...row, label: nextLabel }
-                : row.id === secondId
-                  ? { ...row, label: nextLabel }
-                  : row
-            ));
+            setRows((current) => current.map((row) => {
+              if (row.id === firstId) return { ...row, label: nextLabel };
+              if (row.id === secondId) return { ...row, label: nextLabel };
+              return row;
+            }));
             setRows((current) => [...current.slice(1), nextTwo]);
-          }}>Roll around unsupported map</button>
+          }}>Roll around structured map</button>
           <ul>{rows.map((row) => <li key={row.id}>{row.label}</li>)}</ul>
         </section>;
       }

--- a/packages/farm-react/src/__tests__/compiler-keyed-array-sort-hints.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-keyed-array-sort-hints.test.ts
@@ -291,6 +291,37 @@ describe("React AOT keyed-array sort hints", () => {
     expect(result.code).toContain("keyedRowsMapReorderHintedRuntimeFeature");
   });
 
+  it("carries a structured block-bodied map through a native sort", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Table({ firstId, secondId }) {
+        const [rows, setRows] = useState([
+          { id: "a", label: "Alpha", rank: 1 },
+          { id: "b", label: "Beta", rank: 2 },
+        ]);
+        return <section>
+          <button onClick={() => setRows((current) => current
+            .map((row) => {
+              if (row.id === firstId) return { ...row, rank: 4 };
+              if (row.id === secondId) return { ...row, rank: 3 };
+              return row;
+            })
+            .toSorted((left, right) => left.rank - right.rank)
+          )}>Edit and sort</button>
+          <ul>{rows.map((row) => <li key={row.id}>{row.label}</li>)}</ul>
+        </section>;
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Table"]);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.optimizations.keyedMapUpdateHints).toBe(1);
+    expect(result.optimizations.keyedArraySortHints).toBe(1);
+    expect(result.code).toContain("createCompilerKeyedArrayMapPipeline");
+    expect(result.code).toContain("createCompilerKeyedArrayMapReorder");
+    expect(result.code).toContain("keyedRowsMapReorderHintedRuntimeFeature");
+  });
+
   it("preserves every step in an exact mapped reverse-parity pipeline", async () => {
     const result = await compile(`
       import { useState } from "react";
@@ -455,9 +486,9 @@ describe("React AOT keyed-array sort hints", () => {
       pipeline: "current.map(updateRow).toSorted((a, b) => a.rank - b.rank)",
     },
     {
-      name: "a block-bodied mapper",
+      name: "an unproven block-bodied mapper",
       pipeline:
-        "current.map((row) => { return row.id === editedId ? { ...row, rank: 0 } : row; }).toSorted((a, b) => a.rank - b.rank)",
+        "current.map((row) => { const matches = row.id === editedId; return matches ? { ...row, rank: 0 } : row; }).toSorted((a, b) => a.rank - b.rank)",
     },
     {
       name: "an unsupported second mapper",

--- a/packages/farm-react/src/__tests__/compiler-keyed-update-hints.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-keyed-update-hints.test.ts
@@ -146,6 +146,50 @@ describe("React AOT keyed update hints", () => {
     });
   });
 
+  it("records structured block-bodied maps with safe returning paths", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Inventory({ firstId, secondId, firstLabel, secondLabel }) {
+        const [items, setItems] = useState([
+          { id: "a", label: "Alpha", selected: false },
+          { id: "b", label: "Beta", selected: false },
+        ]);
+        return (
+          <section>
+            <button onClick={() => setItems((current) => current
+              .map((row) => {
+                if (row.id === firstId) {
+                  return { ...row, label: firstLabel };
+                }
+                if (row.id === secondId) return { ...row, label: secondLabel };
+                return row;
+              })
+              .map((row) => {
+                return row.id === firstId ? { ...row, selected: true } : row;
+              })
+            )}>Update two rows</button>
+            <ul>{items.map((item) => <li key={item.id}>{item.label}</li>)}</ul>
+          </section>
+        );
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Inventory"]);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.optimizations.keyedMapUpdateHints).toBe(2);
+    expect(result.code.match(/createCompilerKeyedMapUpdate\(/g)).toHaveLength(1);
+    expect(result.code.match(/_farmApplyMap\d*\(/g)).toHaveLength(2);
+    expect(result.code).toContain("keyedRowsHintedRuntimeFeature");
+    await expect(
+      transformWithEsbuild(result.code, "/app/KeyedUpdateHints.tsx", {
+        loader: "tsx",
+        jsx: "automatic",
+      }),
+    ).resolves.toMatchObject({
+      code: expect.stringContaining("createCompilerKeyedMapUpdate"),
+    });
+  });
+
   it("supports direct-state public List rows without adding a public option", async () => {
     const result = await compile(`
       import { useState } from "react";
@@ -179,11 +223,32 @@ describe("React AOT keyed update hints", () => {
         'setItems((current) => current.map((row) => row.id === "a" ? { ...row, label: "Updated" } : row))',
     },
     {
-      name: "a block-bodied mapper",
+      name: "a block-bodied mapper with an intermediate declaration",
       declaration: "",
       collection: "items",
       update:
-        'setItems((current) => current.map((row) => { return row.id === "a" ? { ...row, label: "Updated" } : row; }))',
+        'setItems((current) => current.map((row) => { const matches = row.id === "a"; return matches ? { ...row, label: "Updated" } : row; }))',
+    },
+    {
+      name: "an effectful block condition",
+      declaration: 'const matches = (row) => row.id === "a";',
+      collection: "items",
+      update:
+        'setItems((current) => current.map((row) => { if (matches(row)) return { ...row, label: "Updated" }; return row; }))',
+    },
+    {
+      name: "a block body that can fall through",
+      declaration: "",
+      collection: "items",
+      update:
+        'setItems((current) => current.map((row) => { if (row.id === "a") return { ...row, label: "Updated" }; }))',
+    },
+    {
+      name: "a block body that replaces every row",
+      declaration: "",
+      collection: "items",
+      update:
+        'setItems((current) => current.map((row) => { if (row.id === "a") return { ...row, label: "Updated" }; return { ...row, label: "Other" }; }))',
     },
     {
       name: "an unsupported second mapper",

--- a/packages/farm-react/src/compiler.ts
+++ b/packages/farm-react/src/compiler.ts
@@ -1236,38 +1236,79 @@ function isSafeKeyedMapReplacement(
   return spreadsItem;
 }
 
-function isSafeKeyedMapResult(
+type SafeKeyedMapBranchProof = { replacement: boolean; unchanged: boolean };
+
+function mergeSafeKeyedMapBranchProofs(
+  left: SafeKeyedMapBranchProof,
+  right: SafeKeyedMapBranchProof,
+): SafeKeyedMapBranchProof {
+  return {
+    replacement: left.replacement || right.replacement,
+    unchanged: left.unchanged || right.unchanged,
+  };
+}
+
+function proveSafeKeyedMapExpression(
   expression: t.Expression,
   item: t.Identifier,
   safeGlobals: ReadonlySet<string>,
-): boolean {
-  type BranchProof = { replacement: boolean; unchanged: boolean };
-  const proveBranch = (branch: t.Expression): BranchProof | undefined => {
-    if (isUnchangedMapItem(branch, item)) return { replacement: false, unchanged: true };
-    if (isSafeKeyedMapReplacement(branch, item, safeGlobals)) {
-      return { replacement: true, unchanged: false };
-    }
-    if (!t.isConditionalExpression(branch)) return undefined;
-    if (validateDerivedExpression(branch.test, safeGlobals)) return undefined;
-    const consequent = proveBranch(branch.consequent);
-    const alternate = proveBranch(branch.alternate);
-    if (!consequent || !alternate) return undefined;
-    return {
-      replacement: consequent.replacement || alternate.replacement,
-      unchanged: consequent.unchanged || alternate.unchanged,
-    };
-  };
+): SafeKeyedMapBranchProof | undefined {
+  if (isUnchangedMapItem(expression, item)) return { replacement: false, unchanged: true };
+  if (isSafeKeyedMapReplacement(expression, item, safeGlobals)) {
+    return { replacement: true, unchanged: false };
+  }
+  if (!t.isConditionalExpression(expression)) return undefined;
+  if (validateDerivedExpression(expression.test, safeGlobals)) return undefined;
+  const consequent = proveSafeKeyedMapExpression(expression.consequent, item, safeGlobals);
+  const alternate = proveSafeKeyedMapExpression(expression.alternate, item, safeGlobals);
+  return consequent && alternate ? mergeSafeKeyedMapBranchProofs(consequent, alternate) : undefined;
+}
 
-  if (!t.isConditionalExpression(expression)) return false;
-  if (validateDerivedExpression(expression.test, safeGlobals)) return false;
-  const consequent = proveBranch(expression.consequent);
-  const alternate = proveBranch(expression.alternate);
-  return Boolean(
-    consequent &&
-    alternate &&
-    (consequent.replacement || alternate.replacement) &&
-    (consequent.unchanged || alternate.unchanged),
-  );
+function proveSafeKeyedMapStatement(
+  statement: t.Statement,
+  item: t.Identifier,
+  safeGlobals: ReadonlySet<string>,
+): SafeKeyedMapBranchProof | undefined {
+  return t.isBlockStatement(statement)
+    ? proveSafeKeyedMapStatements(statement.body, item, safeGlobals)
+    : proveSafeKeyedMapStatements([statement], item, safeGlobals);
+}
+
+function proveSafeKeyedMapStatements(
+  statements: readonly t.Statement[],
+  item: t.Identifier,
+  safeGlobals: ReadonlySet<string>,
+): SafeKeyedMapBranchProof | undefined {
+  const [statement, ...remaining] = statements;
+  if (!statement) return undefined;
+  if (t.isReturnStatement(statement)) {
+    if (remaining.length > 0 || !statement.argument || !t.isExpression(statement.argument)) {
+      return undefined;
+    }
+    return proveSafeKeyedMapExpression(statement.argument, item, safeGlobals);
+  }
+  if (!t.isIfStatement(statement) || validateDerivedExpression(statement.test, safeGlobals)) {
+    return undefined;
+  }
+
+  const consequent = proveSafeKeyedMapStatement(statement.consequent, item, safeGlobals);
+  const alternate = statement.alternate
+    ? remaining.length === 0
+      ? proveSafeKeyedMapStatement(statement.alternate, item, safeGlobals)
+      : undefined
+    : proveSafeKeyedMapStatements(remaining, item, safeGlobals);
+  return consequent && alternate ? mergeSafeKeyedMapBranchProofs(consequent, alternate) : undefined;
+}
+
+function isSafeKeyedMapBody(
+  body: t.BlockStatement | t.Expression,
+  item: t.Identifier,
+  safeGlobals: ReadonlySet<string>,
+): boolean {
+  const proof = t.isBlockStatement(body)
+    ? proveSafeKeyedMapStatements(body.body, item, safeGlobals)
+    : proveSafeKeyedMapExpression(body, item, safeGlobals);
+  return Boolean(proof?.replacement && proof.unchanged);
 }
 
 function keyedMapUpdatePipeline(
@@ -1293,8 +1334,7 @@ function keyedMapUpdatePipeline(
       callback.params.length === 0 ||
       callback.params.length > 3 ||
       callback.params.some((parameter) => !t.isIdentifier(parameter)) ||
-      !t.isExpression(callback.body) ||
-      !isSafeKeyedMapResult(callback.body, callback.params[0] as t.Identifier, safeGlobals)
+      !isSafeKeyedMapBody(callback.body, callback.params[0] as t.Identifier, safeGlobals)
     ) {
       return undefined;
     }
@@ -2041,8 +2081,7 @@ function keyedArrayReorderPipeline(
         callback.params.length === 0 ||
         callback.params.length > 3 ||
         callback.params.some((parameter) => !t.isIdentifier(parameter)) ||
-        !t.isExpression(callback.body) ||
-        !isSafeKeyedMapResult(callback.body, callback.params[0] as t.Identifier, safeGlobals)
+        !isSafeKeyedMapBody(callback.body, callback.params[0] as t.Identifier, safeGlobals)
       ) {
         return undefined;
       }


### PR DESCRIPTION
## Problem

Farm's React compiler already optimized safe keyed `map()` updates, but only when every callback used a concise expression body. Common early-return code such as `if (row.id === id) return { ...row, value }; return row;` therefore discarded the same-key update hint and used complete keyed reconciliation even though it expressed the same proven update.

## Root cause

Keyed-map eligibility required `callback.body` to be an expression and proved only conditional expressions. It had no statement-level control-flow proof, so it could not distinguish a fully returning, side-effect-free `if`/`return` tree from an ambiguous block containing declarations, calls, mutation, or fallthrough.

## Change

- add a recursive proof for block-bodied keyed-map callbacks made only from `if`, nested blocks, and `return`
- require every reachable path to return, at least one path to preserve the original item, and at least one path to return a compiler-safe object-spread replacement
- share the proof between same-order keyed maps and mapped reorder pipelines
- exercise structured maps in the maintained 10,000-row rolling-window benchmark and document the supported form and fallback boundary
- add positive and negative compiler coverage for early-return chains, one-return block wrappers, mapped sorting, intermediate statements, effectful conditions, fallthrough, and all-row replacement

## Safety and compatibility

This changes build-time eligibility only. It adds no public API, option, runtime helper, report field, or bundle-size baseline. Native `map()` execution, callback order, property access, and thrown errors remain unchanged.

The compiler declines the hint for referenced callbacks, intermediate statements, effectful conditions, loops, mutation, missing or ambiguous returns, unconditional/all-row replacement, unsupported expressions, or an unsupported mapper anywhere in a chain. Existing runtime validation remains atomic: changed or duplicate keys, structural changes, sparse or subclassed arrays, ambiguous ownership, and failed validation use complete keyed reconciliation before any DOM write. React-owned and unsupported row structures keep the existing fallback. React 18.3.1 and React 19.2.8 compatibility suites pass.

## Verification

- `pnpm --dir packages/farm-react exec vitest run src/__tests__/compiler-keyed-update-hints.test.ts src/__tests__/compiler-keyed-array-rolling-window-hints.test.ts src/__tests__/compiler-keyed-array-sort-hints.test.ts --maxWorkers=1` — 79 passed
- complete React suite with one worker — 75 files passed; 837 passed, 14 skipped
- stress suite with one worker — 8 files passed; 23 passed, 132 skipped
- `pnpm --filter @farm.js/react test:compat` — React 18.3.1 and 19.2.8 passed
- `pnpm --filter @farm.js/react test:runtime-size` — passed with unchanged baselines; the compiler example remained 31,682 bytes gzip in both compiler modes
- `pnpm --filter @farm.js/react type-check` — passed
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @farm.js/core build` — passed
- React compiler dashboard type-check — passed
- `pnpm docs:check-navigation` — passed (83 visible pages, 12 plugins)
- `pnpm --dir docs exec farm generate --check` — passed
- `pnpm docs:build` — passed through client, SSR, and Nitro/Vercel output
- focused `oxfmt`, `oxlint`, and `git diff --check` — passed
- complete production browser benchmark, Chrome 153.0.8010.36 on Apple M1 macOS arm64:

| Mode | Structured mapped chain | Compiled fallback | vs React | vs fallback |
| --- | ---: | ---: | ---: | ---: |
| Static | 3.40 ms | 14.90 ms | 19.62x | 4.38x |
| Hybrid | 4.10 ms | 16.30 ms | 16.27x | 3.98x |

The new gate passed the unchanged 2x-vs-React and 1.25x-vs-control floors in two complete runs. The repeat measured 12.65x/10.67x versus React and 3.63x/4.04x versus the fallback. Broad performance, persistence, and scalability gates passed in both runs. Unrelated legacy control-relative microgates fluctuated under concurrent host load, with a different set missing their thresholds per run; every affected case still beat React by 3.54x–12.05x. No gate or threshold was changed.

## Documentation and release

Updated the React renderer docs, package README, compiler dashboard README, maintained workload, and benchmark results. No template, generated artifact, package version, or release-flow change.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extends Farm's React compiler keyed-map optimization to block-bodied callbacks made only of fully returning `if`/`return` paths, so early-return code like `if (row.id === id) return { ...row, value }; return row;` keeps the same-key update hint instead of falling back to complete keyed reconciliation.

- Recursively proves every reachable path returns, with at least one unchanged original item and one object-spread replacement.
- Shares the proof between same-order keyed maps and mapped reorder pipelines.
- Declines the hint for referenced callbacks, intermediate statements, effectful conditions, fallthrough, and all-row replacement.
- Updates docs, READMEs, tests, and the 10,000-row rolling-window benchmark to exercise the structured form.

Build-time eligibility only: no API, option, runtime helper, or bundle-size change.

<sup>Written for commit 3122ee97031df7fc63891241eefe60fa91531c99. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/943?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

