### PR TITLE
fix(content): preserve MDX code during asset collection

### DIFF
--- a/docs/src/app/docs/plugins/content/page.md
+++ b/docs/src/app/docs/plugins/content/page.md
@@ -116,6 +116,12 @@ links are managed when their destination has a file extension; extensionless lin
 and dynamic MDX expressions are left unchanged. Static `src` or `href` attributes inside JSX and
 HTML are not interpreted in this first API; use Markdown syntax or a normal module import there.
 
+For `.mdx` files, JavaScript strings, comments, imports/exports, and JSX attributes are not scanned
+for Markdown assets. For example, `{"![Example](./missing.png)"}` stays literal code and does not
+require that image to exist. Actual Markdown images and links nested inside JSX are still managed.
+Farm parses MDX syntax without executing expressions or importing modules; invalid syntax reports
+the content filename. Ordinary `.md` files keep Markdown parsing rules.
+
 The body keeps its original Markdown except for managed destinations, which become content-hashed
 public URLs. `entry.bodyAssets` contains the corresponding image or file metadata for a custom
 Markdown component mapping. Missing assets report the content file plus the Markdown line and

--- a/packages/farm-content/package.json
+++ b/packages/farm-content/package.json
@@ -51,6 +51,8 @@
     "gray-matter": "^4.0.3",
     "image-size": "^2.0.2",
     "mdast-util-from-markdown": "^2.0.2",
+    "mdast-util-mdx": "^3.0.0",
+    "micromark-extension-mdxjs": "^3.0.0",
     "yaml": "^2.8.0"
   },
   "devDependencies": {

--- a/packages/farm-content/src/markdown-assets.test.ts
+++ b/packages/farm-content/src/markdown-assets.test.ts
@@ -1,0 +1,84 @@
+import { mkdtemp, writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type { ContentAssetContext } from "./assets.js";
+import { resolveMarkdownAssets } from "./markdown-assets.js";
+
+const roots: string[] = [];
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+async function context(sourceFile = "post.mdx"): Promise<ContentAssetContext> {
+  const root = await mkdtemp(path.join(tmpdir(), "farm-mdx-assets-"));
+  roots.push(root);
+  await writeFile(
+    path.join(root, "hero.svg"),
+    '<svg xmlns="http://www.w3.org/2000/svg" width="32" height="24"/>',
+  );
+  await writeFile(path.join(root, "guide.pdf"), "%PDF guide");
+  return { root, sourceFile, collectionName: "posts", sourceFiles: new Set(), imports: new Map() };
+}
+
+describe("Markdown and MDX body assets", () => {
+  it.each([
+    '{"![Example](./missing.png)"}',
+    'Inline {"[Download](./missing.pdf)"} text.',
+    "{/* ![Example](./missing.png) */}",
+    'export const example = "![Example](./missing.png)";\n\n# Example',
+    '<Card label={"![Example](./missing.png)"} />',
+    '<Card label="![Example](./missing.png)" />',
+    'import example from "./missing.js";\n\n{(() => { throw new Error("must not execute"); })()}',
+  ])("leaves MDX code and attributes unchanged: %s", async (body) => {
+    const input = await context();
+    const resolved = await resolveMarkdownAssets(body, input);
+    expect(resolved).toEqual({ body, assets: [] });
+    expect(input.imports.size).toBe(0);
+    expect(input.sourceFiles.size).toBe(0);
+  });
+
+  it("manages actual Markdown nested inside JSX without touching adjacent JavaScript", async () => {
+    const input = await context();
+    const body =
+      '<Card label={"![Example](./missing.png)"}>\n  ![Hero](./hero.svg)\n\n  [Download][guide]\n</Card>\n\n[guide]: ./guide.pdf\n';
+    const resolved = await resolveMarkdownAssets(body, input);
+    expect(resolved.assets).toMatchObject([
+      { kind: "image", source: "./hero.svg", width: 32, height: 24 },
+      { kind: "file", source: "./guide.pdf" },
+    ]);
+    expect(resolved.assets).toHaveLength(2);
+    expect(resolved.body).toContain('<Card label={"![Example](./missing.png)"}>');
+    expect(resolved.body).toContain("![Hero](__FARM_CONTENT_ASSET_");
+    expect(resolved.body).toContain("[guide]: __FARM_CONTENT_ASSET_");
+    expect(input.imports.size).toBe(2);
+  });
+
+  it("does not rewrite image-looking JavaScript strings even when that file exists", async () => {
+    const body = '{"![Example](./hero.svg)"}';
+    expect(await resolveMarkdownAssets(body, await context("post.MDX"))).toEqual({
+      body,
+      assets: [],
+    });
+  });
+
+  it("preserves ordinary Markdown rules for braces and code fences", async () => {
+    const body = '{"![Hero](./hero.svg)"}\n\n```mdx\n{"![Example](./missing.png)"}\n```\n';
+    const result = await resolveMarkdownAssets(body, await context("post.md"));
+    expect(result.assets).toHaveLength(1);
+    expect(result.body).toContain('{"![Hero](__FARM_CONTENT_ASSET_');
+    expect(result.body).toContain('{"![Example](./missing.png)"}');
+  });
+
+  it("still reports missing real Markdown images in MDX", async () => {
+    await expect(
+      resolveMarkdownAssets("![Missing](./missing.png)", await context()),
+    ).rejects.toThrow('Asset "./missing.png" does not exist');
+  });
+
+  it("reports invalid MDX syntax with the content file without evaluating it", async () => {
+    await expect(resolveMarkdownAssets("{not closed", await context())).rejects.toThrow(
+      "Could not inspect Markdown assets in post.mdx",
+    );
+  });
+});

--- a/packages/farm-content/src/markdown-assets.ts
+++ b/packages/farm-content/src/markdown-assets.ts
@@ -38,7 +38,19 @@ export async function resolveMarkdownAssets(
 
   let tree: MarkdownNode;
   try {
-    tree = fromMarkdown(body) as MarkdownNode;
+    if (context.sourceFile.toLowerCase().endsWith(".mdx")) {
+      // Parse MDX without evaluating it. Only Markdown children own assets.
+      const [{ mdxFromMarkdown }, { mdxjs }] = await Promise.all([
+        import("mdast-util-mdx"),
+        import("micromark-extension-mdxjs"),
+      ]);
+      tree = fromMarkdown(body, {
+        extensions: [mdxjs()],
+        mdastExtensions: [mdxFromMarkdown()],
+      }) as MarkdownNode;
+    } else {
+      tree = fromMarkdown(body) as MarkdownNode;
+    }
   } catch (error) {
     throw new Error(
       `[farm:content] Could not inspect Markdown assets in ${context.sourceFile}: ${errorMessage(error)}`,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2138,6 +2138,12 @@ importers:
       mdast-util-from-markdown:
         specifier: ^2.0.2
         version: 2.0.2(supports-color@10.2.2)
+      mdast-util-mdx:
+        specifier: ^3.0.0
+        version: 3.0.0(supports-color@10.2.2)
+      micromark-extension-mdxjs:
+        specifier: ^3.0.0
+        version: 3.0.0
       yaml:
         specifier: ^2.8.0
         version: 2.9.0


### PR DESCRIPTION
## Problem

With `assets: true`, valid MDX such as `{"![Example](./missing.png)"}` fails a build because Farm treats the JavaScript string as a Markdown image. If the file exists, Farm silently rewrites the string instead.

## Root cause

The asset collector parsed both `.md` and `.mdx` as ordinary Markdown. It could not distinguish Markdown nodes from MDX expressions, ESM, or JSX attributes.

## Change

- Parse `.mdx` with the standard MDX syntax and AST extensions, loaded lazily only for MDX asset inspection.
- Keep the existing asset collector and source-range replacement logic. Real Markdown images and links inside JSX remain managed.
- Declare both parser extensions as direct runtime dependencies. The lockfile retains only these additions.

## Safety and compatibility

No MDX expressions are executed and no author modules are imported. Ordinary Markdown keeps its existing parsing rules. Missing real assets still fail clearly; invalid MDX syntax includes the content filename. There is no new configuration or client/runtime parser injection. This is renderer-neutral build-time content handling.

## Verification

macOS arm64, Node 24, pnpm 8.12.1:

- `pnpm --filter @farm.js/content test`: 43 passing tests. Before the fix, eight new regression cases failed, including code literals being imported or rewritten.
- `pnpm --filter @farm.js/content type-check`
- `pnpm --filter @farm.js/content build`
- `pnpm exec oxlint packages/farm-content/src/markdown-assets.ts packages/farm-content/src/markdown-assets.test.ts`
- `pnpm exec oxfmt --check packages/farm-content/src/markdown-assets.ts packages/farm-content/src/markdown-assets.test.ts packages/farm-content/package.json docs/src/app/docs/plugins/content/page.md`
- `pnpm install --lockfile-only --frozen-lockfile --ignore-scripts --offline --filter @farm.js/content`
- `pnpm docs:check-navigation`
- Built-package smoke test: the Content plugin generated a server module, Vite 5.4.20 built it for SSR and emitted two hashed assets, and MDX 3.1.1 compiled the resulting body. JavaScript and attribute literals stayed unchanged, including references to nonexistent files.

## Documentation and release

Clarified MDX asset boundaries in the Content plugin guide. No route, sidebar, template, or version changes.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes MDX asset collection in the Content plugin so JavaScript strings, comments, imports, and JSX attributes in `.mdx` files are no longer parsed as Markdown images or links when `assets: true` is set. Previously, valid MDX like `{"![Example](./missing.png)"}` would fail the build or get silently rewritten if the file existed; now it remains literal, and missing real assets still fail clearly. `.mdx` files are parsed with MDX syntax extensions (lazy-loaded) without executing any expressions, while ordinary `.md` files keep their existing parsing rules; invalid MDX syntax reports the content filename.

**Notes**
- Adds `mdast-util-mdx` and `micromark-extension-mdxjs` as runtime dependencies.
- Updates the Content plugin guide with MDX asset boundary behavior.

<sup>Written for commit 2c9323696bf4969d95700497b969c920be5f38ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/967?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

