### PR TITLE
fix(api): reject uploads aborted during body reads

### DIFF
--- a/docs/src/app/docs/api-routes/page.md
+++ b/docs/src/app/docs/api-routes/page.md
@@ -112,6 +112,8 @@ Malformed `application/json` and `application/*+json` bodies also return `400` b
 middleware or handler code executes, including when the endpoint does not declare a body schema.
 If an upload is aborted while Farm is buffering its body, Farm rejects it before invoking the
 endpoint. This does not roll back work in a handler that has already started.
+On Node, finishing an upload is not an abort: only an interrupted upload or an early response
+disconnect cancels the request signal.
 
 ## HTTP QUERY
 

--- a/docs/src/app/docs/api-routes/page.md
+++ b/docs/src/app/docs/api-routes/page.md
@@ -110,6 +110,8 @@ export const GET = createEndpoint(
 Farm parses and validates `body`, `query`, and `headers` before middleware or handler code runs. Header schema keys use the lower-case names exposed by the Fetch `Headers` API. Invalid input returns a `400` response with structured validation issues.
 Malformed `application/json` and `application/*+json` bodies also return `400` before endpoint
 middleware or handler code executes, including when the endpoint does not declare a body schema.
+If an upload is aborted while Farm is buffering its body, Farm rejects it before invoking the
+endpoint. This does not roll back work in a handler that has already started.
 
 ## HTTP QUERY
 

--- a/packages/farm/src/__tests__/production-prebuilt-ssr.test.ts
+++ b/packages/farm/src/__tests__/production-prebuilt-ssr.test.ts
@@ -2497,6 +2497,7 @@ export async function QUERY(request: Request) {
     body: await request.json(),
   });
 }
+export const POST = QUERY;
 `.trim(),
       );
       const config = await resolveConfig(
@@ -2538,22 +2539,23 @@ export async function QUERY(request: Request) {
         },
         "/api/after-response",
       );
-      await runProductionRequest(
-        path.join(root, ".farm", ".output", "server"),
-        async (response) => {
-          expect(response.status).toBe(200);
-          await expect(response.json()).resolves.toEqual({
-            method: "QUERY",
-            body: { filters: ["tools", "seeds"] },
-          });
-        },
-        "/api/structured-search",
-        {
-          method: "QUERY",
-          headers: { "content-type": "application/json" },
-          body: JSON.stringify({ filters: ["tools", "seeds"] }),
-        },
-      );
+      for (const method of ["POST", "QUERY"])
+        await runProductionRequest(
+          path.join(root, ".farm", ".output", "server"),
+          async (response) => {
+            expect(response.status).toBe(200);
+            await expect(response.json()).resolves.toEqual({
+              method,
+              body: { filters: ["tools", "seeds"] },
+            });
+          },
+          "/api/structured-search",
+          {
+            method,
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ filters: ["tools", "seeds"] }),
+          },
+        );
     } finally {
       await fs.rm(root, { recursive: true, force: true });
     }

--- a/packages/farm/src/__tests__/request-body-cancellation.test.ts
+++ b/packages/farm/src/__tests__/request-body-cancellation.test.ts
@@ -2,7 +2,97 @@
 import { setImmediate } from "node:timers/promises";
 import { expect, it, vi } from "vitest";
 import { invokeAPIRouteEndpoint } from "../api/runtime";
-import { bufferFarmRequestBody } from "../server-http";
+import { bufferFarmRequestBody, readFarmRequestBody } from "../server-http";
+
+it.each([false, true])(
+  "does not dispatch an upload aborted during a pending read (cloned: %s)",
+  async (cloned) => {
+    const abort = new AbortController();
+    const reason = new Error("upload disconnected");
+    let beganRead!: () => void;
+    const reading = new Promise<void>((resolve) => {
+      beganRead = resolve;
+    });
+    let sent = false;
+    const source = new ReadableStream<Uint8Array>(
+      {
+        pull(controller) {
+          if (!sent) {
+            sent = true;
+            controller.enqueue(new TextEncoder().encode("partial"));
+          } else {
+            beganRead();
+          }
+        },
+      },
+      { highWaterMark: 0 },
+    );
+    const original = new Request("https://farm.test/api/upload", {
+      method: "POST",
+      body: source,
+      duplex: "half",
+      signal: abort.signal,
+    } as RequestInit);
+    const request = cloned ? original.clone() : original;
+    const endpoint = vi.fn(() => new Response("handler ran"));
+    let failure: unknown;
+    let completed = false;
+    const handling = invokeAPIRouteEndpoint(endpoint, request)
+      .catch((error) => {
+        failure = error;
+      })
+      .finally(() => {
+        completed = true;
+      });
+    try {
+      await reading;
+      abort.abort(reason);
+      await vi.waitFor(() => expect(completed).toBe(true));
+      expect(failure).toBe(reason);
+      expect(endpoint).not.toHaveBeenCalled();
+      expect(request.body!.locked).toBe(false);
+    } finally {
+      if (cloned) await original.body!.cancel();
+      await handling;
+    }
+  },
+);
+
+it("rejects an already-aborted upload with its original reason", async () => {
+  const reason = new Error("already disconnected");
+  const request = new Request("https://farm.test/api/upload", {
+    method: "POST",
+    body: "partial",
+    signal: AbortSignal.abort(reason),
+  });
+  const endpoint = vi.fn();
+  await expect(invokeAPIRouteEndpoint(endpoint, request)).rejects.toBe(reason);
+  expect(endpoint).not.toHaveBeenCalled();
+});
+
+it("does not mistake cancellation of an empty pending read for EOF", async () => {
+  const abort = new AbortController();
+  const request = new Request("https://farm.test/api/upload", {
+    method: "POST",
+    duplex: "half",
+    signal: abort.signal,
+    body: new ReadableStream<Uint8Array>(),
+  } as RequestInit);
+  const reading = readFarmRequestBody(request, 100);
+  const assertion = expect(reading).rejects.toMatchObject({ name: "AbortError" });
+  abort.abort();
+  await assertion;
+  expect(request.body!.locked).toBe(false);
+});
+
+it("accepts normal EOF without treating an empty upload as aborted", async () => {
+  const request = new Request("https://farm.test/api/upload", { method: "POST", body: "" });
+  const endpoint = vi.fn(async (request: Request) => new Response(await request.text()));
+  const response = await invokeAPIRouteEndpoint(endpoint, request);
+  expect(response.status).toBe(200);
+  expect(await response.text()).toBe("");
+  expect(endpoint).toHaveBeenCalledOnce();
+});
 
 it.each([
   { length: "3", status: 413 },

--- a/packages/farm/src/__tests__/request-body-cancellation.test.ts
+++ b/packages/farm/src/__tests__/request-body-cancellation.test.ts
@@ -1,8 +1,41 @@
 // @vitest-environment node
 import { setImmediate } from "node:timers/promises";
+import { EventEmitter } from "node:events";
 import { expect, it, vi } from "vitest";
 import { invokeAPIRouteEndpoint } from "../api/runtime";
-import { bufferFarmRequestBody, readFarmRequestBody } from "../server-http";
+import {
+  bufferFarmRequestBody,
+  readFarmRequestBody,
+  createFarmNodeRequestAbortSignal,
+} from "../server-http";
+
+it("does not treat Node upload completion as a disconnect", async () => {
+  const nodeRequest = new EventEmitter();
+  const nodeResponse = Object.assign(new EventEmitter(), { writableEnded: false });
+  const signal = createFarmNodeRequestAbortSignal(nodeRequest, nodeResponse);
+  const request = new Request("https://farm.test/api/upload", {
+    method: "POST",
+    signal,
+    duplex: "half",
+    body: new ReadableStream<Uint8Array>({
+      pull(controller) {
+        controller.enqueue(new TextEncoder().encode("complete"));
+        controller.close();
+        nodeRequest.emit("close");
+      },
+    }),
+  } as RequestInit);
+  const endpoint = vi.fn(async (request: Request) => new Response(await request.text()));
+  const response = await invokeAPIRouteEndpoint(endpoint, request);
+  expect(await response.text()).toBe("complete");
+  expect(endpoint).toHaveBeenCalledOnce();
+  expect(signal.aborted).toBe(false);
+  // Receiving the whole upload does not prevent a later response disconnect.
+  nodeResponse.emit("close");
+  expect(signal.aborted).toBe(true);
+  expect(nodeRequest.listenerCount("aborted")).toBe(0);
+  expect(nodeResponse.listenerCount("finish")).toBe(0);
+});
 
 it.each([false, true])(
   "does not dispatch an upload aborted during a pending read (cloned: %s)",

--- a/packages/farm/src/nitro/production-runtime.ts
+++ b/packages/farm/src/nitro/production-runtime.ts
@@ -2,6 +2,7 @@ export { _runWithAfterRequest } from "../after";
 export type { FarmServerConfig } from "../server-http";
 export {
   bufferFarmRequestBody,
+  createFarmNodeRequestAbortSignal,
   createFarmRequestBodyErrorResponse,
   matchesFarmIfNoneMatch,
   readFarmRequestBody,

--- a/packages/farm/src/nitro/universal-build.ts
+++ b/packages/farm/src/nitro/universal-build.ts
@@ -4407,6 +4407,7 @@ function generateVirtualEntryCode(
   createFarmThemeDocumentParts,
   createFarmLocaleCookie,
   createFarmProductionLifecycle,
+  createFarmNodeRequestAbortSignal,
   createProductionMiddlewareRunner,
   getTheme as getFarmTheme,
   emitFarmEvent,
@@ -7540,6 +7541,7 @@ export async function fetch(request, context) {
     },
   );
 }
+export { createFarmNodeRequestAbortSignal };
 export default { fetch, lifecycle: farmProductionLifecycle };
   `.trim();
 }
@@ -7903,7 +7905,7 @@ async function buildNitroUniversal(
 // This file adapts Farm's Web fetch handler to Nitro's event handler contract.
 
 import { useNitroApp } from 'nitro/runtime'
-import handler, { farmProductionLifecycle } from './${ssrEntryFile}'
+import handler, { farmProductionLifecycle, createFarmNodeRequestAbortSignal } from './${ssrEntryFile}'
 
 export { farmProductionLifecycle }
 
@@ -7949,7 +7951,13 @@ function createResponseFinishedHook(event) {
 
 // Export the event handler for Nitro
 export default async function farmNitroEventHandler(event) {
-  const response = await handler.fetch(event.req, {
+  // Some Node adapters abort their Request on normal IncomingMessage close.
+  // Use the same actual disconnect events as Farm's development server.
+  const node = event.node
+  const request = node?.req && node?.res
+    ? new Request(event.req, { signal: createFarmNodeRequestAbortSignal(node.req, node.res) })
+    : event.req
+  const response = await handler.fetch(request, {
     waitUntil: (promise) => event.waitUntil(promise),
     onResponseFinished: createResponseFinishedHook(event),
   })

--- a/packages/farm/src/server-http.ts
+++ b/packages/farm/src/server-http.ts
@@ -1,5 +1,50 @@
 import { assertBrowserStableRoutePath } from "./routing/specificity";
 
+interface FarmNodeAbortRequest {
+  aborted?: boolean;
+  once(event: "aborted", listener: () => void): unknown;
+  off(event: "aborted", listener: () => void): unknown;
+}
+
+interface FarmNodeAbortResponse {
+  writableEnded: boolean;
+  once(event: "close" | "finish", listener: () => void): unknown;
+  off(event: "close" | "finish", listener: () => void): unknown;
+}
+
+/** Share disconnect semantics between development and production Node requests. */
+export function createFarmNodeRequestAbortSignal(
+  req: FarmNodeAbortRequest,
+  res: FarmNodeAbortResponse,
+): AbortSignal {
+  const controller = new AbortController();
+  let disposed = false;
+  const dispose = () => {
+    if (disposed) return;
+    disposed = true;
+    req.off("aborted", abort);
+    res.off("close", abortOnEarlyClose);
+    res.off("finish", dispose);
+    controller.signal.removeEventListener("abort", dispose);
+  };
+  const abort = () => controller.abort();
+  const abortOnEarlyClose = () => {
+    if (!res.writableEnded) abort();
+    dispose();
+  };
+
+  if (req.aborted) {
+    controller.abort();
+    return controller.signal;
+  }
+
+  req.once("aborted", abort);
+  res.once("close", abortOnEarlyClose);
+  res.once("finish", dispose);
+  controller.signal.addEventListener("abort", dispose, { once: true });
+  return controller.signal;
+}
+
 export const DEFAULT_FARM_SERVER_BODY_SIZE_LIMIT = 10_000_000;
 export const DEFAULT_FARM_SERVER_HEADERS_TIMEOUT = 60_000;
 export const DEFAULT_FARM_SERVER_REQUEST_TIMEOUT = 300_000;

--- a/packages/farm/src/server-http.ts
+++ b/packages/farm/src/server-http.ts
@@ -310,6 +310,8 @@ export async function readFarmRequestBody(request: Request, limit: number): Prom
     while (true) {
       throwIfAborted(request.signal);
       const { done, value } = await reader.read();
+      // Cancellation resolves a pending read as EOF, not necessarily an error.
+      throwIfAborted(request.signal);
       if (done) break;
       if (!value) continue;
 

--- a/packages/farm/src/vite.ts
+++ b/packages/farm/src/vite.ts
@@ -80,6 +80,7 @@ import {
 } from "./server/vite-config";
 import { resolveFarmDocsFontAssets, toFarmDocsPublicFontAssets } from "./docs/fonts";
 import {
+  createFarmNodeRequestAbortSignal,
   createFarmRequestBodyErrorResponse,
   readNodeRequestBody,
   resolveFarmServerConfig,
@@ -283,50 +284,7 @@ function createRequestFromNodeRequest(
   });
 }
 
-interface FarmNodeAbortRequest {
-  aborted?: boolean;
-  once(event: "aborted", listener: () => void): unknown;
-  off(event: "aborted", listener: () => void): unknown;
-}
-
-interface FarmNodeAbortResponse {
-  writableEnded: boolean;
-  once(event: "close" | "finish", listener: () => void): unknown;
-  off(event: "close" | "finish", listener: () => void): unknown;
-}
-
-/** Exported for tests: forwards a disconnected dev client to Web Request consumers. */
-export function createFarmNodeRequestAbortSignal(
-  req: FarmNodeAbortRequest,
-  res: FarmNodeAbortResponse,
-): AbortSignal {
-  const controller = new AbortController();
-  let disposed = false;
-  const dispose = () => {
-    if (disposed) return;
-    disposed = true;
-    req.off("aborted", abort);
-    res.off("close", abortOnEarlyClose);
-    res.off("finish", dispose);
-    controller.signal.removeEventListener("abort", dispose);
-  };
-  const abort = () => controller.abort();
-  const abortOnEarlyClose = () => {
-    if (!res.writableEnded) abort();
-    dispose();
-  };
-
-  if (req.aborted) {
-    controller.abort();
-    return controller.signal;
-  }
-
-  req.once("aborted", abort);
-  res.once("close", abortOnEarlyClose);
-  res.once("finish", dispose);
-  controller.signal.addEventListener("abort", dispose, { once: true });
-  return controller.signal;
-}
+export { createFarmNodeRequestAbortSignal } from "./server-http";
 
 /** Exported for tests: the request boundary all Farm dev middlewares share. */
 export function withFarmRequestTracing(


### PR DESCRIPTION
## Problem

An upload aborted while Farm is reading its body can still reach the API handler with empty or partial input. Follow-up to #946, which addressed body-size rejection rather than abort handling.

## Root cause

Cancelling a reader resolves a pending `read()` with `done: true`. We checked the signal before the read, but treated that cancellation result as normal EOF afterward.

## Change

Check the abort signal immediately after each awaited read, before accepting either bytes or EOF. Add regressions for ordinary and cloned partial uploads, empty pending reads, already-aborted requests, and normal EOF.

## Safety and compatibility

Uses the existing abort reason and reader cleanup. This is shared API runtime behavior, with no renderer-specific changes or new options. It prevents dispatch during body buffering; it does not roll back handlers that have already started. Server Actions already have their own final abort check.

## Verification

On this standalone branch, macOS / Node 23.11.0 / pnpm 8.12.1:

```sh
pnpm --filter @farm.js/core exec vitest run src/__tests__/request-body-cancellation.test.ts src/__tests__/server-http.test.ts
```

The initial focused run passed 20 tests. Before the fix, three regression cases failed because aborted reads resolved successfully. The combined follow-up changes also passed the core build and type check.

CI then exposed a production adapter mismatch: the bundled Node adapter aborted on normal IncomingMessage close, making completed POST/QUERY uploads fail. This PR now reuses Farm's existing development disconnect helper in the production Nitro entry. Genuine aborted uploads and early response closes still abort; successful upload completion does not. Non-Node requests retain their platform signal.

Additional verification after that correction:

```sh
pnpm --filter @farm.js/core exec vitest run src/__tests__/request-body-cancellation.test.ts src/__tests__/server-http.test.ts src/__tests__/navigation-request-context.test.ts
pnpm --filter @farm.js/core exec vitest run src/__tests__/production-prebuilt-ssr.test.ts -t 'keeps standalone production API failures generic'
```

28 unit tests passed on Node 23.11.0. The isolated production regression passed on Node 24.21.0, including completed POST and QUERY uploads, generic API failures, and post-response work. The original CI failure is covered without weakening the abort check or changing timeouts.

## Documentation and release

Updated the API routes guide to explain the abort boundary. No package versions, templates, or public API changes.
