### PR TITLE
fix(rsc): match pages with shared route precedence and catch-all rules

### DIFF
--- a/docs/src/app/docs/routing/page.md
+++ b/docs/src/app/docs/routing/page.md
@@ -173,6 +173,8 @@ const href = router.build("/docs/[[...slug]]", {
 
 This returns `/docs/core/routing`. Optional catch-all params can be omitted, static routes win over dynamic routes, and route groups such as `(marketing)` do not appear in the URL.
 
+These matching rules also apply with experimental React Server Components enabled. Farm prepares page precedence when the route entry initializes, so filesystem discovery order cannot make `/users/[id]` hide `/users/new`. Optional catch-all pages match both their parent URL and deeper paths.
+
 Route matching decodes each URL path segment once before comparing static names or exposing
 `params`. Route names remain literal (including `%`), and malformed percent escapes remain literal
 instead of aborting the request.

--- a/packages/farm/src/nitro/production-runtime.ts
+++ b/packages/farm/src/nitro/production-runtime.ts
@@ -58,6 +58,8 @@ export {
   reportFarmPreloadWarnings,
 } from "../preload";
 export { searchParamsToObject } from "../search-params";
+export { parseRoutePath, matchRoute as matchFarmPageRoute } from "../utils";
+export { compareRouteSpecificity, getRoutePatternSpecificity } from "../routing/specificity";
 export { createFarmLegacyRequest } from "./legacy-request";
 export {
   renderFarmLegacyErrorHtml,

--- a/packages/farmjs-plugin/src/rsc/core-external.test.ts
+++ b/packages/farmjs-plugin/src/rsc/core-external.test.ts
@@ -305,6 +305,22 @@ export const schema = z.string();`;
           );
           if (name === "default") {
             writeRoute(
+              "users/[id]/page.tsx",
+              `export default function Page({ params }) { return <main>Dynamic user {params.id}</main>; }`,
+            );
+            writeRoute(
+              "users/new/page.tsx",
+              `export default function Page() { return <main>Static new user</main>; }`,
+            );
+            writeRoute(
+              "optional/[[...slug]]/page.tsx",
+              `export default function Page({ params }) { return <main>Optional catch-all {JSON.stringify(params)}</main>; }`,
+            );
+            writeRoute(
+              "(marketing)/pricing/page.tsx",
+              `export default function Page() { return <p>Grouped pricing</p>; }`,
+            );
+            writeRoute(
               "error.tsx",
               `"use client"; export default function ErrorPage({ error, reset, path, searchParams }) {
               return <main>Route error rendered <p>{error.message}</p><p>{path}</p><p>{JSON.stringify(searchParams)}</p><button onClick={reset}>Reset</button></main>;
@@ -656,6 +672,24 @@ export const echo = createEndpoint("/api/echo", { method: "POST" }, async ({ bod
         const aliasedResponse = await fetch(`${origin}${mount}/root-runtime`);
         expect(aliasedResponse.status, logs).toBe(200);
         expect((await aliasedResponse.json()).requestPath).toBe(`${mount}/root-runtime`);
+        if (name === "default") {
+          for (const [pathname, marker] of [
+            ["/users/new", "Static new user"],
+            ["/users/alice", "Dynamic user"],
+            ["/optional", "Optional catch-all"],
+            ["/optional/a/b", "Optional catch-all"],
+            ["/pricing", "Grouped pricing"],
+          ]) {
+            for (const accept of ["text/html", "text/x-component"]) {
+              const response = await fetch(origin + pathname, {
+                headers: { accept },
+                signal: AbortSignal.timeout(10_000),
+              });
+              expect(response.status, logs).toBe(200);
+              expect(await response.text(), logs).toContain(marker);
+            }
+          }
+        }
 
         if (name === "cache-variants") {
           for (const accept of ["text/html", "text/x-component"]) {

--- a/packages/farmjs-plugin/src/rsc/entries/page-routing.test.ts
+++ b/packages/farmjs-plugin/src/rsc/entries/page-routing.test.ts
@@ -1,0 +1,81 @@
+import { expect, it } from "vitest";
+import { matchRoute as matchFarmPageRoute, parseRoutePath } from "../../../../farm/src/utils";
+import {
+  compareRouteSpecificity,
+  getRoutePatternSpecificity,
+} from "../../../../farm/src/routing/specificity";
+import { generateRscEntry } from "./rsc.js";
+
+function createMatcher(paths: string[]) {
+  const entry = generateRscEntry({
+    srcDir: "src",
+    outDir: "dist",
+    basePath: "/",
+    actionsEnabled: false,
+    serverActions: { allowedOrigins: [], bodySizeLimit: 1000 },
+    deploymentId: "routing",
+    debug: false,
+  });
+  const start = entry.indexOf("function filePathToRoute(");
+  const end = entry.indexOf("function mergeDocumentMetadata(", start);
+  return new Function(
+    "pages",
+    "React",
+    "debug",
+    "parseRoutePath",
+    "matchFarmPageRoute",
+    "compareRouteSpecificity",
+    "getRoutePatternSpecificity",
+    `${entry.slice(start, end)}; return matchRoute;`,
+  )(
+    Object.fromEntries(paths.map((p) => [p, { default: () => p }])),
+    {},
+    () => {},
+    parseRoutePath,
+    matchFarmPageRoute,
+    compareRouteSpecificity,
+    getRoutePatternSpecificity,
+  );
+}
+
+it("ranks exact pages before dynamic and catch-all pages independently of file order", () => {
+  const match = createMatcher([
+    "/users/[[...rest]]/page.tsx",
+    "/users/[...slug]/page.tsx",
+    "/users/[id]/page.tsx",
+    "/users/new/page.tsx",
+    "/users/page.tsx",
+  ]);
+  expect(match("/users/new").pattern).toBe("/users/new/page.tsx");
+  expect(match("/users").pattern).toBe("/users/page.tsx");
+  expect(match("/users/alice").params).toEqual({ id: "alice" });
+  expect(match("/users/a/b").params).toEqual({ slug: "a/b" });
+});
+
+it("matches optional catch-alls at their parent and descendant paths", () => {
+  const match = createMatcher(["/docs/[[...slug]]/page.tsx"]);
+  expect(match("/docs")?.params).toEqual({ slug: "" });
+  expect(match("/docs/a/b/")?.params).toEqual({ slug: "a/b" });
+  expect(match("/elsewhere")).toBeNull();
+});
+
+it("uses shared parameter decoding, route groups, and segment specificity", () => {
+  const match = createMatcher([
+    "/[category]/settings/page.tsx",
+    "/shop/[item]/page.tsx",
+    "/(marketing)/about/page.tsx",
+    "/docs/[...slug]/page.tsx",
+  ]);
+  expect(match("/shop/settings").pattern).toBe("/shop/[item]/page.tsx");
+  expect(match("/about").pattern).toBe("/(marketing)/about/page.tsx");
+  expect(match("/docs/caf%C3%A9/a%2520b").params).toEqual({ slug: "café/a%20b" });
+  expect(match("/docs")).toBeNull();
+});
+
+it.each([
+  "/teams/[id]/users/[id]/page.tsx",
+  "/users/[__proto__]/page.tsx",
+  "/docs/[...slug]/edit/page.tsx",
+])("rejects invalid page route %s during entry initialization", (route) => {
+  expect(() => createMatcher([route])).toThrow();
+});

--- a/packages/farmjs-plugin/src/rsc/entries/rsc.ts
+++ b/packages/farmjs-plugin/src/rsc/entries/rsc.ts
@@ -64,6 +64,12 @@ import {
 import { _runWithAfterRequest } from '@farm.js/core/after';
 import { _runWithCurrentRequest, searchParamsToObject } from '@farm.js/core/internal/production-runtime';
 import { getFarmRedirectError, isFarmNotFoundError } from '@farm.js/core/internal/production-runtime';
+import {
+  parseRoutePath,
+  matchFarmPageRoute,
+  compareRouteSpecificity,
+  getRoutePatternSpecificity,
+} from '@farm.js/core/internal/production-runtime';
 
 const farmDeploymentId = ${JSON.stringify(ctx.deploymentId)};
 const farmApiBasePath = ${JSON.stringify(ctx.apiBasePath ?? "/api")};
@@ -389,16 +395,13 @@ async function executeMiddleware(request) {
 /**
  * Convert file path to route pattern
  * e.g., '/src/about/page.tsx' -> '/about'
- * e.g., '/src/blog/[slug]/page.tsx' -> '/blog/:slug'
+ * e.g., '/blog/[slug]/page.tsx' -> '/blog/[slug]'
  */
 function filePathToRoute(filePath) {
   let route = filePath
     .replace('', '')
     .replace(/\\/page\\.[tj]sx?$/, '')
     .replace(/\\/page$/, '') || '/';
-  
-  // Convert [param] to :param for matching
-  route = route.replace(/\\[([^\\]]+)\\]/g, ':$1');
   
   return route;
 }
@@ -429,52 +432,14 @@ const RouteErrorBoundary = React.Component
       return children;
     };
 
-/**
- * Match a URL pathname to a route pattern
- * Supports dynamic segments like :id and catch-all like *
- */
-function matchPath(pattern, pathname) {
-  const patternParts = pattern.split('/').filter(Boolean);
-  const pathParts = pathname.split('/').filter(Boolean);
-  
-  // Special case for root
-  if (pattern === '/' && pathname === '/') {
-    return { params: {} };
-  }
-  
-  if (patternParts.length !== pathParts.length) {
-    // Check for catch-all
-    const lastPattern = patternParts[patternParts.length - 1];
-    if (!lastPattern?.startsWith(':...')) {
-      return null;
-    }
-  }
-  
-  const params = {};
-  
-  for (let i = 0; i < patternParts.length; i++) {
-    const patternPart = patternParts[i];
-    const pathPart = pathParts[i];
-    
-    if (patternPart.startsWith(':...')) {
-      // Catch-all segment
-      const paramName = patternPart.slice(4);
-      params[paramName] = pathParts.slice(i).join('/');
-      return { params };
-    }
-    
-    if (patternPart.startsWith(':')) {
-      // Dynamic segment
-      const paramName = patternPart.slice(1);
-      params[paramName] = pathPart;
-    } else if (patternPart !== pathPart) {
-      // Static segment mismatch
-      return null;
-    }
-  }
-  
-  return { params };
-}
+// Parse and rank once per entry initialization, not on every request. Use the
+// same validation, decoding and specificity rules as Farm's ordinary router.
+const pageRoutes = Object.entries(pages).map(([filePath, module]) => ({
+  filePath,
+  module,
+  segments: parseRoutePath(filePath).segments,
+  specificity: getRoutePatternSpecificity(filePathToRoute(filePath)),
+})).sort((left, right) => compareRouteSpecificity(left.specificity, right.specificity));
 
 /**
  * Simple file-based router
@@ -483,17 +448,16 @@ function matchPath(pattern, pathname) {
 function matchRoute(pathname) {
   const normalized = pathname.replace(/\\/$/, '') || '/';
   
-  for (const filePath of Object.keys(pages)) {
-    const pattern = filePathToRoute(filePath);
-    const match = matchPath(pattern, normalized);
+  for (const { filePath, module, segments } of pageRoutes) {
+    const match = matchFarmPageRoute(normalized, segments);
     
-    if (match) {
-      debug('Matched route:', pattern, 'for path:', normalized);
+    if (match.matches) {
+      debug('Matched route:', filePath, 'for path:', normalized);
       return {
-        Page: pages[filePath].default,
+        Page: module.default,
         pattern: filePath,
         params: match.params,
-        pageMetadata: pages[filePath].metadata,
+        pageMetadata: module.metadata,
       };
     }
   }


### PR DESCRIPTION
## Problem

With experimental RSC enabled, `/users/new` can select `[id]/page.tsx`, and `[[...slug]]` pages can return `404` at both their parent and descendant paths.

## Root cause

The generated RSC entry used its own simplified matcher and iterated the page glob in file order. It rewrote dynamic brackets into colon parameters, losing the shared router's catch-all semantics and specificity rules.

## Change

Use core's existing page parser, matcher, and segment-specificity comparator through the internal production runtime entry point. Prepare and sort page routes once when the entry initializes, not on every request. Keep original file paths for layout and metadata lookup.

## Safety and compatibility

Static pages beat dynamic pages, required catch-alls beat optional ones, and exact parents retain precedence. Parameter decoding, route groups, and validation now agree with the shared router. Invalid, duplicate, reserved, or non-terminal catch-all parameters fail at entry initialization. No public configuration or API changes; other renderers retain their existing shared matcher.

## Verification

macOS, Node 23.11.0, pnpm 8.12.1:

- `pnpm --filter @farm.js/plugin test page-routing.test.ts`: 6 passed. All six regression cases failed before the fix.
- `pnpm --filter @farm.js/plugin test`: all 110 tests passed on this independent branch.
- `pnpm --filter @farm.js/core test route-manager.test.ts utils.test.ts`: 104 passed.
- `pnpm --filter @farm.js/plugin test core-external.test.ts`: 12 passed. The isolated Nitro Node fixture verifies HTML and Flight responses for static/dynamic users, optional catch-alls, and a grouped route without relying on workspace dependencies.
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @farm.js/core build`, core `type-check`, plugin `typecheck`, and plugin `build`: passed.
- Focused `oxfmt --check`, `oxlint`, and `git diff --check`: passed.

Linux and Windows coverage remains for CI. This makes no benchmark claim; parsing and sorting stay off the per-request path.

## Documentation and release

Documented RSC routing parity in the routing guide. No examples, templates, generated artifacts, or version changes.
