### PR TITLE
perf(react): compile keyed map switch branches

### DIFF
--- a/docs/src/app/docs/renderers/react/page.md
+++ b/docs/src/app/docs/renderers/react/page.md
@@ -919,11 +919,28 @@ This needs no option or component primitive. At build time, Farm recognizes a fu
 the direct `useState` collection used by a compiled keyed map or `List`. The setter may contain one
 or more consecutive `map()` calls. Every mapper must be an inline arrow whose returning paths are
 conditional: at least one path returns the original item and another returns a new object that
-spreads that item. This may be a concise expression or a structured block made only from `if` and
-`return` statements plus immutable local `const` aliases. Each alias needs a simple identifier and a
-compiler-safe initializer. The conditions and replacement values must use the same safe expression
-subset. The hint runtime is retained only in modules where at least one such call is emitted;
-direct-only and ordinary keyed builds do not import that capability.
+spreads that item. This may be a concise expression or a structured block made from fully returning
+`if` or `switch` branches plus immutable local `const` aliases. Each alias needs a simple identifier
+and a compiler-safe initializer. A `switch` needs one `default`, a complete return from every case,
+and no shared fallthrough cases or trailing statements. Its discriminant, case tests, conditions,
+and replacement values must use the same safe expression subset. The hint runtime is retained only
+in modules where at least one such call is emitted; direct-only and ordinary keyed builds do not
+import that capability.
+
+```tsx
+setItems((current) =>
+  current.map((item) => {
+    switch (item.status) {
+      case "draft":
+        return { ...item, label: draftLabel };
+      case "published":
+        return { ...item, label: publishedLabel };
+      default:
+        return item;
+    }
+  }),
+);
+```
 
 Every native `map()` still runs and is still O(n). After the complete chain succeeds, Farm compares
 the committed and final item identities once, validates the final key and position for every
@@ -1388,7 +1405,8 @@ need no separate full scan, and the final replacements still point directly to t
 source rows. The complete pipeline then needs one final keyed reconciliation rather than a growing
 chain of intermediate snapshots.
 
-One callback may select several rows with nested expressions or structured early returns:
+One callback may select several rows with nested expressions, structured early returns, or a fully
+returning `switch`:
 
 ```tsx
 setItems((current) =>
@@ -2467,7 +2485,8 @@ The package and example test suites verify more than generated code:
   focus and selection, and cover changed mapped keys, unsafe evaluated bounds, reused or discarded
   intermediate keys, custom slices, mixed queued chains, collection-dependent rows, Strict Mode
   hydration, React 18/19, and unmount cleanup; compiler tests accept recursively proven
-  multi-branch maps while rejecting effectful leaves and callbacks that replace every row;
+  `if` and fully returning `switch` maps while rejecting effectful leaves, switch fallthrough, and
+  callbacks that replace every row;
 - 2,000 deterministic randomized keyed-array removals match normal React; targeted tests require
   zero surviving descriptor and binding reads, preserve DOM identity, and cover queued filters,
   unhinted-chain fallback, collection-reading rows, StrictMode hydration, and unmount cleanup;

--- a/examples/react-compiler-dashboard/README.md
+++ b/examples/react-compiler-dashboard/README.md
@@ -151,8 +151,8 @@ least 2x faster than React and 1.25x faster than that control. Every sample veri
 DOM identity, mapped value, exact row count, fresh suffix, and zero compiled owner executions.
 
 Mapped rolling-window chains have a separate gate so the single-window result cannot hide a chain
-regression. The 10,000-row workload runs one structured block-bodied, two-branch same-key map with
-two compiler-safe local `const` aliases between two queued 50-row rolls. Its control uses
+regression. The 10,000-row workload runs one structured, fully returning `switch` map with safe
+local `const` aliases between two queued 50-row rolls. Its control uses
 unsupported block-bodied rolling setters, so it performs the same native work without retaining
 compiler lineage. Both compiler modes must remain at least 2x faster than React and 1.25x faster
 than that control, and the compiler report must contain both mapped rolling-chain steps. Every

--- a/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
+++ b/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
@@ -327,15 +327,17 @@ export function StandardTableBenchmark() {
             setRows((current) => [...current.slice(trimCount), ...firstAdditions]);
             setRows((current) =>
               current.map((row) => {
-                const matchesReviewed = row.id === reviewedId;
-                if (matchesReviewed) {
-                  return { ...row, amount: row.amount + 1, label: `${row.label} reviewed` };
+                const target = row.id;
+                switch (target) {
+                  case reviewedId:
+                    return { ...row, amount: row.amount + 1, label: `${row.label} reviewed` };
+                  case escalatedId: {
+                    const nextAmount = row.amount + 2;
+                    return { ...row, amount: nextAmount, label: `${row.label} escalated` };
+                  }
+                  default:
+                    return row;
                 }
-                const matchesEscalated = row.id === escalatedId;
-                if (matchesEscalated) {
-                  return { ...row, amount: row.amount + 2, label: `${row.label} escalated` };
-                }
-                return row;
               }),
             );
             setRows((current) => [...current.slice(trimCount), ...secondAdditions]);

--- a/packages/farm-react/README.md
+++ b/packages/farm-react/README.md
@@ -234,14 +234,16 @@ native result, callback order, and thrown errors are preserved.
 
 Each stage requires an inline synchronous conditional mapper that returns the original item on at
 least one path and an object-spread replacement on another. The callback may be a concise expression
-or a structured block containing fully returning `if`/`return` paths and proven local `const`
-aliases. Each alias needs a simple identifier and compiler-safe initializer. An unsupported mapper
-anywhere in the chain disables the complete setter hint. Custom methods still execute but record no
-metadata. Key changes, structural edits, sparse or subclassed arrays, relevant mixed dependencies,
-and failed runtime checks use the existing complete reconciliation and LIS path. Non-functional
-setters, derived collections, referenced callbacks, mutable or destructured declarations, effectful
-initializers, other intermediate statements, fallthrough, mutating mappers, and other unproven forms
-are simply not hinted. No new option is required. A compiler report counts prepared map calls as
+or a structured block containing fully returning `if` or `switch` branches and proven local `const`
+aliases. Each alias needs a simple identifier and compiler-safe initializer. A `switch` needs one
+`default`, a complete return from every case, safe discriminant and case expressions, and no shared
+fallthrough cases or trailing statements. An unsupported mapper anywhere in the chain disables the
+complete setter hint. Custom methods still execute but record no metadata. Key changes, structural
+edits, sparse or subclassed arrays, relevant mixed dependencies, and failed runtime checks use the
+existing complete reconciliation and LIS path. Non-functional setters, derived collections,
+referenced callbacks, mutable or destructured declarations, effectful initializers, other
+intermediate statements, fallthrough, mutating mappers, and other unproven forms are simply not
+hinted. No new option is required. A compiler report counts prepared map calls as
 `keyedMapUpdateHints`. The separate hint runtime capability is imported only when that count is
 nonzero, so direct-only and ordinary keyed builds do not retain it.
 
@@ -549,7 +551,8 @@ setItems((current) =>
 );
 ```
 
-One callback may select several rows through nested expressions or structured early returns:
+One callback may select several rows through nested expressions, structured early returns, or a
+fully returning `switch`:
 
 ```tsx
 setItems((current) =>
@@ -567,10 +570,11 @@ setItems((current) =>
 
 Every condition must be compiler-safe, and every leaf must return the original item or a safe
 object spread of it, with at least one unchanged and one replacement path. Concise expressions and
-blocks made from fully returning `if`/`return` paths plus local `const` aliases are accepted. Each
-alias must have a simple identifier and compiler-safe initializer. Mutable or destructured
-declarations, effectful initializers, other intermediate statements, fallthrough, and ambiguous
-leaves use complete keyed reconciliation. A runtime key change also falls back before any DOM write.
+blocks made from fully returning `if` or `switch` branches plus local `const` aliases are accepted.
+Each alias must have a simple identifier and compiler-safe initializer. A switch requires one
+`default`, complete returning cases, and no fallthrough. Mutable or destructured declarations,
+effectful initializers, other intermediate statements, fallthrough, and ambiguous leaves use
+complete keyed reconciliation. A runtime key change also falls back before any DOM write.
 
 Farm executes every native map and reorder call normally. For consecutive accepted maps, it checks
 each native call but compares only the input and final result of that map segment, avoiding a full
@@ -580,7 +584,8 @@ LIS and patches each changed row once. Unchanged rows need no second key or bind
 supported map-and-reorder setters compose against the same committed rows. Every accepted map
 requires an inline synchronous conditional mapper whose leaves return either the original item or
 an object-spread replacement, plus index-independent compiler-owned host rows. Concise expressions
-and structured blocks with proven local `const` aliases and `if`/`return` paths are supported.
+and structured blocks with proven local `const` aliases plus fully returning `if` or `switch`
+branches are supported.
 Changed keys, referenced callbacks, mutable, destructured, or effectful declarations, other
 intermediate statements or fallthrough, unconditional replacements, `thisArg`, structural calls in
 the same chain, computed or custom methods, sparse or subclassed arrays, collection-reading

--- a/packages/farm-react/src/__tests__/compiler-keyed-array-rolling-window-hints.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-keyed-array-rolling-window-hints.test.ts
@@ -220,6 +220,39 @@ describe("React AOT keyed-array rolling-window hints", () => {
     expect(result.code).toContain("createCompilerKeyedArrayMappedRollingWindow");
   });
 
+  it("retains a rolling-window chain through a safe switch-branched map callback", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Feed({ nextOne, nextTwo, firstId, secondId, nextLabel }) {
+        const [rows, setRows] = useState([{ id: "a", label: "Alpha" }]);
+        return <section>
+          <button onClick={() => {
+            setRows((current) => [...current.slice(1), nextOne]);
+            setRows((current) => current.map((row) => {
+              const target = row.id;
+              switch (target) {
+                case firstId:
+                  return { ...row, label: nextLabel };
+                case secondId:
+                  return { ...row, label: nextLabel };
+                default:
+                  return row;
+              }
+            }));
+            setRows((current) => [...current.slice(1), nextTwo]);
+          }}>Roll around switched map</button>
+          <ul>{rows.map((row) => <li key={row.id}>{row.label}</li>)}</ul>
+        </section>;
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Feed"]);
+    expect(result.optimizations.keyedArrayMappedRollingWindowChainHints).toBe(2);
+    expect(result.optimizations.keyedMapUpdateHints).toBe(1);
+    expect(result.code).toContain("createCompilerKeyedArrayRollingWindowMapPipeline");
+    expect(result.code).toContain("createCompilerKeyedArrayMappedRollingWindow");
+  });
+
   it("does not emit a rolling-window chain hint when one nested map branch is effectful", async () => {
     const result = await compile(`
       import { useState } from "react";

--- a/packages/farm-react/src/__tests__/compiler-keyed-array-sort-hints.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-keyed-array-sort-hints.test.ts
@@ -324,6 +324,42 @@ describe("React AOT keyed-array sort hints", () => {
     expect(result.code).toContain("keyedRowsMapReorderHintedRuntimeFeature");
   });
 
+  it("carries a switch-branched map through a native sort", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Table({ firstId, secondId }) {
+        const [rows, setRows] = useState([
+          { id: "a", label: "Alpha", rank: 1 },
+          { id: "b", label: "Beta", rank: 2 },
+        ]);
+        return <section>
+          <button onClick={() => setRows((current) => current
+            .map((row) => {
+              switch (row.id) {
+                case firstId:
+                  return { ...row, rank: 4 };
+                case secondId:
+                  return { ...row, rank: 3 };
+                default:
+                  return row;
+              }
+            })
+            .toSorted((left, right) => left.rank - right.rank)
+          )}>Edit and sort switched rows</button>
+          <ul>{rows.map((row) => <li key={row.id}>{row.label}</li>)}</ul>
+        </section>;
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Table"]);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.optimizations.keyedMapUpdateHints).toBe(1);
+    expect(result.optimizations.keyedArraySortHints).toBe(1);
+    expect(result.code).toContain("createCompilerKeyedArrayMapPipeline");
+    expect(result.code).toContain("createCompilerKeyedArrayMapReorder");
+    expect(result.code).toContain("keyedRowsMapReorderHintedRuntimeFeature");
+  });
+
   it("preserves every step in an exact mapped reverse-parity pipeline", async () => {
     const result = await compile(`
       import { useState } from "react";

--- a/packages/farm-react/src/__tests__/compiler-keyed-update-hints.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-keyed-update-hints.test.ts
@@ -236,6 +236,50 @@ describe("React AOT keyed update hints", () => {
     });
   });
 
+  it("records fully returning switch branches inside structured map callbacks", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Inventory({ reviewedId, escalatedId, delta }) {
+        const [items, setItems] = useState([
+          { id: "a", label: "Alpha", amount: 1 },
+          { id: "b", label: "Beta", amount: 2 },
+        ]);
+        return (
+          <section>
+            <button onClick={() => setItems((current) => current.map((row) => {
+              const target = row.id;
+              switch (target) {
+                case reviewedId:
+                  return { ...row, label: "Reviewed" };
+                case escalatedId: {
+                  const nextAmount = Math.round(row.amount + delta);
+                  return { ...row, label: String(nextAmount), amount: nextAmount };
+                }
+                default:
+                  return row;
+              }
+            }))}>Update switched rows</button>
+            <ul>{items.map((item) => <li key={item.id}>{item.label}</li>)}</ul>
+          </section>
+        );
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Inventory"]);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.optimizations.keyedMapUpdateHints).toBe(1);
+    expect(result.code.match(/createCompilerKeyedMapUpdate\(/g)).toHaveLength(1);
+    expect(result.code).toContain("keyedRowsHintedRuntimeFeature");
+    await expect(
+      transformWithEsbuild(result.code, "/app/KeyedUpdateHints.tsx", {
+        loader: "tsx",
+        jsx: "automatic",
+      }),
+    ).resolves.toMatchObject({
+      code: expect.stringContaining("createCompilerKeyedMapUpdate"),
+    });
+  });
+
   it("supports direct-state public List rows without adding a public option", async () => {
     const result = await compile(`
       import { useState } from "react";
@@ -316,6 +360,55 @@ describe("React AOT keyed update hints", () => {
       collection: "items",
       update:
         'setItems((current) => current.map((row) => { if (row.id === "a") return { ...row, label: "Updated" }; return { ...row, label: "Other" }; }))',
+    },
+    {
+      name: "a switch without a default branch",
+      declaration: "",
+      collection: "items",
+      update:
+        'setItems((current) => current.map((row) => { switch (row.id) { case "a": return { ...row, label: "Updated" }; case "b": return row; } }))',
+    },
+    {
+      name: "a switch with a fallthrough case",
+      declaration: "",
+      collection: "items",
+      update:
+        'setItems((current) => current.map((row) => { switch (row.id) { case "a": case "b": return { ...row, label: "Updated" }; default: return row; } }))',
+    },
+    {
+      name: "a switch with a break path",
+      declaration: "",
+      collection: "items",
+      update:
+        'setItems((current) => current.map((row) => { switch (row.id) { case "a": return { ...row, label: "Updated" }; default: break; } return row; }))',
+    },
+    {
+      name: "an effectful switch discriminant",
+      declaration: "const resolveStatus = (row) => row.id;",
+      collection: "items",
+      update:
+        'setItems((current) => current.map((row) => { switch (resolveStatus(row)) { case "a": return { ...row, label: "Updated" }; default: return row; } }))',
+    },
+    {
+      name: "an effectful switch case test",
+      declaration: "const resolveStatus = (row) => row.id;",
+      collection: "items",
+      update:
+        'setItems((current) => current.map((row) => { switch (row.id) { case resolveStatus(row): return { ...row, label: "Updated" }; default: return row; } }))',
+    },
+    {
+      name: "a switch that replaces every row",
+      declaration: "",
+      collection: "items",
+      update:
+        'setItems((current) => current.map((row) => { switch (row.id) { case "a": return { ...row, label: "Updated" }; default: return { ...row, label: "Other" }; } }))',
+    },
+    {
+      name: "a switch followed by unreachable statements",
+      declaration: "",
+      collection: "items",
+      update:
+        'setItems((current) => current.map((row) => { switch (row.id) { case "a": return { ...row, label: "Updated" }; default: return row; } return row; }))',
     },
     {
       name: "an unsupported second mapper",

--- a/packages/farm-react/src/compiler.ts
+++ b/packages/farm-react/src/compiler.ts
@@ -1294,6 +1294,36 @@ function isSafeKeyedMapConstDeclaration(
   );
 }
 
+function proveSafeKeyedMapSwitchStatement(
+  statement: t.SwitchStatement,
+  item: t.Identifier,
+  safeGlobals: ReadonlySet<string>,
+): SafeKeyedMapBranchProof | undefined {
+  if (
+    validateDerivedExpression(statement.discriminant, safeGlobals) ||
+    statement.cases.filter((switchCase) => switchCase.test === null).length !== 1
+  ) {
+    return undefined;
+  }
+
+  let proof: SafeKeyedMapBranchProof | undefined;
+  for (const switchCase of statement.cases) {
+    if (
+      (switchCase.test && validateDerivedExpression(switchCase.test, safeGlobals)) ||
+      switchCase.consequent.length === 0
+    ) {
+      return undefined;
+    }
+    const branch =
+      switchCase.consequent.length === 1 && t.isBlockStatement(switchCase.consequent[0])
+        ? proveSafeKeyedMapStatement(switchCase.consequent[0], item, safeGlobals)
+        : proveSafeKeyedMapStatements(switchCase.consequent, item, safeGlobals);
+    if (!branch) return undefined;
+    proof = proof ? mergeSafeKeyedMapBranchProofs(proof, branch) : branch;
+  }
+  return proof;
+}
+
 function proveSafeKeyedMapStatements(
   statements: readonly t.Statement[],
   item: t.Identifier,
@@ -1310,6 +1340,11 @@ function proveSafeKeyedMapStatements(
   if (t.isVariableDeclaration(statement)) {
     return isSafeKeyedMapConstDeclaration(statement, item, safeGlobals)
       ? proveSafeKeyedMapStatements(remaining, item, safeGlobals)
+      : undefined;
+  }
+  if (t.isSwitchStatement(statement)) {
+    return remaining.length === 0
+      ? proveSafeKeyedMapSwitchStatement(statement, item, safeGlobals)
       : undefined;
   }
   if (!t.isIfStatement(statement) || validateDerivedExpression(statement.test, safeGlobals)) {


### PR DESCRIPTION
## Problem

Common keyed-row updates often branch on a row status or type with `switch`. The experimental React compiler already recognizes equivalent concise conditionals and fully returning `if` blocks, but a safe `switch` callback receives no keyed-map hint and therefore returns to complete keyed reconciliation.

## Root cause

The keyed-map branch proof only understood expressions, returns, immutable local constants, and `if` statements. It had no way to prove that a `SwitchStatement` covered every path, kept at least one row unchanged, and returned only safe same-key replacements.

## Change

- Prove `switch` discriminants and case tests with the existing compiler-safe expression validator.
- Require exactly one `default`, a non-empty fully returning body for every case, and no fallthrough or statements after the switch.
- Reuse the existing recursive branch proof for case-local `const` aliases, nested safe branches, unchanged rows, and object-spread replacements.
- Carry accepted switch maps through direct same-order hints, map/reorder pipelines, and mapped rolling-window chains.
- Exercise a switch-based 10,000-row rolling-chain workload in the production dashboard benchmark.

## Safety and compatibility

Every native `map()` and switch callback still executes normally. The compiler only records metadata after the existing native and dense-array checks succeed. Missing defaults, fallthrough, `break`, unsafe discriminants or case tests, mutable/effectful control flow, unconditional replacement, changed keys, or failed runtime validation keep the complete existing reconciliation and LIS path before any DOM mutation.

This adds no public API, option, runtime helper, report field, or always-loaded browser code. React 18 and React 19 remain supported, and compiler-disabled builds are unchanged.

## Verification

- `pnpm --filter @farm.js/react exec vitest run src/__tests__/compiler-keyed-update-hints.test.ts src/__tests__/compiler-keyed-array-sort-hints.test.ts src/__tests__/compiler-keyed-array-rolling-window-hints.test.ts --maxWorkers=1 --minWorkers=1` — 3 files, 93 tests passed.
- `pnpm --filter @farm.js/react exec vitest run --maxWorkers=1 --minWorkers=1` — 75 files, 851 passed, 14 skipped.
- `pnpm --filter @farm.js/react exec vitest run --config vitest.stress.config.ts --maxWorkers=1 --minWorkers=1` — 8 files, 23 passed, 132 skipped.
- `pnpm --filter @farm.js/react type-check` — passed.
- `pnpm --filter @farm.js/react test:runtime-size` — passed; every checked runtime-size baseline is unchanged.
- `pnpm --filter @farm.js/react test:compat` — passed with React 18.3.1 and React 19.2.8.
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @farm.js/core build` — passed.
- `pnpm --dir examples/react-compiler-dashboard type-check` — passed after the core declaration build.
- `pnpm docs:check-navigation` — 83 visible pages and 12 official plugins covered.
- `pnpm --dir docs exec farm generate --check` — generated route, API, and environment types are current.
- `pnpm docs:build` — passed through the Vercel/Nitro production output.
- `FARM_EXPERIMENT_BROWSER_PATH='/Applications/Google Chrome.app/Contents/MacOS/Google Chrome' pnpm --dir examples/react-compiler-dashboard benchmark` — overall, correctness, performance, persistence, scalability, and size gates passed.

The switch-based mapped rolling-chain target measured:

- Static: 3.60 ms median, 19.61x faster than bracketed React and 3.94x faster than the compiled fallback control.
- Hybrid: 3.70 ms median, 19.08x faster than bracketed React and 4.59x faster than the compiled fallback control.
- Both modes kept `keyedArrayMappedRollingWindowChainHints: 2`, `keyedMapUpdateHints: 34`, and zero compiled table owner executions.
- Example output was 31,731-byte gzip in static and 31,730-byte gzip in hybrid; the package runtime-size baselines did not change.

Focused `oxfmt`, `oxlint`, and `git diff --check` also passed.

## Documentation and release

Updated the React renderer guide and package README with the supported switch shape and conservative fallback limits. Updated the existing compiler dashboard example and benchmark guide to make the switch path an executable production contract. No version, template, or release-flow change is included.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extends the React compiler keyed-map hints to accept fully returning `switch` branches, so status/type row updates retain optimized keyed reconciliation instead of falling back. Native `map()` behavior, callback order, and thrown errors are unchanged.

**Behavior**
- Proves switch discriminants, case tests, and case bodies with the existing safe expression and branch validators.
- Requires one `default`, a complete return from every case, and no fallthrough or statements after the switch.
- Carries accepted switch maps through same-order hints, map/reorder pipelines, and rolling-window chains.
- Adds compiler tests and updates the renderer guide, READMEs, and dashboard benchmark.

**Safety**
- Unsafe switches (missing `default`, fallthrough, `break`, effectful expressions, unconditional replacement) keep the existing full reconciliation and LIS path.
- Adds no public API, option, runtime helper, report field, or always-loaded browser code; React 18 and 19 remain supported.

<sup>Written for commit affa92a1b4a67080607650cb27a035832b83e779. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/950?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

