### PR TITLE
fix(pwa): preserve static routes that repeat the base path

### DIFF
--- a/docs/src/app/docs/plugins/pwa/page.md
+++ b/docs/src/app/docs/plugins/pwa/page.md
@@ -215,6 +215,11 @@ array when the app should not ship a service worker.
 URLs, query strings, fragments, dot segments, backslashes, control characters, and encoded path
 separators are rejected.
 
+Write these paths without the deployment prefix: with `basePath: "/app"`, `"/"` is served at
+`/app` and `"/help"` at `/app/help`. An application route named `"/app"` is distinct from the home
+page and is cached at `/app/app`. Farm handles localized HTML output automatically; include the
+locale in a localized route such as `offline: "/en/offline"`, but do not add the deployment prefix.
+
 ## Production lifecycle
 
 During `farm build`, generated-worker mode:

--- a/packages/farm-pwa/src/build.ts
+++ b/packages/farm-pwa/src/build.ts
@@ -9,6 +9,8 @@ export interface PwaBuildInput {
   publicDir?: string;
   preset: string;
   basePath: string;
+  /** Prefix already present in emitted HTML paths (localized Farm SSG output). */
+  htmlBasePath?: string;
   options: ResolvedPwaOptions;
 }
 
@@ -36,6 +38,7 @@ const PRECACHE_EXTENSIONS = new Set([
 export async function writePwaBuildArtifacts(input: PwaBuildInput): Promise<PwaBuildResult> {
   const publicDir = input.publicDir ?? resolvePwaPublicDir(input.outputDir, input.preset);
   const basePath = normalizeBasePath(input.basePath);
+  const htmlBasePath = normalizeBasePath(input.htmlBasePath);
   const workerRelativePath = path.posix.join(basePath.replace(/^\//, ""), "sw.js");
   const workerPath = path.join(publicDir, ...workerRelativePath.split("/"));
   await assertWorkerPathInsidePublicDir(publicDir, workerPath);
@@ -67,7 +70,7 @@ export async function writePwaBuildArtifacts(input: PwaBuildInput): Promise<PwaB
   }
 
   const files = await walkFiles(publicDir);
-  const staticRouteFiles = resolveStaticRouteFiles(files);
+  const staticRouteFiles = resolveStaticRouteFiles(files, htmlBasePath);
   const selectedRoutes = selectStaticRoutes(
     staticRouteFiles,
     input.options.cache.staticRoutes,
@@ -79,8 +82,7 @@ export async function writePwaBuildArtifacts(input: PwaBuildInput): Promise<PwaB
     ? withBasePath(configuredOfflineRoute, basePath)
     : false;
   if (offlineRoute && configuredOfflineRoute) {
-    const emittedOfflineFile =
-      staticRouteFiles[configuredOfflineRoute] ?? staticRouteFiles[offlineRoute];
+    const emittedOfflineFile = staticRouteFiles[configuredOfflineRoute];
     if (!emittedOfflineFile) {
       throw new Error(
         `[farm:pwa] Offline route ${JSON.stringify(input.options.offline)} was not emitted as a static page. ` +
@@ -96,7 +98,10 @@ export async function writePwaBuildArtifacts(input: PwaBuildInput): Promise<PwaB
       PRECACHE_EXTENSIONS.has(path.extname(file).toLowerCase()),
   );
   const precacheFiles = [...new Set([...assetFiles, ...Object.values(selectedRoutes)])].sort();
-  const precacheUrls = precacheFiles.map((file) => toPublicUrl(file, basePath));
+  const htmlFiles = new Set(Object.values(selectedRoutes));
+  const precacheUrls = precacheFiles.map((file) =>
+    toPublicUrl(file, basePath, htmlFiles.has(file) ? htmlBasePath : basePath),
+  );
   const fileHashes = await Promise.all(
     precacheFiles.map(async (file) => {
       const content = await readFile(path.join(publicDir, file));
@@ -107,6 +112,7 @@ export async function writePwaBuildArtifacts(input: PwaBuildInput): Promise<PwaB
     .update(
       JSON.stringify({
         files: fileHashes,
+        urls: precacheUrls,
         routes: selectedRoutes,
         offlineRoute,
         update: input.options.update,
@@ -121,6 +127,7 @@ export async function writePwaBuildArtifacts(input: PwaBuildInput): Promise<PwaB
     workerPath,
     generateServiceWorker({
       basePath,
+      htmlBasePath,
       cacheId,
       precacheUrls,
       staticRoutes: selectedRoutes,
@@ -142,6 +149,7 @@ export async function writePwaBuildArtifacts(input: PwaBuildInput): Promise<PwaB
 
 export interface GenerateServiceWorkerOptions {
   basePath: string;
+  htmlBasePath?: string;
   cacheId: string;
   precacheUrls: string[];
   staticRoutes: Record<string, string>;
@@ -154,7 +162,7 @@ export function generateServiceWorker(options: GenerateServiceWorkerOptions): st
   const routeFiles = Object.fromEntries(
     Object.entries(options.staticRoutes).map(([route, file]) => [
       encodePathname(route),
-      toPublicUrl(file, options.basePath),
+      toPublicUrl(file, options.basePath, options.htmlBasePath ?? "/"),
     ]),
   );
   const offlineFile = options.offlineRoute
@@ -398,9 +406,6 @@ export function withBasePath(route: string, basePath: string): string {
   const normalizedBase = normalizeBasePath(basePath);
   const normalizedRoute = route === "/" ? "/" : `/${route.replace(/^\/+|\/+$/g, "")}`;
   if (normalizedBase === "/") return normalizedRoute;
-  if (normalizedRoute === normalizedBase || normalizedRoute.startsWith(`${normalizedBase}/`)) {
-    return normalizedRoute;
-  }
   return normalizedRoute === "/" ? normalizedBase : `${normalizedBase}${normalizedRoute}`;
 }
 
@@ -420,7 +425,7 @@ async function walkFiles(root: string): Promise<string[]> {
   return files.flat().sort();
 }
 
-function resolveStaticRouteFiles(files: string[]): Record<string, string> {
+function resolveStaticRouteFiles(files: string[], htmlBasePath: string): Record<string, string> {
   const routes: Record<string, string> = {};
   for (const file of files) {
     if (path.extname(file).toLowerCase() !== ".html") continue;
@@ -429,7 +434,7 @@ function resolveStaticRouteFiles(files: string[]): Record<string, string> {
     const route = withoutIndex
       ? `/${withoutIndex.replace(/\.html$/, "").replace(/^\/+|\/+$/g, "")}`
       : "/";
-    routes[route] = normalized;
+    routes[stripBasePath(route, htmlBasePath)] = normalized;
   }
   return routes;
 }
@@ -449,7 +454,7 @@ function selectStaticRoutes(
   const selected: Record<string, string> = {};
   for (const requested of configured) {
     const route = withBasePath(requested, basePath);
-    const emittedFile = emitted[requested] ?? emitted[route];
+    const emittedFile = emitted[requested];
     if (!emittedFile) {
       throw new Error(
         `[farm:pwa] Static route ${JSON.stringify(requested)} was not found in the production output.`,
@@ -460,13 +465,18 @@ function selectStaticRoutes(
   return selected;
 }
 
-function toPublicUrl(file: string, basePath: string): string {
-  const url = `/${file
-    .replace(/\\/g, "/")
-    .split("/")
-    .map((segment) => encodeURIComponent(segment))
-    .join("/")}`;
-  return withBasePath(url, basePath);
+function stripBasePath(route: string, basePath: string): string {
+  const base = normalizeBasePath(basePath);
+  if (base === "/") return route;
+  if (route === base) return "/";
+  return route.startsWith(`${base}/`) ? route.slice(base.length) : route;
+}
+
+function toPublicUrl(file: string, basePath: string, fileBasePath = basePath): string {
+  // Generated assets can already live under basePath. HTML uses the explicit
+  // SSG output prefix instead: a folder named like basePath can be a real route.
+  const route = stripBasePath(`/${file.replace(/\\/g, "/")}`, fileBasePath);
+  return withBasePath(encodePathname(route), basePath);
 }
 
 function encodePathname(pathname: string): string {

--- a/packages/farm-pwa/src/index.test.ts
+++ b/packages/farm-pwa/src/index.test.ts
@@ -114,6 +114,42 @@ describe("pwa browser lifecycle", () => {
 });
 
 describe("pwa production build lifecycle", () => {
+  it.each([undefined, { enabled: false }, { enabled: true }])(
+    "uses the configured HTML output prefix without guessing from folder names: %j",
+    async (i18n) => {
+      const root = await mkdtemp(path.join(tmpdir(), "farm-pwa-plugin-base-"));
+      const publicDir = path.join(root, "public");
+      const localized = i18n?.enabled === true;
+      const homeFile = localized ? "app/en/index.html" : "index.html";
+      const appFile = localized ? "app/en/app/index.html" : "app/index.html";
+      const route = localized ? "/en/app" : "/app";
+      const info = vi.spyOn(console, "info").mockImplementation(() => undefined);
+      try {
+        for (const file of [homeFile, appFile]) {
+          await mkdir(path.dirname(path.join(publicDir, file)), { recursive: true });
+          await writeFile(path.join(publicDir, file), file);
+        }
+        const plugin = pwa({ offline: route, cache: "auto" });
+        await plugin.configure?.({ root, basePath: "/app", i18n } as never, {} as never);
+        const configured = await plugin.build?.configure?.(
+          { preset: "node-server", output: { dir: root, publicDir } },
+          {} as never,
+        );
+        await configured.hooks["prerender:done"]({ prerenderedRoutes: [] });
+        const worker = await readFile(path.join(publicDir, "app", "sw.js"), "utf8");
+        const homeRoute = localized ? "/app/en" : "/app";
+        const homeUrl = localized ? "/app/en/index.html" : "/app/index.html";
+        expect(worker).toContain(`${JSON.stringify(homeRoute)}:${JSON.stringify(homeUrl)}`);
+        expect(worker).toContain(`"/app${route}":"/app${route}/index.html"`);
+        expect(worker).toContain(`const OFFLINE_FILE = "/app${route}/index.html"`);
+        expect(plugin.client.public).toMatchObject({ workerUrl: "/app/sw.js", scope: "/app/" });
+      } finally {
+        info.mockRestore();
+        await rm(root, { recursive: true, force: true });
+      }
+    },
+  );
+
   it("generates the worker after prerendering and before Nitro compiles public assets", async () => {
     const root = await mkdtemp(path.join(tmpdir(), "farm-pwa-plugin-"));
     const outputDir = path.join(root, ".farm", ".output");

--- a/packages/farm-pwa/src/index.ts
+++ b/packages/farm-pwa/src/index.ts
@@ -45,6 +45,7 @@ export function pwa(options: PwaPluginOptions = {}) {
   const resolved = resolvePwaOptions(options);
   let configuredRoot = ".";
   let configuredBasePath = "/";
+  let htmlBasePath = "/";
   let configuredOutputDir = ".farm/.output";
   const publicConfig = {
     workerUrl: "/sw.js",
@@ -60,6 +61,10 @@ export function pwa(options: PwaPluginOptions = {}) {
       configuredRoot = config.root ?? ".";
       const basePath = normalizeBasePath(config.basePath);
       configuredBasePath = basePath;
+      // Only localized SSG output already includes the application's basePath.
+      const i18n = config.i18n;
+      htmlBasePath =
+        i18n && typeof i18n === "object" && "enabled" in i18n && i18n.enabled ? basePath : "/";
       configuredOutputDir = `${config.root ?? "."}/.farm/.output`;
       publicConfig.workerUrl = withBasePath("/sw.js", basePath);
       publicConfig.scope = basePath === "/" ? "/" : `${basePath}/`;
@@ -79,6 +84,7 @@ export function pwa(options: PwaPluginOptions = {}) {
             publicDir: nitroConfig.output?.publicDir,
             preset: nitroConfig.preset ?? "node-server",
             basePath: configuredBasePath,
+            htmlBasePath,
             options: resolved,
           });
           generated = true;

--- a/packages/farm-pwa/src/static-routes.test.ts
+++ b/packages/farm-pwa/src/static-routes.test.ts
@@ -1,0 +1,143 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { runInNewContext } from "node:vm";
+import { afterEach, describe, expect, it } from "vitest";
+import { writePwaBuildArtifacts } from "./build";
+import { resolvePwaOptions } from "./config";
+
+const directories: string[] = [];
+afterEach(async () => {
+  await Promise.all(
+    directories.splice(0).map((root) => rm(root, { recursive: true, force: true })),
+  );
+});
+
+async function output(files: Record<string, string>) {
+  const root = await mkdtemp(path.join(tmpdir(), "farm-pwa-static-routes-"));
+  directories.push(root);
+  const publicDir = path.join(root, "public");
+  for (const [file, body] of Object.entries(files)) {
+    await mkdir(path.dirname(path.join(publicDir, file)), { recursive: true });
+    await writeFile(path.join(publicDir, file), body);
+  }
+  return { outputDir: root, preset: "node-server", basePath: "/app" };
+}
+
+describe("static routes under a base path", () => {
+  it("serves the root and a route repeating the base path as distinct pages offline", async () => {
+    const input = await output({ "index.html": "home", "app/index.html": "application" });
+    const result = await writePwaBuildArtifacts({
+      ...input,
+      options: resolvePwaOptions({ cache: "auto" }),
+    });
+    expect(result.staticRoutes).toEqual({ "/app": "index.html", "/app/app": "app/index.html" });
+    expect(result.precacheUrls).toEqual(["/app/app/index.html", "/app/index.html"]);
+
+    const listeners = new Map<string, (event: any) => void>();
+    const cached = new Map([
+      ["/app/index.html", "home"],
+      ["/app/app/index.html", "application"],
+    ]);
+    runInNewContext(await readFile(result.workerPath, "utf8"), {
+      URL,
+      Set,
+      caches: {
+        match: async (url: string) => (cached.has(url) ? new Response(cached.get(url)) : undefined),
+      },
+      fetch: async () => {
+        throw new Error("offline");
+      },
+      self: {
+        location: { origin: "https://example.com" },
+        addEventListener: (type: string, listener: (event: any) => void) =>
+          listeners.set(type, listener),
+      },
+    });
+    for (const [route, body] of [
+      ["/app", "home"],
+      ["/app/app", "application"],
+    ]) {
+      let response!: Promise<Response>;
+      listeners.get("fetch")!({
+        request: { method: "GET", mode: "navigate", url: `https://example.com${route}` },
+        respondWith(value: Promise<Response>) {
+          response = value;
+        },
+      });
+      expect(await (await response).text()).toBe(body);
+    }
+  });
+
+  it("treats explicit cached routes and the offline fallback as application paths", async () => {
+    const input = await output({ "index.html": "home", "app/index.html": "application" });
+    const result = await writePwaBuildArtifacts({
+      ...input,
+      options: resolvePwaOptions({ cache: { staticRoutes: ["/app"] }, offline: "/app" }),
+    });
+    expect(result.staticRoutes).toEqual({ "/app/app": "app/index.html" });
+    expect(result.precacheUrls).toEqual(["/app/app/index.html"]);
+    expect(await readFile(result.workerPath, "utf8")).toContain(
+      'const OFFLINE_FILE = "/app/app/index.html"',
+    );
+  });
+
+  it("preserves a repeated-base route even when no root page was emitted", async () => {
+    const input = await output({ "app/index.html": "application" });
+    const result = await writePwaBuildArtifacts({
+      ...input,
+      options: resolvePwaOptions({ cache: "auto" }),
+    });
+    expect(result.staticRoutes).toEqual({ "/app/app": "app/index.html" });
+  });
+
+  it.each(["offline", "staticRoutes"])(
+    "does not satisfy a missing %s route with a different mounted route",
+    async (kind) => {
+      const input = await output({ "app/missing/index.html": "a different page" });
+      const options = resolvePwaOptions(
+        kind === "offline" ? { offline: "/missing" } : { cache: { staticRoutes: ["/missing"] } },
+      );
+      await expect(writePwaBuildArtifacts({ ...input, options })).rejects.toThrow(
+        kind === "offline" ? "was not emitted" : "was not found",
+      );
+    },
+  );
+
+  it("strips only an explicit HTML output prefix for localized static pages", async () => {
+    const input = await output({
+      "app/en/index.html": "home",
+      "app/en/app/index.html": "application",
+    });
+    const result = await writePwaBuildArtifacts({
+      ...input,
+      htmlBasePath: "/app",
+      options: resolvePwaOptions({ cache: "auto", offline: "/en/app" }),
+    });
+    expect(result.staticRoutes).toEqual({
+      "/app/en": "app/en/index.html",
+      "/app/en/app": "app/en/app/index.html",
+    });
+    expect(result.precacheUrls).toEqual(["/app/en/app/index.html", "/app/en/index.html"]);
+    expect(await readFile(result.workerPath, "utf8")).toContain(
+      'const OFFLINE_FILE = "/app/en/app/index.html"',
+    );
+  });
+
+  it("keeps already mounted assets and excludes the generated worker on rebuild", async () => {
+    const input = await output({
+      "index.html": "home",
+      "app/_farm/search.js": "search",
+      "assets/app.js": "app",
+    });
+    const options = resolvePwaOptions({ cache: "auto" });
+    const first = await writePwaBuildArtifacts({ ...input, options });
+    const second = await writePwaBuildArtifacts({ ...input, options });
+    expect(second.precacheUrls).toEqual([
+      "/app/_farm/search.js",
+      "/app/assets/app.js",
+      "/app/index.html",
+    ]);
+    expect(second.cacheId).toBe(first.cacheId);
+  });
+});


### PR DESCRIPTION
## Problem

With `basePath: "/app"`, emitted pages `index.html` and `app/index.html` collapse into one cached route, `/app`. Offline navigation to the distinct application route `/app/app` then fails. Explicit cache and offline routes can also select the wrong page.

## Root cause

The same prefix-deduplication helper handled application routes and already-mounted output files. A route beginning with the base-path text was assumed to be mounted already. Fallback lookups repeated that ambiguity.

## Change

- Always mount application route paths exactly once, without guessing from their first segment.
- Carry the known HTML output prefix from resolved i18n configuration, matching the existing Search plugin approach. Ordinary SSG paths stay application-relative; localized output retains its mounted prefix.
- Use exact application-route lookups for explicit caching and offline fallbacks.
- Keep generated asset URL handling and worker exclusion intact. Include resolved precache URLs in the cache ID.

## Safety and compatibility

No new public option. Generated-worker behavior remains production-only and renderer-neutral; custom worker contents, browser registration, image caching, and symlink containment are unchanged. Both ordinary and localized HTML output are covered, along with already-mounted assets and repeat builds.

## Verification

macOS arm64, Node 24, pnpm 8.12.1:

- `pnpm --filter @farm.js/pwa test`: 54 passing tests. Five new regression cases failed before the fix, covering lost routes and wrong-page fallback selection.
- The regression suite executes the generated service worker with network failure and verifies distinct cached responses for `/app` and `/app/app`.
- `pnpm --filter @farm.js/pwa type-check`
- `pnpm --filter @farm.js/pwa build`
- `pnpm exec oxlint packages/farm-pwa/src/build.ts packages/farm-pwa/src/index.ts packages/farm-pwa/src/static-routes.test.ts packages/farm-pwa/src/index.test.ts`
- `pnpm exec oxfmt --check packages/farm-pwa/src/build.ts packages/farm-pwa/src/index.ts packages/farm-pwa/src/static-routes.test.ts packages/farm-pwa/src/index.test.ts docs/src/app/docs/plugins/pwa/page.md`
- `pnpm docs:check-navigation`
- Built-package smoke test invoked the actual plugin build hooks against Node and Vercel output layouts and verified ordinary and localized route mappings. A hosted deployment/browser run was not performed.

## Documentation and release

Added concrete base-path and localized-route examples to the PWA guide. No route, sidebar, template, or version changes.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `@farm.js/pwa` static route resolution so routes that repeat the base path no longer collapse or point at the wrong cached page. With `basePath: "/app"`, `index.html` and `app/index.html` previously both mapped to `/app`; they now map to `/app` and `/app/app`, and `staticRoutes`/`offline` entries are treated as exact application paths.

**Bug Fixes**
- Removes the prefix-deduplication heuristic that guessed routes were already mounted from their first segment.
- Carries the known HTML output prefix from resolved i18n config so localized SSG output maps correctly.
- Missing cache or offline routes now error instead of falling back to a different page.
- Adds regression coverage for distinct offline responses and repeat builds, and updates the PWA guide with base-path examples.

No new public option; custom worker contents, browser registration, image caching, and symlink containment are unchanged.

<sup>Written for commit eb0820565e157fc6f553265eaa99aa5291ffb4c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/968?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

