### PR TITLE
fix(server): release disconnected responses without awaiting cleanup

### DIFF
--- a/docs/src/app/docs/api-routes/page.md
+++ b/docs/src/app/docs/api-routes/page.md
@@ -196,6 +196,8 @@ downloads or protocols that are not JSON event streams.
 When Farm bridges a streamed `Response` to Node, a failed response write also cancels the
 upstream body. Put producer cleanup in the stream's `cancel()` callback. Farm preserves the
 original write error and does not wait indefinitely for that cleanup to finish.
+Disconnects follow the same rule, including when the connection closes under backpressure:
+Farm releases its reader and response listeners without waiting for app-owned cancellation work.
 
 ## Endpoint middleware
 

--- a/packages/farm/src/__tests__/response-disconnect-cleanup.test.ts
+++ b/packages/farm/src/__tests__/response-disconnect-cleanup.test.ts
@@ -1,0 +1,81 @@
+// @vitest-environment node
+import { EventEmitter } from "node:events";
+import type { ServerResponse } from "node:http";
+import { setImmediate } from "node:timers/promises";
+import { expect, it, vi } from "vitest";
+import { sendWebResponse } from "../server/response";
+
+it.each(["destroyed", "close", "error"])(
+  "releases the response without awaiting producer cleanup on %s",
+  async (mode) => {
+    let finishCancel!: () => void;
+    let cancelStarted!: () => void;
+    const cancelling = new Promise<void>((resolve) => {
+      cancelStarted = resolve;
+    });
+    const cancelGate = new Promise<void>((resolve) => {
+      finishCancel = resolve;
+    });
+    const cancel = vi.fn(() => {
+      cancelStarted();
+      return cancelGate;
+    });
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array([1]));
+      },
+      cancel,
+    });
+    const response = Object.assign(new EventEmitter(), {
+      destroyed: mode === "destroyed",
+      writableEnded: false,
+      setHeader: vi.fn(),
+      getHeader: vi.fn(),
+      end: vi.fn(),
+      write: vi.fn(() => false),
+    });
+    let settled = false;
+    const sending = sendWebResponse(
+      response as unknown as ServerResponse,
+      new Response(stream),
+    ).then(() => {
+      settled = true;
+    });
+    try {
+      if (mode !== "destroyed") {
+        await vi.waitFor(() => expect(response.listenerCount("drain")).toBe(1));
+        response.emit(mode);
+      }
+      await cancelling;
+      await setImmediate();
+      expect(settled).toBe(true);
+      expect(stream.locked).toBe(false);
+      expect(cancel).toHaveBeenCalledTimes(1);
+      expect(response.eventNames()).toEqual([]);
+      expect(response.end).not.toHaveBeenCalled();
+    } finally {
+      finishCancel();
+      await sending;
+    }
+  },
+);
+
+it("handles rejecting producer cleanup without an unhandled rejection", async () => {
+  const stream = new ReadableStream({
+    cancel() {
+      return Promise.reject(new Error("cleanup failed"));
+    },
+  });
+  const response = Object.assign(new EventEmitter(), {
+    destroyed: true,
+    writableEnded: false,
+    setHeader: vi.fn(),
+    getHeader: vi.fn(),
+    write: vi.fn(),
+    end: vi.fn(),
+  });
+  await sendWebResponse(response as unknown as ServerResponse, new Response(stream));
+  await setImmediate();
+  expect(stream.locked).toBe(false);
+  expect(response.eventNames()).toEqual([]);
+});

--- a/packages/farm/src/server/response.ts
+++ b/packages/farm/src/server/response.ts
@@ -171,7 +171,7 @@ export async function sendWebResponse(res: ServerResponse, response: Response): 
       if (res.destroyed) {
         // The client disconnected mid-response; drop the rest of the body so
         // the handler can return.
-        await reader.cancel().catch(() => {});
+        void reader.cancel().catch(() => {});
         return;
       }
 
@@ -198,7 +198,7 @@ export async function sendWebResponse(res: ServerResponse, response: Response): 
 
       if (!res.write(value)) {
         if (!(await waitForWritable(res))) {
-          await reader.cancel().catch(() => {});
+          void reader.cancel().catch(() => {});
           return;
         }
       }


### PR DESCRIPTION
## Problem

A disconnected client can leave `sendWebResponse()` pending forever if the response stream's `cancel()` callback never settles. This affects already-destroyed responses and disconnects while waiting for backpressure to clear.

## Root cause

Those two paths awaited producer-owned cleanup, unlike the existing disconnect-during-read and write-failure paths. A cancellation request does not guarantee that the producer's cleanup promise will settle.

## Change

Start cancellation without awaiting it, handle cleanup rejections, and let the existing `finally` release the reader and event listeners.

## Safety and compatibility

Cancellation still runs once. Disconnected responses are not ended or written again. Ordinary streaming, backpressure, and write-error propagation stay unchanged. This is a renderer-neutral change to the shared Node response bridge with no public API changes.

## Verification

macOS, Node 23.11.0, pnpm 8.12.1:

- `pnpm --filter @farm.js/core test response-disconnect-cleanup.test.ts send-web-response.test.ts response-write-failure.test.ts`: 11 tests passed, including the existing real Node streaming coverage.
- `pnpm --filter @farm.js/core type-check`: passed.
- Focused `oxfmt --check`, `oxlint`, and `git diff --check`: passed.
- Before the fix, the three new destroyed/close/error cases remained pending behind a controlled cancellation promise. After the fix, they settle before that promise resolves, unlock the reader, and remove listeners. Rejecting cleanup is also covered.

Linux and Windows coverage is left to CI; no new platform-specific behavior is introduced.

## Documentation and release

Updated API route streaming documentation. No configuration, example, template, generated artifact, or version changes.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `sendWebResponse()` hanging forever when a client disconnects and the response stream's `cancel()` never settles. The two paths that awaited producer cleanup now start cancellation without awaiting it, so the reader and event listeners are released promptly, cancellation still runs exactly once, and write-error propagation stays unchanged.

- Adds tests covering destroyed, close, error, and rejecting cleanup cases.
- Updates API route streaming documentation to describe disconnect handling.

<sup>Written for commit 3b96e369e6e461346d2bfcb65c0cea48f08319b1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/945?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

