### PR TITLE
perf(react): compile keyed map local constants

### DIFF
--- a/docs/src/app/docs/renderers/react/page.md
+++ b/docs/src/app/docs/renderers/react/page.md
@@ -920,7 +920,8 @@ the direct `useState` collection used by a compiled keyed map or `List`. The set
 or more consecutive `map()` calls. Every mapper must be an inline arrow whose returning paths are
 conditional: at least one path returns the original item and another returns a new object that
 spreads that item. This may be a concise expression or a structured block made only from `if` and
-`return` statements. The conditions and replacement values must use the compiler's safe expression
+`return` statements plus immutable local `const` aliases. Each alias needs a simple identifier and a
+compiler-safe initializer. The conditions and replacement values must use the same safe expression
 subset. The hint runtime is retained only in modules where at least one such call is emitted;
 direct-only and ordinary keyed builds do not import that capability.
 
@@ -936,10 +937,11 @@ Farm preserves each source property lookup and call. It records metadata only af
 array, unsupported mapper anywhere in the chain, changed key, insert, removal, reorder, relevant
 second dependency, or failed runtime check uses the existing complete keyed reconciliation and LIS
 path. Native results and thrown mapper or method errors are preserved. Derived collections,
-non-functional setters, referenced callbacks, block bodies with intermediate statements or
-fallthrough, mutating replacements, and other unproven shapes also keep that existing path. This is
-an optimization hint, not a new correctness contract or a way to bypass React fallback behavior.
-The compiler report exposes the number of prepared map calls as `keyedMapUpdateHints`.
+non-functional setters, referenced callbacks, mutable or destructured local declarations,
+effectful initializers, other intermediate statements, fallthrough, mutating replacements, and
+other unproven shapes also keep that existing path. This is an optimization hint, not a new
+correctness contract or a way to bypass React fallback behavior. The compiler report exposes the
+number of prepared map calls as `keyedMapUpdateHints`.
 
 #### Keyed array append hints
 
@@ -1391,8 +1393,10 @@ One callback may select several rows with nested expressions or structured early
 ```tsx
 setItems((current) =>
   current.map((item) => {
-    if (item.id === reviewedId) return { ...item, status: "reviewed" };
-    if (item.id === escalatedId) {
+    const matchesReviewed = item.id === reviewedId;
+    if (matchesReviewed) return { ...item, status: "reviewed" };
+    const matchesEscalated = item.id === escalatedId;
+    if (matchesEscalated) {
       return { ...item, status: "escalated", priority: 1 };
     }
     return item;
@@ -1402,10 +1406,11 @@ setItems((current) =>
 
 The compiler recursively proves every condition and leaf. Each leaf must return the original item
 or a compiler-safe object spread of that item, with at least one unchanged and one replacement
-path. Block bodies may contain only fully returning `if`/`return` paths; declarations, loops,
-mutation, calls, fallthrough, and any other effectful or ambiguous control flow keep complete keyed
-reconciliation. Runtime key validation remains atomic, so a replacement that changes its key falls
-back before the first DOM write.
+path. Block bodies may also introduce local `const` aliases with simple identifier bindings and
+compiler-safe initializers. Mutable or destructured declarations, object/array/function literals,
+unknown calls, loops, mutation, fallthrough, and any other effectful or ambiguous control flow keep
+complete keyed reconciliation. Runtime key validation remains atomic, so a replacement that changes
+its key falls back before the first DOM write.
 
 Before changing the DOM, the runtime verifies ordinary dense arrays, exact native methods, the
 committed collection token, equal lengths, a unique one-to-one source-item match, and the key of
@@ -1581,13 +1586,13 @@ sort or any other order ambiguity keeps the general permutation path.
 
 The proof requires every map callback to be inline, synchronous, compiler-safe, and to return the
 original item on one conditional path and an object-spread replacement on another. Concise
-expressions and structured blocks containing only `if`/`return` paths are accepted. It requires
-compiler-owned host rows whose render and key do not observe the index. Referenced callbacks,
-intermediate statements, fallthrough, unconditional replacements, changed or duplicate keys,
-`thisArg`, maps after structural steps, computed or custom methods, sparse or subclassed arrays,
-collection-reading bindings, React-owned rows, nested host blocks, row conditionals, unrelated dirty
-dependencies, or failed runtime validation use complete keyed reconciliation before any fast-path
-DOM write.
+expressions and structured blocks containing proven local `const` aliases plus `if`/`return` paths
+are accepted. It requires compiler-owned host rows whose render and key do not observe the index.
+Referenced callbacks, mutable, destructured, or effectful declarations, other intermediate
+statements, fallthrough, unconditional replacements, changed or duplicate keys, `thisArg`, maps
+after structural steps, computed or custom methods, sparse or subclassed arrays, collection-reading
+bindings, React-owned rows, nested host blocks, row conditionals, unrelated dirty dependencies, or
+failed runtime validation use complete keyed reconciliation before any fast-path DOM write.
 
 No API or option is added. Reports count the prepared map and reorder calls through the existing
 `keyedMapUpdateHints`, `keyedArraySortHints`, and `keyedArrayReorderHints` fields. Modules that do

--- a/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
+++ b/examples/react-compiler-dashboard/BENCHMARK_RESULTS.md
@@ -2,6 +2,41 @@
 
 Latest run: 2026-09-12
 
+## Safe local aliases in keyed maps — 2026-09-12
+
+Structured keyed `map()` callbacks may now introduce immutable local `const` aliases when every
+binding is a simple identifier and every initializer passes the compiler's existing safe-expression
+proof. This supports common code such as naming row matches or derived scalar values before the
+return tree. Mutable or destructured declarations, object/array/function literals, unknown calls,
+mutation, and fallthrough keep complete keyed reconciliation. This is a compiler eligibility
+change only; it adds no runtime helper, option, report field, or runtime-size baseline.
+
+The maintained 10,000-row mapped rolling-chain workload now names both branch conditions with local
+aliases between two queued 50-row rolls. It verifies both retained DOM identities, branch-specific
+labels and amounts, the exact incoming suffix, browser errors, and zero compiled owner executions.
+The complete production browser suite passed every correctness, performance, optimization-
+persistence, and scalability gate with unchanged thresholds.
+
+| Mode   | Local-alias mapped chain | Compiled fallback | vs React | vs fallback |
+| ------ | -----------------------: | ----------------: | -------: | ----------: |
+| Static |                  4.40 ms |          15.40 ms |   15.90x |       3.50x |
+| Hybrid |                  5.00 ms |          16.20 ms |   13.99x |       3.24x |
+
+Both modes cleared the unchanged 2x React and 1.25x compiled-control floors. The bracketed React
+median was 69.95 ms. The compiler report retained two mapped rolling-chain steps and 34 keyed map
+hints. The example bundle was 31,682 bytes gzip in static mode and 31,681 bytes gzip in hybrid mode;
+the focused runtime-size suite retained every existing byte baseline.
+
+Compiler coverage includes multiple aliases, safe `Math` and primitive conversion calls, chained
+maps, map-and-sort pipelines, rolling-window lineage, mutable and destructured declarations,
+effectful initializers, fallthrough, and all-row replacement. The full React suite, dedicated stress
+suite, and React 18.3.1/19.2.8 compatibility checks preserve the existing behavior and fallback
+boundaries.
+
+Numbers are browser medians from the complete production-build command with 5 warmups, 10 measured
+samples per compiler action, 20 bracketed React samples, 60 dashboard samples of 10 updates, and 3
+scale cycles, using Chrome 153.0.8010.36 and Node.js 23.11.0 on Apple M1 macOS arm64.
+
 ## Structured block-bodied same-key maps — 2026-09-12
 
 Compiler-safe keyed `map()` callbacks may now use structured blocks made only from fully returning

--- a/examples/react-compiler-dashboard/README.md
+++ b/examples/react-compiler-dashboard/README.md
@@ -151,12 +151,12 @@ least 2x faster than React and 1.25x faster than that control. Every sample veri
 DOM identity, mapped value, exact row count, fresh suffix, and zero compiled owner executions.
 
 Mapped rolling-window chains have a separate gate so the single-window result cannot hide a chain
-regression. The 10,000-row workload runs one structured block-bodied, two-branch same-key map
-between two queued 50-row rolls. Its control uses unsupported block-bodied rolling setters, so it
-performs the same native work without retaining compiler lineage. Both compiler modes must remain
-at least 2x faster than React and 1.25x faster than that control, and the compiler report must
-contain both mapped rolling-chain steps. Every sample verifies both retained identities and mapped
-values plus the final incoming suffix.
+regression. The 10,000-row workload runs one structured block-bodied, two-branch same-key map with
+two compiler-safe local `const` aliases between two queued 50-row rolls. Its control uses
+unsupported block-bodied rolling setters, so it performs the same native work without retaining
+compiler lineage. Both compiler modes must remain at least 2x faster than React and 1.25x faster
+than that control, and the compiler report must contain both mapped rolling-chain steps. Every
+sample verifies both retained identities and mapped values plus the final incoming suffix.
 
 Exact-position insertions, removals, and replacements have separate 10,000-row comparisons. Concise
 native `toSpliced(position, 0, item)`, `toSpliced(position, 0, ...items)`, `toSpliced(position, 1)`,

--- a/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
+++ b/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
@@ -327,10 +327,12 @@ export function StandardTableBenchmark() {
             setRows((current) => [...current.slice(trimCount), ...firstAdditions]);
             setRows((current) =>
               current.map((row) => {
-                if (row.id === reviewedId) {
+                const matchesReviewed = row.id === reviewedId;
+                if (matchesReviewed) {
                   return { ...row, amount: row.amount + 1, label: `${row.label} reviewed` };
                 }
-                if (row.id === escalatedId) {
+                const matchesEscalated = row.id === escalatedId;
+                if (matchesEscalated) {
                   return { ...row, amount: row.amount + 2, label: `${row.label} escalated` };
                 }
                 return row;

--- a/packages/farm-react/README.md
+++ b/packages/farm-react/README.md
@@ -234,14 +234,16 @@ native result, callback order, and thrown errors are preserved.
 
 Each stage requires an inline synchronous conditional mapper that returns the original item on at
 least one path and an object-spread replacement on another. The callback may be a concise expression
-or a structured block containing only fully returning `if`/`return` paths. An unsupported mapper
+or a structured block containing fully returning `if`/`return` paths and proven local `const`
+aliases. Each alias needs a simple identifier and compiler-safe initializer. An unsupported mapper
 anywhere in the chain disables the complete setter hint. Custom methods still execute but record no
 metadata. Key changes, structural edits, sparse or subclassed arrays, relevant mixed dependencies,
 and failed runtime checks use the existing complete reconciliation and LIS path. Non-functional
-setters, derived collections, referenced callbacks, intermediate statements, fallthrough, mutating
-mappers, and other unproven forms are simply not hinted. No new option is required. A compiler
-report counts prepared map calls as `keyedMapUpdateHints`. The separate hint runtime capability is
-imported only when that count is nonzero, so direct-only and ordinary keyed builds do not retain it.
+setters, derived collections, referenced callbacks, mutable or destructured declarations, effectful
+initializers, other intermediate statements, fallthrough, mutating mappers, and other unproven forms
+are simply not hinted. No new option is required. A compiler report counts prepared map calls as
+`keyedMapUpdateHints`. The separate hint runtime capability is imported only when that count is
+nonzero, so direct-only and ordinary keyed builds do not retain it.
 
 The same optional runtime recognizes conservative immutable appends on a direct keyed array:
 
@@ -552,8 +554,10 @@ One callback may select several rows through nested expressions or structured ea
 ```tsx
 setItems((current) =>
   current.map((item) => {
-    if (item.id === reviewedId) return { ...item, status: "reviewed" };
-    if (item.id === escalatedId) {
+    const matchesReviewed = item.id === reviewedId;
+    if (matchesReviewed) return { ...item, status: "reviewed" };
+    const matchesEscalated = item.id === escalatedId;
+    if (matchesEscalated) {
       return { ...item, status: "escalated", priority: 1 };
     }
     return item;
@@ -563,9 +567,10 @@ setItems((current) =>
 
 Every condition must be compiler-safe, and every leaf must return the original item or a safe
 object spread of it, with at least one unchanged and one replacement path. Concise expressions and
-blocks made only from fully returning `if`/`return` paths are accepted. Effectful calls, mutation,
-intermediate statements, fallthrough, and ambiguous leaves use complete keyed reconciliation. A
-runtime key change also falls back before any DOM write.
+blocks made from fully returning `if`/`return` paths plus local `const` aliases are accepted. Each
+alias must have a simple identifier and compiler-safe initializer. Mutable or destructured
+declarations, effectful initializers, other intermediate statements, fallthrough, and ambiguous
+leaves use complete keyed reconciliation. A runtime key change also falls back before any DOM write.
 
 Farm executes every native map and reorder call normally. For consecutive accepted maps, it checks
 each native call but compares only the input and final result of that map segment, avoiding a full
@@ -575,11 +580,13 @@ LIS and patches each changed row once. Unchanged rows need no second key or bind
 supported map-and-reorder setters compose against the same committed rows. Every accepted map
 requires an inline synchronous conditional mapper whose leaves return either the original item or
 an object-spread replacement, plus index-independent compiler-owned host rows. Concise expressions
-and structured `if`/`return` blocks are supported. Changed keys, referenced callbacks, intermediate
-statements or fallthrough, unconditional replacements, `thisArg`, structural calls in the same
-chain, computed or custom methods, sparse or subclassed arrays, collection-reading bindings, nested
-or React-owned rows, and failed checks use complete keyed reconciliation. Reports use the existing
-map, sort, and reorder hint counters, and unrelated modules do not retain this optional runtime.
+and structured blocks with proven local `const` aliases and `if`/`return` paths are supported.
+Changed keys, referenced callbacks, mutable, destructured, or effectful declarations, other
+intermediate statements or fallthrough, unconditional replacements, `thisArg`, structural calls in
+the same chain, computed or custom methods, sparse or subclassed arrays, collection-reading
+bindings, nested or React-owned rows, and failed checks use complete keyed reconciliation. Reports
+use the existing map, sort, and reorder hint counters, and unrelated modules do not retain this
+optional runtime.
 
 The maps may also finish the concise pipeline:
 

--- a/packages/farm-react/src/__tests__/compiler-keyed-array-rolling-window-hints.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-keyed-array-rolling-window-hints.test.ts
@@ -200,8 +200,10 @@ describe("React AOT keyed-array rolling-window hints", () => {
           <button onClick={() => {
             setRows((current) => [...current.slice(1), nextOne]);
             setRows((current) => current.map((row) => {
-              if (row.id === firstId) return { ...row, label: nextLabel };
-              if (row.id === secondId) return { ...row, label: nextLabel };
+              const matchesFirst = row.id === firstId;
+              if (matchesFirst) return { ...row, label: nextLabel };
+              const matchesSecond = row.id === secondId;
+              if (matchesSecond) return { ...row, label: nextLabel };
               return row;
             }));
             setRows((current) => [...current.slice(1), nextTwo]);

--- a/packages/farm-react/src/__tests__/compiler-keyed-array-sort-hints.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-keyed-array-sort-hints.test.ts
@@ -302,8 +302,10 @@ describe("React AOT keyed-array sort hints", () => {
         return <section>
           <button onClick={() => setRows((current) => current
             .map((row) => {
-              if (row.id === firstId) return { ...row, rank: 4 };
-              if (row.id === secondId) return { ...row, rank: 3 };
+              const matchesFirst = row.id === firstId;
+              if (matchesFirst) return { ...row, rank: 4 };
+              const matchesSecond = row.id === secondId;
+              if (matchesSecond) return { ...row, rank: 3 };
               return row;
             })
             .toSorted((left, right) => left.rank - right.rank)
@@ -486,9 +488,9 @@ describe("React AOT keyed-array sort hints", () => {
       pipeline: "current.map(updateRow).toSorted((a, b) => a.rank - b.rank)",
     },
     {
-      name: "an unproven block-bodied mapper",
+      name: "a mutable block-local alias",
       pipeline:
-        "current.map((row) => { const matches = row.id === editedId; return matches ? { ...row, rank: 0 } : row; }).toSorted((a, b) => a.rank - b.rank)",
+        "current.map((row) => { let matches = row.id === editedId; return matches ? { ...row, rank: 0 } : row; }).toSorted((a, b) => a.rank - b.rank)",
     },
     {
       name: "an unsupported second mapper",

--- a/packages/farm-react/src/__tests__/compiler-keyed-update-hints.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-keyed-update-hints.test.ts
@@ -190,6 +190,52 @@ describe("React AOT keyed update hints", () => {
     });
   });
 
+  it("records safe local const aliases inside structured map callbacks", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Inventory({ firstId, secondId, delta }) {
+        const [items, setItems] = useState([
+          { id: "a", label: "Alpha", amount: 1, selected: false },
+          { id: "b", label: "Beta", amount: 2, selected: false },
+        ]);
+        return (
+          <section>
+            <button onClick={() => setItems((current) => current
+              .map((row) => {
+                const matchesFirst = row.id === firstId,
+                  nextAmount = Math.round(row.amount + delta);
+                if (matchesFirst) return { ...row, amount: nextAmount };
+                const matchesSecond = row.id === secondId;
+                if (matchesSecond) return { ...row, label: String(nextAmount) };
+                return row;
+              })
+              .map((row) => {
+                const matches = row.id === firstId;
+                return matches ? { ...row, selected: true } : row;
+              })
+            )}>Update aliased rows</button>
+            <ul>{items.map((item) => <li key={item.id}>{item.label}</li>)}</ul>
+          </section>
+        );
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Inventory"]);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.optimizations.keyedMapUpdateHints).toBe(2);
+    expect(result.code.match(/createCompilerKeyedMapUpdate\(/g)).toHaveLength(1);
+    expect(result.code.match(/_farmApplyMap\d*\(/g)).toHaveLength(2);
+    expect(result.code).toContain("keyedRowsHintedRuntimeFeature");
+    await expect(
+      transformWithEsbuild(result.code, "/app/KeyedUpdateHints.tsx", {
+        loader: "tsx",
+        jsx: "automatic",
+      }),
+    ).resolves.toMatchObject({
+      code: expect.stringContaining("createCompilerKeyedMapUpdate"),
+    });
+  });
+
   it("supports direct-state public List rows without adding a public option", async () => {
     const result = await compile(`
       import { useState } from "react";
@@ -223,11 +269,32 @@ describe("React AOT keyed update hints", () => {
         'setItems((current) => current.map((row) => row.id === "a" ? { ...row, label: "Updated" } : row))',
     },
     {
-      name: "a block-bodied mapper with an intermediate declaration",
+      name: "a mutable local declaration",
       declaration: "",
       collection: "items",
       update:
-        'setItems((current) => current.map((row) => { const matches = row.id === "a"; return matches ? { ...row, label: "Updated" } : row; }))',
+        'setItems((current) => current.map((row) => { let matches = row.id === "a"; return matches ? { ...row, label: "Updated" } : row; }))',
+    },
+    {
+      name: "a destructured local declaration",
+      declaration: "",
+      collection: "items",
+      update:
+        'setItems((current) => current.map((row) => { const { id } = row; return id === "a" ? { ...row, label: "Updated" } : row; }))',
+    },
+    {
+      name: "an effectful local initializer",
+      declaration: 'const matches = (row) => row.id === "a";',
+      collection: "items",
+      update:
+        'setItems((current) => current.map((row) => { const selected = matches(row); return selected ? { ...row, label: "Updated" } : row; }))',
+    },
+    {
+      name: "an object-valued local initializer",
+      declaration: "",
+      collection: "items",
+      update:
+        'setItems((current) => current.map((row) => { const metadata = { id: row.id }; return metadata.id === "a" ? { ...row, label: "Updated" } : row; }))',
     },
     {
       name: "an effectful block condition",

--- a/packages/farm-react/src/compiler.ts
+++ b/packages/farm-react/src/compiler.ts
@@ -1274,6 +1274,26 @@ function proveSafeKeyedMapStatement(
     : proveSafeKeyedMapStatements([statement], item, safeGlobals);
 }
 
+function isSafeKeyedMapConstDeclaration(
+  statement: t.VariableDeclaration,
+  item: t.Identifier,
+  safeGlobals: ReadonlySet<string>,
+): boolean {
+  return (
+    statement.kind === "const" &&
+    statement.declarations.length > 0 &&
+    statement.declarations.every(
+      (declaration) =>
+        t.isIdentifier(declaration.id) &&
+        declaration.id.name !== item.name &&
+        !safeGlobals.has(declaration.id.name) &&
+        declaration.init != null &&
+        t.isExpression(declaration.init) &&
+        !validateDerivedExpression(declaration.init, safeGlobals),
+    )
+  );
+}
+
 function proveSafeKeyedMapStatements(
   statements: readonly t.Statement[],
   item: t.Identifier,
@@ -1286,6 +1306,11 @@ function proveSafeKeyedMapStatements(
       return undefined;
     }
     return proveSafeKeyedMapExpression(statement.argument, item, safeGlobals);
+  }
+  if (t.isVariableDeclaration(statement)) {
+    return isSafeKeyedMapConstDeclaration(statement, item, safeGlobals)
+      ? proveSafeKeyedMapStatements(remaining, item, safeGlobals)
+      : undefined;
   }
   if (!t.isIfStatement(statement) || validateDerivedExpression(statement.test, safeGlobals)) {
     return undefined;


### PR DESCRIPTION
## Problem

Farm now compiles structured keyed `map()` callbacks made from safe `if`/`return` paths, but a common readability refactor still disables the hint:

```tsx
current.map((row) => {
  const matches = row.id === editedId;
  if (matches) return { ...row, label: nextLabel };
  return row;
});
```

The local alias does not change the update semantics, yet the callback falls back to complete keyed reconciliation.

## Root cause

The statement proof accepted only `if`, nested blocks, and `return`. It treated every variable declaration as unsupported and could not distinguish an immutable alias with a proven initializer from mutable, destructured, effectful, or object-producing local work.

## Change

- accept one or more local `const` declarations inside the existing structured keyed-map proof
- require every declarator to use a simple identifier, avoid shadowing the row item or a compiler-safe global, include an initializer, and pass the existing safe-expression validator
- preserve the same proof for chained same-order maps, map/reorder pipelines, and mapped rolling-window lineage
- exercise local aliases in the maintained 10,000-row production browser workload
- document supported aliases and exact fallback boundaries in the renderer docs, package README, example guide, and benchmark record
- add positive and negative compiler coverage for multiple declarations/declarators, safe `Math` and primitive conversion calls, mutable and destructured declarations, effectful and object-valued initializers, map+sort, and rolling-window chains

## Safety and compatibility

This changes compiler eligibility only. It adds no public API, option, runtime helper, report field, or runtime-size baseline. Every native callback and initializer still executes in source order, and native property access, returned values, and thrown errors are preserved.

`let`/`var`, destructuring, missing or non-expression initializers, object/array/function literals, unknown calls, assignment, mutation, safe-global or item shadowing, other statements, fallthrough, and unproven returns retain the existing complete React reconciliation path. An unsupported mapper still disables the complete chained hint. Existing atomic runtime validation continues to fall back before DOM writes for changed or duplicate keys, structural changes, sparse or subclassed arrays, ambiguous ownership, or any failed proof.

React 18.3.1 and React 19.2.8 compatibility suites pass. Optional compiler runtime size is unchanged.

## Verification

- `pnpm --dir packages/farm-react exec vitest run src/__tests__/compiler-keyed-update-hints.test.ts src/__tests__/compiler-keyed-array-rolling-window-hints.test.ts src/__tests__/compiler-keyed-array-sort-hints.test.ts --maxWorkers=1` — 83 passed
- complete React suite with one worker — 75 files passed; 840 passed, 14 skipped
- stress suite with one worker — 8 files passed; 23 passed, 132 skipped
- `pnpm --filter @farm.js/react type-check` — passed
- `pnpm --filter @farm.js/react test:runtime-size` — passed with every existing byte baseline unchanged
- `pnpm --filter @farm.js/react test:compat` — React 18.3.1 and React 19.2.8 passed
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @farm.js/core build` — passed
- `pnpm --dir examples/react-compiler-dashboard type-check` — passed
- `pnpm docs:check-navigation` — passed (83 visible pages, 12 plugins)
- `pnpm --dir docs exec farm generate --check` — passed
- `pnpm docs:build` — passed through client, SSR, and Nitro/Vercel output
- focused `oxfmt`, `oxlint`, and `git diff --check` — passed
- complete production browser benchmark with Chrome 153.0.8010.36 on Apple M1 macOS arm64 — overall result `PASS`; correctness, performance, optimization persistence, scalability, and every unchanged gate passed

| Mode | Local-alias mapped chain | Compiled fallback | vs React | vs fallback |
| --- | ---: | ---: | ---: | ---: |
| Static | 4.40 ms | 15.40 ms | 15.90x | 3.50x |
| Hybrid | 5.00 ms | 16.20 ms | 13.99x | 3.24x |

The target retained the unchanged 2x-vs-React and 1.25x-vs-control floors. The bracketed React median was 69.95 ms. Reports remained at two mapped rolling-chain steps and 34 keyed-map hints. The example bundle measured 31,682 bytes gzip in static mode and 31,681 bytes gzip in hybrid mode.

## Documentation and release

Updated the React renderer docs, package README, compiler dashboard README, maintained workload, and benchmark results. No template, generated artifact, package version, or release-flow change.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allows structured keyed `map()` callbacks to keep the compiler's fast path when they introduce immutable local `const` aliases. Previously a declaration like `const matches = row.id === editedId;` disabled the keyed-update hint and forced full React keyed reconciliation; now the compiler proves such aliases and still emits the hint, preserving the same chained-map, sort, and rolling-window lineage.

**Behavior**

- A declaration is accepted when it is `const` with at least one declarator, every declarator is a simple identifier with an initializer that passes the safe-expression proof, and no binding shadows the row item or a compiler-safe global.
- `let`/`var`, destructuring, effectful or object/array/function-valued initializers, and any other statement still disable the hint for the entire chain and retain complete reconciliation.
- The change is compiler eligibility only; it adds no public API, option, runtime helper, report field, or runtime-size baseline, and native callback execution order is preserved.

<sup>Written for commit 3ea106d7793e7873fde804daf58eca6fadb9b2c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/944?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

