### PR TITLE
docs(api): clarify shared route and integration callers

### DIFF
--- a/docs/src/app/docs/api-client/page.md
+++ b/docs/src/app/docs/api-client/page.md
@@ -581,14 +581,21 @@ never fall back to HTTP. Operations marked `isServer: true` remain available onl
 
 ### Integration-only callers
 
-`createIntegrations<AppIntegrations>()` remains supported when only integration callers are
-needed. It returns integration namespaces directly: `apiClient.billing.checkout.post(...)` and
-`api.billing.checkout.post(...)`. With `createApiClients`, those same calls need the
+`createIntegrations<AppIntegrations>()` remains supported and is not deprecated. Existing apps
+do not need to migrate. Use it when only integration callers are needed, or when you prefer to
+keep them separate from app-route callers. It returns integration namespaces directly:
+`apiClient.billing.checkout.post(...)` and `api.billing.checkout.post(...)`.
+With `createApiClients`, those same calls need the
 `.integrations` segment. Choose one setup for the shared module; do not create both pairs for
 the same integrations. Switching factories requires updating the namespace and moving shared
 integration defaults into the `integrations` option; it is not a drop-in rename.
 The paired factory discovers configured integrations; it does not accept the integration-only
 factory's explicit source map or separate server-options argument.
+
+For deliberately separate modules, use `createApiClients<APIRouter>({ routes: apiRoutes,
+integrations: false })` for app routes and `createIntegrations<AppIntegrations>()` for integration
+callers. Disabling the paired factory's namespace does not unregister integrations or their
+HTTP routes; it only leaves integration access to the separate caller module.
 
 ## Server Function Form Actions
 

--- a/docs/src/app/docs/api-client/page.md
+++ b/docs/src/app/docs/api-client/page.md
@@ -26,6 +26,9 @@ paths/methods and types, never server handlers or credentials. Import `api` in s
 Both app-route callers return `{ data, error, key }` and preserve the same input, output, method,
 and dynamic-parameter inference. Keep secrets out of this shared module, including its options.
 
+If the app also has integrations, add `AppIntegrations` as the second type argument to this same
+factory. You do not need a second caller setup. See [Integration callers](#integration-callers).
+
 The HTTP client uses the current origin and `/api` by default. To point every default client at another
 API, configure it once in `farm.config.ts`:
 
@@ -158,10 +161,10 @@ you need one concrete resource; collection/detail overloads otherwise describe m
 Plugin paths containing HTTP method names use a literal alias such as
 `apiClient["/projects/get"].get()`. `$params` is reserved for the scope helper.
 
-You can name this client `api` in server-only code and use the same call shape. This is an HTTP
-client there too: provide a trusted absolute `baseURL`, and explicitly forward only the credentials
-the target needs. It does not bypass middleware or call a plugin handler directly. The existing
-`createServerAPIClient()` endpoint/integration helper is unchanged by scoped route callers.
+Both callers returned by `createApiClients()` support these scopes. Use `api` for local calls
+during a Farm server request and `apiClient` for HTTP calls. For standalone HTTP calls from server
+code, give `apiClient` a trusted absolute `baseURL` and explicitly forward only the credentials
+the target needs. See [Server callers](#server-callers) for local-dispatch boundaries.
 
 ## Type-safe QUERY requests
 
@@ -453,7 +456,9 @@ read loads canonical data.
 
 ## Result shape
 
-API and integration callers return a consistent result object:
+App-route and integration callers both expose `data` and `error`, so callers can branch on
+`result.error`. App-route results also include a typed cache `key`; integration results retain
+their own error contract and do not include that cache key.
 
 ```ts
 const result = await apiClient.hello.post({
@@ -471,7 +476,7 @@ console.log(result.data.message);
 ```
 
 This makes client components easier to write because failed responses do not need to be caught with `try/catch` unless you want that behavior.
-If an HTTP error body is malformed, Farm still returns an `http_error` with the real status and
+For app routes, if an HTTP error body is malformed, Farm still returns an `http_error` with the real status and
 `Response`; the decoding failure is available as `error.cause`.
 
 ## Server callers
@@ -528,18 +533,62 @@ factory for a shared module and a consistent `{ data, error, key }` app-route re
 
 ## Integration callers
 
-Integrations use the same ergonomic style:
+Use the same shared module for file routes, plugin routes, and configured integrations:
+
+**src/lib/api.ts**
 
 ```ts
-const checkout = await apiClient.billing.checkout.post({
-  body: {
-    productId: "pro",
-    successPath: "/dashboard",
-  },
+import { createApiClients } from "@farm.js/core/client";
+import { apiRoutes, type APIRouter } from "./api.generated";
+import type { AppIntegrations } from "./integrations";
+
+export const { api, apiClient } = createApiClients<APIRouter, AppIntegrations>({
+  routes: apiRoutes,
 });
 ```
 
-If an integration operation is marked server-only, call it from `api`, not `apiClient`.
+Export `AppIntegrations = typeof appIntegrations` from the server-only module containing the
+registry passed to `farm.config.ts`'s `integrations` field. Import only its type here, not the
+registry value or provider SDKs. The type describes existing integrations; it does not register
+them. Farm supplies their caller metadata at runtime.
+
+File and plugin routes keep their generated paths, such as `apiClient.hello.post(...)`.
+Integrations live under the reserved `.integrations` namespace on both callers. For example, with
+the `billing` integration from the [custom integration guide](/docs/integrations/custom#shared-registration):
+
+```ts
+// Browser code
+const checkout = await apiClient.integrations.billing.checkout.post({
+  body: { priceId: "price_123" },
+});
+
+// Server code
+const serverCheckout = await api.integrations.billing.checkout.post({
+  body: { priceId: "price_123" },
+});
+```
+
+Integration-specific defaults belong in `integrations: { data, headers, ... }` in the shared
+factory options. Only put browser-safe values there. Set `integrations: false` if the app does
+not need the reserved namespace.
+
+The shared factory does not change integration execution semantics. Integration calls return
+`{ data, error }`, not the app-route `{ data, error, key }` cache contract. Server integration
+calls dispatch to a registered handler when possible and can fall back to HTTP when local
+dispatch is unavailable. App-route `api` calls instead require an active Farm server request and
+never fall back to HTTP. Operations marked `isServer: true` remain available only through
+`api.integrations`, not `apiClient.integrations`.
+
+### Integration-only callers
+
+`createIntegrations<AppIntegrations>()` remains supported when only integration callers are
+needed. It returns integration namespaces directly: `apiClient.billing.checkout.post(...)` and
+`api.billing.checkout.post(...)`. With `createApiClients`, those same calls need the
+`.integrations` segment. Choose one setup for the shared module; do not create both pairs for
+the same integrations. Switching factories requires updating the namespace and moving shared
+integration defaults into the `integrations` option; it is not a drop-in rename.
+The paired factory discovers configured integrations; it does not accept the integration-only
+factory's explicit source map or separate server-options argument.
 
 ## Server Function Form Actions
 

--- a/docs/src/app/docs/api-client/page.md
+++ b/docs/src/app/docs/api-client/page.md
@@ -592,6 +592,14 @@ integration defaults into the `integrations` option; it is not a drop-in rename.
 The paired factory discovers configured integrations; it does not accept the integration-only
 factory's explicit source map or separate server-options argument.
 
+Options are another reason to choose the separate factory. Shared `baseURL`, `headers`,
+`credentials`, and `data` defaults work with either setup: put them under `integrations` when
+using `createApiClients()`. Keep `createIntegrations()` when you want setup-level `request` or
+`forwardHeaders`, separate server defaults, or explicit source maps. The paired factory's
+server integration calls still accept per-call overrides. See the [options comparison and
+request-scoped example](/docs/integrations#integration-only-setup). Keep request-bound callers
+and private server options in server-only code, not in the shared browser module.
+
 For deliberately separate modules, use `createApiClients<APIRouter>({ routes: apiRoutes,
 integrations: false })` for app routes and `createIntegrations<AppIntegrations>()` for integration
 callers. Disabling the paired factory's namespace does not unregister integrations or their

--- a/docs/src/app/docs/integrations/custom/page.md
+++ b/docs/src/app/docs/integrations/custom/page.md
@@ -78,8 +78,14 @@ uses the same registration and caller setup.
 
 ### Shared registration
 
-Register the integration once. The `billing` key becomes the first segment after `api` or
-`apiClient`.
+The examples in this guide use the integration-only `createIntegrations()` factory, so the
+`billing` key becomes the first segment after `api` or `apiClient`. If the app already uses
+`createApiClients()` for file or plugin routes, [add the integration registry type to that same setup](/docs/api-client#integration-callers)
+instead. Import the existing pair from `src/lib/api.ts` and use
+`api.integrations.billing` / `apiClient.integrations.billing` for the calls below; do not create
+a second pair. The integration definitions and registration stay the same.
+
+Register the integration once:
 
 **farm.config.ts**
 

--- a/docs/src/app/docs/integrations/page.md
+++ b/docs/src/app/docs/integrations/page.md
@@ -10,6 +10,10 @@ Integrations are the Farm layer for connecting product services to your app. A p
 
 Farm treats every integration as a small server plugin. That means an integration can participate in framework startup and shutdown, own HTTP routes, and still expose a compact typed API to the rest of the app.
 
+A plugin extends framework behavior; an integration owns a configured service capability, such
+as its SDK client, lifecycle, models, or providers. They can share route machinery without being
+the same public contract. Their API routes can be consumed through one [shared API setup](/docs/api-client#integration-callers).
+
 ## Import the dedicated adapter package
 
 New applications should import each Farm adapter from its dedicated package, such as
@@ -56,7 +60,10 @@ export default defineConfig({
 });
 ```
 
-The object key is the application namespace. If you register Stripe as `billing`, the typed caller lives at `api.billing`. If you register it as `stripe`, it lives at `api.stripe`.
+The object key is the application namespace. Registering Stripe as `billing` exposes
+`api.integrations.billing` with `createApiClients`, or `api.billing` with the integration-only
+`createIntegrations` factory. The same distinction applies to `apiClient`; registering it as
+`stripe` changes the `billing` segment to `stripe`.
 
 ## Own the provider instance in application code
 
@@ -112,6 +119,58 @@ still require an adapter update.
 Provider pages show the exact constructor and any integration-owned options that are still required.
 
 ## Create callers
+
+### One setup for app routes and integrations
+
+If the app uses file or plugin routes as well as integrations, use `createApiClients` once in
+`src/lib/api.ts`. Export the configured registry's type from a server-only module:
+
+**src/lib/integrations.ts**
+
+```ts
+import { billing } from "../integrations/billing";
+
+export const appIntegrations = { billing } as const;
+export type AppIntegrations = typeof appIntegrations;
+```
+
+Here `billing` is the integration defined in the [custom integration guide](/docs/integrations/custom#choose-the-http-surface).
+Pass `appIntegrations` as `integrations` in `farm.config.ts`. Keep provider instances and
+credentials in that server-only registry, not in the shared caller module.
+
+**src/lib/api.ts**
+
+```ts
+import { createApiClients } from "@farm.js/core/client";
+import { apiRoutes, type APIRouter } from "./api.generated";
+import type { AppIntegrations } from "./integrations";
+
+export const { api, apiClient } = createApiClients<APIRouter, AppIntegrations>({
+  routes: apiRoutes,
+  integrations: {
+    data: { appName: "farm-dashboard" },
+  },
+});
+```
+
+App routes use paths such as `apiClient.hello.get(...)`; integration calls use
+`apiClient.integrations.billing.checkout.post(...)` or `api.integrations.billing.checkout.post(...)`.
+`farm generate`, development startup, and builds emit the route manifest. Import only the
+integration registry's type; the configured registry supplies integration metadata at runtime.
+No second `createIntegrations()` call is needed.
+
+Shared setup does not unify result or transport behavior: integrations retain `{ data, error }`
+results and server-side HTTP fallback, while app-route `api` calls require a Farm request and
+return `{ data, error, key }` without HTTP fallback. See [Integration callers](/docs/api-client#integration-callers)
+for the full contract.
+
+### Integration-only setup
+
+If only integration callers are needed, `createIntegrations` remains supported. The examples
+below use this integration-only setup and therefore omit `.integrations`. In an app using the
+shared factory above, reuse that pair and add `.integrations` to these integration call paths
+instead of creating another pair. Integration defaults such as `data` go inside its
+`integrations` option.
 
 **src/lib/api.ts**
 

--- a/docs/src/app/docs/integrations/page.md
+++ b/docs/src/app/docs/integrations/page.md
@@ -202,6 +202,38 @@ callers are needed. For separate modules, set `integrations: false` on the app-r
 `createApiClients()` setup and keep `createIntegrations()` for the integration callers. This
 does not change integration registration in `farm.config.ts`.
 
+Existing caller options can also be a reason to keep `createIntegrations()`. The factories do
+not have interchangeable option signatures:
+
+| Need                                                                                         | `createIntegrations()`                    | `createApiClients()`                                                                              |
+| -------------------------------------------------------------------------------------------- | ----------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| Shared `baseURL`, `headers`, `credentials`, or `data` defaults                               | Pass them in `clientOptions`.             | Pass them under `integrations`. These options alone do not require a separate factory.            |
+| Setup-level `request`, `forwardHeaders`, or separate server defaults                         | Pass a separate `serverOptions` argument. | No separate server-options argument; server integration calls support per-call overrides instead. |
+| Explicit integration definitions or API contracts, for example in isolated packages or tests | Use the source-map overload.              | Uses the configured integration registry.                                                         |
+
+For example, a request-scoped server helper can bind a request and its forwarding policy once:
+
+**src/lib/api.server.ts**
+
+```ts
+import { createIntegrations } from "@farm.js/core/client";
+import type { AppIntegrations } from "./integrations";
+
+export function createRequestIntegrationApi(request: Request) {
+  const { api } = createIntegrations<AppIntegrations>(
+    { data: { appName: "farm-dashboard" } },
+    { request, forwardHeaders: ["cookie", "authorization"] },
+  );
+
+  return api;
+}
+```
+
+Keep this helper in server-only code and call it per request; do not cache a request-bound
+caller globally or import it into browser code. A `serverOptions` argument is not a bundler
+security boundary: private headers, tokens, and requests must stay out of shared client modules.
+Forward credentials only to trusted destinations.
+
 The examples below use this integration-only setup and therefore omit `.integrations`. In an app using the
 shared factory above, reuse that pair and add `.integrations` to these integration call paths
 instead of creating another pair. Integration defaults such as `data` go inside its

--- a/docs/src/app/docs/integrations/page.md
+++ b/docs/src/app/docs/integrations/page.md
@@ -135,8 +135,26 @@ export type AppIntegrations = typeof appIntegrations;
 ```
 
 Here `billing` is the integration defined in the [custom integration guide](/docs/integrations/custom#choose-the-http-surface).
-Pass `appIntegrations` as `integrations` in `farm.config.ts`. Keep provider instances and
-credentials in that server-only registry, not in the shared caller module.
+`appIntegrations` is the real server-side object containing it. `AppIntegrations` is only a
+TypeScript description of that object: `typeof` does not create another integration, and
+`as const` preserves its literal types rather than freezing it at runtime.
+
+Register that object with Farm once:
+
+**farm.config.ts**
+
+```ts
+import { defineConfig } from "@farm.js/core";
+import { appIntegrations } from "./src/lib/integrations";
+
+export default defineConfig({
+  integrations: appIntegrations,
+});
+```
+
+This is where Farm registers the integrations and their routes. Keep provider instances and
+credentials in the server-only registry. Next, create callers for those already-configured
+services in the shared module; this does not create new provider instances:
 
 **src/lib/api.ts**
 
@@ -152,6 +170,18 @@ export const { api, apiClient } = createApiClients<APIRouter, AppIntegrations>({
   },
 });
 ```
+
+The inputs have different jobs:
+
+| Input             | What it supplies                                                                      | Present in browser JavaScript?                              |
+| ----------------- | ------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
+| `APIRouter`       | Generated types for file and plugin routes.                                           | No; it is a type.                                           |
+| `AppIntegrations` | Types for the configured integration operations.                                      | No; `import type` is erased.                                |
+| `apiRoutes`       | Generated paths and methods used to resolve app-route URLs, including dynamic params. | Yes; it is schema-free route metadata, not server handlers. |
+
+The `integrations.data` option above is optional request metadata, not another integration
+registration. You can omit it. The factory returns `api` for server calls and `apiClient` for
+browser calls; both are exported from this one module.
 
 App routes use paths such as `apiClient.hello.get(...)`; integration calls use
 `apiClient.integrations.billing.checkout.post(...)` or `api.integrations.billing.checkout.post(...)`.

--- a/docs/src/app/docs/integrations/page.md
+++ b/docs/src/app/docs/integrations/page.md
@@ -196,8 +196,13 @@ for the full contract.
 
 ### Integration-only setup
 
-If only integration callers are needed, `createIntegrations` remains supported. The examples
-below use this integration-only setup and therefore omit `.integrations`. In an app using the
+`createIntegrations()` remains supported and is not deprecated. There is no required migration:
+keep it when you prefer separate route and integration caller modules, or when only integration
+callers are needed. For separate modules, set `integrations: false` on the app-route
+`createApiClients()` setup and keep `createIntegrations()` for the integration callers. This
+does not change integration registration in `farm.config.ts`.
+
+The examples below use this integration-only setup and therefore omit `.integrations`. In an app using the
 shared factory above, reuse that pair and add `.integrations` to these integration call paths
 instead of creating another pair. Integration defaults such as `data` go inside its
 `integrations` option.

--- a/skills/farmjs/SKILL.md
+++ b/skills/farmjs/SKILL.md
@@ -48,7 +48,7 @@ Core imports:
 
 ```ts
 import type { PageProps, LayoutProps } from "@farm.js/core";
-import { Link, createIntegrations } from "@farm.js/core/client";
+import { Link, createApiClients } from "@farm.js/core/client";
 ```
 
 Use `"use client"` when a component uses React hooks, browser APIs, or client-only integration calls.
@@ -228,18 +228,31 @@ uses HTTP. Both call the same route definition and return `{ data, error, key }`
 endpoint validation/middleware, not outer HTTP/plugin lifecycle middleware; put shared
 authorization in endpoint middleware. Server caches are request-local and there is no HTTP
 fallback. The older `createAPIClient` and `createServerAPIClient` factories remain supported.
-Calls such as `apiClient.products.get(...)` resolve to `{ data, error }` results for HTTP failures and support caching,
+Calls such as `apiClient.products.get(...)` resolve to `{ data, error, key }` results for HTTP failures and support caching,
 invalidation, retries, callbacks, optimistic updates, `useMutation`, and `useFetcher`.
 
-For integration APIs, use `createIntegrations<AppIntegrations>()` and preserve the configured
-namespace:
+If the app also uses integrations, add the registry type to the same factory instead of creating
+a second pair:
 
 ```ts
-import { createIntegrations } from "@farm.js/core/client";
+import { createApiClients } from "@farm.js/core/client";
+import { apiRoutes, type APIRouter } from "./api.generated";
 import type { AppIntegrations } from "./integrations";
 
-export const { api, apiClient } = createIntegrations<AppIntegrations>();
+export const { api, apiClient } = createApiClients<APIRouter, AppIntegrations>({
+  routes: apiRoutes,
+});
 ```
+
+Integration calls use `api.integrations.billing` / `apiClient.integrations.billing`. They retain
+their existing `{ data, error }` results and server-side HTTP fallback; the app-route cache and
+no-fallback guarantees above do not apply to integrations. Keep the registry value and provider
+SDKs server-only; import only `AppIntegrations` into the shared module. Shared integration
+defaults belong under the factory's `integrations` option and must be browser-safe.
+
+`createIntegrations<AppIntegrations>()` remains supported for integration-only callers and
+existing apps. That factory exposes `api.billing` / `apiClient.billing` directly. Do not mix
+its call paths with the paired route factory's reserved `.integrations` namespace.
 
 Use `createServerFn` for typed mutations/actions and `createServerQuery` for typed reads,
 deduplication, prefetch, stale-while-revalidate, focus/reconnect refresh, and structured invalidation.
@@ -267,7 +280,8 @@ export const appIntegrations = {
 export type AppIntegrations = typeof appIntegrations;
 ```
 
-The object key is the application namespace, so `billing` becomes `api.billing`. An integration
+The object key is the application namespace, so `billing` becomes `api.integrations.billing`
+with `createApiClients`, or `api.billing` with integration-only `createIntegrations`. An integration
 may contribute routes/endpoints, typed callers, middleware, React providers, database schemas,
 validated config, plugins, setup/ready/dispose hooks, and runtime logs. Prefer `integrationRoute.*`
 or `endpoint.*` when the integration owns handlers and should generate caller types. An explicit
@@ -294,7 +308,8 @@ integrations, UI registries, and ORM-backed data.
 
 Provider adapters support two ownership modes: pass credentials so the adapter constructs its
 default SDK, or pass an app-owned vendor client through `instance`. Keep the vendor instance in a
-server-only module. Export the integration registry type so `createIntegrations` can infer callers.
+server-only module. Export the integration registry type so the shared caller factory can infer
+integration operations without importing provider code at runtime.
 
 For ordinary email/password auth, install `@farm.js/auth` and use top-level `auth: true`. Read
 sessions through `auth.session()` or `auth.user()` from `@farm.js/auth/server`, and run
@@ -438,7 +453,7 @@ run its client generation immediately before type checking or building.
 
 - Import `Link`, `createApiClients`, and `createIntegrations` from current documented client entries.
 - Do not put server SDKs or secrets in `"use client"` modules.
-- Keep `AppIntegrations` exported so `createIntegrations<AppIntegrations>()` can infer types.
+- Keep `AppIntegrations` exported so `createApiClients<APIRouter, AppIntegrations>()` can infer integration types.
 - For Supabase/custom route APIs, method calls may be nested, for example `.login.post(...)`, not `.login(...)`.
 - Do not mix renderer component formats, top-level auth with `integrations.auth`, or mismatched Farm package versions.
 - Do not import server query handlers into the browser without the server-function transform.

--- a/skills/farmjs/SKILL.md
+++ b/skills/farmjs/SKILL.md
@@ -250,8 +250,11 @@ no-fallback guarantees above do not apply to integrations. Keep the registry val
 SDKs server-only; import only `AppIntegrations` into the shared module. Shared integration
 defaults belong under the factory's `integrations` option and must be browser-safe.
 
-`createIntegrations<AppIntegrations>()` remains supported for integration-only callers and
-existing apps. That factory exposes `api.billing` / `apiClient.billing` directly. Do not mix
+`createIntegrations<AppIntegrations>()` remains supported and is not deprecated. No migration is
+required. Use it for integration-only callers or deliberately separate modules; in the latter
+case, set `integrations: false` on the app-route `createApiClients()` setup. This only disables
+that caller namespace, not the configured integration or its HTTP routes.
+The separate factory exposes `api.billing` / `apiClient.billing` directly. Do not mix
 its call paths with the paired route factory's reserved `.integrations` namespace.
 
 Use `createServerFn` for typed mutations/actions and `createServerQuery` for typed reads,

--- a/skills/farmjs/SKILL.md
+++ b/skills/farmjs/SKILL.md
@@ -257,6 +257,13 @@ that caller namespace, not the configured integration or its HTTP routes.
 The separate factory exposes `api.billing` / `apiClient.billing` directly. Do not mix
 its call paths with the paired route factory's reserved `.integrations` namespace.
 
+Keep `createIntegrations()` when explicit source maps or separate setup-level server options
+(`request`, `forwardHeaders`, or server defaults) are needed. Shared `baseURL`, `headers`,
+`credentials`, and `data` defaults alone do not require it; the paired factory accepts those
+under `integrations` and supports server integration overrides per call. Keep request-bound
+callers inside server request scope. A separate server-options argument does not make an import
+server-only or protect secrets placed in a browser-reachable module.
+
 Use `createServerFn` for typed mutations/actions and `createServerQuery` for typed reads,
 deduplication, prefetch, stale-while-revalidate, focus/reconnect refresh, and structured invalidation.
 Browser server query/action references require Farm's documented server-function transform. Without


### PR DESCRIPTION
## Problem

Follow-up to #958. The API-client guide recommends `createApiClients()` but its integration example still calls `apiClient.billing`, which belongs to the integration-only factory. The integrations guide also presents a second caller setup without explaining when it is needed, and the scoped-route section still describes the paired server caller as HTTP-only.

## Root cause

The new factory reuses the existing integration namespace under `.integrations`, while `createIntegrations()` exposes configured names directly. The implementation already supports both routes and integrations in one pair, but the prose and examples mixed the two contracts. Runtime tests do not check the Markdown guidance.

## Change

- Show one `createApiClients<APIRouter, AppIntegrations>({ routes: apiRoutes })` setup for app/plugin routes and integrations.
- Correct integration calls to `api.integrations.billing` and `apiClient.integrations.billing` in the paired-factory guide.
- Show the server registry, its `farm.config.ts` registration, and the shared caller module together. Explain which inputs are TypeScript-only and which contain public runtime metadata.
- Document integration-only caller paths as a supported alternative, not a required second setup.
- Explain plugin versus integration ownership, browser-safe options, server-only operations, and the existing differences in results and HTTP fallback.
- Correct the stale scoped-route server paragraph and update the Farm authoring skill to recommend the same shared setup.

## Safety and compatibility

Documentation only. No runtime, public API, provider registration, renderer, target, or generated declaration changes. `createIntegrations()` remains supported and is not deprecated. The paired factory does not accept its explicit source map or separate server-options argument. Provider clients and credentials stay server-only; the shared module imports only registry types and schema-free route metadata.

## Verification

Local environment: macOS arm64, Node 23.11.0, pnpm 8.12.1.

- `pnpm --filter @farm.js/core exec vitest run src/__tests__/api-clients.test.ts src/__tests__/api-client.typing.test.ts src/__tests__/integration-client.test.ts` — 44 tests passed.
- `pnpm --filter @farm.js/core type-check` — passed.
- `pnpm docs:check-navigation` — passed; 83 visible pages and 12 official plugins.
- `pnpm --dir docs exec farm generate --check` — passed.
- `pnpm exec oxfmt --check docs/src/app/docs/api-client/page.md docs/src/app/docs/integrations/page.md docs/src/app/docs/integrations/custom/page.md skills/farmjs/SKILL.md` — passed.
- `git diff --check` — passed.
- `pnpm docs:build` — initial Vercel production build passed. The built API-client page was inspected in a local browser. Final explanatory prose additions were checked with formatting, navigation, and generated-type checks; final-commit production verification is left to PR CI.

No regression test was added because no runtime mechanism changes. Existing paired-caller tests verify the integration aliases and shared options on both callers. This change does not alter layout, styling, or interactions.

## Documentation and release

Updates the API-client guide, integrations overview, custom-integration guide, and `skills/farmjs/SKILL.md`. No release bump, templates, package changes, or generated artifacts.

Suggested separate follow-up: propagate request cancellation through local integration dispatch, with tests for already-aborted requests and in-flight cancellation. Do not change provider ownership or existing HTTP-fallback compatibility in this docs PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies the Farm API-client docs so app/route and integration callers share one `createApiClients()` setup instead of the guide mixing in a separate `createIntegrations()` factory. Also covers when the integration-only factory is the better choice. Docs-only; no runtime, package, or generated-declaration changes.

- Integration calls in the shared setup use the reserved `api.integrations.billing` / `apiClient.integrations.billing` namespace; the integration-only factory still exposes `api.billing` directly and is not deprecated.
- Explains which inputs (`APIRouter`, `AppIntegrations`) are TypeScript-only and which (`apiRoutes`, `integrations.data`) are runtime metadata, and keeps provider SDKs server-only.
- Documents that app-route results keep `{ data, error, key }` while integrations keep `{ data, error }` and server-side HTTP fallback; the paired server caller is not HTTP-only.
- Updates the integrations overview, custom-integration guide, and `skills/farmjs/SKILL.md` to recommend the shared setup, with `createIntegrations()` covered as an integration-only alternative.
- Switching factories is not a rename: add `.integrations` and move shared integration defaults into the `integrations` option; `integrations: false` only disables that caller namespace, not registration or routes.
- Adds an options comparison so `createIntegrations()` stays preferred when setup-level `request`, `forwardHeaders`, `serverOptions`, or explicit source maps are needed; the shared factory accepts those defaults under `integrations` and per-call server overrides instead.

<sup>Written for commit 18051da1afb93cbf35869d64ef85d2c7735a7e48. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/962?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

