### PR TITLE
perf(react): compile block-bodied keyed edge insertions

### DIFF
--- a/docs/src/app/docs/renderers/react/page.md
+++ b/docs/src/app/docs/renderers/react/page.md
@@ -972,12 +972,16 @@ appends:
 ```tsx
 setItems((current) => [...current, nextItem]);
 setItems((current) => [...current, ...nextItems]);
+setItems((current) => {
+  return [...current, ...nextItems];
+});
 ```
 
-At build time, Farm recognizes a concise functional setter whose array literal starts with exactly
-`...current` and has at least one trailing item or spread. The application still creates its normal
-immutable array. Generated metadata connects that result to the last committed array and records
-where its appended suffix begins. Queued functional appends form one validated chain.
+At build time, Farm recognizes a concise functional setter or a setter block containing exactly one
+direct value-returning `return`. Its returned array literal must start with exactly `...current` and
+have at least one trailing item or spread. The application still creates its normal immutable array.
+Generated metadata connects that result to the last committed array and records where its appended
+suffix begins. Queued functional appends form one validated chain.
 
 At update time, existing keyed rows already have the same item, key, and index. Farm therefore
 reads keys, descriptors, and bindings only for the appended suffix, creates only those host rows,
@@ -985,12 +989,13 @@ and inserts them together with a document fragment. It does not rerun the owner 
 the existing row DOM.
 
 The proof is intentionally narrow. Both values must be native arrays. Middle insertion, removal,
-direct replacement, a copy with no appended entries, block-bodied updaters, duplicate
-keys, React-owned or nested host-block rows, row conditionals, and rows whose bindings read the
-collection itself keep complete keyed reconciliation. Keys that read the collection also prevent
-the compiler from emitting the hint. A preceding unhinted update, an unrelated
-dirty dependency, or any failed source/length check also discards the hint. These fallbacks preserve
-normal React behavior; the syntax does not opt the component into a different correctness model.
+direct replacement, a copy with no appended entries, updater blocks with extra statements,
+conditional returns, or no value-returning `return`, duplicate keys, React-owned or nested
+host-block rows, row conditionals, and rows whose bindings read the collection itself keep complete
+keyed reconciliation. Keys that read the collection also prevent the compiler from emitting the
+hint. A preceding unhinted update, an unrelated dirty dependency, or any failed source/length check
+also discards the hint. These fallbacks preserve normal React behavior; the syntax does not opt the
+component into a different correctness model.
 The compiler report exposes emitted sites as `keyedArrayAppendHints`, and the hinted runtime is
 retained only when a module emits at least one append or same-order map hint.
 
@@ -1033,8 +1038,9 @@ row. It then removes only rejected rows, patches only changed survivors, and cre
 its final values. The owner stays mounted, survivor DOM identity is preserved, and the suffix is
 appended once.
 
-Only concise updater results that form one direct chain for the same state array are linked. The row
-and key must be compiler-owned and index-independent. A reorder in the structural-append chain, an
+Only concise updater results and blocks with one direct value-returning `return` that form one
+direct chain for the same state array are linked. The row and key must be compiler-owned and
+index-independent. A reorder in the structural-append chain, an
 unsupported or non-adjacent map, an unhinted update to that state, another dirty row dependency,
 collection-reading binding, custom, sparse, or subclassed array, nested or React-owned row,
 duplicate final key, or reuse of any committed key in the appended suffix keeps complete React
@@ -1051,6 +1057,9 @@ at the beginning:
 ```tsx
 setItems((current) => [nextItem, ...current]);
 setItems((current) => [...nextItems, ...current]);
+setItems((current) => {
+  return [...nextItems, ...current];
+});
 
 setItems((current) => current.filter((item) => item.id !== expiredId));
 setItems((current) => [nextItem, ...current]);
@@ -1071,11 +1080,11 @@ setItems((current) =>
 setItems((current) => [nextItem, ...current]);
 ```
 
-At build time, Farm recognizes a concise functional setter whose array literal ends with exactly
-`...current` and has at least one leading item or spread. The application still creates its normal
-immutable array. Generated metadata connects the result to the last committed array and records
-the prefix length. Multiple hinted prepends queued before one compiler flush form one validated
-chain.
+At build time, Farm recognizes a concise functional setter or a setter block containing exactly one
+direct value-returning `return`. Its returned array literal must end with exactly `...current` and
+have at least one leading item or spread. The application still creates its normal immutable array.
+Generated metadata connects the result to the last committed array and records the prefix length.
+Multiple hinted prepends queued before one compiler flush form one validated chain.
 
 At update time, Farm verifies native arrays, source identity, lengths, and every existing suffix
 item before changing the DOM. It reads keys, descriptors, and bindings only for the new prefix,
@@ -1097,8 +1106,9 @@ mapped values. The component owner stays mounted and surviving DOM identity is p
 
 This proof requires compiler-owned host rows whose render callback and key do not read the row
 index. Index-aware rows, collection-derived keys, collection-reading bindings, React-owned or
-nested host-block rows, row conditionals, middle insertion, direct replacement, block-bodied
-updaters, a reordered structural chain, an unsupported or non-adjacent map, duplicate final keys,
+nested host-block rows, row conditionals, middle insertion, direct replacement, updater blocks with
+extra statements, conditional returns, or no value-returning `return`, a reordered structural chain,
+an unsupported or non-adjacent map, duplicate final keys,
 reuse of any committed key in the prefix, custom, sparse, or subclassed arrays, an unrelated dirty
 dependency, or any failed runtime check keeps complete keyed reconciliation before a DOM write. A
 mapped survivor whose key changes and a prepend queued after an unhinted update also fall back.

--- a/examples/react-compiler-dashboard/README.md
+++ b/examples/react-compiler-dashboard/README.md
@@ -69,11 +69,12 @@ row-binding reads, which is the deterministic guard against returning to a full 
 performance, scalability, or persistence gate writes the JSON report and exits with a nonzero
 status.
 
-Keyed array appends have a separate persistence gate. A concise functional append is measured
-against bracketed React and an equivalent block-bodied compiled snapshot control. Both compiler
-modes must remain at least 4x faster than React at 10,000 and up to 20,000 rows, and at least 1.25x
-faster than the compiled control. The report must contain a nonzero `keyedArrayAppendHints` count;
-deterministic package tests separately require work to equal only the appended suffix.
+Keyed array appends have a separate persistence gate. A single-return block-bodied functional
+append is measured against bracketed React and a compiled snapshot control whose updater block has
+an extra local declaration. Both compiler modes must remain at least 4x faster than React at 10,000
+and up to 20,000 rows, and at least 1.25x faster than the compiled control. The report must contain a
+nonzero `keyedArrayAppendHints` count; deterministic package tests separately require work to equal
+only the appended suffix.
 
 Queued structural appends have an independent 10,000-row comparison. One concise setter removes a
 row with `filter()` and the immediately adjacent setter appends one fresh row, while the
@@ -104,12 +105,13 @@ through the intervening map instead of returning to complete keyed reconciliatio
 modes must remain at least 2x faster than React and 1.25x faster than the matching block-bodied
 control.
 
-Keyed array prepends have the same independent comparison. A concise functional prepend is
-measured against bracketed React and an equivalent block-bodied compiled snapshot control. Both
-compiler modes must remain at least 3x faster than React at 10,000 and 20,000 existing rows, and at
-least 1.25x faster than the compiled control at 10,000 rows. The report must contain a nonzero
-`keyedArrayPrependHints` count; deterministic package tests separately require key, descriptor, and
-binding work to equal only the new prefix while preserving every existing DOM row.
+Keyed array prepends have the same independent comparison. A single-return block-bodied functional
+prepend is measured against bracketed React and a compiled snapshot control whose updater block has
+an extra local declaration. Both compiler modes must remain at least 3x faster than React at 10,000
+and 20,000 existing rows, and at least 1.25x faster than the compiled control at 10,000 rows. The
+report must contain a nonzero `keyedArrayPrependHints` count; deterministic package tests separately
+require key, descriptor, and binding work to equal only the new prefix while preserving every
+existing DOM row.
 
 Queued structural prepends have a separate 10,000-row gate. One concise setter drops the oldest row
 with a bounded `slice()` and the adjacent setter prepends one fresh row; a block-bodied pair
@@ -408,7 +410,7 @@ The default JSON report is `/tmp/farm-react-dashboard-benchmark.json`; change it
   the application's immutable collection copy, while the hinted path avoids the runtime's second
   complete entry scan.
 - The append snapshot control creates the same 1,000 array items and DOM rows but intentionally uses
-  an unsupported block-bodied updater, isolating the saved full key-and-binding scan.
+  an updater block with an extra local declaration, isolating the saved full key-and-binding scan.
 - The queued structural-append control removes one keyed row and appends one fresh row across
   adjacent setters. Its block-bodied pair performs the same native array and DOM-visible work
   through complete reconciliation; the hinted path reuses survivor positions and reads only the
@@ -423,8 +425,9 @@ The default JSON report is `/tmp/farm-react-dashboard-benchmark.json`; change it
 - The filter-map-append control maps one retained row before adding the new suffix. Its block-bodied
   control performs the same native operations through complete reconciliation; the hinted path
   carries the changed survivor back to its committed row, then removes and appends atomically.
-- The prepend snapshot control does the same work at the beginning of the array. It isolates the
-  saved suffix scan while the hinted path still creates and inserts every required new DOM row.
+- The prepend snapshot control does the same work at the beginning of the array through an updater
+  block with an extra local declaration. It isolates the saved suffix scan while the hinted path
+  still creates and inserts every required new DOM row.
 - The slice snapshot control retains the same 9,000-row suffix through an unsupported block-bodied
   updater. It isolates the saved survivor scan while both paths remove the same 1,000 DOM rows.
 - The exact-position controls pass event-local runtime position and delete-count variables to concise native

--- a/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
+++ b/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
@@ -145,7 +145,9 @@ export function StandardTableBenchmark() {
             const nextSeed = seed + 1;
             const additions = buildRows(1_000, nextSeed);
             setSeed(nextSeed);
-            setRows((current) => [...current, ...additions]);
+            setRows((current) => {
+              return [...current, ...additions];
+            });
             setOperation("append 1,000");
             setRevision((value) => value + 1);
           }}
@@ -175,7 +177,9 @@ export function StandardTableBenchmark() {
             const nextSeed = seed + 1;
             const additions = buildRows(1_000, nextSeed);
             setSeed(nextSeed);
-            setRows((current) => [...additions, ...current]);
+            setRows((current) => {
+              return [...additions, ...current];
+            });
             setOperation("prepend 1,000");
             setRevision((value) => value + 1);
           }}

--- a/packages/farm-react/README.md
+++ b/packages/farm-react/README.md
@@ -255,15 +255,19 @@ The same optional runtime recognizes conservative immutable appends on a direct 
 ```tsx
 setItems((current) => [...current, nextItem]);
 setItems((current) => [...current, ...nextItems]);
+setItems((current) => {
+  return [...current, ...nextItems];
+});
 ```
 
 Because every existing item keeps its key and index, Farm validates the committed source and the
 queued append chain, reads keys and descriptors only for the appended suffix, and mounts that
-suffix in one fragment. Existing row DOM is left untouched. The concise functional updater and
-native arrays are required; middle insertion, removal, direct replacement, duplicate
-keys, rows that read the collection itself, and failed runtime checks use complete keyed
-reconciliation. A key that reads the collection prevents hint emission entirely. The compiler
-report exposes the emitted-site count as
+suffix in one fragment. Existing row DOM is left untouched. The setter may be concise or use a
+block containing exactly one direct value-returning `return`. Extra statements, conditional
+returns, and missing returns keep complete keyed reconciliation. Native arrays are required;
+middle insertion, removal, direct replacement, duplicate keys, rows that read the collection
+itself, and failed runtime checks use complete keyed reconciliation. A key that reads the
+collection prevents hint emission entirely. The compiler report exposes the emitted-site count as
 `keyedArrayAppendHints`.
 
 Adjacent removal and append setters can share the same committed-row proof:
@@ -305,8 +309,9 @@ row. It then removes only rejected rows, patches only changed survivors, and cre
 its final values. The owner stays mounted, survivor DOM identity is preserved, and the suffix is
 appended once.
 
-Only concise updater results that form one direct chain for the same state array are linked. The row
-and key must be compiler-owned and index-independent. A reorder in the structural-append chain, an
+Only concise updater results and blocks with one direct value-returning `return` that form one
+direct chain for the same state array are linked. The row and key must be compiler-owned and
+index-independent. A reorder in the structural-append chain, an
 unsupported or non-adjacent map, an unhinted update to that state, another dirty row dependency,
 collection-reading binding, custom, sparse, or subclassed array, nested or React-owned row,
 duplicate final key, or reuse of any committed key in the appended suffix keeps complete React
@@ -320,6 +325,9 @@ The mirror-image prepend form is supported when the keyed row and key do not rea
 ```tsx
 setItems((current) => [nextItem, ...current]);
 setItems((current) => [...nextItems, ...current]);
+setItems((current) => {
+  return [...nextItems, ...current];
+});
 
 setItems((current) => current.filter((item) => item.id !== expiredId));
 setItems((current) => [nextItem, ...current]);
@@ -346,6 +354,9 @@ When an adjacent filter or bounded slice runs first, the compiler also carries t
 positions into the prepend. The runtime removes only rejected rows, preserves every surviving DOM
 node, and creates only the final prefix instead of rescanning and rebinding the whole result.
 Multiple adjacent prepends share the same proof.
+
+The setter may be concise or use a block containing exactly one direct value-returning `return`.
+Extra statements, conditional returns, and missing returns keep complete keyed reconciliation.
 
 One or more immediately adjacent safe same-key `map()` setters may run after the prepend or between
 the removal and prepend. A safe map may also run immediately before the removal. Farm carries every

--- a/packages/farm-react/src/__tests__/compiler-keyed-array-append-hints.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-keyed-array-append-hints.test.ts
@@ -44,6 +44,35 @@ describe("React AOT keyed-array append hints", () => {
     });
   });
 
+  it("records appends returned from a single-return updater block", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Inventory({ additions }) {
+        const [rows, setRows] = useState([{ id: "a", label: "Alpha" }]);
+        return <main>
+          <button onClick={() => setRows((current) => {
+            return [...current, ...additions];
+          })}>Append</button>
+          <ul>{rows.map((row) => <li key={row.id}>{row.label}</li>)}</ul>
+        </main>;
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Inventory"]);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.optimizations.keyedArrayAppendHints).toBe(1);
+    expect(result.code).toContain("createCompilerKeyedArrayAppend");
+    expect(result.code).toContain("keyedRowsHintedRuntimeFeature");
+    await expect(
+      transformWithEsbuild(result.code, "/app/KeyedArrayAppendHints.tsx", {
+        loader: "tsx",
+        jsx: "automatic",
+      }),
+    ).resolves.toMatchObject({
+      code: expect.stringContaining("createCompilerKeyedArrayAppend"),
+    });
+  });
+
   it("supports the public List primitive without another option", async () => {
     const result = await compile(`
       import { useState } from "react";
@@ -363,9 +392,23 @@ describe("React AOT keyed-array append hints", () => {
       update: "setRows((current) => [...current])",
     },
     {
-      name: "a block-bodied updater",
+      name: "an updater block with a local declaration",
       update:
         'setRows((current) => { const next = [...current, { id: "b", label: "Beta" }]; return next; })',
+    },
+    {
+      name: "an updater block with conditional returns",
+      update:
+        'setRows((current) => { if (current.length > 0) return [...current, { id: "b", label: "Beta" }]; return current; })',
+    },
+    {
+      name: "an updater block without a return",
+      update: 'setRows((current) => { [...current, { id: "b", label: "Beta" }]; })',
+    },
+    {
+      name: "an updater block with a directive",
+      update:
+        'setRows((current) => { "use strict"; return [...current, { id: "b", label: "Beta" }]; })',
     },
     {
       name: "a side-effecting trailing call",

--- a/packages/farm-react/src/__tests__/compiler-keyed-array-prepend-hints.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-keyed-array-prepend-hints.test.ts
@@ -42,6 +42,36 @@ describe("React AOT keyed-array prepend hints", () => {
     });
   });
 
+  it("records prepends returned from a single-return updater block", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Feed({ additions }) {
+        const [rows, setRows] = useState([{ id: "a", label: "Alpha" }]);
+        return <main>
+          <button onClick={() => setRows((current) => {
+            return [...additions, ...current];
+          })}>Prepend</button>
+          <ul>{rows.map((row) => <li key={row.id}>{row.label}</li>)}</ul>
+        </main>;
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Feed"]);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.optimizations.keyedArrayPrependHints).toBe(1);
+    expect(result.code).toContain("createCompilerKeyedArrayPrepend");
+    expect(result.code).toContain("prependIndexIndependent={true}");
+    expect(result.code).toContain("keyedRowsPrependHintedRuntimeFeature");
+    await expect(
+      transformWithEsbuild(result.code, "/app/KeyedArrayPrependHints.tsx", {
+        loader: "tsx",
+        jsx: "automatic",
+      }),
+    ).resolves.toMatchObject({
+      code: expect.stringContaining("createCompilerKeyedArrayPrepend"),
+    });
+  });
+
   it("supports safe prefix batches and the public List primitive", async () => {
     const result = await compile(`
       import { useState } from "react";
@@ -292,9 +322,27 @@ describe("React AOT keyed-array prepend hints", () => {
       update: 'setRows((current) => [{ id: "b", label: "Beta" }, ...current])',
     },
     {
-      name: "a block-bodied updater",
+      name: "an updater block with a local declaration",
       row: "(row) => <li key={row.id}>{row.label}</li>",
-      update: 'setRows((current) => { return [{ id: "b", label: "Beta" }, ...current]; })',
+      update:
+        'setRows((current) => { const next = [{ id: "b", label: "Beta" }, ...current]; return next; })',
+    },
+    {
+      name: "an updater block with conditional returns",
+      row: "(row) => <li key={row.id}>{row.label}</li>",
+      update:
+        'setRows((current) => { if (current.length > 0) return [{ id: "b", label: "Beta" }, ...current]; return current; })',
+    },
+    {
+      name: "an updater block without a return",
+      row: "(row) => <li key={row.id}>{row.label}</li>",
+      update: 'setRows((current) => { [{ id: "b", label: "Beta" }, ...current]; })',
+    },
+    {
+      name: "an updater block with a directive",
+      row: "(row) => <li key={row.id}>{row.label}</li>",
+      update:
+        'setRows((current) => { "use strict"; return [{ id: "b", label: "Beta" }, ...current]; })',
     },
     {
       name: "an append",

--- a/packages/farm-react/src/compiler.ts
+++ b/packages/farm-react/src/compiler.ts
@@ -1517,12 +1517,18 @@ function rewriteKeyedArrayAppendHints(
         updater.async ||
         updater.generator ||
         updater.params.length !== 1 ||
-        !t.isIdentifier(updater.params[0]) ||
-        !t.isArrayExpression(updater.body) ||
-        updater.body.elements.length < 2 ||
-        updater.body.elements.some((element) => element === null) ||
-        !t.isSpreadElement(updater.body.elements[0]) ||
-        !t.isIdentifier(updater.body.elements[0].argument, {
+        !t.isIdentifier(updater.params[0])
+      ) {
+        return;
+      }
+      const updateExpression = returnedExpression(updater);
+      if (
+        (t.isBlockStatement(updater.body) && updater.body.directives.length > 0) ||
+        !t.isArrayExpression(updateExpression) ||
+        updateExpression.elements.length < 2 ||
+        updateExpression.elements.some((element) => element === null) ||
+        !t.isSpreadElement(updateExpression.elements[0]) ||
+        !t.isIdentifier(updateExpression.elements[0].argument, {
           name: updater.params[0].name,
         })
       ) {
@@ -1552,7 +1558,7 @@ function rewriteKeyedArrayAppendHints(
         return validateDerivedExpression(value, safeGlobals) === undefined;
       };
       if (
-        updater.body.elements.slice(1).some((element) => {
+        updateExpression.elements.slice(1).some((element) => {
           if (!element || t.isJSXNamespacedName(element) || t.isArgumentPlaceholder(element)) {
             return true;
           }
@@ -1568,7 +1574,7 @@ function rewriteKeyedArrayAppendHints(
         [t.cloneNode(previous)],
         t.blockStatement([
           t.variableDeclaration("const", [
-            t.variableDeclarator(t.cloneNode(nextValue), t.cloneNode(updater.body, true)),
+            t.variableDeclarator(t.cloneNode(nextValue), t.cloneNode(updateExpression, true)),
           ]),
           t.returnStatement(
             t.callExpression(t.cloneNode(helperIdentifier), [
@@ -1615,14 +1621,20 @@ function rewriteKeyedArrayPrependHints(
         updater.async ||
         updater.generator ||
         updater.params.length !== 1 ||
-        !t.isIdentifier(updater.params[0]) ||
-        !t.isArrayExpression(updater.body) ||
-        updater.body.elements.length < 2 ||
-        updater.body.elements.some((element) => element === null)
+        !t.isIdentifier(updater.params[0])
       ) {
         return;
       }
-      const suffix = updater.body.elements[updater.body.elements.length - 1];
+      const updateExpression = returnedExpression(updater);
+      if (
+        (t.isBlockStatement(updater.body) && updater.body.directives.length > 0) ||
+        !t.isArrayExpression(updateExpression) ||
+        updateExpression.elements.length < 2 ||
+        updateExpression.elements.some((element) => element === null)
+      ) {
+        return;
+      }
+      const suffix = updateExpression.elements[updateExpression.elements.length - 1];
       if (
         !t.isSpreadElement(suffix) ||
         !t.isIdentifier(suffix.argument, { name: updater.params[0].name })
@@ -1653,7 +1665,7 @@ function rewriteKeyedArrayPrependHints(
         return validateDerivedExpression(value, safeGlobals) === undefined;
       };
       if (
-        updater.body.elements.slice(0, -1).some((element) => {
+        updateExpression.elements.slice(0, -1).some((element) => {
           if (!element || t.isJSXNamespacedName(element) || t.isArgumentPlaceholder(element)) {
             return true;
           }
@@ -1669,7 +1681,7 @@ function rewriteKeyedArrayPrependHints(
         [t.cloneNode(previous)],
         t.blockStatement([
           t.variableDeclaration("const", [
-            t.variableDeclarator(t.cloneNode(nextValue), t.cloneNode(updater.body, true)),
+            t.variableDeclarator(t.cloneNode(nextValue), t.cloneNode(updateExpression, true)),
           ]),
           t.returnStatement(
             t.callExpression(t.cloneNode(helperIdentifier), [


### PR DESCRIPTION
## Problem

Safe immutable keyed appends and prepends only reached the existing edge-insertion fast paths when their functional setter used a concise arrow body:

```tsx
setRows((current) => [...current, ...additions]);
```

The equivalent common block form fell back to complete keyed reconciliation:

```tsx
setRows((current) => {
  return [...current, ...additions];
});
```

## Root cause

The append and prepend rewrites inspected `updater.body` as an array expression directly. They therefore never applied the compiler's existing exact single-return proof to an otherwise identical array expression inside a block.

## Change

- Resolve the updater value through the existing `returnedExpression` proof before validating append or prepend structure.
- Compile exact one-statement, value-returning blocks through the existing keyed append/prepend helpers.
- Keep directives, local declarations, conditional returns, missing returns, and every previously unsupported array shape on complete React reconciliation.
- Exercise block-bodied append and prepend in the maintained 10,000/20,000-row production benchmark.
- Document accepted syntax and fallback boundaries in the renderer guide, package README, and benchmark README.

## Safety and compatibility

There is no new runtime helper, option, public API, or renderer-neutral behavior. Eligible blocks generate the same validated runtime path as concise setters. The runtime still verifies native dense arrays, committed source identity, lengths, keys, row ownership, and append/prepend boundaries before any DOM mutation; failed validation uses complete React reconciliation.

Extra statements, directives, conditional or missing returns, unsafe derived values, duplicate keys, index-sensitive prepends, collection-reading bindings, React-owned/nested rows, and unsupported array structures remain fallbacks. Native array evaluation, thrown errors, queued state semantics, DOM identity, hydration behavior, and React ownership are unchanged. Runtime-size fixtures and React 18/19 compatibility remain intact.

## Verification

- `pnpm --filter @farm.js/react exec vitest run src/__tests__/compiler-keyed-array-append-hints.test.ts src/__tests__/compiler-keyed-array-prepend-hints.test.ts src/__tests__/compiler-runtime-keyed-array-append-hints.test.tsx src/__tests__/compiler-runtime-keyed-array-prepend-hints.test.tsx` — 88 passed, 2 skipped
- `pnpm --filter @farm.js/react exec vitest run --maxWorkers=1 --minWorkers=1` — 862 passed, 14 skipped
- `pnpm --filter @farm.js/react exec vitest run --config vitest.stress.config.ts --maxWorkers=1 --minWorkers=1` — 23 passed, 132 skipped
- `pnpm --filter @farm.js/react type-check`
- `pnpm --filter @farm.js/react test:runtime-size` — every fixture unchanged
- `pnpm --filter @farm.js/react test:compat` — React 18.3.1 and 19.2.8 passed
- `pnpm --dir examples/react-compiler-dashboard type-check`
- `pnpm docs:check-navigation`
- `pnpm --dir docs exec farm generate --check`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm docs:build` — Vercel/Nitro production build passed
- focused `oxfmt`, `oxlint`, and `git diff --check`
- `FARM_EXPERIMENT_BROWSER_PATH='/Applications/Google Chrome.app/Contents/MacOS/Google Chrome' pnpm --dir examples/react-compiler-dashboard benchmark`
  - correctness: PASS
  - ordinary performance-regression gate: PASS
  - optimization-persistence gate: PASS — 12.72x/28.30x at 10k and 8.63x/23.22x at 20k
  - block append: 3.26x static and 5.41x hybrid versus React; 2.14x and 1.67x versus the fallback control; 20k scale was 3.78x and 10.05x
  - block prepend: 2.84x static and 5.19x hybrid versus React; 1.87x and 1.60x versus the fallback control; 20k scale was 4.36x and 11.66x
  - compiled component owner executions: 0 in static and hybrid modes
  - compiler report: 9 append and 5 prepend sites, with 2 compiled and 2 fallback components

The aggregate benchmark result was `CORRECTNESS_PASS_PERFORMANCE_REGRESSION`: the static append/prepend timings missed their existing 4x/3x floors, and the unrelated multi-map control also missed its gate. The edge timings remain within the benchmark's already recorded machine variance: an earlier unchanged append path measured 3.86x static and 2.57x hybrid against the same 4x floor. No threshold was weakened and the run was not repeated to select more favorable numbers.

Environment: macOS, Google Chrome 153, Node 23.11.0, pnpm 8.12.1.

## Documentation and release

Updated the React renderer guide, `@farm.js/react` README, and compiler dashboard example/README. No version, template, generated artifact, or release-flow change.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keyed array append and prepend fast paths now compile block-bodied setters with a single `return`, so `setRows((current) => { return [...current, ...additions]; })` no longer falls back to complete reconciliation like it did before.

- Resolves the updater value through the existing `returnedExpression` proof before validating append/prepend structure.
- Blocks with extra statements, directives, conditional returns, or missing returns still use complete React reconciliation.
- Runtime behavior, validation checks, and React 18/19 compatibility are unchanged; no new helper, option, or public API.
- Docs updated in the renderer guide, `@farm.js/react` README, and dashboard benchmark README.

<sup>Written for commit 1e302ee866e9feafd2c077c52beb6506f7101bce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/966?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

