### PR TITLE
fix(content): preserve first Markdown reference definitions

### DIFF
--- a/docs/src/app/docs/plugins/content/page.md
+++ b/docs/src/app/docs/plugins/content/page.md
@@ -106,6 +106,10 @@ Farm recognizes inline and reference-style Markdown images and file links:
 [release-diagram]: ./release-diagram.svg
 ```
 
+Reference labels follow Markdown's case-insensitive matching. If a label is defined more than
+once, the first definition wins; later duplicates are left unchanged and do not add asset imports
+or missing-file errors.
+
 Relative image destinations are checked as real images with intrinsic dimensions. Relative file
 links are managed when their destination has a file extension; extensionless links and links to
 `.md` or `.mdx` remain content navigation. Remote URLs, root-relative URLs, fragments, data URLs,

--- a/packages/farm-content/src/loader.test.ts
+++ b/packages/farm-content/src/loader.test.ts
@@ -298,6 +298,89 @@ describe("content collection loading", () => {
     expect(generated).toContain("decodeContentValue(");
   });
 
+  it.each(["md", "mdx"])(
+    "uses the first duplicate Markdown asset definition in %s",
+    async (extension) => {
+      const root = await fixtureRoot();
+      const directory = path.join(root, "content", "posts");
+      await writeFile(path.join(directory, "first.pdf"), "%PDF first\n");
+      await writeFile(path.join(directory, "second.pdf"), "%PDF second\n");
+      const source = `content/posts/references.${extension}`;
+      await writeFile(
+        path.join(root, source),
+        [
+          "---",
+          "title: References",
+          "publishedAt: 2026-09-09",
+          "---",
+          "[Download][GUIDE]",
+          "",
+          "[Guide]: ./first.pdf",
+          "[guide]: ./second.pdf",
+          "",
+        ].join("\n"),
+      );
+
+      const loaded = await loadContentCollections(root, {
+        posts: collection({ source: files(source), schema: postSchema, assets: true }),
+      });
+      const entry = loaded.collections.posts[0];
+      expect(entry.bodyAssets).toMatchObject([{ kind: "file", source: "./first.pdf" }]);
+      expect(entry.bodyAssets).toHaveLength(1);
+      expect(entry.body).toContain("[Guide]: __FARM_CONTENT_ASSET_");
+      expect(entry.body).toContain("[guide]: ./second.pdf");
+      expect(loaded.sourceFiles).not.toContain(path.join(directory, "second.pdf"));
+      const output = path.join(root, ".farm", "content", "server.mjs");
+      await writeContentServerModule(output, loaded.collections, loaded.assetImports);
+      const generated = await readFile(output, "utf8");
+      expect(generated).toContain('from "../../content/posts/first.pdf?url"');
+      expect(generated).not.toContain("second.pdf?url");
+    },
+  );
+
+  it("ignores missing shadowed image definitions but still validates the first definition", async () => {
+    const root = await fixtureRoot();
+    const directory = path.join(root, "content", "posts");
+    await writeFile(
+      path.join(directory, "hero.svg"),
+      '<svg xmlns="http://www.w3.org/2000/svg" width="32" height="24"/>',
+    );
+    const source = "content/posts/references.md";
+    const body = "![Hero][hero]\n\n[hero]: ./hero.svg\n[HERO]: ./missing.svg\n";
+    await writeFile(path.join(root, source), `---\ntitle: Images\n---\n${body}`);
+    const collections = {
+      posts: collection({ source: files(source), schema: postSchema, assets: true }),
+    };
+    const loaded = await loadContentCollections(root, collections);
+    expect(loaded.collections.posts[0].bodyAssets).toMatchObject([
+      { kind: "image", source: "./hero.svg", width: 32, height: 24 },
+    ]);
+    expect(loaded.collections.posts[0].body).toContain("[HERO]: ./missing.svg");
+    expect(loaded.sourceFiles).not.toContain(path.join(directory, "missing.svg"));
+
+    await writeFile(
+      path.join(root, source),
+      "---\ntitle: Images\n---\n![Hero][hero]\n\n[hero]: ./missing.svg\n[HERO]: ./hero.svg\n",
+    );
+    await expect(loadContentCollections(root, collections)).rejects.toThrow(
+      'Asset "./missing.svg" does not exist',
+    );
+  });
+
+  it("leaves a remote first definition unchanged even when a later duplicate is local", async () => {
+    const root = await fixtureRoot();
+    const source = "content/posts/references.md";
+    const body =
+      "[Guide][guide]\n\n[guide]: https://example.com/guide.pdf\n[guide]: ./missing.pdf\n";
+    await writeFile(path.join(root, source), `---\ntitle: Remote\n---\n${body}`);
+    const loaded = await loadContentCollections(root, {
+      posts: collection({ source: files(source), schema: postSchema, assets: true }),
+    });
+    expect(loaded.collections.posts[0].body).toBe(body);
+    expect(loaded.collections.posts[0].bodyAssets).toEqual([]);
+    expect(loaded.assetImports.size).toBe(0);
+  });
+
   it("supports optional, defaulted, and nested frontmatter asset declarations", async () => {
     const root = await fixtureRoot();
     await writeFile(path.join(root, "content", "posts", "guide.pdf"), "%PDF guide\n");

--- a/packages/farm-content/src/markdown-assets.ts
+++ b/packages/farm-content/src/markdown-assets.ts
@@ -80,7 +80,8 @@ function collectCandidates(tree: MarkdownNode): MarkdownAssetCandidate[] {
 
   visit(tree, (node) => {
     if (node.type === "definition" && node.identifier) {
-      definitions.set(node.identifier, node);
+      // CommonMark resolves duplicate reference labels to their first definition.
+      if (!definitions.has(node.identifier)) definitions.set(node.identifier, node);
       return;
     }
     if (node.type === "imageReference" && node.identifier) {


### PR DESCRIPTION
## Problem

Content assets did not follow Markdown's first-definition-wins rule:

```md
[Download][guide]

[guide]: ./first.pdf
[guide]: ./second.pdf
```

Farm processed `second.pdf` and left the actual linked file unmanaged. A missing file in the unused second definition could also fail the build.

## Root cause

The Markdown definition collector overwrote earlier entries in its Map. The parser already normalizes reference labels, but asset collection did not preserve the first matching definition. Existing coverage only used unique definitions.

## Change

Keep the first definition for each normalized label. Add Markdown and MDX regressions covering file imports, case-insensitive labels, image metadata, shadowed missing files, and a remote first definition. A missing file in the first definition still fails normally.

## Safety and compatibility

No public API, dependency, version, or renderer change. Original Markdown remains untouched except for the selected managed destination. Asset validation, path containment, server-only boundaries, and errors for genuinely used missing files remain intact. This matches [CommonMark reference precedence](https://spec.commonmark.org/0.31.2/#example-204).

## Verification

macOS, Node 24.21.0, pnpm 8.12.1, Vitest 3.2.7:

```sh
pnpm --filter @farm.js/content test
pnpm --filter @farm.js/content type-check
pnpm --filter @farm.js/content build
pnpm exec oxlint packages/farm-content/src/markdown-assets.ts packages/farm-content/src/loader.test.ts
pnpm exec oxfmt --check packages/farm-content/src/markdown-assets.ts packages/farm-content/src/loader.test.ts docs/src/app/docs/plugins/content/page.md
pnpm docs:check-navigation
git diff --check
```

All 31 tests pass. The four added regressions failed before the fix. Coverage checks the generated server module imports only the winning file. A separate compiled-plugin smoke built and imported a real Vite 5.4.20 SSR bundle, verified the winning asset's hashed URL and emitted bytes, and confirmed an unused missing duplicate did not fail the build.

No full Farm application/browser or docs build was run. CI will cover the remaining platform matrix.

## Documentation and release

Documents case-insensitive reference matching and duplicate-definition precedence in the Content guide. No navigation, generated types, examples, templates, package versions, or release-flow changes.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Markdown reference definition handling in content assets so the first definition wins for each normalized label, matching CommonMark. Later duplicate definitions are left unchanged and no longer override the selected file or cause missing-file errors.

- Keeps the first definition per normalized label; later duplicates are ignored and do not add asset imports or fail validation.
- Adds Markdown and MDX regression tests covering duplicate labels, case-insensitive labels, image metadata, shadowed missing files, and remote-first definitions.
- Documents duplicate-definition precedence and case-insensitive reference matching in the Content guide.

<sup>Written for commit 8e283d5137d981821f780dde7861da932d7f948a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/964?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

