### PR TITLE
feat(client): resolve instance headers per call

### DIFF
--- a/docs/src/app/docs/api-client/page.md
+++ b/docs/src/app/docs/api-client/page.md
@@ -58,6 +58,52 @@ export const { api, apiClient } = createApiClients<APIRouter>({
 Farm forwards `credentials` to every route request from that client. The API must also allow the
 calling origin and credentialed requests through its CORS policy.
 
+## Header defaults
+
+Instance `headers` accepts a string-valued object or a function returning one. The function can
+be synchronous or asynchronous; Farm calls it when an operation is called, not when the client
+is created.
+
+```ts
+import { createApiClients } from "@farm.js/core/client";
+import { apiRoutes, type APIRouter } from "./api.generated";
+
+export const { api, apiClient } = createApiClients<APIRouter>({
+  routes: apiRoutes,
+  headers: () => ({
+    "Accept-Language":
+      typeof document === "undefined" ? "en" : document.documentElement.lang || "en",
+  }),
+});
+
+// This call overrides the instance language without changing later calls.
+await apiClient.hello.get({ headers: { "accept-language": "fr" } });
+```
+
+Use `headers: async () => ({ ... })` when obtaining defaults requires asynchronous work.
+The exported `ClientHeaders` type describes all three forms. Static objects remain supported;
+per-call `headers` remain objects, not resolver functions.
+
+Header names are case-insensitive. App routes merge forwarded server request headers first,
+then instance defaults, then per-call headers. Thus the example explicitly chooses English on
+the server; omit its `Accept-Language` default when you want `api` to preserve the incoming
+request's language. The existing server forwarding allowlist is unchanged.
+
+Farm snapshots the resolved defaults once per operation call, before cache lookup or dispatch.
+Cache hits still resolve headers; changed effective headers isolate the route client's cache
+and in-flight deduplication. Retries reuse the same snapshot. A thrown error, rejected promise,
+or invalid header produces the normal error result without fetching or returning cached data.
+
+These defaults also apply to `api.integrations` and `apiClient.integrations` when enabled.
+Providing `integrations.headers` replaces the shared header defaults for integration calls only;
+it does not merge the two resolvers. See [integration header defaults](/docs/integrations#header-defaults)
+for integration-specific precedence and separate server defaults.
+
+A resolver is not a server-only boundary. Anything imported into this shared module may reach
+the browser, and the resolver runs wherever its caller runs. Do not put provider credentials or
+private environment values here. Read request-specific values inside the resolver or a
+request-scoped server module, never by mutating a shared singleton with one user's credentials.
+
 ## Call a route
 
 **Browser usage**

--- a/docs/src/app/docs/integrations/page.md
+++ b/docs/src/app/docs/integrations/page.md
@@ -302,6 +302,42 @@ export default defineConfig({
 
 Same-origin routing is not an authorization boundary. Authenticate agent HTTP and WebSocket requests in application middleware or provider routing hooks, and authorize every sensitive tool or callable method on the server.
 
+## Header defaults
+
+`createIntegrations` supports static headers and sync or async header resolvers, just like
+[`createApiClients`](/docs/api-client#header-defaults). Use a resolver when defaults must be read
+at call time rather than captured when the module loads:
+
+```ts
+import { createIntegrations } from "@farm.js/core/client";
+import type { AppIntegrations } from "./integrations";
+
+export const { api, apiClient } = createIntegrations<AppIntegrations>({
+  headers: () => ({
+    "Accept-Language":
+      typeof document === "undefined" ? "en" : document.documentElement.lang || "en",
+  }),
+});
+```
+
+`headers: async () => ({ ... })` is also supported. Each operation resolves its instance headers
+once, for both browser HTTP calls and server dispatch (including the server HTTP fallback).
+The existing separate factories and explicit-source overloads accept the same option.
+
+Custom header precedence, lowest to highest, is: forwarded server request headers, instance
+defaults, operation-definition headers, then per-call `headers`. Overrides are case-insensitive;
+per-call headers remain plain objects. Farm still controls protocol/body headers, such as its
+integration marker and JSON/form encoding. Resolver failures return `{ data: null, error }`
+without dispatching or fetching.
+
+The second, server-options argument to `createIntegrations` can provide a different `headers`
+resolver for `api`; it replaces the first argument's header defaults rather than merging them.
+Keep any server-only version in a server-only module. A function or the server-options argument
+does not itself hide secrets from a browser bundle. For ordinary session cookies, retain Farm's
+existing request forwarding and browser credential behavior instead of copying secrets into
+shared defaults. The example's English server default overrides a forwarded language; omit that
+default if the incoming request should decide it.
+
 ## Shared data
 
 `createIntegrations({ data })` adds small per-call metadata to integration requests. It is useful for tenant IDs, locale, analytics context, or feature flags.

--- a/examples/basic/src/lib/integration-lab-api.ts
+++ b/examples/basic/src/lib/integration-lab-api.ts
@@ -4,4 +4,9 @@ import type { integrationLab } from './integration-lab.ts';
 export const {
   api: integrationApi,
   apiClient: integrationApiClient,
-} = createIntegrations<typeof integrationLab>();
+} = createIntegrations<typeof integrationLab>({
+  headers: async () => ({
+    'Accept-Language':
+      typeof document === 'undefined' ? 'en' : document.documentElement.lang || 'en',
+  }),
+});

--- a/examples/basic/src/lib/integration-lab.ts
+++ b/examples/basic/src/lib/integration-lab.ts
@@ -18,6 +18,7 @@ export interface IntegrationLabResult {
   message: string;
   caller: string;
   requestId: string;
+  language?: string | null;
   trace: string[];
   lifecycle?: {
     label: string;
@@ -125,7 +126,7 @@ const routeLab = defineIntegration({
           appendTrace(context, 'before');
         },
       ],
-      handler(_request, context) {
+      handler(request, context) {
         appendTrace(context, 'handler');
 
         return Response.json({
@@ -133,6 +134,7 @@ const routeLab = defineIntegration({
           message: context.input.body!.message,
           caller: readCaller(context),
           requestId: context.requestId,
+          language: request.headers.get('accept-language'),
           trace: readTrace(context),
           lifecycle: { ...routeLabState },
         } satisfies IntegrationLabResult);

--- a/packages/farm/src/__tests__/client-header-resolvers.test.ts
+++ b/packages/farm/src/__tests__/client-header-resolvers.test.ts
@@ -1,0 +1,310 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createAPIClient, createApiClients } from "../api/client";
+import { createEndpoint } from "../api/endpoint";
+import { _runWithAPIRequestRuntime } from "../api/server-context";
+import { createIntegrations } from "../integration-client";
+import { endpoint } from "../integration-api";
+import { defineIntegration, integrationRoute, resolveIntegrationPlugins } from "../integrations";
+import { PluginManager } from "../plugin";
+import { _runWithCurrentRequest, getCurrentRequest } from "../server/request";
+
+const read = createEndpoint({ method: "GET" }, () => ({ authorization: "", locale: "" }));
+const query = createEndpoint({ method: "QUERY" }, () => ({ authorization: "", locale: "" }));
+type Router = { session: { get: typeof read; query: typeof query } };
+const cache = { staleTime: 60_000, dedupeMs: 60_000 };
+const sources = {
+  headersDemo: {
+    session: endpoint.get<{ authorization: string; locale: string }>("/api/headers-demo/session", {
+      responseFormat: "json",
+      headers: { "X-Order": "operation" },
+    }),
+  },
+};
+
+function echoFetch() {
+  const fetch = vi.fn(async (_url: string, init?: RequestInit) => {
+    const headers = new Headers(init?.headers);
+    return Response.json({
+      authorization: headers.get("authorization"),
+      locale: headers.get("accept-language"),
+    });
+  });
+  vi.stubGlobal("fetch", fetch);
+  return fetch;
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("instance header resolvers", () => {
+  it.each([false, true])(
+    "resolves route headers per call, including cache hits (async: %s)",
+    async (async) => {
+      const fetch = echoFetch();
+      let authorization = "Bearer alice";
+      const headers = vi.fn(() => {
+        const value = { authorization, "Accept-Language": "en" };
+        return async ? Promise.resolve(value) : value;
+      });
+      const api = createAPIClient<Router>({ baseURL: "https://farm.test/api", headers });
+      expect(headers).not.toHaveBeenCalled();
+      expect((await api.session.get({}, { cache })).data?.authorization).toBe("Bearer alice");
+      expect((await api.session.get({}, { cache })).data?.authorization).toBe("Bearer alice");
+      expect(fetch).toHaveBeenCalledOnce();
+      authorization = "Bearer bob";
+      const result = await api.session.get({ headers: { "accept-language": "fr" } }, { cache });
+      expect(result.data).toEqual({ authorization: "Bearer bob", locale: "fr" });
+      expect(result.key).not.toContain("Bearer");
+      expect(fetch).toHaveBeenCalledTimes(2);
+      expect(headers).toHaveBeenCalledTimes(3);
+    },
+  );
+
+  it("keeps one header snapshot for retries and QUERY cache keys", async () => {
+    const defaults = { Authorization: "Bearer alice", "Content-Type": "application/json" };
+    const headers = vi.fn(() => defaults);
+    const fetch = vi.fn(async (_url: string, init?: RequestInit) => {
+      const sent = new Headers(init?.headers);
+      if (fetch.mock.calls.length === 1) {
+        defaults.Authorization = "Bearer bob";
+        defaults["Content-Type"] = "application/custom+json";
+        return Response.json({ error: "Retry" }, { status: 503 });
+      }
+      return Response.json({ authorization: sent.get("authorization"), locale: "" });
+    });
+    vi.stubGlobal("fetch", fetch);
+    const api = createAPIClient<Router>({ baseURL: "https://farm.test/api", headers });
+    const first = await api.session.query({}, { cache, retry: { count: 1 } });
+    expect(first.data?.authorization).toBe("Bearer alice");
+    expect(headers).toHaveBeenCalledOnce();
+    expect(new Headers(fetch.mock.calls[1][1]?.headers).get("content-type")).toBe(
+      "application/json",
+    );
+    const second = await api.session.query({}, { cache });
+    expect(second.data?.authorization).toBe("Bearer bob");
+    expect(second.key).not.toBe(first.key);
+    expect(fetch).toHaveBeenCalledTimes(3);
+  });
+
+  it.each(["throw", "reject", "invalid"] as const)(
+    "fails closed through the route result lifecycle on %s",
+    async (failure) => {
+      const fetch = echoFetch();
+      let fail = false;
+      const headers = () => {
+        if (!fail) return { authorization: "Bearer alice" };
+        if (failure === "invalid") return { "invalid\nheader": "value" };
+        const error = new Error("Unable to resolve headers");
+        if (failure === "throw") throw error;
+        return Promise.reject(error);
+      };
+      const api = createAPIClient<Router>({ baseURL: "https://farm.test/api", headers });
+      await api.session.get({}, { cache });
+      fail = true;
+      const onError = vi.fn();
+      const onSettled = vi.fn();
+      const update = vi.fn((data) => data);
+      const result = await api.session.get(
+        {},
+        {
+          cache,
+          onError,
+          onSettled,
+          optimistic: { update: [[api.session.get, update]] },
+        },
+      );
+      expect(result.data).toBeUndefined();
+      expect(result.error).toBeInstanceOf(Error);
+      expect(onError).toHaveBeenCalledOnce();
+      expect(onSettled).toHaveBeenCalledOnce();
+      expect(update).not.toHaveBeenCalled();
+      expect(fetch).toHaveBeenCalledOnce();
+    },
+  );
+
+  it("isolates concurrent async header resolution and in-flight cache ownership", async () => {
+    const aliceHeaders = deferred<Record<string, string>>();
+    const aliceResponse = deferred<Response>();
+    const sentAlice = deferred<void>();
+    const headers = vi
+      .fn()
+      .mockImplementationOnce(() => aliceHeaders.promise)
+      .mockResolvedValue({ authorization: "Bearer bob" });
+    const fetch = vi.fn(async (_url: string, init?: RequestInit) => {
+      const authorization = new Headers(init?.headers).get("authorization");
+      if (authorization === "Bearer alice") {
+        sentAlice.resolve();
+        return aliceResponse.promise;
+      }
+      return Response.json({ authorization, locale: "" });
+    });
+    vi.stubGlobal("fetch", fetch);
+    const api = createAPIClient<Router>({ baseURL: "https://farm.test/api", headers });
+    const first = api.session.get({}, { cache });
+    const second = api.session.get({}, { cache });
+    expect((await second).data?.authorization).toBe("Bearer bob");
+    aliceHeaders.resolve({ authorization: "Bearer alice" });
+    await sentAlice.promise;
+    expect((await api.session.get({}, { cache })).data?.authorization).toBe("Bearer bob");
+    aliceResponse.resolve(Response.json({ authorization: "Bearer alice", locale: "" }));
+    expect((await first).data?.authorization).toBe("Bearer alice");
+    expect((await api.session.get({}, { cache })).data?.authorization).toBe("Bearer bob");
+    expect(fetch).toHaveBeenCalledTimes(3);
+  });
+
+  it("resolves paired server route headers on every call inside the captured request", async () => {
+    const fetch = echoFetch();
+    const dispatch = vi.fn(async (request: Request) =>
+      Response.json(Object.fromEntries(request.headers)),
+    );
+    let locale = "en";
+    const headers = vi.fn(async () => {
+      await Promise.resolve();
+      return { "accept-language": locale, "x-request": getCurrentRequest().url };
+    });
+    const { api } = createApiClients<Router>({ headers });
+    await _runWithAPIRequestRuntime({ basePath: "/backend", dispatch }, () =>
+      _runWithCurrentRequest(
+        new Request("https://farm.test/page", {
+          headers: { cookie: "session=alice", "accept-language": "es", "content-length": "100" },
+        }),
+        async () => {
+          const first = await api.session.get({}, { cache });
+          expect(first.data).toMatchObject({
+            cookie: "session=alice",
+            "accept-language": "en",
+            "x-request": "https://farm.test/page",
+          });
+          expect(first.data).not.toHaveProperty("content-length");
+          locale = "fr";
+          const second = await api.session.get({ headers: { "Accept-Language": "de" } }, { cache });
+          expect(second.data).toMatchObject({ cookie: "session=alice", "accept-language": "de" });
+        },
+      ),
+    );
+    expect(headers).toHaveBeenCalledTimes(2);
+    expect(dispatch).toHaveBeenCalledTimes(2);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it.each(["client", "server"] as const)(
+    "resolves integration %s headers with case-insensitive operation and call overrides",
+    async (side) => {
+      if (side === "client") vi.stubGlobal("window", { location: { origin: "https://farm.test" } });
+      const fetch = echoFetch();
+      let authorization = "Bearer alice";
+      const defaults = { "x-order": "instance", "Accept-Language": "en" };
+      const headers = vi.fn(async () => ({ ...defaults, authorization }));
+      const { api, apiClient } = createIntegrations(sources, {
+        baseURL: "https://farm.test/api",
+        headers,
+      });
+      const caller = side === "server" ? api : apiClient;
+      expect(headers).not.toHaveBeenCalled();
+      await caller.headersDemo.session();
+      authorization = "Bearer bob";
+      const result = await caller.headersDemo.session(
+        {},
+        { headers: { "X-ORDER": "call", "accept-language": "fr" } },
+      );
+      expect(result.data).toEqual({ authorization: "Bearer bob", locale: "fr" });
+      expect(new Headers(fetch.mock.calls[0][1]?.headers).get("x-order")).toBe("operation");
+      expect(new Headers(fetch.mock.calls[1][1]?.headers).get("x-order")).toBe("call");
+      expect(headers).toHaveBeenCalledTimes(2);
+      expect(defaults).toEqual({ "x-order": "instance", "Accept-Language": "en" });
+    },
+  );
+
+  it.each([false, true])(
+    "shares or overrides paired integration defaults (override: %s)",
+    async (override) => {
+      echoFetch();
+      vi.stubGlobal("window", {
+        location: { origin: "https://farm.test" },
+        __FARM_INTEGRATION_API_MANIFEST__: sources,
+      });
+      const shared = vi.fn(() => ({ "Accept-Language": "en" }));
+      const integration = vi.fn(async () => ({ "Accept-Language": "fr" }));
+      const { apiClient } = createApiClients<Router, typeof sources>({
+        headers: shared,
+        ...(override ? { integrations: { headers: integration } } : {}),
+      });
+      expect((await apiClient.session.get()).data?.locale).toBe("en");
+      expect((await apiClient.integrations.headersDemo.session()).data?.locale).toBe(
+        override ? "fr" : "en",
+      );
+      expect(shared).toHaveBeenCalledTimes(override ? 1 : 2);
+      expect(integration).toHaveBeenCalledTimes(override ? 1 : 0);
+    },
+  );
+
+  it("resolves registered server integration headers after forwarding the current request", async () => {
+    const fetch = echoFetch();
+    const integration = defineIntegration({
+      category: "custom",
+      type: "resolver-demo",
+      instance: {},
+      routes: [
+        integrationRoute.get("/api/resolver-demo/session", {
+          responseFormat: "json",
+          handler: (request) => Response.json(Object.fromEntries(request.headers)),
+        }),
+      ],
+    });
+    const manager = new PluginManager({
+      config: { integrations: { resolverDemo: integration } } as any,
+      isDev: true,
+      isProd: false,
+    });
+    manager.addPlugins(resolveIntegrationPlugins({ resolverDemo: integration }));
+    await manager.runHookParallel("init");
+    const clientHeaders = vi.fn(() => ({ "accept-language": "en" }));
+    const serverHeaders = vi.fn(async () => {
+      await Promise.resolve();
+      return { "accept-language": "fr", "x-request": getCurrentRequest().url };
+    });
+    const { api } = createIntegrations<{ resolverDemo: typeof integration }>(
+      { headers: clientHeaders },
+      { headers: serverHeaders },
+    );
+    const result = await _runWithCurrentRequest(
+      new Request("https://farm.test/page", {
+        headers: { cookie: "session=alice", "accept-language": "es" },
+      }),
+      () => api.resolverDemo.session.get({}, { headers: { "Accept-Language": "de" } }),
+    );
+    expect(result.data).toMatchObject({
+      cookie: "session=alice",
+      "accept-language": "de",
+      "x-request": "https://farm.test/page",
+    });
+    expect(clientHeaders).not.toHaveBeenCalled();
+    expect(serverHeaders).toHaveBeenCalledOnce();
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it.each(["client", "server"] as const)(
+    "returns integration %s resolver failures without HTTP",
+    async (side) => {
+      if (side === "client") vi.stubGlobal("window", { location: { origin: "https://farm.test" } });
+      const fetch = echoFetch();
+      const error = new Error("Header lookup failed");
+      const { api, apiClient } = createIntegrations(sources, {
+        headers: async () => {
+          throw error;
+        },
+      });
+      const result = await (side === "server" ? api : apiClient).headersDemo.session();
+      expect(result).toEqual({ data: null, error });
+      expect(fetch).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/packages/farm/src/__tests__/client-headers.typing.test.ts
+++ b/packages/farm/src/__tests__/client-headers.typing.test.ts
@@ -4,7 +4,8 @@ import ts from "typescript";
 import { expect, it } from "vitest";
 
 it("exposes header resolvers through the published client declarations", () => {
-  const filename = path.resolve("client-headers.type-test.ts");
+  // TypeScript normalizes compiler filenames to forward slashes, including on Windows.
+  const filename = path.resolve("client-headers.type-test.ts").replace(/\\/g, "/");
   const source = `
 import {
   createAPIClient, createApiClients, createIntegrations, endpoint,

--- a/packages/farm/src/__tests__/client-headers.typing.test.ts
+++ b/packages/farm/src/__tests__/client-headers.typing.test.ts
@@ -1,0 +1,69 @@
+// @vitest-environment node
+import path from "node:path";
+import ts from "typescript";
+import { expect, it } from "vitest";
+
+it("exposes header resolvers through the published client declarations", () => {
+  const filename = path.resolve("client-headers.type-test.ts");
+  const source = `
+import {
+  createAPIClient, createApiClients, createIntegrations, endpoint,
+  type ClientHeaders, type APIClientOptions, type IntegrationClientOptions,
+} from "@farm.js/core/client";
+
+type Router = { hello: { get: { __types: {
+  body: never; query: never; response: { message: string };
+} } } };
+const sources = { demo: { session: endpoint.get<{ user: string }>("/api/demo/session") } };
+const values: ClientHeaders[] = [
+  { "X-App": "demo" },
+  () => ({ "X-App": "demo" }),
+  async () => ({ "X-App": "demo" }),
+];
+for (const headers of values) {
+  const options: APIClientOptions = { headers, integrations: { headers } };
+  const integrationOptions: IntegrationClientOptions = { headers };
+  const { api, apiClient } = createApiClients<Router, typeof sources>(options);
+  const routesOnly = createApiClients<Router>({ headers, integrations: false }).apiClient;
+  createAPIClient<Router>({ headers });
+  const integrationOnly = createIntegrations<typeof sources>(integrationOptions, { headers });
+  const explicit = createIntegrations(sources, integrationOptions, { headers });
+  api.hello.get().then(result => { const value: string | undefined = result.data?.message; });
+  apiClient.integrations.demo.session().then(result => { const value: string | undefined = result.data?.user; });
+  routesOnly.hello.get();
+  integrationOnly.api.demo.session({}, { headers: { "X-Call": "demo" } });
+  explicit.apiClient.demo.session();
+  // @ts-expect-error per-call headers are objects, not resolvers
+  integrationOnly.apiClient.demo.session({}, { headers: () => ({ "X-Call": "demo" }) });
+  // @ts-expect-error route inference must remain intact
+  api.missing.get();
+}
+// @ts-expect-error resolver values must be strings
+const wrong: ClientHeaders = () => ({ "X-App": 123 });
+// @ts-expect-error async resolvers must return a header object
+const wrongAsync: ClientHeaders = async () => "not headers";
+`;
+  const options: ts.CompilerOptions = {
+    strict: true,
+    noEmit: true,
+    skipLibCheck: true,
+    target: ts.ScriptTarget.ES2020,
+    module: ts.ModuleKind.ESNext,
+    moduleResolution: ts.ModuleResolutionKind.Bundler,
+    baseUrl: process.cwd(),
+    paths: { "@farm.js/core/client": ["./types/client.d.ts"] },
+  };
+  const host = ts.createCompilerHost(options);
+  const getSourceFile = host.getSourceFile.bind(host);
+  host.getSourceFile = (name, languageVersion, onError, shouldCreateNewSourceFile) =>
+    name === filename
+      ? ts.createSourceFile(name, source, languageVersion, true)
+      : getSourceFile(name, languageVersion, onError, shouldCreateNewSourceFile);
+  const program = ts.createProgram({ rootNames: [filename], options, host });
+  const diagnostics = ts.formatDiagnosticsWithColorAndContext(ts.getPreEmitDiagnostics(program), {
+    getCanonicalFileName: (name) => name,
+    getCurrentDirectory: () => process.cwd(),
+    getNewLine: () => "\n",
+  });
+  expect(diagnostics).toBe("");
+}, 30_000);

--- a/packages/farm/src/api/client.ts
+++ b/packages/farm/src/api/client.ts
@@ -23,6 +23,7 @@ import { getFarmAPIBaseURL, resolveFarmAPIRequestURL } from "./config";
 import { ClientRouteManifest, type APIRouteManifest, type BoundRouteParams } from "./client-routes";
 import type { RoutePathParams } from "./route";
 import { _resolveCurrentRequest } from "../server/request-bridge";
+import { resolveClientHeaders, type ClientHeaders } from "../client-headers";
 import { resolveAPIRequestRuntime, type APIRequestRuntime } from "./server-client-bridge";
 export type { APIRouteManifest } from "./client-routes";
 import {
@@ -46,7 +47,7 @@ export type APIClientOptions = {
   /** Generated path/method metadata required for dynamic shorthand and $params scopes. */
   routes?: APIRouteManifest;
   baseURL?: string;
-  headers?: Record<string, string>;
+  headers?: ClientHeaders;
   credentials?: RequestCredentials;
   cacheDefaults?: CacheOptions;
   integrations?: IntegrationClientOptions;
@@ -506,15 +507,14 @@ export function createApiClients<
           const value = currentRequest.headers.get(name);
           if (value !== null) headers.set(name, value);
         }
-        new Headers(options.headers).forEach((value, name) => headers.set(name, value));
         local = createAPIClientRuntime(
           {
             ...options,
             integrations: false,
             baseURL: new URL(runtime.basePath, origin).toString(),
-            headers: Object.fromEntries(headers),
           },
           {
+            headers,
             cache: new FarmClientDataCache({ subscribeToInvalidation: false }),
             routeMeta,
             fetch: (url, init) => {
@@ -615,6 +615,7 @@ function createAPIClientRuntime<
 >(
   options: APIClientOptions | APIClientWithoutIntegrationsOptions = {},
   transport?: {
+    headers?: HeadersInit;
     fetch(url: string, init: RequestInit): Promise<Response>;
     cache: FarmClientDataCache;
     routeMeta: WeakMap<AnyRouteRef, RouteMeta>;
@@ -752,7 +753,7 @@ function createAPIClientRuntime<
   };
 
   // Create a simple fetch-based client (browser compatible)
-  const fetchClient = async (path: string, requestOptions: any = {}) => {
+  const fetchClient = async (path: string, requestOptions: any, defaultHeaders: Headers) => {
     const url = resolveFarmAPIRequestURL(path, baseURL);
     const method = String(requestOptions.method || "GET").toUpperCase();
 
@@ -769,7 +770,7 @@ function createAPIClientRuntime<
     }
 
     // Prepare fetch options
-    const headers = new Headers(options.headers);
+    const headers = new Headers(defaultHeaders);
     new Headers(requestOptions.headers).forEach((value, key) => headers.set(key, value));
     const fetchOptions: RequestInit = {
       method,
@@ -822,6 +823,15 @@ function createAPIClientRuntime<
   ): Promise<APIResult<any, Error>> => {
     const methodUpper = method.toUpperCase() as StatusEvent["method"];
     const requestId = `${Date.now()}-${++requestCounter}`;
+    const defaultHeaders = new Headers(transport?.headers);
+    let requestContextError: Error | undefined;
+    try {
+      const resolved = resolveClientHeaders(options.headers);
+      const headers = resolved instanceof Headers ? resolved : await resolved;
+      headers.forEach((value, name) => defaultHeaders.set(name, value));
+    } catch (error) {
+      requestContextError = normalizeError(error);
+    }
     const cacheOptions = clientOptions?.cache
       ? {
           ...options.cacheDefaults,
@@ -830,7 +840,7 @@ function createAPIClientRuntime<
       : undefined;
     const configuredCacheKey = clientOptions?.key ?? cacheOptions?.key;
     const cacheKey = normalizeFarmClientCacheKey(
-      configuredCacheKey ?? buildCacheKey(methodUpper, path, input, baseURL, options.headers),
+      configuredCacheKey ?? buildCacheKey(methodUpper, path, input, baseURL, defaultHeaders),
     ) as CacheKey<any>;
     const now = Date.now();
 
@@ -858,11 +868,14 @@ function createAPIClientRuntime<
       isCacheEnabled ||
       Boolean(clientOptions?.optimistic?.update?.length) ||
       Boolean(clientOptions?.invalidate);
-    let requestCacheContext: string | undefined;
-    let requestContextError: Error | undefined;
-    if (needsCacheState) {
+    let requestCacheContext = requestContextError ? `invalid:${requestId}` : undefined;
+    if (needsCacheState && !requestContextError) {
       try {
-        requestCacheContext = getRequestCacheContext(options, input, cacheOptions?.scope);
+        requestCacheContext = getRequestCacheContext(
+          { headers: defaultHeaders, credentials: options.credentials },
+          input,
+          cacheOptions?.scope,
+        );
       } catch (error) {
         requestCacheContext = `invalid:${requestId}`;
         requestContextError = normalizeError(error);
@@ -908,7 +921,7 @@ function createAPIClientRuntime<
           target,
           targetInput,
           baseURL,
-          options.headers,
+          defaultHeaders,
           transport ? baseURL : undefined,
         );
         if (!targetKey) continue;
@@ -1030,10 +1043,14 @@ function createAPIClientRuntime<
 
           try {
             if (requestContextError) throw requestContextError;
-            const { response, data, decodeError } = await fetchClient(path, {
-              ...input,
-              method: methodUpper,
-            });
+            const { response, data, decodeError } = await fetchClient(
+              path,
+              {
+                ...input,
+                method: methodUpper,
+              },
+              defaultHeaders,
+            );
 
             const error = response.ok ? null : createResponseError(response, data, decodeError);
 
@@ -1164,7 +1181,7 @@ function createAPIClientRuntime<
           target,
           undefined,
           baseURL,
-          options.headers,
+          defaultHeaders,
           transport ? baseURL : undefined,
         );
         if (!targetKey) continue;
@@ -1188,7 +1205,7 @@ function createAPIClientRuntime<
       }
     };
 
-    const optimisticSnapshots = applyOptimisticUpdates();
+    const optimisticSnapshots = requestContextError ? [] : applyOptimisticUpdates();
 
     if (isCacheEnabled) {
       if (entry && !isStale && policy !== "network-only") {
@@ -1606,7 +1623,7 @@ function buildCacheKey(
   path: string,
   input: any,
   baseURL: string,
-  defaultHeaders?: Record<string, string>,
+  defaultHeaders?: HeadersInit,
 ): string {
   const keyInput =
     input && typeof input === "object"
@@ -1660,7 +1677,7 @@ function getHeader(headers: unknown, name: string): string | undefined {
 }
 
 function getRequestCacheContext(
-  options: Pick<APIClientOptions, "headers" | "credentials">,
+  options: { headers?: HeadersInit; credentials?: RequestCredentials },
   input: unknown,
   scope: CacheScope | undefined,
 ): string | undefined {
@@ -1714,7 +1731,7 @@ function resolveTargetKey(
   target: InvalidateTarget | AnyRouteRef,
   input?: unknown,
   baseURL = "http://localhost:3000",
-  defaultHeaders?: Record<string, string>,
+  defaultHeaders?: HeadersInit,
   localBaseURL?: string,
 ): string | null {
   if (!target) return null;

--- a/packages/farm/src/client-headers.ts
+++ b/packages/farm/src/client-headers.ts
@@ -1,0 +1,13 @@
+/** Instance defaults, resolved once per call before cache lookup or dispatch. */
+export type ClientHeaders =
+  | Record<string, string>
+  | (() => Record<string, string> | Promise<Record<string, string>>);
+
+/** Snapshot synchronous defaults immediately; keep async resolvers local to the call. */
+export function resolveClientHeaders(source?: ClientHeaders): Headers | Promise<Headers> {
+  const value = typeof source === "function" ? source() : source;
+  if (value && typeof (value as Promise<Record<string, string>>).then === "function") {
+    return Promise.resolve(value).then((headers) => new Headers(headers));
+  }
+  return new Headers(value as Record<string, string> | undefined);
+}

--- a/packages/farm/src/client.ts
+++ b/packages/farm/src/client.ts
@@ -16,6 +16,7 @@ export type {
   ServerAPIClientWithoutIntegrationsOptions,
 } from "./api/client";
 export type { FarmAPIStream } from "./api/transport";
+export type { ClientHeaders } from "./client-headers";
 export { useMutation } from "./mutation-client";
 export type {
   AnyMutationTarget,

--- a/packages/farm/src/integration-client.ts
+++ b/packages/farm/src/integration-client.ts
@@ -5,6 +5,7 @@ import type {
 } from "./integration-api";
 import type { FarmIntegration as FarmIntegrationDefinition } from "./integrations";
 import { resolveFarmAPIRequestURL } from "./api/config";
+import { resolveClientHeaders, type ClientHeaders } from "./client-headers";
 
 /**
  * Small per-call integration metadata. When sent from a browser, values are
@@ -14,7 +15,7 @@ export type IntegrationClientData = Record<string, unknown>;
 
 export type IntegrationClientOptions = {
   baseURL?: string;
-  headers?: Record<string, string>;
+  headers?: ClientHeaders;
   credentials?: RequestCredentials;
   data?: IntegrationClientData;
   isServer?: false | undefined;
@@ -725,12 +726,11 @@ async function executeClientOperation(
     const url = resolveFarmAPIRequestURL(operation.path, baseURL);
     appendQuery(url, input.query as Record<string, unknown> | undefined);
 
-    const headers = new Headers({
-      "x-farm-integration-client": "1",
-      ...options.headers,
-      ...operation.headers,
-      ...requestOptions?.headers,
-    });
+    const resolved = resolveClientHeaders(options.headers);
+    const headers = resolved instanceof Headers ? resolved : await resolved;
+    appendHeaders(headers, operation.headers);
+    appendHeaders(headers, requestOptions?.headers);
+    headers.set("x-farm-integration-client", "1");
 
     if (operation.responseFormat !== "response") {
       headers.set("accept", "application/json");
@@ -827,7 +827,8 @@ async function executeServerOperation(
         serverRequestOptions?.forwardHeaders ?? options.forwardHeaders,
       ),
     );
-    appendHeaders(headers, options.headers);
+    const resolved = resolveClientHeaders(options.headers);
+    appendHeaders(headers, resolved instanceof Headers ? resolved : await resolved);
     appendHeaders(headers, operation.headers);
     appendHeaders(headers, requestOptions?.headers);
     headers.set("x-farm-integration-client", "1");

--- a/packages/farm/types/client.d.ts
+++ b/packages/farm/types/client.d.ts
@@ -21,6 +21,7 @@ import type { ServerFn } from "@farm.js/core/server-fn";
 import type {
   RouteAPIClient as CoreRouteAPIClient,
   APIClientOptions as CoreAPIClientOptions,
+  ClientHeaders as CoreClientHeaders,
   ApiClients as CoreApiClients,
   APIClientWithoutIntegrationsOptions as CoreAPIClientWithoutIntegrationsOptions,
 } from "../dist/client";
@@ -560,9 +561,11 @@ declare module "@farm.js/core/client" {
   export function isChunkLoadError(errorLike: unknown): boolean;
   export function installChunkErrorRecovery(options?: FarmChunkRecoveryOptions): () => void;
 
+  export type ClientHeaders = CoreClientHeaders;
+
   export interface APIClientOptions extends CoreAPIClientOptions {
     baseURL?: string;
-    headers?: Record<string, string>;
+    headers?: ClientHeaders;
     cacheDefaults?: CacheOptions;
   }
 
@@ -1336,7 +1339,7 @@ declare module "@farm.js/core/client" {
 
   export interface IntegrationClientOptions {
     baseURL?: string;
-    headers?: Record<string, string>;
+    headers?: ClientHeaders;
     credentials?: RequestCredentials;
     data?: IntegrationClientData;
     isServer?: false | undefined;

--- a/skills/farmjs/SKILL.md
+++ b/skills/farmjs/SKILL.md
@@ -214,6 +214,16 @@ image URLs, and generated `lang`, `dir`, and `hreflang` markup. API routes stay 
 normal `/api/**` paths and can call the same server APIs. Read
 `docs/src/app/docs/internationalization/page.md` and `examples/i18n` before changing this feature.
 
+## Caller header defaults
+
+`createApiClients`, `createAPIClient`, `createIntegrations`, and integration-only factories accept
+`headers` as a string-valued object or a sync/async function returning one. Resolve once per call
+before cache lookup/dispatch; retries reuse the snapshot. Per-call headers stay objects and
+override defaults case-insensitively. Integration operation headers override instance defaults;
+`integrations.headers` and separate integration server header options replace shared defaults.
+Resolvers are not a server-only boundary: keep secrets and provider imports out of shared caller
+modules. See `docs/src/app/docs/api-client/page.md#header-defaults` and the integrations guide.
+
 ## Typed APIs and Server Data
 
 API routes live under `src/app/api/**/route.ts`. Prefer `createEndpoint` from

--- a/tests/e2e/framework-features.spec.ts
+++ b/tests/e2e/framework-features.spec.ts
@@ -474,6 +474,7 @@ test.describe("Framework feature integration", () => {
           source: "routes",
           message: "server-routes",
           caller: "server",
+          language: "en",
         }),
         endpoints: expect.objectContaining({
           source: "endpoints",
@@ -489,12 +490,21 @@ test.describe("Framework feature integration", () => {
     );
 
     await page.goto("/feature-lab/integrations");
+    await page.evaluate(() => {
+      document.documentElement.lang = "fr";
+    });
 
     await page.getByTestId("call-integration-routes").click();
     await expect(page.getByTestId("integration-client-routes")).toContainText(
       '"message":"browser-routes"',
     );
     await expect(page.getByTestId("integration-client-routes")).toContainText('"caller":"browser"');
+    await expect(page.getByTestId("integration-client-routes")).toContainText('"language":"fr"');
+    await page.evaluate(() => {
+      document.documentElement.lang = "es";
+    });
+    await page.getByTestId("call-integration-routes").click();
+    await expect(page.getByTestId("integration-client-routes")).toContainText('"language":"es"');
 
     await page.getByTestId("call-integration-endpoints").click();
     await expect(page.getByTestId("integration-client-endpoints")).toContainText(


### PR DESCRIPTION
## Problem

Caller instances accept static header records, but cannot derive fresh synchronous or asynchronous defaults at call time. Apps otherwise have to thread those values through individual calls.

```ts
export const { api, apiClient } = createApiClients<APIRouter>({
  routes: apiRoutes,
  headers: async () => ({ "Accept-Language": await readPreferredLanguage() }),
});
```

The same `headers` option should work with `createIntegrations`, including separate server defaults and explicit-source callers.

## Root cause

The HTTP callers treat `options.headers` as a record; paired server route callers additionally capture it on their first call within a request. Passing a function is either ignored or fails header construction. Resolving only at fetch time would also leave route cache identity, QUERY keys, and retry behavior inconsistent with the sent headers.

## Change

- Add the shared `ClientHeaders` type: a string-valued record or a sync/async zero-argument resolver returning one.
- Snapshot defaults once per operation call, before route cache lookup or integration dispatch. Synchronous defaults retain a synchronous resolution path.
- Use that snapshot for route cache identity, QUERY keys, optimistic/invalidation target keys, dispatch, and retries. Keep forwarded server request headers separate from caller defaults so paired `api` calls resolve afresh.
- Merge custom integration headers case-insensitively in the browser, matching server precedence. Retain Farm's integration protocol marker on both paths.
- Return resolver errors through the existing result lifecycle without HTTP, direct dispatch, cached data, or optimistic updates.
- Update the published client declaration facade as well as source types. Add runtime and TypeScript regression coverage.

## Safety and compatibility

- Static header objects remain supported. Per-call headers remain objects and override instance defaults; integration operation headers sit between instance defaults and per-call overrides.
- `integrations.headers` replaces shared defaults for integration calls only. A separate integration server `headers` option replaces the client defaults for `api`, preserving existing option precedence.
- Every call resolves headers, including cache hits. Retries reuse the resolved snapshot; changing effective headers does not reuse another header context's cache/in-flight request.
- No new request forwarding, timeouts, retries, credentials, or provider imports. Resolvers are not a server-only/bundler boundary, and secrets must stay out of shared caller modules.
- Renderer-neutral implementation. Real browser checks use the React basic example, in Vite development and built Nitro node-server production. Other renderers/targets are not claimed as separately exercised.

## Verification

macOS arm64, Node 23.11.0, pnpm 8.12.1:

- Against unchanged `main` (`b8591d6e`) in an isolated worktree, all 15 tests in `client-header-resolvers.test.ts` fail; they pass with this change.
- `pnpm --filter @farm.js/core test src/__tests__/client-header-resolvers.test.ts src/__tests__/client-headers.typing.test.ts src/__tests__/api-client.test.ts src/__tests__/api-clients.test.ts src/__tests__/integration-client.test.ts src/__tests__/api-client.typing.test.ts` — 105 passed.
- `pnpm --filter @farm.js/core type-check`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @farm.js/core build` — ESM, CJS, and declarations. The first attempt with the default Node heap exhausted the declaration worker's memory; the explicit heap build passes.
- `pnpm --filter @farm.js/cli build`
- `pnpm exec playwright test tests/e2e/framework-features.spec.ts --grep 'runs integration handlers'` — desktop Chrome, 1 passed.
- `pnpm exec playwright test tests/e2e/framework-features.spec.ts --grep 'runs integration handlers' --config playwright.production.config.ts` — Chromium, 1 passed. The test checks server defaults plus French → Spanish browser defaults without recreating the instance. Installed the missing Playwright headless browser locally; no test/config weakening.
- `pnpm docs:check-navigation`
- `pnpm --dir docs exec farm generate --check`
- `pnpm docs:build` — Vercel production output passes.
- Focused `pnpm exec oxfmt --check` and `pnpm exec oxlint` on changed supported files; lint has no errors and one existing unused `resolveSourceAPI` warning. Example formatting follows the existing style (examples are excluded by repository formatter config).
- `git diff --check`

## Documentation and release

Document resolver timing, override precedence, error handling, cache/retry behavior, and browser/secret boundaries in the API client and integrations guides. Update the Farm.js skill and existing integration-lab example/browser test. No new page, generated route contract, dependency, or release-version changes.

This is a separate feature PR from #962; it does not include that PR's unified-caller documentation changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Callers' instance `headers` previously had to be a static record; they now also accept a sync or async resolver and are re-read once per operation call instead of being captured up front. The resolved header snapshot feeds cache identity, QUERY keys, optimistic/invalidation targets, dispatch, and retries, so execution state stays aligned with the sent headers.

- Supported in `createApiClients`, `createAPIClient`, `createIntegrations`, and their explicit/server overload forms; `@farm.js/core/client` now exports the `ClientHeaders` type.
- Header precedence is forwarded request headers, then instance defaults, then integration operation headers, then per-call `headers`, with case-insensitive merging on both browser and server.
- `integrations.headers` replaces shared defaults for integration calls only; the second `createIntegrations` server argument replaces the defaults for `api` instead of merging.
- Resolver errors return the normal error result without fetching, dispatching, reading cached data, or applying optimistic updates.
- Every operation resolves headers, including cache hits; changed effective headers no longer reuse the previous cache entry or in-flight request, and retries reuse only the first snapshot.
- Static header objects and per-call header objects keep working, so no code changes are needed for existing callers; keep secrets out of shared modules because resolvers are not a server-only boundary.
- The published-declaration typing test also passes on Windows via normalized virtual compiler paths.

<sup>Written for commit d903663e17f1ad0c48bd5f46dfc15dae21e8f590. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/965?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

