### PR TITLE
fix(search): preserve routes that repeat the base path

### DIFF
--- a/docs/src/app/docs/plugins/search/page.md
+++ b/docs/src/app/docs/plugins/search/page.md
@@ -90,6 +90,11 @@ search({
 `*` matches within one URL segment, `**` matches descendants, and `?` matches one non-slash
 character. A pattern such as `/docs/**` includes both `/docs` and its descendants.
 
+Route names are preserved even when they repeat the mount path. With `basePath: "/app"`,
+`include: ["/app/**"]` selects the application's `/app` pages and produces result URLs beneath
+`/app/app`; it does not select the home page. Custom `output` directories are also relative to
+`basePath`, so `output: "app/search"` produces `/app/app/search/`.
+
 Only emitted HTML can enter the index. Dynamic routes, API routes, server functions, and runtime
 responses are not crawled. An authenticated page should remain dynamic and must never be made
 static merely to make it searchable.

--- a/packages/farm-search/src/build.test.ts
+++ b/packages/farm-search/src/build.test.ts
@@ -75,6 +75,79 @@ describe.sequential("writeSearchIndex", () => {
     ).rejects.toThrow("No static HTML pages matched");
   });
 
+  it("keeps application routes that repeat basePath distinct and filters before prefixing", async () => {
+    const { outputDir, publicDir } = await createOutput();
+    for (const route of ["", "app", "app/app", "app/private"]) {
+      await mkdir(path.join(publicDir, route), { recursive: true });
+      await writeFile(
+        path.join(publicDir, route, "index.html"),
+        page(route || "Home", "Searchable content"),
+      );
+    }
+    const input = { outputDir, publicDir, preset: "node-server", basePath: "/app" };
+    const result = await writeSearchIndex({
+      ...input,
+      options: resolveSearchOptions({ exclude: ["/app/private"] }),
+    });
+    expect(result.indexedRoutes).toEqual(["/app", "/app/app", "/app/app/app"]);
+    expect(result.skippedRoutes).toEqual(["/app/app/private"]);
+
+    const rootOnly = await writeSearchIndex({
+      ...input,
+      options: resolveSearchOptions({ include: ["/"] }),
+    });
+    expect(rootOnly.indexedRoutes).toEqual(["/app"]);
+    expect(rootOnly.skippedRoutes).toEqual(["/app/app", "/app/app/app", "/app/app/private"]);
+  }, 30_000);
+
+  it("does not guess the HTML path prefix from a matching directory without a home page", async () => {
+    const { outputDir, publicDir } = await createOutput();
+    await mkdir(path.join(publicDir, "app"), { recursive: true });
+    await writeFile(path.join(publicDir, "app", "index.html"), page("App", "Searchable app"));
+    const result = await writeSearchIndex({
+      outputDir,
+      publicDir,
+      preset: "node-server",
+      basePath: "/app",
+      options: resolveSearchOptions({ include: ["/app"] }),
+    });
+    expect(result.indexedRoutes).toEqual(["/app/app"]);
+  }, 30_000);
+
+  it("strips only the explicit HTML base path for already-prefixed output", async () => {
+    const { outputDir, publicDir } = await createOutput();
+    for (const route of ["app", "app/app", "app/app/private"]) {
+      await mkdir(path.join(publicDir, route), { recursive: true });
+      await writeFile(path.join(publicDir, route, "index.html"), page(route, "Searchable content"));
+    }
+    const result = await writeSearchIndex({
+      outputDir,
+      publicDir,
+      preset: "vercel",
+      basePath: "/app",
+      htmlBasePath: "/app",
+      options: resolveSearchOptions({ exclude: ["/app/private"] }),
+    });
+    expect(result.indexedRoutes).toEqual(["/app", "/app/app"]);
+    expect(result.skippedRoutes).toEqual(["/app/app/private"]);
+  }, 30_000);
+
+  it("mounts a custom bundle directory beneath basePath even when its name repeats it", async () => {
+    const { outputDir, publicDir } = await createOutput();
+    await writeFile(path.join(publicDir, "index.html"), page("Home", "Searchable home"));
+    const result = await writeSearchIndex({
+      outputDir,
+      publicDir,
+      preset: "node-server",
+      basePath: "/app",
+      options: resolveSearchOptions({ output: "app/search" }),
+    });
+    expect(result.bundlePath).toBe("/app/app/search/");
+    await expect(
+      access(path.join(publicDir, "app", "app", "search", "pagefind.js")),
+    ).resolves.toBeUndefined();
+  }, 30_000);
+
   it("does not delete or write outside publicDir through a symlinked output parent", async () => {
     const { root, outputDir, publicDir } = await createOutput();
     const externalDir = path.join(root, "external");

--- a/packages/farm-search/src/build.ts
+++ b/packages/farm-search/src/build.ts
@@ -8,6 +8,8 @@ export interface SearchBuildInput {
   publicDir?: string;
   preset: string;
   basePath: string;
+  /** Prefix already present in emitted HTML paths (localized Farm SSG output). */
+  htmlBasePath?: string;
   options: ResolvedSearchOptions;
 }
 
@@ -30,7 +32,10 @@ export async function writeSearchIndex(input: SearchBuildInput): Promise<SearchB
   const routes = htmlFiles
     .map((file) => ({
       file,
-      logicalRoute: stripBasePath(routeFromHtmlFile(path.relative(publicDir, file)), basePath),
+      logicalRoute: stripBasePath(
+        routeFromHtmlFile(path.relative(publicDir, file)),
+        input.htmlBasePath ?? "/",
+      ),
     }))
     .sort((left, right) => left.logicalRoute.localeCompare(right.logicalRoute));
   const selected = routes.filter(({ logicalRoute }) =>
@@ -116,9 +121,6 @@ export function withBasePath(route: string, basePath: string): string {
   const normalizedBase = normalizeBasePath(basePath);
   const normalizedRoute = route === "/" ? "/" : `/${route.replace(/^\/+|\/+$/g, "")}`;
   if (normalizedBase === "/") return normalizedRoute;
-  if (normalizedRoute === normalizedBase || normalizedRoute.startsWith(`${normalizedBase}/`)) {
-    return normalizedRoute;
-  }
   return normalizedRoute === "/" ? normalizedBase : `${normalizedBase}${normalizedRoute}`;
 }
 

--- a/packages/farm-search/src/index.test.ts
+++ b/packages/farm-search/src/index.test.ts
@@ -114,4 +114,47 @@ describe("search plugin", () => {
       first.configure?.({ root: "/app", plugins: [first, second] }, {} as never),
     ).toThrow("one search() plugin instance");
   });
+
+  it("passes the resolved localized HTML prefix to both build paths", async () => {
+    const plugin = search({ output: "app/search" });
+    await plugin.configure?.(
+      { root: "/project", basePath: "/app", i18n: { enabled: true }, plugins: [plugin] },
+      {} as never,
+    );
+    expect(plugin.client?.public).toMatchObject({ bundlePath: "/app/app/search/" });
+    const configured = await plugin.build?.configure?.(
+      { preset: "node-server", output: { dir: "/output" } },
+      {} as never,
+    );
+    const info = vi.spyOn(console, "info").mockImplementation(() => undefined);
+    try {
+      await configured.hooks["prerender:done"]({ prerenderedRoutes: [] });
+      expect(writeSearchIndex).toHaveBeenLastCalledWith(
+        expect.objectContaining({ htmlBasePath: "/app", basePath: "/app" }),
+      );
+      await plugin.build?.before?.({} as never, {} as never);
+      await plugin.build?.after?.(
+        { root: "/project", preset: "vercel", outputDir: "/output", success: true } as never,
+        {} as never,
+      );
+      expect(writeSearchIndex).toHaveBeenLastCalledWith(
+        expect.objectContaining({ htmlBasePath: "/app" }),
+      );
+
+      await plugin.build?.before?.({} as never, {} as never);
+      await plugin.configure?.(
+        { root: "/project", basePath: "/app", i18n: { enabled: false }, plugins: [plugin] },
+        {} as never,
+      );
+      await plugin.build?.after?.(
+        { root: "/project", preset: "node-server", outputDir: "/output", success: true } as never,
+        {} as never,
+      );
+      expect(writeSearchIndex).toHaveBeenLastCalledWith(
+        expect.objectContaining({ htmlBasePath: "/" }),
+      );
+    } finally {
+      info.mockRestore();
+    }
+  });
 });

--- a/packages/farm-search/src/index.ts
+++ b/packages/farm-search/src/index.ts
@@ -23,6 +23,7 @@ export type {
 export function search(options: SearchOptions = {}) {
   const resolved = resolveSearchOptions(options);
   let configuredBasePath = "/";
+  let htmlBasePath = "/";
   let generated = false;
   const publicConfig: FarmSearchPublicConfig = {
     available: false,
@@ -42,6 +43,14 @@ export function search(options: SearchOptions = {}) {
         throw new Error("[farm:search] Configure search in one search() plugin instance");
       }
       configuredBasePath = normalizeBasePath(config.basePath);
+      // RouteManager emits ordinary SSG paths relative to the app, while its
+      // localized SSG paths already include basePath. Do not infer this from
+      // folder names: an application route can have the same name as basePath.
+      const i18n = config.i18n;
+      htmlBasePath =
+        i18n && typeof i18n === "object" && "enabled" in i18n && i18n.enabled
+          ? configuredBasePath
+          : "/";
       publicConfig.bundlePath = `${withBasePath(`/${resolved.output}`, configuredBasePath)}/`;
     },
 
@@ -60,6 +69,7 @@ export function search(options: SearchOptions = {}) {
             publicDir: nitroConfig.output?.publicDir,
             preset: nitroConfig.preset ?? "node-server",
             basePath: configuredBasePath,
+            htmlBasePath,
             options: resolved,
           });
           generated = true;
@@ -88,6 +98,7 @@ export function search(options: SearchOptions = {}) {
           outputDir: result.outputDir ?? `${result.root}/.farm/.output`,
           preset: result.preset,
           basePath: configuredBasePath,
+          htmlBasePath,
           options: resolved,
         });
         generated = true;


### PR DESCRIPTION
## Problem

With `basePath: "/app"`, the home page and an application route named `/app` could both enter the search index as `/app`. Include/exclude patterns could also select the wrong pages. A custom `output: "app/search"` incorrectly produced `/app/search/` instead of `/app/app/search/`.

## Root cause

The indexer guessed whether a file path was already base-prefixed by comparing its first segment. The prefixing helper then made the same guess again. Existing tests used route names that differed from the configured mount path, so they missed these collisions.

## Change

- Keep emitted HTML paths, application route paths, and public result URLs distinct.
- Prefix application routes and bundle directories exactly once, even when a route starts with the same segment as `basePath`.
- Pass the existing localized-SSG prefix explicitly from resolved Farm configuration. Ordinary SSG output remains app-relative; localized output retains its current behavior in both the prerender hook and final-output fallback.
- Add regressions for repeated prefixes, missing home pages, route filters, localized output, custom bundle paths, and plugin reuse.

## Safety and compatibility

No new user-facing option, runtime dependency, version change, or client API. This stays in the renderer-neutral build-time plugin. Existing symlink/output containment checks are unchanged. Node-style public output and Vercel's final static directory are covered. The internal HTML prefix follows the current RouteManager SSG contract; this does not change core routing or deployment behavior.

## Verification

macOS, Node 24.21.0, pnpm 8.12.1, Vitest 3.2.7:

```sh
pnpm --filter @farm.js/search test
pnpm --filter @farm.js/search type-check
pnpm --filter @farm.js/search build
pnpm exec oxlint packages/farm-search/src/build.ts packages/farm-search/src/index.ts packages/farm-search/src/build.test.ts packages/farm-search/src/index.test.ts
pnpm exec oxfmt --check packages/farm-search/src/build.ts packages/farm-search/src/index.ts packages/farm-search/src/build.test.ts packages/farm-search/src/index.test.ts docs/src/app/docs/plugins/search/page.md
pnpm docs:check-navigation
git diff --check
```

All 24 tests pass. The five added regressions failed before the fix. Build tests create real Pagefind bundles. A separate compiled-output smoke exercised the real plugin prerender callback and Vercel-output fallback, then inspected the emitted Pagefind fragments to confirm distinct `/app` and `/app/app` URLs and unchanged localized URLs.

No full application/browser or docs build was run for this focused change. CI will cover the remaining platform matrix.

## Documentation and release

Clarifies repeated route names and custom output paths in the Search guide. No navigation, generated types, examples, templates, package versions, or release-flow changes.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the search plugin so routes and output paths that repeat the base path (for example an application route named `/app` under `basePath: '/app'`) are indexed at their real URLs instead of being collapsed or filtered out.

**Bug Fixes**
- The HTML path prefix now comes from resolved Farm config instead of being guessed from folder names.
- Application routes and custom bundle directories are prefixed exactly once, even when their first segment matches `basePath`.
- Custom `output` paths are now relative to `basePath`, so `output: "app/search"` produces `/app/app/search/`.
- Added regression tests for repeated prefixes, missing home pages, route filters, localized output, custom output paths, and plugin reuse.

<sup>Written for commit d513a70ab50be7ac5ef69bedafc04a88fe4b4861. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/963?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

