### PR TITLE
fix(runtime): finish cancelled responses before producer cleanup

### DIFF
--- a/docs/src/app/docs/after/page.md
+++ b/docs/src/app/docs/after/page.md
@@ -34,6 +34,9 @@ export default async function ProductPage({ params }) {
 ```
 
 Farm waits for a streamed response body to finish before starting the callback. Redirect and not-found responses use the same request lifecycle.
+Cancelling a Web response also finishes that lifecycle, even if the stream producer's cleanup
+is still pending. Farm starts `after()` callbacks and stops counting the response as active;
+the caller of `cancel()` still receives the producer's cleanup promise, including any rejection.
 
 ## Use it in an API route
 

--- a/packages/farm/src/__tests__/web-response-cancellation.test.ts
+++ b/packages/farm/src/__tests__/web-response-cancellation.test.ts
@@ -1,0 +1,114 @@
+// @vitest-environment node
+import { expect, it, vi } from "vitest";
+import { after, _runWithAfterRequest } from "../after";
+import { createFarmProductionLifecycle } from "../production-lifecycle";
+import { resolveFarmServerConfig } from "../server-http";
+
+it.each(["resolve", "reject"] as const)(
+  "finishes Web response bookkeeping before producer cleanup can %s",
+  async (outcome) => {
+    let settleCleanup!: () => void;
+    const cleanupError = new Error("cleanup failed");
+    const cleanup = new Promise<void>((resolve, reject) => {
+      settleCleanup = () => (outcome === "resolve" ? resolve() : reject(cleanupError));
+    });
+    const cancel = vi.fn(() => cleanup);
+    const source = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array([1]));
+      },
+      cancel,
+    });
+    const callback = vi.fn();
+    let lifetime!: Promise<void>;
+    const lifecycle = createFarmProductionLifecycle({ server: resolveFarmServerConfig(undefined) });
+    const response = await lifecycle.runRequest(() =>
+      _runWithAfterRequest(
+        new Request("https://farm.test/"),
+        () => {
+          after(callback);
+          return new Response(source);
+        },
+        {
+          waitUntil(promise) {
+            lifetime = promise;
+          },
+        },
+      ),
+    );
+    // Reading starts another pull, so also cover cancellation during a read
+    // and repeated completion notifications from nested wrappers.
+    const reader = response.body!.getReader();
+    await expect(reader.read()).resolves.toMatchObject({ done: false });
+    const reason = new Error("consumer disconnected");
+    let settled = false;
+    let failure: unknown;
+    const cancelling = reader
+      .cancel(reason)
+      .catch((error) => {
+        failure = error;
+      })
+      .finally(() => {
+        settled = true;
+      });
+    try {
+      expect(cancel).toHaveBeenCalledWith(reason);
+      await vi.waitFor(() => expect(callback).toHaveBeenCalledOnce());
+      await lifetime;
+      expect(lifecycle.activeRequests).toBe(0);
+      await expect(lifecycle.waitForIdle(10)).resolves.toBe(true);
+      expect(settled).toBe(false);
+      expect(source.locked).toBe(false);
+    } finally {
+      settleCleanup();
+      await cancelling;
+      reader.releaseLock();
+      await lifecycle.close();
+    }
+    expect(failure).toBe(outcome === "reject" ? cleanupError : undefined);
+    expect(callback).toHaveBeenCalledOnce();
+    expect(lifecycle.activeRequests).toBe(0);
+  },
+);
+
+it.each(["after", "lifecycle"] as const)(
+  "completes %s on cancellation with a buffered chunk and no pending read",
+  async (kind) => {
+    let finish!: () => void;
+    const cleanup = new Promise<void>((resolve) => {
+      finish = resolve;
+    });
+    const cancel = vi.fn(() => cleanup);
+    const original = new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new Uint8Array([1]));
+        },
+        cancel,
+      }),
+    );
+    const callback = vi.fn();
+    const lifecycle = createFarmProductionLifecycle({ server: resolveFarmServerConfig(undefined) });
+    const response =
+      kind === "after"
+        ? await _runWithAfterRequest(new Request("https://farm.test/"), () => {
+            after(callback);
+            return original;
+          })
+        : await lifecycle.runRequest(() => original);
+    // Flush the automatic pull of the already-queued chunk without consuming
+    // the wrapper's buffer and triggering another read.
+    await Promise.resolve();
+    const cancelling = response.body!.cancel();
+    try {
+      expect(cancel).toHaveBeenCalledOnce();
+      if (kind === "after") await vi.waitFor(() => expect(callback).toHaveBeenCalledOnce());
+      else expect(lifecycle.activeRequests).toBe(0);
+      expect(original.body!.locked).toBe(false);
+    } finally {
+      finish();
+      await cancelling;
+      await lifecycle.close();
+    }
+  },
+);

--- a/packages/farm/src/after.ts
+++ b/packages/farm/src/after.ts
@@ -168,9 +168,11 @@ function wrapResponseBody(
         finishSoon(state);
       }
     },
-    async cancel(reason) {
+    cancel(reason) {
       try {
-        await reader.cancel(reason);
+        // Preserve the caller's cleanup promise, but response completion must
+        // not depend on whether producer-owned cancellation ever settles.
+        return reader.cancel(reason);
       } finally {
         releaseReader();
         finishSoon(state);

--- a/packages/farm/src/production-lifecycle.ts
+++ b/packages/farm/src/production-lifecycle.ts
@@ -256,25 +256,35 @@ function trackResponseCompletion(
   }
 
   const reader = response.body.getReader();
+  let released = false;
+  const releaseReader = () => {
+    if (released) return;
+    released = true;
+    reader.releaseLock();
+  };
   const body = new ReadableStream<Uint8Array>({
     async pull(controller) {
       try {
         const result = await reader.read();
         if (result.done) {
+          releaseReader();
           finish();
           controller.close();
           return;
         }
         controller.enqueue(result.value);
       } catch (error) {
+        releaseReader();
         finish();
         controller.error(error);
       }
     },
-    async cancel(reason) {
+    cancel(reason) {
       try {
-        await reader.cancel(reason);
+        // Cancellation closes the response now; producer cleanup may finish later.
+        return reader.cancel(reason);
       } finally {
+        releaseReader();
         finish();
       }
     },


### PR DESCRIPTION
## Problem

Cancelling a Web response can leave `after()` callbacks waiting and keep `activeRequests` at one if the producer's cleanup promise never settles.

## Root cause

Both Web response wrappers waited for `reader.cancel()` before marking the response finished. A consumer being gone and producer cleanup completing are separate lifecycle events.

## Change

Finish response bookkeeping and release the reader when cancellation starts, while returning the producer's cleanup promise to the caller. Add exact-once cleanup and nested-wrapper coverage.

## Safety and compatibility

Cleanup rejections still reach the cancellation caller. `waitUntil` continues tracking post-response callbacks. Adapter-provided completion hooks and Node finish/close behavior are unchanged. This fixes the Web response fallback, not every possible application shutdown delay.

## Verification

On this standalone branch, macOS / Node 23.11.0 / pnpm 8.12.1:

```sh
pnpm --filter @farm.js/core exec vitest run src/__tests__/web-response-cancellation.test.ts src/__tests__/after.test.ts src/__tests__/production-lifecycle.test.ts
```

24 tests pass. Before the fix, the two buffered-response regressions left callbacks unstarted and the request active while a controlled cleanup promise was pending. Tests also cover cancellation during reads, cleanup rejection, and repeated completion notifications. The combined follow-up changes passed the core build and type check.

## Documentation and release

Updated the `after()` guide with cancellation semantics. No new configuration, versions, or generated artifacts.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cancelling a Web response now finishes request lifecycle bookkeeping immediately instead of waiting for the stream producer’s cleanup to settle. This starts `after()` callbacks and frees the active request even when producer cleanup never resolves, while the cleanup promise (and its rejection) still goes to the `cancel()` caller. Also updates the `after()` guide with the new cancellation semantics.

<sup>Written for commit de8b54c45f134b8216b163048fde73bb80ea43e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/954?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

