### PR TITLE
perf(react): compile grouped keyed map switch cases

### DIFF
--- a/docs/src/app/docs/renderers/react/page.md
+++ b/docs/src/app/docs/renderers/react/page.md
@@ -922,16 +922,18 @@ conditional: at least one path returns the original item and another returns a n
 spreads that item. This may be a concise expression or a structured block made from fully returning
 `if` or `switch` branches plus immutable local `const` aliases. Each alias needs a simple identifier
 and a compiler-safe initializer. A `switch` needs one `default`, a complete return from every case,
-and no shared fallthrough cases or trailing statements. Its discriminant, case tests, conditions,
-and replacement values must use the same safe expression subset. The hint runtime is retained only
-in modules where at least one such call is emitted; direct-only and ordinary keyed builds do not
-import that capability.
+and no trailing statements. Consecutive empty case labels may share the next fully returning body;
+a case that executes anything before falling through, or a final label with no body, is rejected.
+Its discriminant, case tests, conditions, and replacement values must use the same safe expression
+subset. The hint runtime is retained only in modules where at least one such call is emitted;
+direct-only and ordinary keyed builds do not import that capability.
 
 ```tsx
 setItems((current) =>
   current.map((item) => {
     switch (item.status) {
       case "draft":
+      case "queued":
         return { ...item, label: draftLabel };
       case "published":
         return { ...item, label: publishedLabel };
@@ -955,8 +957,8 @@ array, unsupported mapper anywhere in the chain, changed key, insert, removal, r
 second dependency, or failed runtime check uses the existing complete keyed reconciliation and LIS
 path. Native results and thrown mapper or method errors are preserved. Derived collections,
 non-functional setters, referenced callbacks, mutable or destructured local declarations,
-effectful initializers, other intermediate statements, fallthrough, mutating replacements, and
-other unproven shapes also keep that existing path. This is an optimization hint, not a new
+effectful initializers, other intermediate statements, partial or dangling fallthrough, mutating
+replacements, and other unproven shapes also keep that existing path. This is an optimization hint, not a new
 correctness contract or a way to bypass React fallback behavior. The compiler report exposes the
 number of prepared map calls as `keyedMapUpdateHints`.
 
@@ -1426,9 +1428,9 @@ The compiler recursively proves every condition and leaf. Each leaf must return 
 or a compiler-safe object spread of that item, with at least one unchanged and one replacement
 path. Block bodies may also introduce local `const` aliases with simple identifier bindings and
 compiler-safe initializers. Mutable or destructured declarations, object/array/function literals,
-unknown calls, loops, mutation, fallthrough, and any other effectful or ambiguous control flow keep
-complete keyed reconciliation. Runtime key validation remains atomic, so a replacement that changes
-its key falls back before the first DOM write.
+unknown calls, loops, mutation, partial or dangling fallthrough, and any other effectful or ambiguous
+control flow keep complete keyed reconciliation. Runtime key validation remains atomic, so a
+replacement that changes its key falls back before the first DOM write.
 
 Before changing the DOM, the runtime verifies ordinary dense arrays, exact native methods, the
 committed collection token, equal lengths, a unique one-to-one source-item match, and the key of
@@ -1604,13 +1606,14 @@ sort or any other order ambiguity keeps the general permutation path.
 
 The proof requires every map callback to be inline, synchronous, compiler-safe, and to return the
 original item on one conditional path and an object-spread replacement on another. Concise
-expressions and structured blocks containing proven local `const` aliases plus `if`/`return` paths
-are accepted. It requires compiler-owned host rows whose render and key do not observe the index.
+expressions and structured blocks containing proven local `const` aliases plus fully returning `if`
+or `switch` branches are accepted. It requires compiler-owned host rows whose render and key do not observe the index.
 Referenced callbacks, mutable, destructured, or effectful declarations, other intermediate
-statements, fallthrough, unconditional replacements, changed or duplicate keys, `thisArg`, maps
-after structural steps, computed or custom methods, sparse or subclassed arrays, collection-reading
-bindings, React-owned rows, nested host blocks, row conditionals, unrelated dirty dependencies, or
-failed runtime validation use complete keyed reconciliation before any fast-path DOM write.
+statements, partial or dangling fallthrough, unconditional replacements, changed or duplicate keys,
+`thisArg`, maps after structural steps, computed or custom methods, sparse or subclassed arrays,
+collection-reading bindings, React-owned rows, nested host blocks, row conditionals, unrelated dirty
+dependencies, or failed runtime validation use complete keyed reconciliation before any fast-path
+DOM write.
 
 No API or option is added. Reports count the prepared map and reorder calls through the existing
 `keyedMapUpdateHints`, `keyedArraySortHints`, and `keyedArrayReorderHints` fields. Modules that do
@@ -2485,8 +2488,8 @@ The package and example test suites verify more than generated code:
   focus and selection, and cover changed mapped keys, unsafe evaluated bounds, reused or discarded
   intermediate keys, custom slices, mixed queued chains, collection-dependent rows, Strict Mode
   hydration, React 18/19, and unmount cleanup; compiler tests accept recursively proven
-  `if` and fully returning `switch` maps while rejecting effectful leaves, switch fallthrough, and
-  callbacks that replace every row;
+  `if` and fully returning `switch` maps, including grouped empty labels, while rejecting effectful
+  leaves, partial or dangling fallthrough, and callbacks that replace every row;
 - 2,000 deterministic randomized keyed-array removals match normal React; targeted tests require
   zero surviving descriptor and binding reads, preserve DOM identity, and cover queued filters,
   unhinted-chain fallback, collection-reading rows, StrictMode hydration, and unmount cleanup;

--- a/examples/react-compiler-dashboard/README.md
+++ b/examples/react-compiler-dashboard/README.md
@@ -152,7 +152,7 @@ DOM identity, mapped value, exact row count, fresh suffix, and zero compiled own
 
 Mapped rolling-window chains have a separate gate so the single-window result cannot hide a chain
 regression. The 10,000-row workload runs one structured, fully returning `switch` map with safe
-local `const` aliases between two queued 50-row rolls. Its control uses
+local `const` aliases and two grouped case labels between two queued 50-row rolls. Its control uses
 unsupported block-bodied rolling setters, so it performs the same native work without retaining
 compiler lineage. Both compiler modes must remain at least 2x faster than React and 1.25x faster
 than that control, and the compiler report must contain both mapped rolling-chain steps. Every

--- a/examples/react-compiler-dashboard/scripts/benchmark.mjs
+++ b/examples/react-compiler-dashboard/scripts/benchmark.mjs
@@ -643,22 +643,32 @@ async function measureTrial(browser, trial, compilerMode, port) {
           const rows = table.querySelectorAll("tbody tr");
           const reviewedSurvivor = rows[100];
           const escalatedSurvivor = rows[101];
+          const secondaryReviewedSurvivor = rows[102];
           const reviewedLabel = reviewedSurvivor?.querySelector("td:nth-child(2)")?.textContent;
           const escalatedLabel = escalatedSurvivor?.querySelector("td:nth-child(2)")?.textContent;
+          const secondaryReviewedLabel = secondaryReviewedSurvivor
+            ?.querySelector("td:nth-child(2)")
+            ?.textContent;
           const reviewedAmount = Number(
             reviewedSurvivor?.querySelector("td:nth-child(4)")?.textContent?.slice(1),
           );
           const escalatedAmount = Number(
             escalatedSurvivor?.querySelector("td:nth-child(4)")?.textContent?.slice(1),
           );
+          const secondaryReviewedAmount = Number(
+            secondaryReviewedSurvivor?.querySelector("td:nth-child(4)")?.textContent?.slice(1),
+          );
           const previousLast = rows[9_999]?.getAttribute("data-row-id");
           if (
             !reviewedSurvivor ||
             !escalatedSurvivor ||
+            !secondaryReviewedSurvivor ||
             !reviewedLabel ||
             !escalatedLabel ||
+            !secondaryReviewedLabel ||
             !Number.isFinite(reviewedAmount) ||
-            !Number.isFinite(escalatedAmount)
+            !Number.isFinite(escalatedAmount) ||
+            !Number.isFinite(secondaryReviewedAmount)
           ) {
             throw new Error("Mapped rolling-chain source rows are invalid.");
           }
@@ -668,6 +678,7 @@ async function measureTrial(browser, trial, compilerMode, port) {
               rowCount() === 10_000 &&
               nextRows[0] === reviewedSurvivor &&
               nextRows[1] === escalatedSurvivor &&
+              nextRows[2] === secondaryReviewedSurvivor &&
               reviewedSurvivor.querySelector("td:nth-child(2)")?.textContent ===
                 `${reviewedLabel} reviewed` &&
               reviewedSurvivor.querySelector("td:nth-child(4)")?.textContent ===
@@ -676,6 +687,10 @@ async function measureTrial(browser, trial, compilerMode, port) {
                 `${escalatedLabel} escalated` &&
               escalatedSurvivor.querySelector("td:nth-child(4)")?.textContent ===
                 `$${escalatedAmount + 2}` &&
+              secondaryReviewedSurvivor.querySelector("td:nth-child(2)")?.textContent ===
+                `${secondaryReviewedLabel} reviewed` &&
+              secondaryReviewedSurvivor.querySelector("td:nth-child(4)")?.textContent ===
+                `$${secondaryReviewedAmount + 1}` &&
               nextRows[9_999]?.getAttribute("data-row-id") !== previousLast
             );
           });

--- a/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
+++ b/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
@@ -322,6 +322,7 @@ export function StandardTableBenchmark() {
             const secondAdditions = buildRows(50, secondSeed);
             const reviewedId = rows[100].id;
             const escalatedId = rows[101].id;
+            const secondaryReviewedId = rows[102].id;
             const trimCount = 50;
             setSeed(secondSeed);
             setRows((current) => [...current.slice(trimCount), ...firstAdditions]);
@@ -330,6 +331,7 @@ export function StandardTableBenchmark() {
                 const target = row.id;
                 switch (target) {
                   case reviewedId:
+                  case secondaryReviewedId:
                     return { ...row, amount: row.amount + 1, label: `${row.label} reviewed` };
                   case escalatedId: {
                     const nextAmount = row.amount + 2;
@@ -357,6 +359,7 @@ export function StandardTableBenchmark() {
             const secondAdditions = buildRows(50, secondSeed);
             const reviewedId = rows[100].id;
             const escalatedId = rows[101].id;
+            const secondaryReviewedId = rows[102].id;
             const trimCount = 50;
             setSeed(secondSeed);
             setRows((current) => {
@@ -364,7 +367,7 @@ export function StandardTableBenchmark() {
             });
             setRows((current) =>
               current.map((row) =>
-                row.id === reviewedId
+                row.id === reviewedId || row.id === secondaryReviewedId
                   ? { ...row, amount: row.amount + 1, label: `${row.label} reviewed` }
                   : row.id === escalatedId
                     ? { ...row, amount: row.amount + 2, label: `${row.label} escalated` }

--- a/packages/farm-react/README.md
+++ b/packages/farm-react/README.md
@@ -236,14 +236,15 @@ Each stage requires an inline synchronous conditional mapper that returns the or
 least one path and an object-spread replacement on another. The callback may be a concise expression
 or a structured block containing fully returning `if` or `switch` branches and proven local `const`
 aliases. Each alias needs a simple identifier and compiler-safe initializer. A `switch` needs one
-`default`, a complete return from every case, safe discriminant and case expressions, and no shared
-fallthrough cases or trailing statements. An unsupported mapper anywhere in the chain disables the
-complete setter hint. Custom methods still execute but record no metadata. Key changes, structural
+`default`, a complete return from every case, safe discriminant and case expressions, and no trailing
+statements. Consecutive empty labels may share the next fully returning body; partially executed
+fallthrough and dangling labels are rejected. An unsupported mapper anywhere in the chain disables
+the complete setter hint. Custom methods still execute but record no metadata. Key changes, structural
 edits, sparse or subclassed arrays, relevant mixed dependencies, and failed runtime checks use the
 existing complete reconciliation and LIS path. Non-functional setters, derived collections,
 referenced callbacks, mutable or destructured declarations, effectful initializers, other
-intermediate statements, fallthrough, mutating mappers, and other unproven forms are simply not
-hinted. No new option is required. A compiler report counts prepared map calls as
+intermediate statements, partial or dangling fallthrough, mutating mappers, and other unproven forms
+are simply not hinted. No new option is required. A compiler report counts prepared map calls as
 `keyedMapUpdateHints`. The separate hint runtime capability is imported only when that count is
 nonzero, so direct-only and ordinary keyed builds do not retain it.
 
@@ -572,9 +573,10 @@ Every condition must be compiler-safe, and every leaf must return the original i
 object spread of it, with at least one unchanged and one replacement path. Concise expressions and
 blocks made from fully returning `if` or `switch` branches plus local `const` aliases are accepted.
 Each alias must have a simple identifier and compiler-safe initializer. A switch requires one
-`default`, complete returning cases, and no fallthrough. Mutable or destructured declarations,
-effectful initializers, other intermediate statements, fallthrough, and ambiguous leaves use
-complete keyed reconciliation. A runtime key change also falls back before any DOM write.
+`default` and complete returning cases. Consecutive empty labels may share the next body, while
+partial or dangling fallthrough is rejected. Mutable or destructured declarations, effectful
+initializers, other intermediate statements, and ambiguous leaves use complete keyed
+reconciliation. A runtime key change also falls back before any DOM write.
 
 Farm executes every native map and reorder call normally. For consecutive accepted maps, it checks
 each native call but compares only the input and final result of that map segment, avoiding a full
@@ -587,11 +589,11 @@ an object-spread replacement, plus index-independent compiler-owned host rows. C
 and structured blocks with proven local `const` aliases plus fully returning `if` or `switch`
 branches are supported.
 Changed keys, referenced callbacks, mutable, destructured, or effectful declarations, other
-intermediate statements or fallthrough, unconditional replacements, `thisArg`, structural calls in
-the same chain, computed or custom methods, sparse or subclassed arrays, collection-reading
-bindings, nested or React-owned rows, and failed checks use complete keyed reconciliation. Reports
-use the existing map, sort, and reorder hint counters, and unrelated modules do not retain this
-optional runtime.
+intermediate statements or partial/dangling fallthrough, unconditional replacements, `thisArg`,
+structural calls in the same chain, computed or custom methods, sparse or subclassed arrays,
+collection-reading bindings, nested or React-owned rows, and failed checks use complete keyed
+reconciliation. Reports use the existing map, sort, and reorder hint counters, and unrelated modules
+do not retain this optional runtime.
 
 The maps may also finish the concise pipeline:
 

--- a/packages/farm-react/src/__tests__/compiler-keyed-array-rolling-window-hints.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-keyed-array-rolling-window-hints.test.ts
@@ -232,7 +232,6 @@ describe("React AOT keyed-array rolling-window hints", () => {
               const target = row.id;
               switch (target) {
                 case firstId:
-                  return { ...row, label: nextLabel };
                 case secondId:
                   return { ...row, label: nextLabel };
                 default:

--- a/packages/farm-react/src/__tests__/compiler-keyed-array-sort-hints.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-keyed-array-sort-hints.test.ts
@@ -337,9 +337,8 @@ describe("React AOT keyed-array sort hints", () => {
             .map((row) => {
               switch (row.id) {
                 case firstId:
-                  return { ...row, rank: 4 };
                 case secondId:
-                  return { ...row, rank: 3 };
+                  return { ...row, rank: 4 };
                 default:
                   return row;
               }

--- a/packages/farm-react/src/__tests__/compiler-keyed-update-hints.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-keyed-update-hints.test.ts
@@ -236,10 +236,10 @@ describe("React AOT keyed update hints", () => {
     });
   });
 
-  it("records fully returning switch branches inside structured map callbacks", async () => {
+  it("records grouped switch labels inside structured map callbacks", async () => {
     const result = await compile(`
       import { useState } from "react";
-      export function Inventory({ reviewedId, escalatedId, delta }) {
+      export function Inventory({ reviewedId, archivedId, escalatedId, delta }) {
         const [items, setItems] = useState([
           { id: "a", label: "Alpha", amount: 1 },
           { id: "b", label: "Beta", amount: 2 },
@@ -250,6 +250,7 @@ describe("React AOT keyed update hints", () => {
               const target = row.id;
               switch (target) {
                 case reviewedId:
+                case archivedId:
                   return { ...row, label: "Reviewed" };
                 case escalatedId: {
                   const nextAmount = Math.round(row.amount + delta);
@@ -369,11 +370,18 @@ describe("React AOT keyed update hints", () => {
         'setItems((current) => current.map((row) => { switch (row.id) { case "a": return { ...row, label: "Updated" }; case "b": return row; } }))',
     },
     {
-      name: "a switch with a fallthrough case",
+      name: "a switch with a partially executed fallthrough case",
       declaration: "",
       collection: "items",
       update:
-        'setItems((current) => current.map((row) => { switch (row.id) { case "a": case "b": return { ...row, label: "Updated" }; default: return row; } }))',
+        'setItems((current) => current.map((row) => { switch (row.id) { case "a": const label = row.label; case "b": return { ...row, label }; default: return row; } }))',
+    },
+    {
+      name: "a switch with a dangling grouped label",
+      declaration: "",
+      collection: "items",
+      update:
+        'setItems((current) => current.map((row) => { switch (row.id) { case "a": return { ...row, label: "Updated" }; default: return row; case "b": } }))',
     },
     {
       name: "a switch with a break path",

--- a/packages/farm-react/src/compiler.ts
+++ b/packages/farm-react/src/compiler.ts
@@ -1307,12 +1307,13 @@ function proveSafeKeyedMapSwitchStatement(
   }
 
   let proof: SafeKeyedMapBranchProof | undefined;
-  for (const switchCase of statement.cases) {
-    if (
-      (switchCase.test && validateDerivedExpression(switchCase.test, safeGlobals)) ||
-      switchCase.consequent.length === 0
-    ) {
+  for (const [index, switchCase] of statement.cases.entries()) {
+    if (switchCase.test && validateDerivedExpression(switchCase.test, safeGlobals)) {
       return undefined;
+    }
+    if (switchCase.consequent.length === 0) {
+      if (index === statement.cases.length - 1) return undefined;
+      continue;
     }
     const branch =
       switchCase.consequent.length === 1 && t.isBlockStatement(switchCase.consequent[0])


### PR DESCRIPTION
## Problem

The keyed-map proof added in #950 accepts fully returning `switch` callbacks but rejects ordinary grouped labels such as `case "draft": case "queued": return ...`. Those callbacks therefore fall back to complete keyed reconciliation even though the labels share one safe return body.

## Root cause

The compiler rejected every `SwitchCase` with an empty `consequent`. That correctly excluded dangling labels, but it also excluded a non-final empty label whose JavaScript behavior is to continue directly into the next case body.

## Change

Accept a non-final empty case label and prove the next non-empty case body with the existing recursive keyed-map proof. Keep validating every case test. A final empty label, a case that executes statements before falling through, a missing default, a non-returning body, or any unsafe expression still disables the hint.

The keyed update, sort, and rolling-window compiler suites now exercise grouped labels. The 10,000-row production dashboard benchmark updates two rows through one grouped body and verifies both values and DOM identities. Package and renderer docs describe the supported shape and its fallback boundaries.

## Safety and compatibility

- The native `map` callback and `switch` still execute; this only broadens build-time eligibility.
- Runtime atomic validation, key checks, React fallback, and thrown JavaScript errors are unchanged.
- Partially executed and dangling fallthrough remain rejected before metadata is emitted.
- No public API, compiler option, runtime helper, report field, or renderer-neutral behavior changes.
- Runtime-size fixtures are unchanged, and React 18.3.1 plus React 19.2.8 compatibility passed.

## Verification

- `pnpm --filter @farm.js/react type-check`
- `pnpm --filter @farm.js/react test:runtime-size`
- `pnpm --filter @farm.js/react exec vitest run --maxWorkers=1 --minWorkers=1` — 75 files, 852 passed, 14 skipped
- `pnpm --filter @farm.js/react exec vitest run --config vitest.stress.config.ts --maxWorkers=1 --minWorkers=1` — 8 files, 23 passed, 132 skipped
- `pnpm --filter @farm.js/react test:compat` — React 18.3.1 and 19.2.8
- `pnpm --dir examples/react-compiler-dashboard type-check`
- `pnpm docs:check-navigation`
- `pnpm --dir docs exec farm generate --check`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm docs:build`
- focused compiler suites — 3 files, 94 passed
- `pnpm exec oxlint ...` — 0 warnings, 0 errors
- `git diff --check`

The production browser benchmark passed correctness twice, retained zero compiled component owner executions, retained 2 mapped rolling-chain hints and 34 keyed-map hints, and kept the static/hybrid example at 31,742 gzip bytes. The grouped mapped-chain gate passed both runs:

- run 1: 18.26x static and 12.10x hybrid versus React; 3.81x and 4.17x versus the fallback control
- isolated rerun: 17.80x static and 28.38x hybrid versus React; 4.12x and 4.08x versus the fallback control

The aggregate command exited nonzero on unrelated timing thresholds that varied between runs: hybrid append at 2.57x in run 1; then static append at 3.86x (4x threshold) and hybrid 20k updates at 6.37x in run 2. This change adds no runtime code and does not touch those paths; the failures are recorded here rather than weakening the benchmark gates.

## Documentation and release

Updated the React renderer guide, package README, and compiler dashboard README/example. No version or release metadata changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lets the keyed-map compiler hint accept grouped `switch` case labels, so callbacks with shared return bodies (e.g. `case "draft": case "queued": return ...`) now take the fast keyed path instead of falling back to complete keyed reconciliation.

- Rejects only a final empty label or a case that executes statements before fallthrough; all other validation is unchanged.
- No runtime code, public API, or compiler option changes; native `map` and `switch` still execute normally.
- Tests and the 10,000-row dashboard benchmark now cover grouped labels, including DOM identity and value checks.

<sup>Written for commit 2631efc1316cc0f2a1c3ccb7efda15b47e275b87. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/957?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

