### PR TITLE
perf(react): compile block-bodied keyed map setters

### DIFF
--- a/docs/src/app/docs/renderers/react/page.md
+++ b/docs/src/app/docs/renderers/react/page.md
@@ -916,17 +916,19 @@ setItems((current) =>
 ```
 
 This needs no option or component primitive. At build time, Farm recognizes a functional setter on
-the direct `useState` collection used by a compiled keyed map or `List`. The setter may contain one
-or more consecutive `map()` calls. Every mapper must be an inline arrow whose returning paths are
-conditional: at least one path returns the original item and another returns a new object that
-spreads that item. This may be a concise expression or a structured block made from fully returning
-`if` or `switch` branches plus immutable local `const` aliases. Each alias needs a simple identifier
-and a compiler-safe initializer. A `switch` needs one `default`, a complete return from every case,
-and no trailing statements. Consecutive empty case labels may share the next fully returning body;
-a case that executes anything before falling through, or a final label with no body, is rejected.
-Its discriminant, case tests, conditions, and replacement values must use the same safe expression
-subset. The hint runtime is retained only in modules where at least one such call is emitted;
-direct-only and ordinary keyed builds do not import that capability.
+the direct `useState` collection used by a compiled keyed map or `List`. The setter may be concise or
+use a block containing exactly one value-returning `return`, and that returned expression may contain
+one or more consecutive `map()` calls. Extra updater statements, conditional returns, or a missing
+return keep complete keyed reconciliation. Every mapper must be an inline arrow whose returning
+paths are conditional: at least one path returns the original item and another returns a new object
+that spreads that item. This may be a concise expression or a structured block made from fully
+returning `if` or `switch` branches plus immutable local `const` aliases. Each alias needs a simple
+identifier and a compiler-safe initializer. A `switch` needs one `default`, a complete return from
+every case, and no trailing statements. Consecutive empty case labels may share the next fully
+returning body; a case that executes anything before falling through, or a final label with no body,
+is rejected. Its discriminant, case tests, conditions, and replacement values must use the same safe
+expression subset. The hint runtime is retained only in modules where at least one such call is
+emitted; direct-only and ordinary keyed builds do not import that capability.
 
 ```tsx
 setItems((current) =>
@@ -1398,8 +1400,9 @@ setItems((current) =>
 );
 ```
 
-For a concise functional setter, Farm can prepare one or more consecutive safe same-key `map()`
-calls before or after native `toSorted()` or `toReversed()` calls as one update pipeline.
+For a concise functional setter or a setter block containing exactly one direct `return`, Farm can
+prepare one or more consecutive safe same-key `map()` calls before or after native `toSorted()` or
+`toReversed()` calls as one update pipeline.
 JavaScript still performs every map and reorder normally. For two or more accepted maps, the
 compiler runtime checks each native call as it completes but records replacement lineage only once,
 by comparing the input and final result of each consecutive map segment. The intermediate arrays
@@ -1604,7 +1607,8 @@ setters too. For example, a queued reverse followed by a safe map and another re
 changed row in committed order without moving DOM rows or constructing the generic source map. A
 sort or any other order ambiguity keeps the general permutation path.
 
-The proof requires every map callback to be inline, synchronous, compiler-safe, and to return the
+The setter may be concise or a block with exactly one direct value-returning `return`. The proof
+requires every map callback to be inline, synchronous, compiler-safe, and to return the
 original item on one conditional path and an object-spread replacement on another. Concise
 expressions and structured blocks containing proven local `const` aliases plus fully returning `if`
 or `switch` branches are accepted. It requires compiler-owned host rows whose render and key do not observe the index.

--- a/examples/react-compiler-dashboard/README.md
+++ b/examples/react-compiler-dashboard/README.md
@@ -151,12 +151,13 @@ least 2x faster than React and 1.25x faster than that control. Every sample veri
 DOM identity, mapped value, exact row count, fresh suffix, and zero compiled owner executions.
 
 Mapped rolling-window chains have a separate gate so the single-window result cannot hide a chain
-regression. The 10,000-row workload runs one structured, fully returning `switch` map with safe
-local `const` aliases and two grouped case labels between two queued 50-row rolls. Its control uses
-unsupported block-bodied rolling setters, so it performs the same native work without retaining
-compiler lineage. Both compiler modes must remain at least 2x faster than React and 1.25x faster
-than that control, and the compiler report must contain both mapped rolling-chain steps. Every
-sample verifies both retained identities and mapped values plus the final incoming suffix.
+regression. The 10,000-row workload runs one structured, fully returning `switch` map from a
+single-return block-bodied setter, with safe local `const` aliases and two grouped case labels between
+two queued 50-row rolls. Its control uses unsupported block-bodied rolling setters, so it performs
+the same native work without retaining compiler lineage. Both compiler modes must remain at least 2x
+faster than React and 1.25x faster than that control, and the compiler report must contain both mapped
+rolling-chain steps. Every sample verifies both retained identities and mapped values plus the final
+incoming suffix.
 
 Exact-position insertions, removals, and replacements have separate 10,000-row comparisons. Concise
 native `toSpliced(position, 0, item)`, `toSpliced(position, 0, ...items)`, `toSpliced(position, 1)`,

--- a/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
+++ b/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
@@ -326,8 +326,8 @@ export function StandardTableBenchmark() {
             const trimCount = 50;
             setSeed(secondSeed);
             setRows((current) => [...current.slice(trimCount), ...firstAdditions]);
-            setRows((current) =>
-              current.map((row) => {
+            setRows((current) => {
+              return current.map((row) => {
                 const target = row.id;
                 switch (target) {
                   case reviewedId:
@@ -340,8 +340,8 @@ export function StandardTableBenchmark() {
                   default:
                     return row;
                 }
-              }),
-            );
+              });
+            });
             setRows((current) => [...current.slice(trimCount), ...secondAdditions]);
             setOperation("map through two queued rolling windows");
             setRevision((value) => value + 1);

--- a/packages/farm-react/README.md
+++ b/packages/farm-react/README.md
@@ -232,6 +232,8 @@ once; intermediate arrays never receive DOM work. Every user `map()` remains O(n
 keyed runtime's second full key-and-binding scan. Queued hints compose. The source method lookup,
 native result, callback order, and thrown errors are preserved.
 
+The setter may be concise or use a block containing exactly one value-returning `return`. Extra
+updater statements, conditional returns, and missing returns keep complete keyed reconciliation.
 Each stage requires an inline synchronous conditional mapper that returns the original item on at
 least one path and an object-spread replacement on another. The callback may be a concise expression
 or a structured block containing fully returning `if` or `switch` branches and proven local `const`
@@ -578,10 +580,11 @@ partial or dangling fallthrough is rejected. Mutable or destructured declaration
 initializers, other intermediate statements, and ambiguous leaves use complete keyed
 reconciliation. A runtime key change also falls back before any DOM write.
 
-Farm executes every native map and reorder call normally. For consecutive accepted maps, it checks
-each native call but compares only the input and final result of that map segment, avoiding a full
-lineage scan for every intermediate array. It verifies the committed token, dense-array shape, a
-one-to-one source-item match, and every final replacement key before touching the DOM, then runs one
+The functional setter may be concise or a block containing exactly one direct value-returning
+`return`. Farm executes every native map and reorder call normally. For consecutive accepted maps,
+it checks each native call but compares only the input and final result of that map segment, avoiding
+a full lineage scan for every intermediate array. It verifies the committed token, dense-array
+shape, a one-to-one source-item match, and every final replacement key before touching the DOM, then runs one
 LIS and patches each changed row once. Unchanged rows need no second key or binding read. Queued
 supported map-and-reorder setters compose against the same committed rows. Every accepted map
 requires an inline synchronous conditional mapper whose leaves return either the original item or
@@ -612,7 +615,7 @@ sort remains an ambiguous permutation, so Farm performs one validated source loo
 Safe maps on both sides of a reorder flatten their replacements back to the same committed rows.
 
 Safe maps may also run before, between, or after index-independent `filter` or `slice` steps in one
-concise functional setter. A final native reorder is optional:
+concise functional setter or one block with a single direct `return`. A final native reorder is optional:
 
 ```tsx
 setItems((current) =>

--- a/packages/farm-react/src/__tests__/compiler-keyed-update-hints.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-keyed-update-hints.test.ts
@@ -108,6 +108,43 @@ describe("React AOT keyed update hints", () => {
     });
   });
 
+  it("records keyed maps returned from a block-bodied state updater", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Inventory({ editedId, nextLabel }) {
+        const [items, setItems] = useState([
+          { id: "a", label: "Alpha", selected: false },
+          { id: "b", label: "Beta", selected: false },
+        ]);
+        return (
+          <section>
+            <button onClick={() => setItems((current) => {
+              return current
+                .map((row) => row.id === editedId ? { ...row, label: nextLabel } : row)
+                .map((row) => row.id === editedId ? { ...row, selected: true } : row);
+            })}>Update</button>
+            <ul>{items.map((item) => <li key={item.id}>{item.label}</li>)}</ul>
+          </section>
+        );
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Inventory"]);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.optimizations.keyedMapUpdateHints).toBe(2);
+    expect(result.code.match(/createCompilerKeyedMapUpdate\(/g)).toHaveLength(1);
+    expect(result.code.match(/_farmApplyMap\d*\(/g)).toHaveLength(2);
+    expect(result.code).toContain("keyedRowsHintedRuntimeFeature");
+    await expect(
+      transformWithEsbuild(result.code, "/app/KeyedUpdateHints.tsx", {
+        loader: "tsx",
+        jsx: "automatic",
+      }),
+    ).resolves.toMatchObject({
+      code: expect.stringContaining("createCompilerKeyedMapUpdate"),
+    });
+  });
+
   it("records one keyed update for a safe multi-branch map", async () => {
     const result = await compile(`
       import { useState } from "react";
@@ -312,6 +349,27 @@ describe("React AOT keyed update hints", () => {
       collection: "visible",
       update:
         'setItems((current) => current.map((row) => row.id === "a" ? { ...row, label: "Updated" } : row))',
+    },
+    {
+      name: "an updater block with statements before its return",
+      declaration: "",
+      collection: "items",
+      update:
+        'setItems((current) => { const next = current.map((row) => row.id === "a" ? { ...row, label: "Updated" } : row); return next; })',
+    },
+    {
+      name: "an updater block with conditional returns",
+      declaration: "",
+      collection: "items",
+      update:
+        'setItems((current) => { if (current.length > 0) return current.map((row) => row.id === "a" ? { ...row, label: "Updated" } : row); return current; })',
+    },
+    {
+      name: "an updater block without a return",
+      declaration: "",
+      collection: "items",
+      update:
+        'setItems((current) => { current.map((row) => row.id === "a" ? { ...row, label: "Updated" } : row); })',
     },
     {
       name: "a mutable local declaration",

--- a/packages/farm-react/src/compiler.ts
+++ b/packages/farm-react/src/compiler.ts
@@ -1432,12 +1432,17 @@ function rewriteKeyedMapUpdateHints(
         updater.async ||
         updater.generator ||
         updater.params.length !== 1 ||
-        !t.isIdentifier(updater.params[0]) ||
-        !t.isExpression(updater.body)
+        !t.isIdentifier(updater.params[0])
       ) {
         return;
       }
-      const callbacks = keyedMapUpdatePipeline(updater.body, updater.params[0].name, safeGlobals);
+      const updateExpression = returnedExpression(updater);
+      if (!updateExpression) return;
+      const callbacks = keyedMapUpdatePipeline(
+        updateExpression,
+        updater.params[0].name,
+        safeGlobals,
+      );
       if (!callbacks) return;
 
       const previous = t.cloneNode(updater.params[0]);


### PR DESCRIPTION
## Problem

A common functional setter style still missed the keyed-map compiler path:

```tsx
setRows((current) => {
  return current.map(/* safe keyed replacement */);
});
```

The equivalent concise arrow was compiled, but adding an otherwise equivalent single direct `return` forced complete React keyed reconciliation.

## Root cause

The keyed-map rewrite required the updater arrow body itself to be an expression. The compiler already has a shared `returnedExpression` proof that accepts either a concise body or a block containing exactly one value-returning `return`, but this rewrite did not use it.

## Change

- Reuse `returnedExpression` before analyzing keyed map pipelines.
- Compile direct-return block setters through the existing keyed-map hint and runtime validation path.
- Cover consecutive maps so the proof still emits one wrapper and preserves every native `map()` call.
- Exercise the syntax in the 10,000-row mapped rolling-chain production benchmark.
- Document the accepted form and fallback boundaries in the renderer docs, package README, and example README.

## Safety and compatibility

There is no new runtime path, public API, option, or renderer behavior. The change only broadens compile-time eligibility for an existing proven path.

Updater blocks with extra statements, conditional returns, a missing return, async/generator behavior, or otherwise unsupported map pipelines still use complete React keyed reconciliation. Native map lookup, callback order, thrown errors, queued state semantics, runtime token/array/key validation, DOM identity, and fallback behavior remain unchanged.

The compiler runtime is still tree-shakeable and its measured size is unchanged. React 18.3.1 and 19.2.8 compatibility suites pass.

## Verification

- `pnpm --filter @farm.js/react type-check`
- `pnpm --filter @farm.js/react test:runtime-size`
- `pnpm --filter @farm.js/react exec vitest run --maxWorkers=1 --minWorkers=1` — 856 passed, 14 skipped
- `pnpm --filter @farm.js/react exec vitest run --config vitest.stress.config.ts --maxWorkers=1 --minWorkers=1` — 23 passed, 132 skipped
- `pnpm --filter @farm.js/react test:compat` — React 18.3.1 and 19.2.8 passed
- `pnpm --dir examples/react-compiler-dashboard type-check`
- `pnpm docs:check-navigation`
- `pnpm --dir docs exec farm generate --check`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm docs:build` — Vercel/Nitro production output passed
- `FARM_EXPERIMENT_BROWSER_PATH='/Applications/Google Chrome.app/Contents/MacOS/Google Chrome' pnpm --dir examples/react-compiler-dashboard benchmark`
  - correctness: PASS
  - ordinary performance-regression gate: PASS
  - optimization-persistence gate: PASS (14.95x/18.58x at 10k; 14.96x/16.10x at 20k)
  - block-bodied mapped rolling-chain gate: PASS — 12.65x static and 18.02x hybrid versus React; snapshot controls 3.47x and 4.21x
  - compiled owner executions: 0 in static and hybrid modes
  - compiler report counts and dashboard bundle sizes: unchanged from the concise-setter baseline
  - aggregate result remained `CORRECTNESS_PASS_PERFORMANCE_REGRESSION` because the unrelated existing multi-map screenshot control measured 0.94x/1.00x against its 2x threshold, while that path's update measurements were still 11.95x/12.43x faster. No gate or threshold was weakened.

Environment: macOS, Google Chrome, Node 23.11.0, pnpm 8.12.1.

## Documentation and release

Updated the React renderer docs, `@farm.js/react` README, and compiler dashboard example/README. No version or release-flow change.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Compiles block-bodied state setters that directly return a keyed map pipeline, so they use the same optimized keyed update path as concise arrow setters. Extra statements, conditional returns, or missing returns still fall back to full reconciliation.

**Changes**
- Reuses the existing `returnedExpression` proof to accept blocks with exactly one value-returning `return`.
- Adds tests for accepted and rejected block-bodied setters, including consecutive maps.
- Updates the benchmark to exercise the block-bodied form and adds documentation across the renderer docs, `@farm.js/react` README, and example README.
- No runtime, API, or renderer behavior changes.

<sup>Written for commit 6888637d767f7198fc5b2383d17de34ed1c432f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/959?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

