### PR TITLE
fix(server): return 413 without waiting for cloned upload cleanup

### DIFF
--- a/docs/src/app/docs/configuration/page.md
+++ b/docs/src/app/docs/configuration/page.md
@@ -601,6 +601,8 @@ Do not use `allowedOrigins` as a replacement for CORS or as a public API allowli
 
 `bodySizeLimit` accepts bytes or strings such as `"500kb"`, `"2mb"`, and `"2MiB"`. Farm checks `Content-Length` when present and also counts streamed bytes, so chunked requests cannot bypass the limit.
 
+When streamed action input exceeds the limit, Farm cancels it without awaiting producer cleanup or another branch of a cloned request. Cleanup errors do not replace the action's `413` rejection.
+
 Rejected requests use generic, non-cacheable responses: `403` for origin failures, `413` for oversized bodies, and `415` for unsupported content types. Detailed parsing or execution errors stay in server logs.
 
 ## Next-style route exports

--- a/docs/src/app/docs/configuration/page.md
+++ b/docs/src/app/docs/configuration/page.md
@@ -544,6 +544,8 @@ export default defineConfig({
 
 Farm checks `Content-Length` when present and also counts the received bytes, so chunked requests cannot bypass `bodySizeLimit`. Oversized requests receive `413 Payload Too Large` before the route or integration handler runs. Server Actions keep their separate, tighter `serverActions.bodySizeLimit` setting.
 
+Body rejection initiates stream cancellation without waiting for producer cleanup. This also applies to cloned requests: an unread original body cannot delay the rejection, and a cleanup failure does not replace the `413` response.
+
 The RSC development bridge applies these limits too. `POST`, `PUT`, `PATCH`, `DELETE`, and `QUERY`
 bodies keep their original bytes, including multipart uploads and binary data. `GET` and `HEAD`
 remain bodyless. Action origin validation runs before buffering an action body.

--- a/packages/farm/src/__tests__/request-body-cancellation.test.ts
+++ b/packages/farm/src/__tests__/request-body-cancellation.test.ts
@@ -1,0 +1,79 @@
+// @vitest-environment node
+import { setImmediate } from "node:timers/promises";
+import { expect, it, vi } from "vitest";
+import { invokeAPIRouteEndpoint } from "../api/runtime";
+import { bufferFarmRequestBody } from "../server-http";
+
+it.each([
+  { length: "3", status: 413 },
+  { length: undefined, status: 413 },
+  { length: "invalid", status: 400 },
+])(
+  "rejects a cloned body without waiting for its original branch ($length)",
+  async ({ length, status }) => {
+    const request = new Request("http://farm.test/api/upload", {
+      method: "POST",
+      body: new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new Uint8Array([1, 2, 3]));
+        },
+      }),
+      duplex: "half",
+      headers: length === undefined ? {} : { "content-length": length },
+    } as RequestInit);
+    const clone = request.clone();
+    const cancel = vi.spyOn(ReadableStream.prototype, "cancel");
+    const cancelReader = vi.spyOn(ReadableStreamDefaultReader.prototype, "cancel");
+    const endpoint = vi.fn(() => new Response("should not run"));
+    let response: Response | undefined;
+    const handling = invokeAPIRouteEndpoint(endpoint, clone, {}, 2).then((value) => {
+      response = value;
+    });
+    try {
+      await vi.waitFor(() =>
+        expect(length === undefined ? cancelReader : cancel).toHaveBeenCalled(),
+      );
+      await setImmediate();
+      expect(response?.status).toBe(status);
+      expect(endpoint).not.toHaveBeenCalled();
+      expect(clone.body!.locked).toBe(false);
+    } finally {
+      cancel.mockRestore();
+      cancelReader.mockRestore();
+      // Resolve the other native tee branch even when the regression assertion fails.
+      await request.body!.cancel();
+      await handling;
+    }
+  },
+);
+
+it.each(["declared", "counted"])(
+  "preserves the body-limit error when %s cancellation rejects",
+  async (mode) => {
+    const request = new Request("http://farm.test/api/upload", {
+      method: "POST",
+      body: new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new Uint8Array([1, 2, 3]));
+        },
+        cancel() {
+          return Promise.reject(new Error("producer cleanup failed"));
+        },
+      }),
+      duplex: "half",
+      headers: mode === "declared" ? { "content-length": "3" } : {},
+    } as RequestInit);
+    const endpoint = vi.fn(() => new Response("should not run"));
+    const response = await invokeAPIRouteEndpoint(endpoint, request, {}, 2);
+    expect(response.status).toBe(413);
+    expect(endpoint).not.toHaveBeenCalled();
+    await setImmediate();
+  },
+);
+
+it("still buffers an accepted clone and leaves the original readable", async () => {
+  const request = new Request("http://farm.test/api/upload", { method: "POST", body: "ok" });
+  const buffered = await bufferFarmRequestBody(request.clone(), 2);
+  expect(await buffered.text()).toBe("ok");
+  expect(await request.text()).toBe("ok");
+});

--- a/packages/farm/src/__tests__/server-action-body-cancellation.test.ts
+++ b/packages/farm/src/__tests__/server-action-body-cancellation.test.ts
@@ -1,0 +1,66 @@
+// @vitest-environment node
+import { setImmediate } from "node:timers/promises";
+import { expect, it, vi } from "vitest";
+import { prepareServerActionRequest } from "../server-action-security";
+
+function actionRequest(body: ReadableStream<Uint8Array>) {
+  return new Request("https://farm.test/action", {
+    method: "POST",
+    headers: { origin: "https://farm.test", "content-type": "text/plain" },
+    body,
+    duplex: "half",
+  } as RequestInit);
+}
+
+it("rejects a streamed oversized action without waiting for the original tee branch", async () => {
+  const request = actionRequest(
+    new ReadableStream({
+      start(controller) {
+        controller.enqueue(new Uint8Array([1, 2, 3]));
+      },
+    }),
+  );
+  const clone = request.clone();
+  const cancel = vi.spyOn(ReadableStreamDefaultReader.prototype, "cancel");
+  let failure: unknown;
+  const reading = prepareServerActionRequest(
+    clone,
+    { allowedOrigins: [], bodySizeLimit: 2 },
+    "javascript",
+    "action-id",
+  ).catch((error) => {
+    failure = error;
+  });
+  try {
+    await vi.waitFor(() => expect(cancel).toHaveBeenCalled());
+    await setImmediate();
+    expect(failure).toMatchObject({ code: "BODY_TOO_LARGE", status: 413 });
+    expect(clone.body!.locked).toBe(false);
+  } finally {
+    cancel.mockRestore();
+    await request.body!.cancel();
+    await reading;
+  }
+});
+
+it("keeps the action size error when producer cancellation rejects", async () => {
+  const request = actionRequest(
+    new ReadableStream({
+      start(controller) {
+        controller.enqueue(new Uint8Array([1, 2, 3]));
+      },
+      cancel() {
+        return Promise.reject(new Error("cleanup failed"));
+      },
+    }),
+  );
+  await expect(
+    prepareServerActionRequest(
+      request,
+      { allowedOrigins: [], bodySizeLimit: 2 },
+      "javascript",
+      "action-id",
+    ),
+  ).rejects.toMatchObject({ code: "BODY_TOO_LARGE", status: 413 });
+  await setImmediate();
+});

--- a/packages/farm/src/server-action-security.ts
+++ b/packages/farm/src/server-action-security.ts
@@ -451,12 +451,15 @@ async function readBodyWithLimit(request: Request, limit: number): Promise<Uint8
 
       total += value.byteLength;
       if (total > limit) {
-        await reader.cancel("Server action body is too large");
-        throw new ServerActionRequestError(
+        const error = new ServerActionRequestError(
           "BODY_TOO_LARGE",
           413,
           "Server action body is too large",
         );
+        // As with API bodies, a cloned stream may wait for its untouched tee
+        // branch. Cleanup must neither delay rejection nor replace its error.
+        void reader.cancel(error).catch(() => {});
+        throw error;
       }
       chunks.push(value);
     }

--- a/packages/farm/src/server-http.ts
+++ b/packages/farm/src/server-http.ts
@@ -290,7 +290,9 @@ export async function readFarmRequestBody(request: Request, limit: number): Prom
   try {
     validateContentLength(request.headers.get("content-length"), limit);
   } catch (error) {
-    await request.body?.cancel(error).catch(() => {});
+    // A cloned Request is a tee branch: its cancellation may wait for the
+    // untouched branch. Rejection must not wait for producer-owned cleanup.
+    void request.body?.cancel(error).catch(() => {});
     throw error;
   }
   throwIfAborted(request.signal);
@@ -313,8 +315,9 @@ export async function readFarmRequestBody(request: Request, limit: number): Prom
 
       total += value.byteLength;
       if (total > limit) {
-        await reader.cancel("Request body is too large");
-        throw new FarmRequestBodyError("BODY_TOO_LARGE", 413, "Request body is too large");
+        const error = new FarmRequestBodyError("BODY_TOO_LARGE", 413, "Request body is too large");
+        void reader.cancel(error).catch(() => {});
+        throw error;
       }
       chunks.push(value);
     }

--- a/packages/farmjs-plugin/src/rsc/core-external.test.ts
+++ b/packages/farmjs-plugin/src/rsc/core-external.test.ts
@@ -12,6 +12,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { createServer } from "node:net";
+import { request as httpRequest } from "node:http";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -555,6 +556,45 @@ export const echo = createEndpoint("/api/echo", { method: "POST" }, async ({ bod
         });
 
         const origin = `http://127.0.0.1:${port}`;
+        if (name === "default") {
+          for (const uploadCase of [
+            {
+              path: "/api/echo",
+              headers: { "content-length": "10000001", "content-type": "application/octet-stream" },
+              body: Buffer.from("abc"),
+            },
+            {
+              path: "/",
+              headers: { "x-farm-action-id": "unresolved-action", "content-type": "text/plain" },
+              body: Buffer.alloc(1_000_001, 120),
+            },
+          ]) {
+            const uploadResult = await new Promise<{ status: number; outcome: string }>(
+              (resolve) => {
+                const upload = httpRequest(
+                  origin + uploadCase.path,
+                  { method: "POST", headers: { ...uploadCase.headers, origin } },
+                  (response) => {
+                    response.resume();
+                    resolve({ status: response.statusCode || 0, outcome: "response" });
+                    upload.destroy();
+                  },
+                );
+                upload.on("error", (error) => resolve({ status: 0, outcome: error.message }));
+                upload.setTimeout(10_000, () => {
+                  resolve({ status: 0, outcome: "timed out without response" });
+                  upload.destroy();
+                });
+                upload.write(uploadCase.body);
+                // Leave the upload open: either the declared or streamed limit is exceeded.
+              },
+            );
+            expect(
+              uploadResult,
+              `Oversized upload to ${uploadCase.path} should receive 413 before the client finishes sending`,
+            ).toEqual({ status: 413, outcome: "response" });
+          }
+        }
         if (name === "default" || name === "custom") {
           for (const route of ["broken", "layout-failure", "sync-failure", "middleware-failure"]) {
             const error = await fetch(origin + "/" + route + "?tag=a&tag=b", {


### PR DESCRIPTION
## Problem

An oversized upload can hang instead of returning `413` when Farm reads a cloned request while the original body remains unread. The same mechanism affects streamed Server Action input.

## Root cause

Both body readers awaited stream cancellation before rejecting. Cancelling one branch of `Request.clone()` can remain pending until the other tee branch finishes. A rejecting producer cleanup could also replace the intended size error.

## Change

Initiate cancellation without awaiting it and preserve the original validation error. Apply this to declared-length and streamed API body rejection, and to the separate Server Action streamed limit check.

## Safety and compatibility

Existing API and Server Action limits, error types, origin checks, and successful body reads stay unchanged. Accepted clones leave the original body readable. Cleanup still starts, and its rejections are handled. This changes the shared readers used across runtimes, not the public configuration or renderer contract.

## Verification

macOS, Node 23.11.0, pnpm 8.12.1:

- `pnpm --filter @farm.js/core test server-http.test.ts request-body-cancellation.test.ts server-action-body-cancellation.test.ts server-action-security.test.ts`: 40 passed.
- `pnpm --filter @farm.js/plugin test core-external.test.ts`: 12 passed. The fixture builds isolated Nitro Node output and boots it without workspace dependencies. New raw HTTP tests leave API and action uploads open and require `413` before the client finishes sending.
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @farm.js/core build`: passed, including declarations.
- `pnpm --filter @farm.js/core type-check`: passed.
- Focused `oxfmt --check`, `oxlint`, and `git diff --check`: passed.
- Before the fix, four API body regression cases and both action body cases failed. They now pass, alongside the successful-body controls and cancellation-rejection coverage.

Linux and Windows runs remain for CI.

## Documentation and release

Clarified cancellation behavior for API and action body limits in configuration docs. No example, template, generated artifact, or version changes.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes oversized uploads hanging instead of returning `413` when Farm reads a cloned request while the original body remains unread. The same fix applies to streamed Server Action input.

**Bug Fixes**

- Starts body-stream cancellation without awaiting producer cleanup.
- Preserves the intended `413` error when cleanup rejects.
- Existing limits, error types, origin checks, and successful body reads are unchanged; accepted clones keep the original body readable.
- Adds regression tests for cloned requests, cancellation rejection, and raw uploads that stay open past the limit.
- Updates configuration docs to describe the non-blocking cancellation behavior.

<sup>Written for commit 33c15e154b0e6b295fed147755b57442406cedc2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/946?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

