### PR TITLE
fix(api): surface NDJSON parse errors before stream cleanup

### DIFF
--- a/docs/src/app/docs/api-routes/page.md
+++ b/docs/src/app/docs/api-routes/page.md
@@ -193,6 +193,10 @@ soon as the source yields it, respects response backpressure, cancels the source
 disconnects, and defaults to `Cache-Control: no-store`. Use ordinary `Response` objects for binary
 downloads or protocols that are not JSON event streams.
 
+The client decoder rejects malformed NDJSON with its original `SyntaxError` and cancels the
+source without waiting for cleanup or an unread response clone. Explicit stream cancellation
+and early iterator return still await the producer's cleanup.
+
 When Farm bridges a streamed `Response` to Node, a failed response write also cancels the
 upstream body. Put producer cleanup in the stream's `cancel()` callback. Farm preserves the
 original write error and does not wait indefinitely for that cleanup to finish.

--- a/packages/farm/src/__tests__/json-stream-cancellation.test.ts
+++ b/packages/farm/src/__tests__/json-stream-cancellation.test.ts
@@ -1,0 +1,102 @@
+// @vitest-environment node
+import { expect, it, vi } from "vitest";
+import { readJSONStream } from "../api/transport";
+
+it("reports malformed NDJSON before an unread response clone finishes", async () => {
+  const original = new Response(
+    new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode("not json\n"));
+      },
+    }),
+  );
+  const response = original.clone();
+  let failure: unknown;
+  const iterator = readJSONStream(response)[Symbol.asyncIterator]();
+  const reading = iterator.next().catch((error) => {
+    failure = error;
+  });
+  try {
+    await vi.waitFor(() => expect(failure).toBeInstanceOf(SyntaxError));
+    expect(response.body!.locked).toBe(false);
+    await expect(iterator.next()).resolves.toEqual({ done: true, value: undefined });
+  } finally {
+    await original.body!.cancel();
+    await reading;
+  }
+});
+
+it("keeps the parse error when producer cancellation rejects", async () => {
+  const cancel = vi.fn(() => Promise.reject(new Error("cleanup failed")));
+  const response = new Response(
+    new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode("{broken}\n"));
+      },
+      cancel,
+    }),
+  );
+  const stream = readJSONStream(response);
+  await expect(stream[Symbol.asyncIterator]().next()).rejects.toBeInstanceOf(SyntaxError);
+  expect(cancel).toHaveBeenCalledWith(expect.any(SyntaxError));
+  expect(response.body!.locked).toBe(false);
+  await stream.cancel();
+});
+
+it.each(["return", "cancel"] as const)(
+  "still exposes producer cleanup completion from explicit %s",
+  async (method) => {
+    let finish!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      finish = resolve;
+    });
+    const cancel = vi.fn(() => gate);
+    const response = new Response(new ReadableStream<Uint8Array>({ cancel }));
+    const stream = readJSONStream(response);
+    const iterator = stream[Symbol.asyncIterator]();
+    let settled = false;
+    const cancelling = (method === "return" ? iterator.return!() : stream.cancel("closed")).then(
+      () => {
+        settled = true;
+      },
+    );
+    try {
+      expect(cancel).toHaveBeenCalledOnce();
+      await Promise.resolve();
+      expect(settled).toBe(false);
+    } finally {
+      finish();
+      await cancelling;
+    }
+    expect(response.body!.locked).toBe(false);
+  },
+);
+
+it("decodes split UTF-8 and a final line without a newline", async () => {
+  const bytes = new TextEncoder().encode(' \n{"label":"café"}\n{"done":true}');
+  const response = new Response(
+    new ReadableStream<Uint8Array>({
+      start(controller) {
+        for (const byte of bytes) controller.enqueue(new Uint8Array([byte]));
+        controller.close();
+      },
+    }),
+  );
+  const values = [];
+  for await (const value of readJSONStream(response)) values.push(value);
+  expect(values).toEqual([{ label: "café" }, { done: true }]);
+  expect(response.body!.locked).toBe(false);
+});
+
+it("preserves a source read error and releases its reader", async () => {
+  const failure = new Error("connection lost");
+  const response = new Response(
+    new ReadableStream<Uint8Array>({
+      pull(controller) {
+        controller.error(failure);
+      },
+    }),
+  );
+  await expect(readJSONStream(response)[Symbol.asyncIterator]().next()).rejects.toBe(failure);
+  expect(response.body!.locked).toBe(false);
+});

--- a/packages/farm/src/api/transport.ts
+++ b/packages/farm/src/api/transport.ts
@@ -168,13 +168,10 @@ export function readJSONStream<TItem>(response: Response): FarmAPIStream<TItem> 
     } catch (error) {
       completed = true;
       buffer = "";
-      try {
-        await reader.cancel(error);
-      } catch {
-        // Preserve the decode error even if the underlying stream also fails cleanup.
-      } finally {
-        releaseReader();
-      }
+      // A tee branch can wait for an unread sibling during cancellation. The
+      // parse failure is already known and must not wait for producer cleanup.
+      void reader.cancel(error).catch(() => {});
+      releaseReader();
       throw error;
     }
   };


### PR DESCRIPTION
## Problem

A malformed NDJSON response can hang instead of reporting its syntax error when the response has an unread clone.

## Root cause

The decoder awaited reader cancellation before throwing the already-known parse error. Native tee cancellation can wait indefinitely for the other response branch.

## Change

Start cancellation, handle cleanup rejection, release the reader, and surface the original `SyntaxError` without waiting for producer cleanup.

## Safety and compatibility

Explicit `stream.cancel()` and early iterator return still await cleanup. The single-consumer contract, incremental UTF-8 decoding, source errors, and normal completion are unchanged. No new API or renderer dependency.

## Verification

On this standalone branch, macOS / Node 23.11.0 / pnpm 8.12.1:

```sh
pnpm --filter @farm.js/core exec vitest run src/__tests__/json-stream-cancellation.test.ts src/__tests__/api-transport.test.ts
```

12 tests pass, covering native response clones, rejecting cleanup, explicit cancellation/return, split UTF-8, and read failures. Before the fix, the unread-clone regression received no syntax error until the sibling branch was cancelled. The combined follow-up changes also passed the core build and type check.

## Documentation and release

Documented parse-error cleanup versus explicit cancellation in the API routes guide. No versions or generated artifacts changed.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a hang when a malformed NDJSON response has an unread clone. The decoder now surfaces the original `SyntaxError` immediately instead of waiting for stream cleanup.

**Bug Fixes**
- Starts cancellation and releases the reader without awaiting producer cleanup.
- Preserves explicit cancellation and early iterator return behavior.
- Adds tests covering unread clones, cleanup rejection, split UTF-8, and source errors.

<sup>Written for commit d4faf3582a9ec527056e97b87bf56d08cd66440f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/953?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

