### PR TITLE
fix(scripts): respect consent changes before deferred loads

### DIFF
--- a/docs/src/app/docs/plugins/scripts/page.md
+++ b/docs/src/app/docs/plugins/scripts/page.md
@@ -145,8 +145,10 @@ compliance. Your application or consent platform owns those decisions. Grant con
 page load after restoring the user's saved choice. Granting a category starts any script whose load
 trigger already fired.
 
-Denying or clearing consent prevents future loading. Browsers cannot reliably undo code that has
-already executed, so changing consent after a script is ready does not unload it.
+Denying or clearing consent prevents new loads, including scripts waiting for dependencies or a
+retry delay. A blocked `load()` rejects with `ScriptConsentRequiredError`; granting consent again
+resumes triggered scripts. Browsers cannot reliably undo requests already started or code that has
+already executed, so changing consent after insertion does not cancel or unload that script.
 
 ## Dependencies
 

--- a/packages/farm-scripts/src/client.test.ts
+++ b/packages/farm-scripts/src/client.test.ts
@@ -99,6 +99,140 @@ describe("Farm Scripts browser runtime", () => {
     expect(analytics.status).toBe("ready");
   });
 
+  it.each(["denied", "unknown"] as const)(
+    "blocks a dependency-delayed script when consent becomes %s and resumes after a new grant",
+    async (consent) => {
+      vi.useFakeTimers();
+      const vendor = defineScript({ name: "vendor", src: "/vendor.js", load: "manual" });
+      const extension = defineScript({
+        name: "extension",
+        src: "/extension.js",
+        load: "manual",
+        consent: "analytics",
+        dependsOn: [vendor],
+      });
+      const runtime = startScriptRuntime([vendor.definition, extension.definition], window);
+      grantScriptConsent("analytics");
+      const loading = extension.load().catch((error) => error);
+      expect(script("vendor")).not.toBeNull();
+      expect(script("extension")).toBeNull();
+
+      setScriptConsent("analytics", consent);
+      script("vendor")!.dispatchEvent(new Event("load"));
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(script("extension")).toBeNull();
+      expect(await loading).toBeInstanceOf(ScriptConsentRequiredError);
+      expect(extension.status).toBe("blocked");
+
+      grantScriptConsent("analytics");
+      await vi.advanceTimersByTimeAsync(0);
+      expect(script("extension")).not.toBeNull();
+      script("extension")!.dispatchEvent(new Event("load"));
+      await expect(extension.load()).resolves.toBeUndefined();
+      expect(extension.status).toBe("ready");
+      runtime.close();
+    },
+  );
+
+  it("does not retry a script after consent is withdrawn during the retry delay", async () => {
+    vi.useFakeTimers();
+    const analytics = defineScript({
+      name: "analytics",
+      src: "/analytics.js",
+      load: "manual",
+      consent: "analytics",
+      retries: 1,
+      retryDelay: 250,
+    });
+    const runtime = register(analytics);
+    grantScriptConsent("analytics");
+    const loading = analytics.load().catch((error) => error);
+    script("analytics")!.dispatchEvent(new Event("error"));
+    await vi.advanceTimersByTimeAsync(0);
+    setScriptConsent("analytics", "denied");
+    await vi.advanceTimersByTimeAsync(250);
+
+    expect(script("analytics")).toBeNull();
+    expect(await loading).toBeInstanceOf(ScriptConsentRequiredError);
+    expect(analytics.status).toBe("blocked");
+
+    grantScriptConsent("analytics");
+    expect(script("analytics")).not.toBeNull();
+    script("analytics")!.dispatchEvent(new Event("load"));
+    await expect(analytics.load()).resolves.toBeUndefined();
+    runtime.close();
+  });
+
+  it("does not start another dependency after the parent script loses consent", async () => {
+    vi.useFakeTimers();
+    const first = defineScript({ name: "first", src: "/first.js", load: "manual" });
+    const second = defineScript({ name: "second", src: "/second.js", load: "manual" });
+    const analytics = defineScript({
+      name: "analytics",
+      src: "/analytics.js",
+      load: "manual",
+      consent: "analytics",
+      dependsOn: [first, second],
+    });
+    const runtime = startScriptRuntime(
+      [first.definition, second.definition, analytics.definition],
+      window,
+    );
+    grantScriptConsent("analytics");
+    const loading = analytics.load().catch((error) => error);
+    setScriptConsent("analytics", "denied");
+    script("first")!.dispatchEvent(new Event("load"));
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(script("second")).toBeNull();
+    expect(script("analytics")).toBeNull();
+    expect(await loading).toBeInstanceOf(ScriptConsentRequiredError);
+    expect(analytics.status).toBe("blocked");
+    runtime.close();
+  });
+
+  it("rechecks consent after a loading status listener withdraws it", async () => {
+    const analytics = defineScript({
+      name: "analytics",
+      src: "/analytics.js",
+      load: "manual",
+      consent: "analytics",
+      retries: 1,
+    });
+    const runtime = register(analytics);
+    grantScriptConsent("analytics");
+    const unsubscribe = analytics.subscribe(({ status, attempt }) => {
+      if (status === "loading" && attempt === 1) setScriptConsent("analytics", "denied");
+    });
+    const loading = analytics.load().catch((error) => error);
+    expect(script("analytics")).toBeNull();
+    expect(await loading).toBeInstanceOf(ScriptConsentRequiredError);
+    expect(analytics.status).toBe("blocked");
+    unsubscribe();
+    runtime.close();
+  });
+
+  it("does not unload an already ready script when consent is withdrawn", async () => {
+    const analytics = defineScript({
+      name: "analytics",
+      src: "/analytics.js",
+      load: "manual",
+      consent: "analytics",
+    });
+    const runtime = register(analytics);
+    grantScriptConsent("analytics");
+    const loading = analytics.load();
+    const element = script("analytics")!;
+    element.dispatchEvent(new Event("load"));
+    await loading;
+    setScriptConsent("analytics", "denied");
+    await expect(analytics.load()).resolves.toBeUndefined();
+    expect(script("analytics")).toBe(element);
+    expect(analytics.status).toBe("ready");
+    runtime.close();
+  });
+
   it("supports hydration, interaction, and side-effect-only loading strategies", async () => {
     const hydrated = defineScript({
       name: "hydrated",

--- a/packages/farm-scripts/src/client.ts
+++ b/packages/farm-scripts/src/client.ts
@@ -490,10 +490,7 @@ async function loadRegisteredScript(
     }
   }
   if (entry.promise) return entry.promise;
-  if (entry.definition.consent && getConsent(store, entry.definition.consent) !== "granted") {
-    setEntryState(store, entry, "blocked");
-    throw new ScriptConsentRequiredError(name, entry.definition.consent);
-  }
+  assertScriptConsent(store, entry);
   if (entry.definition.preconnect) addPreconnect(store, entry.definition);
   if (stack.includes(name)) {
     throw new Error(
@@ -503,6 +500,7 @@ async function loadRegisteredScript(
 
   const promise = (async () => {
     for (const dependency of entry.definition.dependsOn) {
+      assertScriptConsent(store, entry);
       try {
         await loadRegisteredScript(store, dependency, [...stack, name]);
       } catch (error) {
@@ -518,6 +516,9 @@ async function loadRegisteredScript(
     for (let attempt = 1; attempt <= maximumAttempts; attempt += 1) {
       entry.attempt = attempt;
       notify(store, entry);
+      // Dependencies, retry delays, and status listeners can change consent.
+      // A blocked load must not be treated as a retryable network failure.
+      assertScriptConsent(store, entry);
       try {
         const value = await loadElement(store, entry.definition);
         setEntryState(store, entry, "ready");
@@ -538,6 +539,14 @@ async function loadRegisteredScript(
     return await promise;
   } finally {
     if (entry.promise === promise && entry.status !== "loading") entry.promise = undefined;
+  }
+}
+
+function assertScriptConsent(store: ScriptStore, entry: ScriptEntry): void {
+  const category = entry.definition.consent;
+  if (category && getConsent(store, category) !== "granted") {
+    setEntryState(store, entry, "blocked");
+    throw new ScriptConsentRequiredError(entry.definition.name, category);
   }
 }
 


### PR DESCRIPTION
## Problem

An analytics script can still start after the user withdraws consent while it is waiting for a dependency or a retry. The same happens if a loading-status listener withdraws consent immediately before insertion.

## Root cause

Consent was checked once, before dependency loading. Later insertion attempts reused that decision even though consent could have changed.

## Change

Recheck consent before subsequent dependencies and each insertion attempt, after status listeners run. Keep consent failures in the existing blocked state instead of treating them as retryable network failures. Add regression tests for withdrawal, clearing consent, retries, status listeners, and granting consent again.

## Safety and compatibility

Already-started requests and ready scripts are not cancelled or unloaded. Granting consent again resumes triggered scripts. No new options or renderer-specific behavior.

## Verification

macOS, Node 24.21.0, pnpm 8.12.1, Vitest 3.2.7, JSDOM 25.0.1:

- `pnpm --filter @farm.js/scripts test`: 28 tests pass.
- `pnpm --filter @farm.js/scripts type-check`
- `pnpm --filter @farm.js/scripts build`
- `pnpm docs:check-navigation`
- Focused `oxfmt --check`, `oxlint`, and `git diff --check` pass.
- Compiled-client smoke confirms withdrawal blocks insertion and a new grant resumes loading.

Before the fix, four new regression cases failed by inserting a script after consent withdrawal; ordinary loading and the ready-script control passed. The tests use explicit load events and fake timers, not network timing.

## Documentation and release

Clarify consent withdrawal and resumption in the Scripts guide. No dependency, version, template, or generated-route changes. This PR targets main independently of the PWA fix.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `@farm.js/scripts` so a script can no longer start after the user withdraws consent while it waits for a dependency, a retry delay, or a loading-status listener.

- Rechecks consent before each dependency and each insertion attempt, after status listeners run.
- Treats consent failures as blocked, not retryable network failures.
- Granting consent again resumes triggered scripts; already-started requests and ready scripts are unaffected.
- Adds regression tests and clarifies the consent withdrawal behavior in the Scripts docs.

<sup>Written for commit 0e425303a3a0e615371b4e1e7fca85971878d714. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/960?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

