### PR TITLE
fix(rsc): retain parent layouts and providers on nested pages

### DIFF
--- a/docs/src/app/docs/layouts/page.md
+++ b/docs/src/app/docs/layouts/page.md
@@ -34,6 +34,8 @@ export default function RootLayout({ children }: LayoutProps) {
 
 A layout file wraps every page below its folder. Use this for dashboards, docs, account settings, or any area with shared navigation and chrome.
 
+With experimental React Server Components enabled, layouts compose in the same order: the root layout wraps the nested layout, which wraps the page. Adding a dashboard layout does not remove the root navigation or its Client Component providers. Layouts receive `children` and the matched `params`, following `LayoutProps`; server-only layouts do not require client hydration just because they wrap interactive children.
+
 **src/app/dashboard/layout.tsx**
 
 ```tsx

--- a/packages/farmjs-plugin/src/rsc/core-external.test.ts
+++ b/packages/farmjs-plugin/src/rsc/core-external.test.ts
@@ -239,6 +239,7 @@ export const schema = z.string();`;
   it.each([
     { name: "default", api: undefined, baseURL: "/api", mount: "/api" },
     { name: "cache-variants", api: undefined, baseURL: "/api", mount: "/api" },
+    { name: "nested-layouts", api: undefined, baseURL: "/api", mount: "/api" },
     {
       name: "custom",
       api: {
@@ -370,6 +371,45 @@ export const schema = z.string();`;
           );
         }
         const fixtureModules = path.join(fixtureRoot, "node_modules");
+        if (name === "nested-layouts") {
+          const writeRoute = (file: string, source: string) => {
+            const target = path.join(srcDir, file);
+            mkdirSync(path.dirname(target), { recursive: true });
+            writeFileSync(target, source);
+          };
+          writeRoute(
+            "nested/layout.tsx",
+            `import { useId } from "react"; export default function Layout({ children }) { const id = useId(); return <section id={id}>Nested layout {children}</section>; }`,
+          );
+          writeRoute(
+            "nested/page.tsx",
+            `export default function Page() { return <main>Nested page</main>; }`,
+          );
+          writeRoute(
+            "components/provider.tsx",
+            `"use client";
+            import { createContext, useContext } from "react";
+            const Context = createContext("missing provider");
+            export function Provider({ children }) { return <Context.Provider value="root provider present">{children}</Context.Provider>; }
+            export function Consumer() { return <p>{useContext(Context)}</p>; }
+          `,
+          );
+          writeRoute(
+            "nested/client/page.tsx",
+            `"use client";
+            import { useState } from "react"; import { Consumer } from "../../components/provider";
+            export default function Page() { const [count, setCount] = useState(0); return <main>Client page<Consumer /><button onClick={() => setCount(count + 1)}>Count {count}</button></main>; }
+          `,
+          );
+          writeRoute(
+            "async-layout/[id]/layout.tsx",
+            `export default async function Layout({ children, params }) { await Promise.resolve(); return <aside>Async layout {params.id} {children}</aside>; }`,
+          );
+          writeRoute(
+            "async-layout/[id]/page.tsx",
+            `export default async function Page() { await Promise.resolve(); return <p>Async page</p>; }`,
+          );
+        }
         for (const packageName of [
           "@farm.js/core",
           "@vitejs/plugin-rsc",
@@ -395,8 +435,9 @@ export const schema = z.string();`;
         }
         writeFileSync(
           path.join(srcDir, "layout.tsx"),
-          `export default function Layout({ children }) {
-  return <html><body>{children}</body></html>;
+          `${name === "nested-layouts" ? 'import { Provider } from "./components/provider";' : ""}
+export default function Layout({ children }) {
+  return ${name === "nested-layouts" ? "<section>Root layout marker <Provider>{children}</Provider></section>" : "<html><body>{children}</body></html>"};
 }`,
         );
         writeFileSync(
@@ -700,6 +741,36 @@ export const echo = createEndpoint("/api/echo", { method: "POST" }, async ({ bod
             });
             expect(await wildcard.text(), logs).toContain("RSC root runtime fixture");
             expect(wildcard.headers.get("vary")).toBe("*");
+          }
+        }
+        if (name === "nested-layouts") {
+          for (const [pathname, markers] of [
+            ["/", ["Root layout marker"]],
+            ["/nested", ["Root layout marker", "Nested layout", "Nested page"]],
+            ["/async-layout/42", ["Root layout marker", "Async layout", "42", "Async page"]],
+          ] as const) {
+            for (const accept of ["text/html", "text/x-component"]) {
+              const response = await fetch(origin + pathname, {
+                headers: { accept },
+                signal: AbortSignal.timeout(10_000),
+              });
+              expect(response.status, logs).toBe(200);
+              const body = await response.text();
+              for (const marker of markers) expect(body, logs).toContain(marker);
+            }
+          }
+          const client = await fetch(origin + "/nested/client", {
+            signal: AbortSignal.timeout(10_000),
+          });
+          expect(client.status, logs).toBe(200);
+          const body = await client.text();
+          for (const marker of [
+            "Root layout marker",
+            "Nested layout",
+            "root provider present",
+            "Client page",
+          ]) {
+            expect(body, logs).toContain(marker);
           }
         }
         // A custom API prefix is not a server-action URL, even with actions enabled.

--- a/packages/farmjs-plugin/src/rsc/entries/layout-composition.test.ts
+++ b/packages/farmjs-plugin/src/rsc/entries/layout-composition.test.ts
@@ -1,0 +1,78 @@
+import React from "react";
+import { expect, it } from "vitest";
+import { generateRscEntry } from "./rsc.js";
+
+const entry = generateRscEntry({
+  srcDir: "src",
+  outDir: "dist",
+  basePath: "/",
+  actionsEnabled: false,
+  serverActions: { allowedOrigins: [], bodySizeLimit: 1000 },
+  deploymentId: "layouts",
+  debug: false,
+});
+const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor;
+
+it("retains a layout module reused at more than one ancestor", () => {
+  const start = entry.indexOf("function getLayoutModules(pageFilePath)");
+  const end = entry.indexOf("\n}\n\n/**\n * Main request handler", start) + 2;
+  const shared = { default: () => null };
+  const getLayouts = new Function(
+    "layouts",
+    `${entry.slice(start, end)}; return getLayoutModules;`,
+  )({ "/layout.tsx": shared, "/team/layout.tsx": shared });
+  expect(getLayouts("/team/page.tsx")).toEqual([shared, shared]);
+});
+
+function compose(
+  modules: unknown[],
+  page: unknown,
+  props = {
+    params: { id: "1" },
+    searchParams: { tag: ["a", "b"] },
+    middlewareData: { role: "reader" },
+  },
+) {
+  const start = entry.indexOf("const LayoutModules = getLayoutModules(pattern);");
+  const end = entry.indexOf("const metadata =", start);
+  const renderStart = entry.indexOf("// Render layout");
+  const renderEnd = entry.indexOf("// Single wrapper", renderStart);
+  return new AsyncFunction(
+    "pattern",
+    "getLayoutModules",
+    "h",
+    "pageContent",
+    "pageProps",
+    `${entry.slice(start, end)}\n${entry.slice(renderStart, renderEnd)}; return layoutContent;`,
+  )("/team/page.tsx", () => modules, React.createElement, page, props);
+}
+
+it("wraps the page with every root-to-leaf layout and passes only the layout props contract", async () => {
+  const Root = () => null;
+  const Nested = () => null;
+  const page = React.createElement("main", null, "page");
+  const result = await compose([{ default: Root }, { default: Nested }], page);
+  expect(result.type).toBe(Root);
+  expect(result.props.children.type).toBe(Nested);
+  expect(result.props.children.props.children).toBe(page);
+  expect(result.props.params).toEqual({ id: "1" });
+  expect(result.props.children.props.params).toEqual({ id: "1" });
+  expect(result.props).not.toHaveProperty("searchParams");
+  expect(result.props).not.toHaveProperty("middlewareData");
+});
+
+it("preserves the page without introducing a layout when no layout exists", async () => {
+  const page = React.createElement("main");
+  expect(await compose([], page)).toBe(page);
+});
+
+it("composes native async parent layouts around synchronous children", async () => {
+  const Nested = () => null;
+  async function Root({ children, params }: any) {
+    return React.createElement("section", { "data-id": params.id }, children);
+  }
+  const result = await compose([{ default: Root }, { default: Nested }], "page");
+  expect(result.type).toBe("section");
+  expect(result.props["data-id"]).toBe("1");
+  expect(result.props.children.type).toBe(Nested);
+});

--- a/packages/farmjs-plugin/src/rsc/entries/rsc.ts
+++ b/packages/farmjs-plugin/src/rsc/entries/rsc.ts
@@ -513,8 +513,8 @@ function mergeDocumentMetadata(...sources) {
 
 /**
  * Find every applicable layout module from root to the page directory.
- * Rendering still uses the nearest layout, while document metadata inherits
- * through the complete root -> nested layouts -> page chain.
+ * Rendering and document metadata share the complete root -> nested layouts
+ * -> page chain.
  */
 function getLayoutModules(pageFilePath) {
   const tryKeys = (...keys) => {
@@ -539,7 +539,7 @@ function getLayoutModules(pageFilePath) {
       );
       if (matchedLayout) break;
     }
-    if (matchedLayout && !matches.includes(matchedLayout)) matches.push(matchedLayout);
+    if (matchedLayout) matches.push(matchedLayout);
   }
 
   return matches;
@@ -761,8 +761,6 @@ async function handleFarmRequest(request) {
   
   const { Page, pattern, params, pageMetadata } = matched;
   const LayoutModules = getLayoutModules(pattern);
-  const LayoutModule = LayoutModules[LayoutModules.length - 1];
-  const Layout = LayoutModule?.default || (function PassThrough({ children }) { return children; });
   const metadata = mergeDocumentMetadata(
     ...LayoutModules.map((layoutModule) => layoutModule.metadata),
     pageMetadata,
@@ -812,12 +810,16 @@ async function handleFarmRequest(request) {
     });
   }
   
-  // Render layout
-  let layoutContent;
-  if (Layout.constructor.name === 'AsyncFunction') {
-    layoutContent = await Layout({ children: pageContent });
-  } else {
-    layoutContent = h(Layout, null, pageContent);
+  // Render layouts inside out so every ancestor wraps its descendants.
+  let layoutContent = pageContent;
+  for (let index = LayoutModules.length - 1; index >= 0; index--) {
+    const Layout = LayoutModules[index].default;
+    const layoutProps = { params: pageProps.params, children: layoutContent };
+    if (Layout.constructor.name === 'AsyncFunction') {
+      layoutContent = await Layout(layoutProps);
+    } else {
+      layoutContent = h(Layout, layoutProps);
+    }
   }
   
   // Single wrapper so #root has exactly one child (avoids duplicate block / "two pages" in DOM).


### PR DESCRIPTION
## Problem

Adding a nested RSC layout drops the root layout, including shared navigation and Client Component providers. A page should render inside every applicable ancestor, not only the nearest one.

## Root cause

The entry already collected the complete layout chain for metadata but selected only its final element for rendering. It also deduplicated layouts by module identity, incorrectly dropping an ancestor when two layout files reused the same module.

## Change

Compose layouts from the page outward, retaining each matched ancestor. Pass only `children` and matched `params`, following the existing `LayoutProps` contract. A page without layouts stays unwrapped, and metadata keeps its existing root-to-leaf merge order.

## Safety and compatibility

Synchronous and native async layouts remain supported. Server-only layouts do not become client components. No new configuration or public types; other renderers are unchanged. This builds on the corrected async classification from #948. It was tested as a stack, then retargeted to main after #948 merged without changing the tested head commit.

## Verification

macOS, Node 23.11.0, pnpm 8.12.1:

- `pnpm --filter @farm.js/plugin test layout-composition.test.ts`: 4 passed. Coverage includes ancestor order, layout props, no-layout passthrough, native async composition, and a reused layout module. The three original composition cases failed before the fix.
- `pnpm --filter @farm.js/plugin test core-external.test.ts`: 13 passed. A dedicated isolated Nitro Node fixture checks HTML and Flight output for root/nested layouts and a native async layout with params. A nested client page's server-rendered output also proves that the root context provider remains present.
- `pnpm --filter @farm.js/plugin test`: all 109 tests passed independently; all 115 passed after rebasing onto #948 and the merged upload/disconnect fixes.
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @farm.js/core build`, plugin `typecheck`, and plugin `build`: passed.
- Focused `oxfmt --check`, `oxlint`, and `git diff --check`: passed.

These are production SSR and Flight checks, not new browser interaction or performance benchmarks. The initial independent PR passed Linux/Windows CI. The final stacked head also passed the [complete CI workflow](https://github.com/farming-labs/farm.js/actions/runs/34718476570), including Linux, Windows, React 18/19, example builds, and framework E2E. That run used workflow_dispatch because automatic PR CI targets main only. Latest Vercel previews are rate-limited by the account's build quota, not failing code compilation.

## Documentation and release

Documented RSC ancestor composition, providers, and layout props in the layouts guide. No examples, templates, generated artifacts, or version changes.
