### PR TITLE
fix(images): preserve size errors when source cleanup stalls or fails

### DIFF
--- a/docs/src/app/docs/images/page.md
+++ b/docs/src/app/docs/images/page.md
@@ -153,6 +153,10 @@ Pass a `loader` prop when an application already uses an image CDN. The loader r
 ## Security model
 
 The optimizer accepts only configured widths and qualities. It does not forward browser cookies or authorization headers, limits response bodies, checks file signatures instead of trusting `Content-Type`, revalidates redirect destinations, and blocks loopback, link-local, and private network targets. On Node, Farm validates the DNS addresses used by the actual image connection so a hostname cannot switch to a private target between an earlier check and the fetch.
+
+An oversized source returns `413` whether its size is declared in `Content-Length` or discovered
+while reading. Farm cancels the source without waiting for cleanup; a failed cleanup cannot
+replace that response with a `500`.
 Formats explicitly rejected with `q=0` are never emitted. Farm uses the configured format order to
 break equal-quality ties and keeps the source format when the client only sends wildcard ranges.
 

--- a/packages/farm/src/__tests__/image-body-cancellation.test.ts
+++ b/packages/farm/src/__tests__/image-body-cancellation.test.ts
@@ -1,0 +1,120 @@
+// @vitest-environment node
+import { expect, it, vi } from "vitest";
+import { createFarmImageHandler } from "../image-server";
+import { resolveFarmImageConfig } from "../image-config";
+
+it.each([false, true])(
+  "rejects an oversized cloned image without waiting for its sibling (declared: %s)",
+  async (declared) => {
+    const original = new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new Uint8Array(17));
+        },
+      }),
+      { headers: declared ? { "content-length": "17" } : {} },
+    );
+    const source = original.clone();
+    const transform = vi.fn();
+    const handler = createFarmImageHandler(resolveFarmImageConfig({ maximumResponseBody: 16 }), {
+      fetch: vi.fn(async () => source) as typeof fetch,
+      transform,
+    });
+    let response: Response | null | undefined;
+    const handling = handler(
+      new Request("https://app.example.test/_farm/image?url=%2Flarge.png&w=640&q=75"),
+    ).then((result) => {
+      response = result;
+    });
+    try {
+      await vi.waitFor(() => expect(response?.status).toBe(413));
+      expect(source.body!.locked).toBe(false);
+      expect(transform).not.toHaveBeenCalled();
+    } finally {
+      await original.body!.cancel();
+      await handling;
+    }
+  },
+);
+
+it("releases an accepted source and preserves its bytes for transformation", async () => {
+  const bytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 13, 10, 26, 10]);
+  const source = new Response(bytes, { headers: { "content-type": "image/png" } });
+  const transform = vi.fn(async (input) => ({ body: input.source, contentType: input.sourceType }));
+  const handler = createFarmImageHandler(resolveFarmImageConfig({ maximumResponseBody: 16 }), {
+    fetch: vi.fn(async () => source) as typeof fetch,
+    transform,
+  });
+  const response = await handler(
+    new Request("https://app.example.test/_farm/image?url=%2Fsmall.png&w=640&q=75"),
+  );
+  expect(response?.status).toBe(200);
+  expect(transform).toHaveBeenCalledWith(expect.objectContaining({ source: bytes }));
+  expect(source.body!.locked).toBe(false);
+});
+
+it.each([
+  ["declared", "pending"],
+  ["declared", "rejecting"],
+  ["counted", "pending"],
+  ["counted", "rejecting"],
+])("returns 413 for a %s size violation with %s cleanup", async (size, cleanup) => {
+  let finish!: () => void;
+  const gate = new Promise<void>((resolve) => {
+    finish = resolve;
+  });
+  const cancel = vi.fn(() =>
+    cleanup === "pending" ? gate : Promise.reject(new Error("cleanup failed")),
+  );
+  const source = new Response(
+    new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array(17));
+      },
+      cancel,
+    }),
+    { headers: size === "declared" ? { "content-length": "17" } : {} },
+  );
+  const transform = vi.fn();
+  const handler = createFarmImageHandler(resolveFarmImageConfig({ maximumResponseBody: 16 }), {
+    fetch: vi.fn(async () => source) as typeof fetch,
+    transform,
+  });
+  let response: Response | null | undefined;
+  const handling = handler(
+    new Request("https://app.example.test/_farm/image?url=%2Flarge.png&w=640&q=75"),
+  ).then((result) => {
+    response = result;
+  });
+  try {
+    await vi.waitFor(() => expect(response?.status).toBe(413));
+    expect(await response!.text()).toBe("Image is too large");
+    expect(cancel).toHaveBeenCalledOnce();
+    expect(transform).not.toHaveBeenCalled();
+    expect(source.body!.locked).toBe(false);
+  } finally {
+    finish();
+    await handling;
+  }
+});
+
+it("unlocks an image source when reading fails", async () => {
+  const source = new Response(
+    new ReadableStream<Uint8Array>({
+      pull(controller) {
+        controller.error(new Error("source failed"));
+      },
+    }),
+  );
+  const transform = vi.fn();
+  const handler = createFarmImageHandler(resolveFarmImageConfig(undefined), {
+    fetch: vi.fn(async () => source) as typeof fetch,
+    transform,
+  });
+  const response = await handler(
+    new Request("https://app.example.test/_farm/image?url=%2Fphoto.png&w=640&q=75"),
+  );
+  expect(response?.status).toBe(500);
+  expect(source.body!.locked).toBe(false);
+  expect(transform).not.toHaveBeenCalled();
+});

--- a/packages/farm/src/image-server.ts
+++ b/packages/farm/src/image-server.ts
@@ -394,7 +394,8 @@ async function fetchImageSource(
 async function readResponseWithLimit(response: Response, limit: number): Promise<Uint8Array> {
   const contentLength = response.headers.get("content-length");
   if (contentLength && Number(contentLength) > limit) {
-    await cancelResponseBody(response);
+    // Cleanup (including an unread tee branch) must not delay the size rejection.
+    void cancelResponseBody(response);
     throw new FarmImageRequestError("BODY_TOO_LARGE", 413, "Source image is too large");
   }
 
@@ -403,15 +404,20 @@ async function readResponseWithLimit(response: Response, limit: number): Promise
   const chunks: Uint8Array[] = [];
   let byteLength = 0;
 
-  while (true) {
-    const { done, value } = await reader.read();
-    if (done) break;
-    byteLength += value.byteLength;
-    if (byteLength > limit) {
-      await reader.cancel();
-      throw new FarmImageRequestError("BODY_TOO_LARGE", 413, "Source image is too large");
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      byteLength += value.byteLength;
+      if (byteLength > limit) {
+        const error = new FarmImageRequestError("BODY_TOO_LARGE", 413, "Source image is too large");
+        void reader.cancel(error).catch(() => {});
+        throw error;
+      }
+      chunks.push(value);
     }
-    chunks.push(value);
+  } finally {
+    reader.releaseLock();
   }
 
   const result = new Uint8Array(byteLength);


### PR DESCRIPTION
## Problem

An oversized image source can return `500` instead of `413` when its cleanup rejects. Pending cleanup can also delay the size response indefinitely.

## Root cause

The streamed size check awaited cancellation before creating the size error. The declared-length check also waited for cleanup, and the body reader was not released on every exit path.

## Change

Preserve the size error, initiate cancellation without blocking rejection, and release the reader in `finally`. Cover declared and counted size limits, native clones, pending/rejecting cleanup, source read errors, and accepted bytes.

## Safety and compatibility

Oversized sources never reach the transformer. Image validation, redirect cleanup, source allowlists, and public configuration are unchanged. Tests use the supported app-owned image fetcher and native Web Streams.

## Verification

On this standalone branch, macOS / Node 23.11.0 / pnpm 8.12.1:

```sh
pnpm --filter @farm.js/core exec vitest run src/__tests__/image-body-cancellation.test.ts src/__tests__/image-server.test.ts
```

36 tests pass. Before the fix, rejecting streamed cleanup returned `500`, pending cleanup withheld `413`, and read errors left the reader locked. The combined follow-up changes also passed the core build and type check. Focused lint passes with one existing warning in the unchanged image path-pattern matcher.

## Documentation and release

Documented oversized-source response behavior in the images guide. No versions, templates, or API changes.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes oversized image source handling so stalled or failed cleanup no longer turns a size rejection into a 500 or delays the 413, and the source body reader is always released.

- Declared `Content-Length` and counted byte limits now initiate cancellation without waiting for it.
- Read errors release the reader instead of leaving it locked.
- Adds tests for pending and rejecting cleanup, cloned sources, read failures, and accepted images.
- Documents the oversized-source 413 behavior in the images guide.

<sup>Written for commit c4086aed045252d8cc75bce07eb8816b347f4037. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/955?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

