### PR TITLE
fix(rsc): select loading and error boundaries from page ancestry

### DIFF
--- a/docs/src/app/docs/routing/page.md
+++ b/docs/src/app/docs/routing/page.md
@@ -1033,6 +1033,10 @@ export default function DashboardError({ error, reset }: ErrorProps) {
 
 With experimental RSC enabled, failures before the HTML shell is sent render the nearest
 `error.tsx` through RSC and SSR with status `500` and `Cache-Control: private, no-store`.
+RSC loading and error boundaries follow the selected page's file ancestors, including route
+groups and catch-all folders. For example, `/users/[id]/error.tsx` does not handle a sibling
+`/users/new/page.tsx`. Failures before page selection, such as middleware errors, use only the
+root error boundary when one exists.
 This fallback uses a standalone document shell, outside the failed page/layout tree, so a broken
 layout cannot prevent the error UI from rendering. Client boundaries receive a client-owned
 `reset()` that reloads the current URL. Production responses show a generic error message;

--- a/packages/farmjs-plugin/src/rsc/core-external.test.ts
+++ b/packages/farmjs-plugin/src/rsc/core-external.test.ts
@@ -306,6 +306,32 @@ export const schema = z.string();`;
           );
           if (name === "default") {
             writeRoute(
+              "accounts/[id]/page.tsx",
+              `export default async function Page() { throw new Error("private dynamic account failure"); }`,
+            );
+            writeRoute(
+              "accounts/[id]/error.tsx",
+              `"use client"; export default function ErrorPage() { return <main>Dynamic account error rendered</main>; }`,
+            );
+            writeRoute(
+              "accounts/new/page.tsx",
+              `export default async function Page() { throw new Error("private static account failure"); }`,
+            );
+            for (const [folder, marker] of [
+              ["(shop)/products", "Grouped product error rendered"],
+              ["docs/[[...slug]]", "Optional docs error rendered"],
+              ["middleware-failure", "Unselected page error rendered"],
+            ]) {
+              writeRoute(
+                `${folder}/page.tsx`,
+                `export default async function Page() { throw new Error("private boundary ancestry failure"); }`,
+              );
+              writeRoute(
+                `${folder}/error.tsx`,
+                `"use client"; export default function ErrorPage() { return <main>${marker}</main>; }`,
+              );
+            }
+            writeRoute(
               "users/[id]/page.tsx",
               `export default function Page({ params }) { return <main>Dynamic user {params.id}</main>; }`,
             );
@@ -638,6 +664,31 @@ export const echo = createEndpoint("/api/echo", { method: "POST" }, async ({ bod
 
         const origin = `http://127.0.0.1:${port}`;
         if (name === "default") {
+          for (const [pathname, expected, excluded] of [
+            ["/accounts/new", "Route error rendered", "Dynamic account error rendered"],
+            ["/accounts/alice", "Dynamic account error rendered", "Route error rendered"],
+            ["/products", "Grouped product error rendered", "Route error rendered"],
+            ["/docs", "Optional docs error rendered", "Route error rendered"],
+            ["/docs/a/b", "Optional docs error rendered", "Route error rendered"],
+            ["/middleware-failure", "Route error rendered", "Unselected page error rendered"],
+          ]) {
+            for (const accept of ["text/html", "text/x-component"]) {
+              const response = await fetch(origin + pathname, {
+                headers: { accept },
+                signal: AbortSignal.timeout(10_000),
+              });
+              const body = await response.text();
+              expect(response.status, logs).toBe(500);
+              expect(response.headers.get("content-type")).toContain(accept);
+              expect(response.headers.get("cache-control")).toBe("private, no-store");
+              expect(body).not.toContain("private ");
+              // Flight contains client module references; HTML contains rendered fallback UI.
+              if (accept === "text/html") {
+                expect(body, logs).toContain(expected);
+                expect(body, logs).not.toContain(excluded);
+              }
+            }
+          }
           for (const uploadCase of [
             {
               path: "/api/echo",

--- a/packages/farmjs-plugin/src/rsc/entries/boundary-ancestry.test.ts
+++ b/packages/farmjs-plugin/src/rsc/entries/boundary-ancestry.test.ts
@@ -1,0 +1,82 @@
+import { expect, it } from "vitest";
+import { generateRscEntry } from "./rsc.js";
+
+const entry = generateRscEntry({
+  srcDir: "src",
+  outDir: "dist",
+  basePath: "/",
+  actionsEnabled: false,
+  serverActions: { allowedOrigins: [], bodySizeLimit: 1000 },
+  deploymentId: "boundary-ancestry",
+  debug: false,
+});
+
+function matcher(modules: Record<string, unknown>) {
+  const start = entry.indexOf("function getRouteModules(");
+  const end = entry.indexOf("/**\n * Main request handler", start);
+  expect(start).toBeGreaterThan(-1);
+  expect(end).toBeGreaterThan(start);
+  return new Function(
+    "loadings",
+    "errors",
+    "layouts",
+    `${entry.slice(start, end)}; return getMatchingBoundary;`,
+  )(modules, modules, modules) as (
+    page: string | undefined,
+    modules: Record<string, unknown>,
+    kind: string,
+  ) => unknown;
+}
+
+it.each(["loading", "error"] as const)(
+  "selects %s boundaries only along the chosen page ancestry",
+  (kind) => {
+    const Root = () => null;
+    const Dynamic = () => null;
+    const Group = () => null;
+    const Optional = () => null;
+    const modules = {
+      [`/${kind}.tsx`]: { default: Root },
+      [`/users/[id]/${kind}.tsx`]: { default: Dynamic },
+      [`/(shop)/products/${kind}.tsx`]: { default: Group },
+      [`/docs/[[...slug]]/${kind}.tsx`]: { default: Optional },
+    };
+    const match = matcher(modules);
+    expect(match("/users/new/page.tsx", modules, kind)).toBe(Root);
+    expect(match("/users/[id]/page.tsx", modules, kind)).toBe(Dynamic);
+    expect(match("/(shop)/products/page.tsx", modules, kind)).toBe(Group);
+    expect(match("/docs/[[...slug]]/page.tsx", modules, kind)).toBe(Optional);
+    expect(match("/docs/[[...slug]]/nested/page.tsx", modules, kind)).toBe(Optional);
+    expect(match("/docs/page.tsx", modules, kind)).toBe(Root);
+    expect(match(undefined, modules, kind)).toBe(Root);
+  },
+);
+
+it.each(["loading", "error"] as const)(
+  "preserves relative module keys, extensions and nearest %s precedence",
+  (kind) => {
+    const Root = () => null;
+    const Parent = () => null;
+    const Leaf = () => null;
+    const modules = {
+      [`${kind}.js`]: { default: Root },
+      [`team/${kind}.ts`]: { default: Parent },
+      [`team/settings/${kind}.jsx`]: { default: Leaf },
+      [`team/settings/deeper/${kind}.tsx`]: {},
+    };
+    const match = matcher(modules);
+    expect(match("team/settings/deeper/page.jsx", modules, kind)).toBe(Leaf);
+    expect(match("team/page.ts", modules, kind)).toBe(Parent);
+    expect(match("teamwork/page.tsx", modules, kind)).toBe(Root);
+    expect(match("page.js", modules, kind)).toBe(Root);
+    expect(match("/elsewhere/page.tsx", {}, kind)).toBeNull();
+  },
+);
+
+it("wires loading, render errors and pre-shell failures to the same selected page", () => {
+  expect(entry).toContain("getMatchingBoundary(pattern, loadings, 'loading')");
+  expect(entry).toContain("getMatchingBoundary(pattern, errors, 'error')");
+  expect(entry).toContain("getMatchingBoundary(matchedPage?.pattern, errors, 'error')");
+  expect(entry).toContain("matchedPage = matched;");
+  expect(entry).not.toContain("boundaryPathToRoute");
+});

--- a/packages/farmjs-plugin/src/rsc/entries/layout-composition.test.ts
+++ b/packages/farmjs-plugin/src/rsc/entries/layout-composition.test.ts
@@ -14,7 +14,7 @@ const entry = generateRscEntry({
 const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor;
 
 it("retains a layout module reused at more than one ancestor", () => {
-  const start = entry.indexOf("function getLayoutModules(pageFilePath)");
+  const start = entry.indexOf("function getRouteModules(");
   const end = entry.indexOf("\n}\n\n/**\n * Main request handler", start) + 2;
   const shared = { default: () => null };
   const getLayouts = new Function(

--- a/packages/farmjs-plugin/src/rsc/entries/rsc.ts
+++ b/packages/farmjs-plugin/src/rsc/entries/rsc.ts
@@ -323,57 +323,6 @@ debug('Discovered middlewares:', Object.keys(middlewares));
 debug('Discovered API routes:', Array.from(apiRouteMap.keys()));
 
 /**
- * Convert loading/error file path to route pattern (segment the boundary applies to).
- * Inlined to avoid runtime dependency on plugin package; logic is simple and covered by e2e.
- */
-function boundaryPathToRoute(filePath, globVal, kind) {
-  const re = kind === 'loading' ? /\\/loading\\.[tj]sx?$/i : /\\/error\\.[tj]sx?$/i;
-  let route = filePath.replace(globVal, '').replace(re, '').replace(/\\\\/g, '/') || '/';
-  route = route.replace(/\\[([^\\]]+)\\]/g, ':$1');
-  return route;
-}
-function getMatchingLoading(pathname, globVal) {
-  const normalized = pathname.replace(/\\/$/, '') || '/';
-  const pathParts = normalized.split('/').filter(Boolean);
-  let best = null, bestLength = -1;
-  for (const filePath of Object.keys(loadings)) {
-    const pattern = boundaryPathToRoute(filePath, globVal, 'loading');
-    const patternParts = pattern === '/' ? [] : pattern.split('/').filter(Boolean);
-    if (patternParts.length > pathParts.length) continue;
-    let matches = true;
-    for (let i = 0; i < patternParts.length; i++) {
-      const p = patternParts[i], seg = pathParts[i];
-      if (!seg || (p.startsWith(':') && p !== ':...') || p === ':...') continue;
-      if (!p.startsWith(':') && p !== seg) { matches = false; break; }
-    }
-    if (matches && patternParts.length > bestLength && loadings[filePath]?.default) {
-      best = loadings[filePath].default; bestLength = patternParts.length;
-    }
-  }
-  return best;
-}
-function getMatchingError(pathname, globVal) {
-  const normalized = pathname.replace(/\\/$/, '') || '/';
-  const pathParts = normalized.split('/').filter(Boolean);
-  let best = null, bestLength = -1;
-  for (const filePath of Object.keys(errors)) {
-    const pattern = boundaryPathToRoute(filePath, globVal, 'error');
-    const patternParts = pattern === '/' ? [] : pattern.split('/').filter(Boolean);
-    if (patternParts.length > pathParts.length) continue;
-    let matches = true;
-    for (let i = 0; i < patternParts.length; i++) {
-      const p = patternParts[i], seg = pathParts[i];
-      if (!seg || (p.startsWith(':') && p !== ':...') || p === ':...') continue;
-      if (!p.startsWith(':') && p !== seg) { matches = false; break; }
-    }
-    if (matches && patternParts.length > bestLength && errors[filePath]?.default) {
-      best = errors[filePath].default; bestLength = patternParts.length;
-    }
-  }
-  return best;
-}
-
-/**
  * Convert middleware file path to route path
  * e.g., '/src/middleware.ts' -> '/'
  * e.g., '/src/counter/middleware.ts' -> '/counter'
@@ -476,14 +425,14 @@ function mergeDocumentMetadata(...sources) {
 }
 
 /**
- * Find every applicable layout module from root to the page directory.
- * Rendering and document metadata share the complete root -> nested layouts
- * -> page chain.
+ * Find modules along the selected page's actual file ancestry, root to leaf.
+ * Keep route groups and catch-all folders; matching URL prefixes can pick
+ * boundaries from a sibling page that the router did not select.
  */
-function getLayoutModules(pageFilePath) {
+function getRouteModules(pageFilePath, modules, kind) {
   const tryKeys = (...keys) => {
     for (const k of keys) {
-      if (layouts[k]?.default) return layouts[k];
+      if (modules[k]?.default) return modules[k];
     }
     return null;
   };
@@ -495,18 +444,29 @@ function getLayoutModules(pageFilePath) {
   for (let depth = 0; depth <= parts.length; depth++) {
     const relativeDir = parts.slice(0, depth).join('/');
     const absoluteDir = relativeDir ? '/' + relativeDir : '';
-    let matchedLayout = null;
+    let matchedModule = null;
     for (const ext of extensions) {
-      matchedLayout = tryKeys(
-        absoluteDir + '/layout.' + ext,
-        relativeDir ? relativeDir + '/layout.' + ext : 'layout.' + ext,
+      matchedModule = tryKeys(
+        absoluteDir + '/' + kind + '.' + ext,
+        relativeDir ? relativeDir + '/' + kind + '.' + ext : kind + '.' + ext,
       );
-      if (matchedLayout) break;
+      if (matchedModule) break;
     }
-    if (matchedLayout) matches.push(matchedLayout);
+    if (matchedModule) matches.push(matchedModule);
   }
 
   return matches;
+}
+
+function getLayoutModules(pageFilePath) {
+  return getRouteModules(pageFilePath, layouts, 'layout');
+}
+
+function getMatchingBoundary(pageFilePath, modules, kind) {
+  // Before page selection (for example, middleware failure), only the root
+  // boundary applies. Do not guess a route from a partially processed URL.
+  const matches = getRouteModules(pageFilePath ?? '/page.tsx', modules, kind);
+  return matches.at(-1)?.default ?? null;
 }
 
 /**
@@ -515,6 +475,7 @@ function getLayoutModules(pageFilePath) {
  */
 async function handleFarmRequest(request) {
   let url = new URL(request.url);
+  let matchedPage = null;
   let errorData = new Map();
   let errorContext = new Map();
   let errorHeaders = new Headers();
@@ -717,6 +678,7 @@ async function handleFarmRequest(request) {
   code += `
   // Match the URL to a page component
   const matched = matchRoute(url.pathname);
+  matchedPage = matched;
   
   if (!matched) {
     debug('404 - No route found for:', url.pathname);
@@ -758,14 +720,14 @@ async function handleFarmRequest(request) {
   }
   
   // Route-level loading boundary: wrap in Suspense so async content shows fallback
-  const LoadingComponent = getMatchingLoading(url.pathname, glob);
+  const LoadingComponent = getMatchingBoundary(pattern, loadings, 'loading');
   if (LoadingComponent) {
     const loadingFallback = h(LoadingComponent, { params, path: url.pathname });
     pageContent = h(React.Suspense, { fallback: loadingFallback }, pageContent);
   }
   
   // Route-level error boundary (Next.js error.tsx): catches render errors in this segment
-  const ErrorComponent = getMatchingError(url.pathname, glob);
+  const ErrorComponent = getMatchingBoundary(pattern, errors, 'error');
   if (ErrorComponent) {
     pageContent = h(RouteErrorBoundary, {
       Fallback: ErrorComponent,
@@ -904,17 +866,16 @@ async function handleFarmRequest(request) {
     }
     // Render outside the failed page/layout tree, but retain request context.
     const pathname = url.pathname.replace(/\\/$/, '') || '/';
-    const ErrorComponent = getMatchingError(pathname, '');
+    const ErrorComponent = getMatchingBoundary(matchedPage?.pattern, errors, 'error');
     if (ErrorComponent) {
       try {
         return await _runWithCurrentRequest(request, () =>
           _runWithMiddlewareData(errorData, () =>
             _runWithMiddlewareContext(errorContext, async () => {
               const h = React.createElement;
-              const matched = matchRoute(pathname);
               const errSearchParams = searchParamsToObject(url.searchParams);
               const fallbackProps = {
-                params: matched?.params || {},
+                params: matchedPage?.params || {},
                 path: pathname,
                 search: url.search,
                 searchParams: errSearchParams,

--- a/packages/farmjs-plugin/src/rsc/entries/security.test.ts
+++ b/packages/farmjs-plugin/src/rsc/entries/security.test.ts
@@ -261,7 +261,7 @@ describe("generated server action security", () => {
     expect(layoutMetadata).toBeLessThan(pageMetadata);
 
     const mergeStart = serverEntry.indexOf("function mergeDocumentMetadata(...sources)");
-    const mergeEnd = serverEntry.indexOf("\n}\n\n/**\n * Find every applicable", mergeStart) + 2;
+    const mergeEnd = serverEntry.indexOf("\n}\n\n/**\n * Find modules", mergeStart) + 2;
     const mergeDocumentMetadata = new Function(
       `${serverEntry.slice(mergeStart, mergeEnd)}; return mergeDocumentMetadata;`,
     )() as (...sources: Array<{ title?: string; description?: string } | undefined>) => {
@@ -277,7 +277,7 @@ describe("generated server action security", () => {
     ).toEqual({ title: "Nested", description: "Page description" });
     expect(mergeDocumentMetadata(undefined, {})).toEqual({});
 
-    const layoutsStart = serverEntry.indexOf("function getLayoutModules(pageFilePath)");
+    const layoutsStart = serverEntry.indexOf("function getRouteModules(");
     const layoutsEnd = serverEntry.indexOf("\n}\n\n/**\n * Main request handler", layoutsStart) + 2;
     const applicableLayouts = new Function(`
       const root = { default() {}, metadata: { title: 'Root' } };


### PR DESCRIPTION
## Problem

RSC can render a sibling route's error UI even after selecting the correct page. For example, `/accounts/new/page.tsx` can pick `/accounts/[id]/error.tsx`. Loading/error boundaries in route groups and optional catch-all folders also match inconsistently. This follows up on #947 and #949.

## Root cause

Boundary selection still used a separate URL-prefix matcher. A matching pathname is not proof that a boundary belongs to the selected page's file ancestry.

## Change

Share the existing layout ancestry traversal with loading/error boundaries. Keep the selected page for pre-shell error handling. Before a page is selected, such as on middleware failure, only the root error boundary applies.

## Safety and compatibility

Preserves layout composition, metadata, route-group folders, catch-all ancestry, extension precedence, and relative module keys. Existing redirects/not-found handling, production error sanitization, and private no-store error responses remain intact. Applies to the shared RSC development/production entry; no changes to other renderers or the experimental compiler.

## Verification

On this standalone branch, macOS / Node 23.11.0 / pnpm 8.12.1:

```sh
pnpm --filter @farm.js/plugin exec vitest run
pnpm --filter @farm.js/plugin typecheck
```

126 tests pass, including isolated Nitro Node builds booted after removing their source project and workspace dependencies. HTML and Flight requests cover static/dynamic siblings, route groups, optional catch-all parent/deep URLs, and pre-selection middleware errors.

Before the fix, the production regression rendered `Dynamic account error rendered` for `/accounts/new` instead of the root fallback. The combined follow-up changes also passed core/plugin builds and type checks and documentation navigation checks.

## Documentation and release

Updated the routing guide with file-ancestry selection and pre-selection failure behavior. No versions, templates, flags, or generated route changes.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes RSC loading and error boundary selection so sibling routes no longer inherit each other's boundary files. Boundaries are now resolved from the selected page's file ancestry; before a page is selected, only the root error boundary applies.

**Notes**
- Boundary matching reuses the layout ancestry traversal, so route groups and catch-all folders are handled consistently.
- Layout composition, metadata, redirect/not-found handling, and production error sanitization are unchanged.
- Routing docs now describe file-ancestry selection and pre-selection failure behavior.

<sup>Written for commit b92b62480360973e710fc340bdd0ecc23998d78e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/956?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

