### PR TITLE
fix(pwa): preserve images when runtime caching fails

### DIFF
--- a/docs/src/app/docs/plugins/pwa/page.md
+++ b/docs/src/app/docs/plugins/pwa/page.md
@@ -114,6 +114,11 @@ Image requests with an `Authorization` header and responses marked `Cache-Contro
 `no-store`, or `no-cache` are never stored. Only use this option for public images because Cache
 Storage survives sign-out in the same browser profile.
 
+Runtime image caching is best-effort. If browser storage is unavailable or full, a successful
+network response still loads normally. If the network fails, an available cached image remains the
+fallback; without one, the network error is preserved. Install-time precaching still requires all
+selected assets to be cached successfully.
+
 Customize the storage bounds with short names:
 
 ```ts

--- a/packages/farm-pwa/src/build.ts
+++ b/packages/farm-pwa/src/build.ts
@@ -250,8 +250,15 @@ function staleWhileRevalidateImage(request) {
   const response = (async () => {
     if (request.headers.has("authorization")) return fetch(request);
 
-    const cache = await caches.open(IMAGE_CACHE);
-    const cached = await cache.match(request);
+    let cache;
+    let cached;
+    try {
+      cache = await caches.open(IMAGE_CACHE);
+      cached = await cache.match(request);
+    } catch {
+      // Runtime caching is optional when browser storage is unavailable.
+      return fetch(request);
+    }
     const cachedAt = Number(cached?.headers.get("x-farm-pwa-cached-at") || 0);
     const fresh = cached && Date.now() - cachedAt <= IMAGE_OPTIONS.ttlMs;
     update = fetchAndCacheImage(request, cache);
@@ -281,15 +288,22 @@ async function fetchAndCacheImage(request, cache) {
   const response = await fetch(request);
   if (!isPublicCacheableImage(response)) return response;
 
-  const headers = new Headers(response.headers);
-  headers.set("x-farm-pwa-cached-at", String(Date.now()));
-  const stored = new Response(response.clone().body, {
-    status: response.status,
-    statusText: response.statusText,
-    headers,
-  });
-  await cache.put(request, stored);
-  await trimImageCache(cache, IMAGE_OPTIONS.limit);
+  let stored;
+  try {
+    const headers = new Headers(response.headers);
+    headers.set("x-farm-pwa-cached-at", String(Date.now()));
+    stored = new Response(response.clone().body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers,
+    });
+    await cache.put(request, stored);
+    await trimImageCache(cache, IMAGE_OPTIONS.limit);
+  } catch {
+    // Quota and storage failures must not discard a successful network response.
+    // Do not wait for tee cancellation, which can depend on the response consumer.
+    if (stored?.body) void stored.body.cancel().catch(() => undefined);
+  }
   return response;
 }
 

--- a/packages/farm-pwa/src/runtime-cache.test.ts
+++ b/packages/farm-pwa/src/runtime-cache.test.ts
@@ -1,0 +1,183 @@
+import { runInNewContext } from "node:vm";
+import { describe, expect, it, vi } from "vitest";
+import { generateServiceWorker } from "./build";
+
+function imageWorker(cached?: Response) {
+  const cache = {
+    match: vi.fn(async () => cached),
+    put: vi.fn(async (_request: Request, response: Response) => {
+      await response.arrayBuffer();
+    }),
+    keys: vi.fn(async (): Promise<Request[]> => []),
+    delete: vi.fn(async () => true),
+  };
+  const caches = { open: vi.fn(async () => cache) };
+  const network = new Response("network image", {
+    headers: { "content-type": "image/png", "cache-control": "public, max-age=300" },
+  });
+  const fetch = vi.fn(async () => network);
+  const listeners = new Map<string, (event: any) => void>();
+  runInNewContext(
+    generateServiceWorker({
+      basePath: "/",
+      cacheId: "runtime-cache-test",
+      precacheUrls: [],
+      staticRoutes: {},
+      offlineRoute: false,
+      update: "prompt",
+      images: { strategy: "swr", limit: 1, ttlMs: 60_000 },
+    }),
+    {
+      caches,
+      fetch,
+      Headers,
+      Response,
+      URL,
+      self: {
+        location: { origin: "https://example.test" },
+        addEventListener: (type: string, listener: (event: any) => void) =>
+          listeners.set(type, listener),
+      },
+    },
+  );
+  const dispatch = (headers?: HeadersInit) => {
+    const request = new Request("https://example.test/photo.png", { headers });
+    Object.defineProperty(request, "destination", { value: "image" });
+    let response!: Promise<Response>;
+    let lifetime!: Promise<unknown>;
+    listeners.get("fetch")!({
+      request,
+      respondWith: (value: Promise<Response>) => (response = value),
+      waitUntil: (value: Promise<unknown>) => (lifetime = value),
+    });
+    return { response, lifetime, request };
+  };
+  return { cache, caches, fetch, network, dispatch, listeners };
+}
+
+describe("generated service worker runtime image caching", () => {
+  it.each(["open", "match", "put", "keys", "trim-match", "delete"])(
+    "preserves a successful network response when cache %s fails",
+    async (stage) => {
+      const worker = imageWorker();
+      const failure = new DOMException("Cache storage unavailable", "QuotaExceededError");
+      if (stage === "open") worker.caches.open.mockRejectedValue(failure);
+      else if (stage === "match") worker.cache.match.mockRejectedValue(failure);
+      else if (stage === "put") worker.cache.put.mockRejectedValue(failure);
+      else if (stage === "keys") worker.cache.keys.mockRejectedValue(failure);
+      else {
+        worker.cache.keys.mockResolvedValue([
+          new Request("https://example.test/old.png"),
+          new Request("https://example.test/photo.png"),
+        ]);
+        if (stage === "trim-match") {
+          worker.cache.match.mockResolvedValueOnce(undefined).mockRejectedValue(failure);
+        } else worker.cache.delete.mockRejectedValue(failure);
+      }
+
+      const { response, lifetime } = worker.dispatch();
+      await expect(response).resolves.toBe(worker.network);
+      expect(await (await response).text()).toBe("network image");
+      await lifetime;
+      expect(worker.fetch).toHaveBeenCalledOnce();
+    },
+  );
+
+  it("stores public images without consuming the returned response", async () => {
+    const worker = imageWorker();
+    const { response, lifetime, request } = worker.dispatch();
+    expect(await (await response).text()).toBe("network image");
+    await lifetime;
+    expect(worker.cache.put).toHaveBeenCalledWith(request, expect.any(Response));
+    expect(worker.cache.put.mock.calls[0][1].headers.get("x-farm-pwa-cached-at")).toBeTruthy();
+    expect(worker.cache.keys).toHaveBeenCalledOnce();
+  });
+
+  it.each(["pending", "rejected"])(
+    "does not wait for %s cleanup of a failed cache write",
+    async (cleanup) => {
+      const worker = imageWorker();
+      const clone = worker.network.clone();
+      vi.spyOn(worker.network, "clone").mockReturnValue(clone);
+      const cancel = vi.spyOn(clone.body!, "cancel");
+      if (cleanup === "pending") cancel.mockReturnValue(new Promise(() => {}));
+      else cancel.mockRejectedValue(new Error("Cleanup failed"));
+      worker.cache.put.mockRejectedValue(new DOMException("Quota exceeded", "QuotaExceededError"));
+
+      const { response, lifetime } = worker.dispatch();
+      await expect(response).resolves.toBe(worker.network);
+      expect(cancel).toHaveBeenCalledOnce();
+      expect(await (await response).text()).toBe("network image");
+      await lifetime;
+    },
+  );
+
+  it("returns a newer image instead of stale data when its cache write fails", async () => {
+    const cached = new Response("old image", { headers: { "x-farm-pwa-cached-at": "1" } });
+    const worker = imageWorker(cached);
+    worker.cache.put.mockRejectedValue(new Error("Cache write failed"));
+    const { response, lifetime } = worker.dispatch();
+    await expect(response).resolves.toBe(worker.network);
+    await lifetime;
+  });
+
+  it("keeps a fresh cached response available when background caching fails", async () => {
+    const cached = new Response("cached image", {
+      headers: { "x-farm-pwa-cached-at": String(Date.now()) },
+    });
+    const worker = imageWorker(cached);
+    worker.cache.put.mockRejectedValue(new Error("Cache write failed"));
+    const { response, lifetime } = worker.dispatch();
+    await expect(response).resolves.toBe(cached);
+    await lifetime;
+    expect(worker.fetch).toHaveBeenCalledOnce();
+  });
+
+  it("does not suppress install-time precache failures", async () => {
+    const worker = imageWorker();
+    const failure = new DOMException("Cache storage unavailable", "QuotaExceededError");
+    worker.caches.open.mockRejectedValue(failure);
+    let lifetime!: Promise<unknown>;
+    worker.listeners.get("install")!({
+      waitUntil: (value: Promise<unknown>) => (lifetime = value),
+    });
+    await expect(lifetime).rejects.toBe(failure);
+    expect(worker.fetch).not.toHaveBeenCalled();
+  });
+
+  it.each(["private", "no-store", "no-cache"])("does not store %s images", async (policy) => {
+    const worker = imageWorker();
+    worker.network.headers.set("cache-control", policy);
+    const { response, lifetime } = worker.dispatch();
+    await expect(response).resolves.toBe(worker.network);
+    await lifetime;
+    expect(worker.cache.put).not.toHaveBeenCalled();
+  });
+
+  it("bypasses Cache Storage for authorized image requests", async () => {
+    const worker = imageWorker();
+    const { response, lifetime } = worker.dispatch({ authorization: "Bearer example" });
+    await expect(response).resolves.toBe(worker.network);
+    await lifetime;
+    expect(worker.caches.open).not.toHaveBeenCalled();
+  });
+
+  it("preserves a real network failure when there is no cached image", async () => {
+    const worker = imageWorker();
+    const failure = new TypeError("Network unavailable");
+    worker.fetch.mockRejectedValue(failure);
+    const { response, lifetime } = worker.dispatch();
+    await expect(response).rejects.toBe(failure);
+    await lifetime;
+    expect(worker.cache.put).not.toHaveBeenCalled();
+  });
+
+  it("returns a stale cached image when the network is unavailable", async () => {
+    const cached = new Response("cached image", { headers: { "x-farm-pwa-cached-at": "1" } });
+    const worker = imageWorker(cached);
+    worker.fetch.mockRejectedValue(new TypeError("Network unavailable"));
+    const { response, lifetime } = worker.dispatch();
+    await expect(response).resolves.toBe(cached);
+    await lifetime;
+  });
+});


### PR DESCRIPTION
## Problem

An image downloaded successfully can appear broken when browser Cache Storage is full or unavailable. On a cache miss, a failed write rejects the service worker response instead of returning the downloaded image.

## Root cause

Runtime image handling required cache reads, writes, and trimming to succeed. Storage failures therefore escaped into the response path.

## Change

Fall back to the network when runtime cache reads fail and preserve successful responses when writes or trimming fail. Cancel unused cloned bodies without waiting for cleanup. Add generated-worker tests for cache failures and neighboring success/error paths.

## Safety and compatibility

Preserve genuine network errors, stale-image fallback, background revalidation lifetime, and authorization/private-response exclusions. Install-time precaching remains strict. Custom service workers, configuration, and renderer behavior are unchanged.

## Verification

macOS, Node 24.21.0, pnpm 8.12.1, Vitest 3.2.7:

- `pnpm --filter @farm.js/pwa test`: 44 tests pass, including production build lifecycle coverage.
- `pnpm --filter @farm.js/pwa type-check`
- `pnpm --filter @farm.js/pwa build`
- `pnpm docs:check-navigation`
- Focused `oxfmt --check`, `oxlint`, and `git diff --check` pass.
- Compiled-generator smoke preserves the 200 image response after a simulated quota failure.

Before the fix, six new regression cases failed for cache open, match, put, key enumeration, trim lookup, and deletion. Tests execute the generated worker with simulated storage failures; they do not exhaust a real browser's disk quota. Package checks also pass against published core beta.94.

## Documentation and release

Document best-effort runtime image caching and strict installation in the PWA guide. No dependency, version, template, or generated-route changes. This PR targets main independently of the Scripts fix.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes PWA image handling so a successful download is no longer broken when Cache Storage is full or unavailable. Runtime image caching is now best-effort and storage failures never reject the response.

**Bug Fixes**
- Cache open and match failures skip Cache Storage and fetch directly.
- Cache put and trim failures return the downloaded image and cancel the unused cloned body without waiting for cleanup.
- Preserves network errors, stale-image fallback, background revalidation, and exclusions for authorized or private responses.
- Install-time precaching remains strict; selected assets must still cache successfully.
- Adds generated-worker regression tests for cache open, match, put, key enumeration, trim lookup, and deletion failures.
- Documents best-effort runtime image caching in the PWA guide.

<sup>Written for commit 715d6abb7f605bc1d5edfb930bb206d8c427a0fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/961?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

