### PR TITLE
fix(rsc): preserve synchronous rendering when source contains async

### DIFF
--- a/docs/src/app/docs/renderers/page.md
+++ b/docs/src/app/docs/renderers/page.md
@@ -48,6 +48,8 @@ storage, integrations, observability, and deployment output.
 | React Server Components and optimized boundaries | Available experimentally | Not applicable                  | Not applicable       | Not applicable       | Not applicable       |
 | Other integration UI providers and starters      | Available                | Provider-specific compatibility | React-oriented today | React-oriented today | React-oriented today |
 
+In experimental React Server Components, synchronous page and layout components are rendered through React, including supported server hooks such as `useId()`. A string or variable containing `async` does not make a component asynchronous. Stateful hooks and effects still belong in Client Components.
+
 Preact resolves the React-shaped bindings through `preact/compat`. Solid exposes signal-backed
 getters, Vue exposes refs and computed values, and Svelte exposes readable stores. The underlying
 navigation, action, query-cache, theme, and i18n transports live in the renderer-neutral

--- a/packages/farmjs-plugin/src/rsc/core-external.test.ts
+++ b/packages/farmjs-plugin/src/rsc/core-external.test.ts
@@ -311,6 +311,30 @@ export const schema = z.string();`;
             }`,
             );
             writeRoute(
+              "hook-control/page.tsx",
+              `import { useId } from "react"; export default function Page() { const id = useId(); return <main id={id}>Hook control</main>; }`,
+            );
+            writeRoute(
+              "hook-sniff/page.tsx",
+              `import { useId } from "react"; export default function Page() { const label = "async is just text"; const id = useId(); return <main id={id}>Hook scan {label}</main>; }`,
+            );
+            writeRoute(
+              "hook-layout/layout.tsx",
+              `import { useId } from "react"; export default function Layout({ children }) { const id = useId(); const label = "async is just text"; return <section id={id}>Hook layout {label} {children}</section>; }`,
+            );
+            writeRoute(
+              "hook-layout/page.tsx",
+              `export default function Page() { return <main>Hook layout page</main>; }`,
+            );
+            writeRoute(
+              "async-layout/[id]/layout.tsx",
+              `export default async function Layout({ children }) { await Promise.resolve(); return <aside>Async layout {children}</aside>; }`,
+            );
+            writeRoute(
+              "async-layout/[id]/page.tsx",
+              `export default async function Page({ params }) { await Promise.resolve(); return <p>Async page {params.id}</p>; }`,
+            );
+            writeRoute(
               "bad-boundary/page.tsx",
               `export default async function Page() { throw new Error("private original failure"); }`,
             );
@@ -692,6 +716,24 @@ export const echo = createEndpoint("/api/echo", { method: "POST" }, async ({ bod
           body: "not an action",
         });
         expect(pagePost.status).toBe(403);
+        if (name === "default") {
+          for (const [pathname, markers] of [
+            ["/hook-control", ["Hook control"]],
+            ["/hook-sniff", ["Hook scan", "async is just text"]],
+            ["/hook-layout", ["Hook layout", "Hook layout page", "async is just text"]],
+            ["/async-layout/42", ["Async layout", "42", "Async page"]],
+          ] as const) {
+            for (const accept of ["text/html", "text/x-component"]) {
+              const response = await fetch(origin + pathname, {
+                headers: { accept },
+                signal: AbortSignal.timeout(10_000),
+              });
+              expect(response.status, logs).toBe(200);
+              const body = await response.text();
+              for (const marker of markers) expect(body, logs).toContain(marker);
+            }
+          }
+        }
 
         const missing = await fetch(`${origin}${mount}/missing-api-route`);
         expect(missing.status).toBe(404);

--- a/packages/farmjs-plugin/src/rsc/entries/component-rendering.test.ts
+++ b/packages/farmjs-plugin/src/rsc/entries/component-rendering.test.ts
@@ -1,0 +1,59 @@
+import React from "react";
+import { expect, it } from "vitest";
+import { generateRscEntry } from "./rsc.js";
+
+const entry = generateRscEntry({
+  srcDir: "src",
+  outDir: "dist",
+  basePath: "/",
+  actionsEnabled: false,
+  serverActions: { allowedOrigins: [], bodySizeLimit: 1000 },
+  deploymentId: "components",
+  debug: false,
+});
+const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor;
+
+function render(kind: "Page" | "Layout", Component: unknown) {
+  const isPage = kind === "Page";
+  const start = entry.indexOf(isPage ? "// Render page content" : "// Render layout");
+  const end = entry.indexOf(
+    isPage ? "// Route-level loading boundary" : "// Single wrapper",
+    start,
+  );
+  return new AsyncFunction(
+    kind,
+    "h",
+    "pageProps",
+    "initialPageContent",
+    `${isPage ? "" : "const pageContent = initialPageContent;"}${entry.slice(start, end)}; return ${isPage ? "pageContent" : "layoutContent"};`,
+  )(Component, React.createElement, { params: { id: "1" } }, "child");
+}
+
+it.each(["Page", "Layout"] as const)(
+  "leaves synchronous %s functions containing async text to React",
+  async (kind) => {
+    function Component() {
+      throw new Error("async is just text, not a reason to call me directly");
+    }
+    const element = await render(kind, Component);
+    expect(React.isValidElement(element)).toBe(true);
+    expect(element.type).toBe(Component);
+  },
+);
+
+it.each(["Page", "Layout"] as const)("does not inspect %s source text", async (kind) => {
+  function Component() {
+    return null;
+  }
+  Component.toString = () => {
+    throw new Error("source inspection is not rendering");
+  };
+  expect((await render(kind, Component)).type).toBe(Component);
+});
+
+it.each(["Page", "Layout"] as const)("preserves native async %s execution", async (kind) => {
+  async function Component(props: { children?: unknown; params?: { id: string } }) {
+    return kind === "Page" ? props.params!.id : props.children;
+  }
+  expect(await render(kind, Component)).toBe(kind === "Page" ? "1" : "child");
+});

--- a/packages/farmjs-plugin/src/rsc/entries/component-rendering.test.ts
+++ b/packages/farmjs-plugin/src/rsc/entries/component-rendering.test.ts
@@ -20,13 +20,24 @@ function render(kind: "Page" | "Layout", Component: unknown) {
     isPage ? "// Route-level loading boundary" : "// Single wrapper",
     start,
   );
+  expect(start).toBeGreaterThanOrEqual(0);
+  expect(end).toBeGreaterThan(start);
   return new AsyncFunction(
-    kind,
+    "Page",
+    "Layout",
+    "LayoutModules",
     "h",
     "pageProps",
     "initialPageContent",
     `${isPage ? "" : "const pageContent = initialPageContent;"}${entry.slice(start, end)}; return ${isPage ? "pageContent" : "layoutContent"};`,
-  )(Component, React.createElement, { params: { id: "1" } }, "child");
+  )(
+    Component,
+    Component,
+    [{ default: Component }],
+    React.createElement,
+    { params: { id: "1" } },
+    "child",
+  );
 }
 
 it.each(["Page", "Layout"] as const)(

--- a/packages/farmjs-plugin/src/rsc/entries/rsc.ts
+++ b/packages/farmjs-plugin/src/rsc/entries/rsc.ts
@@ -785,9 +785,11 @@ async function handleFarmRequest(request) {
   // Helper to create elements without JSX
   const h = React.createElement;
   
-  // Render page content - handle async components
+  // Render page content - only native async functions need direct awaiting.
+  // Synchronous components must retain React's hook dispatcher. Source text
+  // containing the word async does not change how a component executes.
   let pageContent;
-  if (Page.constructor.name === 'AsyncFunction' || Page.toString().includes('async')) {
+  if (Page.constructor.name === 'AsyncFunction') {
     pageContent = await Page(pageProps);
   } else {
     pageContent = h(Page, pageProps);
@@ -812,7 +814,7 @@ async function handleFarmRequest(request) {
   
   // Render layout
   let layoutContent;
-  if (Layout.constructor.name === 'AsyncFunction' || Layout.toString().includes('async')) {
+  if (Layout.constructor.name === 'AsyncFunction') {
     layoutContent = await Layout({ children: pageContent });
   } else {
     layoutContent = h(Layout, null, pageContent);


### PR DESCRIPTION
## Problem

A synchronous RSC page or layout containing the word `async` in a string can return `500` when it uses a supported server hook such as `useId()`.

## Root cause

The generated entry used `Component.toString().includes('async')` to decide whether to call a component directly. That mistakes ordinary text for function semantics and invokes synchronous hooks outside React's dispatcher.

## Change

Remove source-text guessing for both pages and layouts. Keep the existing constructor-based direct-await path for native async functions; synchronous components continue through `React.createElement`.

## Safety and compatibility

Native async pages/layouts, redirects, not-found control flow, and error boundaries retain their existing execution path. No new configuration or API. This is specific to the experimental React RSC entry; it does not modify the React compiler or other renderers. Layout-chain composition is a separate fix.

## Verification

macOS, Node 23.11.0, pnpm 8.12.1:

- `pnpm --filter @farm.js/plugin test component-rendering.test.ts core-external.test.ts`: 18 passed. Four component regression cases failed before the fix, while both native async controls already passed.
- `pnpm --filter @farm.js/plugin test`: all 110 tests passed on this independent branch.
- Unit coverage checks sync page/layout functions containing `async`, a throwing `toString` override, and native async execution.
- The isolated Nitro Node fixture tests HTML and Flight responses for real `useId()` pages/layouts containing `async`, plus ordinary hook and native async controls. It boots copied production output without workspace dependencies.
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @farm.js/core build`, plugin `typecheck`, and plugin `build`: passed.
- Focused formatting, lint, and `git diff --check`: passed.

Linux and Windows coverage remains for CI. These are server render and Flight checks, not a new browser interaction or performance benchmark.

## Documentation and release

Clarified synchronous RSC hook behavior in the renderers guide. No examples, templates, generated artifacts, or version changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes synchronous React Server Components being misclassified as async when they contain the word `async` in text, which could cause 500 errors when using server hooks like `useId()`.

- Replaces `toString().includes('async')` checks with constructor-based detection for pages and layouts.
- Synchronous components now always render through `React.createElement`, preserving React's hook dispatcher.
- Native async functions continue to be awaited directly.
- Adds unit and integration tests covering sync components with `async` text, a throwing `toString`, and native async execution.
- Updates the renderers guide to clarify sync component behavior.

<sup>Written for commit b335f1accca8e27b4e5c7eaf8b160660e92e387b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/948?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

