### PR TITLE
feat(client): support cancellation and call deadlines

### DIFF
--- a/docs/src/app/docs/api-client/page.md
+++ b/docs/src/app/docs/api-client/page.md
@@ -104,6 +104,44 @@ the browser, and the resolver runs wherever its caller runs. Do not put provider
 private environment values here. Read request-specific values inside the resolver or a
 request-scoped server module, never by mutating a shared singleton with one user's credentials.
 
+## Cancellation and deadlines
+
+Set `timeoutMs` on `createApiClients` for a default deadline, or override it per call:
+
+```ts
+export const { api, apiClient } = createApiClients<APIRouter>({
+  routes: apiRoutes,
+  timeoutMs: 10_000,
+});
+
+const controller = new AbortController();
+const pending = apiClient.hello.get({}, { signal: controller.signal, timeoutMs: 2_000 });
+controller.abort();
+const result = await pending;
+// result.error.code is "aborted" (or "timeout" when Farm's deadline expires).
+```
+
+The budget starts at call time and includes asynchronous header resolution, transport,
+response decoding, and retry waits. `0` disables the deadline (also the default); accepted
+values are integers from `0` to `2147483647`. A per-call `0` disables an instance deadline.
+Keep `signal` per call, not on a shared long-lived instance.
+
+Cancellation returns `{ data: undefined, error, key }` with status `0`, stops retries, skips
+cached results when already aborted, and rolls back pending optimistic updates even when
+`rollbackOnError` is false. Calls with a signal or deadline do not participate in in-flight
+deduplication, so one caller cannot cancel another. Completed results can still use the cache.
+Background revalidation retains its call budget until it finishes. A returned stream is handed
+to the caller: the deadline ends at that handoff, not at the end of stream consumption; the
+caller's signal still reaches the underlying HTTP request.
+
+Local `api` dispatch combines the call signal with the incoming request signal. Handlers can
+pass `request.signal` to cancellable work. Farm stops waiting when cancelled, but a handler or
+custom transport that ignores the signal may continue running. Cancellation cannot undo
+completed writes or external side effects.
+
+These defaults also reach integration callers; `integrations.timeoutMs` overrides the shared
+deadline. See [integration cancellation](/docs/integrations#cancellation-and-deadlines).
+
 ## Call a route
 
 **Browser usage**

--- a/docs/src/app/docs/integrations/page.md
+++ b/docs/src/app/docs/integrations/page.md
@@ -338,6 +338,34 @@ existing request forwarding and browser credential behavior instead of copying s
 shared defaults. The example's English server default overrides a forwarded language; omit that
 default if the incoming request should decide it.
 
+## Cancellation and deadlines
+
+`createIntegrations<AppIntegrations>({ timeoutMs: 10_000 })` sets one whole-call deadline for
+both callers. The separate server-options argument can override it for `api`. The same option
+works in the existing integration-only factories and in `createApiClients`'s `integrations`
+options. A call can pass `{ signal, timeoutMs }` as its second argument:
+
+```ts
+const controller = new AbortController();
+const pending = apiClient.billing.checkout(
+  { body: { priceId: "price_123" } },
+  { signal: controller.signal, timeoutMs: 5_000 },
+);
+controller.abort();
+const { error } = await pending;
+```
+
+The deadline includes header resolution, HTTP or local dispatch, and response decoding.
+`0` disables it; use an integer between `0` and `2147483647`. Cancellation returns the normal
+`{ data: null, error }` result. Farm deadlines produce an error named `TimeoutError`; ordinary
+`controller.abort()` produces `AbortError`. A custom abort reason is normalized to an error.
+
+Direct server handlers receive the combined per-call and incoming request signal on their
+`Request`, just as HTTP calls receive the call signal. Cancellation stops waiting, not side
+effects: handlers must pass the signal to their own work when supported. A handler ignoring it
+can still finish or write data. For raw `Response` operations the deadline ends when the response
+is returned; use the signal to cancel subsequent HTTP body consumption.
+
 ## Shared data
 
 `createIntegrations({ data })` adds small per-call metadata to integration requests. It is useful for tenant IDs, locale, analytics context, or feature flags.

--- a/examples/basic/src/lib/api.ts
+++ b/examples/basic/src/lib/api.ts
@@ -1,4 +1,7 @@
 import { createApiClients } from "@farm.js/core/client";
 import { apiRoutes, type APIRouter } from "./api.generated";
 
-export const { api, apiClient } = createApiClients<APIRouter>({ routes: apiRoutes });
+export const { api, apiClient } = createApiClients<APIRouter>({
+  routes: apiRoutes,
+  timeoutMs: 30_000,
+});

--- a/examples/basic/src/lib/integration-lab-api.ts
+++ b/examples/basic/src/lib/integration-lab-api.ts
@@ -5,6 +5,7 @@ export const {
   api: integrationApi,
   apiClient: integrationApiClient,
 } = createIntegrations<typeof integrationLab>({
+  timeoutMs: 30_000,
   headers: async () => ({
     'Accept-Language':
       typeof document === 'undefined' ? 'en' : document.documentElement.lang || 'en',

--- a/packages/farm/src/__tests__/api-client.test.ts
+++ b/packages/farm/src/__tests__/api-client.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+// Keep native Request and AbortSignal in one realm; browser cases stub window explicitly.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createAPIClient, createServerAPIClient, getAPIRouteRefMetadata } from "../api/client";
 import {

--- a/packages/farm/src/__tests__/client-cancellation.test.ts
+++ b/packages/farm/src/__tests__/client-cancellation.test.ts
@@ -1,0 +1,265 @@
+// @vitest-environment node
+import { afterEach, expect, it, vi } from "vitest";
+import { createAPIClient, createApiClients } from "../api/client";
+import { createEndpoint } from "../api/endpoint";
+import { _runWithAPIRequestRuntime } from "../api/server-context";
+import { createIntegrations } from "../integration-client";
+import { endpoint } from "../integration-api";
+import { defineIntegration, integrationRoute, resolveIntegrationPlugins } from "../integrations";
+import { PluginManager } from "../plugin";
+import { _runWithCurrentRequest } from "../server/request";
+
+const get = createEndpoint({ method: "GET" }, () => ({ value: 1 }));
+type Router = { value: { get: typeof get } };
+const sources = { demo: { read: endpoint.get<{ value: number }>("/api/demo/read") } };
+const cache = { staleTime: 60_000, dedupeMs: 60_000 };
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+it("rejects an already-aborted route call before headers, cache, or dispatch", async () => {
+  const fetch = vi.fn(async () => Response.json({ value: 1 }));
+  vi.stubGlobal("fetch", fetch);
+  const headers = vi.fn(() => ({}));
+  const api = createAPIClient<Router>({ headers });
+  await api.value.get({}, { cache });
+  const result = await api.value.get({}, { cache, signal: AbortSignal.abort("cancelled") });
+  expect(result.error).toMatchObject({ code: "aborted", status: 0, cause: "cancelled" });
+  expect(result.data).toBeUndefined();
+  expect(headers).toHaveBeenCalledOnce();
+  expect(fetch).toHaveBeenCalledOnce();
+});
+
+it("times out header resolution without retries or later dispatch", async () => {
+  vi.useFakeTimers();
+  const headers = deferred<Record<string, string>>();
+  const fetch = vi.fn(async () => Response.json({ value: 1 }));
+  vi.stubGlobal("fetch", fetch);
+  const api = createAPIClient<Router>({ timeoutMs: 25, headers: () => headers.promise });
+  const onError = vi.fn();
+  const pending = api.value.get({}, { retry: { count: 3 }, onError });
+  await vi.advanceTimersByTimeAsync(25);
+  expect((await pending).error).toMatchObject({ code: "timeout", status: 0 });
+  headers.resolve({});
+  await Promise.resolve();
+  expect(fetch).not.toHaveBeenCalled();
+  expect(onError).toHaveBeenCalledOnce();
+  expect(vi.getTimerCount()).toBe(0);
+});
+
+it("cancels during a retry wait and cleans up its timer", async () => {
+  vi.useFakeTimers();
+  const fetch = vi.fn(async () => Response.json({}, { status: 503 }));
+  vi.stubGlobal("fetch", fetch);
+  const api = createAPIClient<Router>({ timeoutMs: 30 });
+  const pending = api.value.get({}, { retry: { count: 2, delay: 1000 } });
+  await vi.advanceTimersByTimeAsync(30);
+  expect((await pending).error).toMatchObject({ code: "timeout" });
+  expect(fetch).toHaveBeenCalledOnce();
+  expect(vi.getTimerCount()).toBe(0);
+});
+
+it("keeps cancellable callers independent and ignores a late response", async () => {
+  const first = deferred<Response>();
+  const entered = deferred<void>();
+  const fetch = vi
+    .fn()
+    .mockImplementationOnce(() => {
+      entered.resolve();
+      return first.promise;
+    })
+    .mockResolvedValue(Response.json({ value: 2 }));
+  vi.stubGlobal("fetch", fetch);
+  const api = createAPIClient<Router>();
+  const controller = new AbortController();
+  const pending = api.value.get({}, { cache, signal: controller.signal });
+  await entered.promise;
+  const second = await api.value.get({}, { cache });
+  controller.abort();
+  expect((await pending).error).toMatchObject({ code: "aborted" });
+  expect(second.data).toEqual({ value: 2 });
+  first.resolve(Response.json({ value: 9 }));
+  await Promise.resolve();
+  expect((await api.value.get({}, { cache })).data).toEqual({ value: 2 });
+  expect(fetch).toHaveBeenCalledTimes(2);
+});
+
+it("lets calls disable the default deadline and rejects invalid deadlines", async () => {
+  vi.useFakeTimers();
+  const response = deferred<Response>();
+  const fetch = vi.fn(() => response.promise);
+  vi.stubGlobal("fetch", fetch);
+  const api = createAPIClient<Router>({ timeoutMs: 10 });
+  const pending = api.value.get({}, { timeoutMs: 0 });
+  await vi.advanceTimersByTimeAsync(100);
+  response.resolve(Response.json({ value: 1 }));
+  expect((await pending).error).toBeNull();
+  for (const timeoutMs of [-1, NaN, Infinity, 2 ** 31, 0.5]) {
+    expect((await api.value.get({}, { timeoutMs })).error?.message).toContain("timeoutMs");
+  }
+  expect(fetch).toHaveBeenCalledOnce();
+  expect(vi.getTimerCount()).toBe(0);
+});
+
+it.each(["call", "parent"])("propagates %s cancellation to local app routes", async (cancel) => {
+  const call = new AbortController();
+  const parent = new AbortController();
+  const entered = deferred<Request>();
+  const response = deferred<Response>();
+  const dispatch = vi.fn((request: Request) => {
+    entered.resolve(request);
+    return response.promise;
+  });
+  const { api } = createApiClients<Router>();
+  const pending = _runWithAPIRequestRuntime({ basePath: "/api", dispatch }, () =>
+    _runWithCurrentRequest(new Request("https://farm.test/page", { signal: parent.signal }), () =>
+      api.value.get({}, { signal: call.signal }),
+    ),
+  );
+  const request = await entered.promise;
+  (cancel === "call" ? call : parent).abort();
+  expect((await pending).error).toMatchObject({ code: "aborted" });
+  expect(request.signal.aborted).toBe(true);
+  response.resolve(Response.json({ value: 1 }));
+});
+
+it.each(["client", "server"] as const)(
+  "bounds %s integration headers and supports deadline overrides",
+  async (side) => {
+    vi.useFakeTimers();
+    if (side === "client") vi.stubGlobal("window", { location: { origin: "https://farm.test" } });
+    const headers = deferred<Record<string, string>>();
+    const fetch = vi.fn(async () => Response.json({ value: 1 }));
+    vi.stubGlobal("fetch", fetch);
+    const pair = createIntegrations(sources, { timeoutMs: 20, headers: () => headers.promise });
+    const api = side === "server" ? pair.api : pair.apiClient;
+    const pending = api.demo.read({}, { timeoutMs: 5 });
+    await vi.advanceTimersByTimeAsync(5);
+    expect((await pending).error).toMatchObject({ name: "TimeoutError" });
+    headers.resolve({});
+    await Promise.resolve();
+    expect(fetch).not.toHaveBeenCalled();
+    expect((await api.demo.read({}, { timeoutMs: 0 })).data).toEqual({ value: 1 });
+    expect(vi.getTimerCount()).toBe(0);
+  },
+);
+
+it("propagates cancellation to registered direct integration handlers", async () => {
+  const entered = deferred<Request>();
+  const response = deferred<Response>();
+  const integration = defineIntegration({
+    category: "custom",
+    type: "cancellation-demo",
+    instance: {},
+    routes: [
+      integrationRoute.get("/api/cancel-demo/read", {
+        responseFormat: "json",
+        handler: (request) => {
+          entered.resolve(request);
+          return response.promise;
+        },
+      }),
+    ],
+  });
+  const manager = new PluginManager({
+    config: { integrations: { cancelDemo: integration } } as any,
+    isDev: true,
+    isProd: false,
+  });
+  manager.addPlugins(resolveIntegrationPlugins({ cancelDemo: integration }));
+  await manager.runHookParallel("init");
+  const { api } = createIntegrations<{ cancelDemo: typeof integration }>({ timeoutMs: 0 });
+  const controller = new AbortController();
+  const pending = _runWithCurrentRequest(new Request("https://farm.test/page"), () =>
+    api.cancelDemo.read.get({}, { signal: controller.signal }),
+  );
+  const request = await entered.promise;
+  controller.abort();
+  expect((await pending).error).toMatchObject({ name: "AbortError" });
+  expect(request.signal.aborted).toBe(true);
+  response.resolve(Response.json({ value: 1 }));
+});
+
+it("bounds response decoding and rolls back cancelled optimistic layers", async () => {
+  vi.useFakeTimers();
+  const fetch = vi
+    .fn()
+    .mockResolvedValueOnce(Response.json({ value: 1 }))
+    .mockResolvedValueOnce(
+      new Response(
+        new ReadableStream({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode('{"value":'));
+          },
+        }),
+        { headers: { "content-type": "application/json" } },
+      ),
+    );
+  vi.stubGlobal("fetch", fetch);
+  const api = createAPIClient<Router>({ timeoutMs: 10 });
+  const initial = await api.value.get({}, { cache });
+  const pending = api.value.get(
+    {},
+    {
+      cache: { ...cache, policy: "network-only" },
+      optimistic: { update: [[initial.key, () => ({ value: 2 })]] },
+    },
+  );
+  await vi.advanceTimersByTimeAsync(10);
+  expect((await pending).error).toMatchObject({ code: "timeout" });
+  expect((await api.value.get({}, { cache })).data).toEqual({ value: 1 });
+  expect(vi.getTimerCount()).toBe(0);
+});
+
+it("keeps background revalidation deadlines alive across retries", async () => {
+  vi.useFakeTimers();
+  const fetch = vi
+    .fn()
+    .mockResolvedValueOnce(Response.json({ value: 1 }))
+    .mockImplementation(async () => Response.json({}, { status: 503 }));
+  vi.stubGlobal("fetch", fetch);
+  const api = createAPIClient<Router>({ timeoutMs: 10 });
+  const backgroundCache = { policy: "stale-while-revalidate" as const, staleTime: 0 };
+  await api.value.get({}, { cache: backgroundCache });
+  expect(
+    (await api.value.get({}, { cache: backgroundCache, retry: { count: 2, delay: 100 } })).data,
+  ).toEqual({ value: 1 });
+  await vi.advanceTimersByTimeAsync(200);
+  expect(fetch).toHaveBeenCalledTimes(2);
+  expect(vi.getTimerCount()).toBe(0);
+});
+
+it.each(["client", "server"] as const)(
+  "passes signals to %s integration HTTP calls",
+  async (side) => {
+    if (side === "client") vi.stubGlobal("window", { location: { origin: "https://farm.test" } });
+    const entered = deferred<AbortSignal>();
+    const response = deferred<Response>();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((_url, init) => {
+        entered.resolve(init.signal);
+        return response.promise;
+      }),
+    );
+    const pair = createIntegrations(sources);
+    const controller = new AbortController();
+    const pending = (side === "server" ? pair.api : pair.apiClient).demo.read(
+      {},
+      { signal: controller.signal },
+    );
+    const signal = await entered.promise;
+    controller.abort();
+    expect((await pending).error).toMatchObject({ name: "AbortError" });
+    expect(signal.aborted).toBe(true);
+    response.resolve(Response.json({ value: 1 }));
+  },
+);

--- a/packages/farm/src/__tests__/client-cancellation.typing.test.ts
+++ b/packages/farm/src/__tests__/client-cancellation.typing.test.ts
@@ -1,0 +1,54 @@
+// @vitest-environment node
+import path from "node:path";
+import ts from "typescript";
+import { expect, it } from "vitest";
+
+it("exposes cancellation and deadlines through the published client declarations", () => {
+  // TypeScript normalizes compiler filenames to forward slashes, including on Windows.
+  const filename = path.resolve("client-cancellation.type-test.ts").replace(/\\/g, "/");
+  const source = `
+import { createApiClients, createIntegrations, endpoint, type APIClientSystemError } from "@farm.js/core/client";
+type Router = { hello: { get: { __types: { body: never; query: never; response: { message: string } } } } };
+const sources = { demo: { read: endpoint.get<{ value: number }>("/api/demo/read") } };
+const { api, apiClient } = createApiClients<Router, typeof sources>({ timeoutMs: 100, integrations: { timeoutMs: 200 } });
+api.hello.get({}, { signal: AbortSignal.abort(), timeoutMs: 0 });
+apiClient.hello.get({}, { signal: new AbortController().signal, timeoutMs: 50 });
+apiClient.integrations.demo.read({}, { signal: AbortSignal.abort(), timeoutMs: 0 });
+const explicit = createIntegrations(sources, { timeoutMs: 100 }, { timeoutMs: 200 });
+const automatic = createIntegrations<typeof sources>({ timeoutMs: 100 });
+explicit.api.demo.read({}, { timeoutMs: 0, signal: AbortSignal.abort() });
+automatic.apiClient.demo.read({}, { timeoutMs: 50 });
+function handle(error: APIClientSystemError) {
+  if (error.code === "timeout" || error.code === "aborted") { const status: 0 = error.status; }
+}
+// @ts-expect-error deadlines are numeric
+api.hello.get({}, { timeoutMs: "100" });
+// @ts-expect-error signals belong to individual calls
+createApiClients<Router>({ signal: AbortSignal.abort() });
+// @ts-expect-error route inference remains intact
+api.hello.get({ body: { missing: true } });
+`;
+  const options: ts.CompilerOptions = {
+    strict: true,
+    noEmit: true,
+    skipLibCheck: true,
+    target: ts.ScriptTarget.ES2020,
+    module: ts.ModuleKind.ESNext,
+    moduleResolution: ts.ModuleResolutionKind.Bundler,
+    baseUrl: process.cwd(),
+    paths: { "@farm.js/core/client": ["./types/client.d.ts"] },
+  };
+  const host = ts.createCompilerHost(options);
+  const getSourceFile = host.getSourceFile.bind(host);
+  host.getSourceFile = (name, languageVersion, onError, shouldCreateNewSourceFile) =>
+    name === filename
+      ? ts.createSourceFile(name, source, languageVersion, true)
+      : getSourceFile(name, languageVersion, onError, shouldCreateNewSourceFile);
+  const program = ts.createProgram({ rootNames: [filename], options, host });
+  const diagnostics = ts.formatDiagnosticsWithColorAndContext(ts.getPreEmitDiagnostics(program), {
+    getCanonicalFileName: (name) => name,
+    getCurrentDirectory: () => process.cwd(),
+    getNewLine: () => "\n",
+  });
+  expect(diagnostics).toBe("");
+}, 30_000);

--- a/packages/farm/src/__tests__/integration-client.test.ts
+++ b/packages/farm/src/__tests__/integration-client.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+// Keep native Request and AbortSignal in one realm; browser cases stub window explicitly.
 import { afterEach, describe, expect, expectTypeOf, it, vi } from "vitest";
 import { defineIntegration, integrationRoute, resolveIntegrationPlugins } from "../integrations";
 import {

--- a/packages/farm/src/api/client.ts
+++ b/packages/farm/src/api/client.ts
@@ -24,6 +24,7 @@ import { ClientRouteManifest, type APIRouteManifest, type BoundRouteParams } fro
 import type { RoutePathParams } from "./route";
 import { _resolveCurrentRequest } from "../server/request-bridge";
 import { resolveClientHeaders, type ClientHeaders } from "../client-headers";
+import { createClientCancellation } from "../client-cancellation";
 import { resolveAPIRequestRuntime, type APIRequestRuntime } from "./server-client-bridge";
 export type { APIRouteManifest } from "./client-routes";
 import {
@@ -49,6 +50,8 @@ export type APIClientOptions = {
   baseURL?: string;
   headers?: ClientHeaders;
   credentials?: RequestCredentials;
+  /** Whole-call deadline in milliseconds. 0 (default) disables it. */
+  timeoutMs?: number;
   cacheDefaults?: CacheOptions;
   integrations?: IntegrationClientOptions;
 };
@@ -122,6 +125,7 @@ export class APIClientError<
 
 export type APIClientSystemError =
   | APIClientError<"http_error", unknown, number>
+  | APIClientError<"aborted" | "timeout", unknown, 0>
   | APIClientError<"network_error", unknown, 0>;
 
 export type RequestEvent = {
@@ -201,6 +205,9 @@ export type ClientOptions<
   TUpdates extends readonly unknown[] = readonly OptimisticUpdate[],
 > = {
   key?: CacheKey<TData> | FarmClientCacheKey;
+  signal?: AbortSignal;
+  /** Override the instance deadline; 0 disables it for this call. */
+  timeoutMs?: number;
   cache?: CacheOptions;
   retry?: RetryOptions;
   invalidate?: InvalidateOptions;
@@ -515,6 +522,7 @@ export function createApiClients<
           },
           {
             headers,
+            signal: currentRequest.signal,
             cache: new FarmClientDataCache({ subscribeToInvalidation: false }),
             routeMeta,
             fetch: (url, init) => {
@@ -524,7 +532,7 @@ export function createApiClients<
                 );
               }
               currentRequest.signal.throwIfAborted();
-              return runtime.dispatch(new Request(url, { ...init, signal: currentRequest.signal }));
+              return runtime.dispatch(new Request(url, init));
             },
           },
         );
@@ -542,6 +550,7 @@ export function createApiClients<
             baseURL: options.baseURL,
             headers: options.headers,
             credentials: options.credentials,
+            timeoutMs: options.timeoutMs,
             ...options.integrations,
           }),
         },
@@ -616,6 +625,7 @@ function createAPIClientRuntime<
   options: APIClientOptions | APIClientWithoutIntegrationsOptions = {},
   transport?: {
     headers?: HeadersInit;
+    signal?: AbortSignal;
     fetch(url: string, init: RequestInit): Promise<Response>;
     cache: FarmClientDataCache;
     routeMeta: WeakMap<AnyRouteRef, RouteMeta>;
@@ -630,6 +640,7 @@ function createAPIClientRuntime<
           baseURL: options.baseURL,
           headers: options.headers,
           credentials: options.credentials,
+          timeoutMs: options.timeoutMs,
           ...(typeof options.integrations === "object" ? options.integrations : {}),
         };
   const rootAliases =
@@ -753,7 +764,12 @@ function createAPIClientRuntime<
   };
 
   // Create a simple fetch-based client (browser compatible)
-  const fetchClient = async (path: string, requestOptions: any, defaultHeaders: Headers) => {
+  const fetchClient = async (
+    path: string,
+    requestOptions: any,
+    defaultHeaders: Headers,
+    cancellation: ReturnType<typeof createClientCancellation>,
+  ) => {
     const url = resolveFarmAPIRequestURL(path, baseURL);
     const method = String(requestOptions.method || "GET").toUpperCase();
 
@@ -776,6 +792,7 @@ function createAPIClientRuntime<
       method,
       headers,
       credentials: options.credentials,
+      signal: cancellation.signal,
     };
     if (method === "QUERY" && !headers.has("content-type")) {
       headers.set("content-type", "application/json");
@@ -792,7 +809,9 @@ function createAPIClientRuntime<
       }
     }
 
+    cancellation.check();
     const response = await (transport?.fetch ?? fetch)(url.toString(), fetchOptions);
+    cancellation.check();
     const invalidations = decodeFarmCacheInvalidations(
       response.headers?.get?.(FARM_CACHE_INVALIDATION_HEADER),
     );
@@ -806,6 +825,7 @@ function createAPIClientRuntime<
     let data: unknown;
     try {
       data = await readAPIResponseData(response, method);
+      cancellation.check();
     } catch (decodeError) {
       if (!(decodeError instanceof APIResponseDecodeError)) throw decodeError;
       if (response.ok) throw decodeError.cause;
@@ -821,420 +841,472 @@ function createAPIClientRuntime<
     input: any = {},
     clientOptions?: ClientOptions<any, any>,
   ): Promise<APIResult<any, Error>> => {
-    const methodUpper = method.toUpperCase() as StatusEvent["method"];
-    const requestId = `${Date.now()}-${++requestCounter}`;
-    const defaultHeaders = new Headers(transport?.headers);
-    let requestContextError: Error | undefined;
-    try {
-      const resolved = resolveClientHeaders(options.headers);
-      const headers = resolved instanceof Headers ? resolved : await resolved;
-      headers.forEach((value, name) => defaultHeaders.set(name, value));
-    } catch (error) {
-      requestContextError = normalizeError(error);
-    }
-    const cacheOptions = clientOptions?.cache
-      ? {
-          ...options.cacheDefaults,
-          ...clientOptions.cache,
-        }
-      : undefined;
-    const configuredCacheKey = clientOptions?.key ?? cacheOptions?.key;
-    const cacheKey = normalizeFarmClientCacheKey(
-      configuredCacheKey ?? buildCacheKey(methodUpper, path, input, baseURL, defaultHeaders),
-    ) as CacheKey<any>;
-    const now = Date.now();
-
-    const emitStatus = (phase: StatusPhase, payload?: Partial<StatusEvent>) => {
-      clientOptions?.onStatus?.({
-        phase,
-        requestId,
-        method: methodUpper,
-        key: cacheKey,
-        input,
-        timestamp: Date.now(),
-        ...payload,
-      });
+    const cancellation = createClientCancellation(
+      clientOptions?.signal,
+      clientOptions?.timeoutMs ?? options.timeoutMs,
+      transport?.signal,
+    );
+    const normalizeCallError = (error: unknown): Error => {
+      if (!cancellation.signal?.aborted) return normalizeError(error);
+      const normalized = new APIClientError(
+        cancellation.timedOut ? "timeout" : "aborted",
+        undefined,
+        {
+          status: 0,
+          message: cancellation.timedOut ? "Client request timed out" : "Client request aborted",
+        },
+      );
+      (normalized as Error & { cause?: unknown }).cause = cancellation.signal.reason;
+      return normalized;
     };
-
-    const policy = cacheOptions?.policy ?? (cacheOptions ? "cache-first" : "network-only");
-    const staleTime = cacheOptions?.staleTime ?? 0;
-    const hasReliableDefaultCacheKey =
-      methodUpper !== "QUERY" || !isFormData(input?.body) || configuredCacheKey !== undefined;
-    const isCacheEnabled =
-      Boolean(cacheOptions) &&
-      (methodUpper === "GET" || methodUpper === "QUERY") &&
-      hasReliableDefaultCacheKey;
-    const needsCacheState =
-      isCacheEnabled ||
-      Boolean(clientOptions?.optimistic?.update?.length) ||
-      Boolean(clientOptions?.invalidate);
-    let requestCacheContext = requestContextError ? `invalid:${requestId}` : undefined;
-    if (needsCacheState && !requestContextError) {
+    try {
+      const methodUpper = method.toUpperCase() as StatusEvent["method"];
+      const requestId = `${Date.now()}-${++requestCounter}`;
+      const defaultHeaders = new Headers(transport?.headers);
+      let requestContextError: Error | undefined;
       try {
-        requestCacheContext = getRequestCacheContext(
-          { headers: defaultHeaders, credentials: options.credentials },
-          input,
-          cacheOptions?.scope,
-        );
+        cancellation.check();
+        const resolved = resolveClientHeaders(options.headers);
+        const headers =
+          resolved instanceof Headers ? resolved : await cancellation.run(() => resolved);
+        cancellation.check();
+        headers.forEach((value, name) => defaultHeaders.set(name, value));
       } catch (error) {
-        requestCacheContext = `invalid:${requestId}`;
-        requestContextError = normalizeError(error);
+        requestContextError = normalizeCallError(error);
       }
-    }
+      const cacheOptions = clientOptions?.cache
+        ? {
+            ...options.cacheDefaults,
+            ...clientOptions.cache,
+          }
+        : undefined;
+      const configuredCacheKey = clientOptions?.key ?? cacheOptions?.key;
+      const cacheKey = normalizeFarmClientCacheKey(
+        configuredCacheKey ?? buildCacheKey(methodUpper, path, input, baseURL, defaultHeaders),
+      ) as CacheKey<any>;
+      const now = Date.now();
 
-    let cacheState = sharedCacheState;
-    let inflightState = sharedInflightState;
-    let requestScopedState: ScopedRequestState | undefined;
-    if (requestCacheContext !== undefined) {
-      if (scopedRequestState && scopedRequestState.context !== requestCacheContext) {
-        scopedRequestState.retired = true;
-        if (scopedRequestState.inflight.size === 0) scopedRequestState.cache.dispose();
-        scopedRequestState = undefined;
-      }
-      scopedRequestState ??= {
-        context: requestCacheContext,
-        cache: new FarmClientDataCache({ subscribeToInvalidation: !transport }),
-        inflight: new Map(),
-        retired: false,
+      const emitStatus = (phase: StatusPhase, payload?: Partial<StatusEvent>) => {
+        clientOptions?.onStatus?.({
+          phase,
+          requestId,
+          method: methodUpper,
+          key: cacheKey,
+          input,
+          timestamp: Date.now(),
+          ...payload,
+        });
       };
-      requestScopedState = scopedRequestState;
-      cacheState = requestScopedState.cache;
-      localCaches?.add(cacheState);
-      inflightState = requestScopedState.inflight;
-    }
-    const optimisticState = getOptimisticState(cacheState);
 
-    const entry = getValidCacheEntry(cacheState, cacheKey, now);
-    const isStale = entry ? isEntryStale(entry, now) : true;
-
-    const applyOptimisticUpdates = () => {
-      if (!clientOptions?.optimistic?.update?.length) return [] as OptimisticSnapshot[];
-
-      const snapshots = new Map<string, OptimisticSnapshot>();
-      for (const update of clientOptions.optimistic.update) {
-        const [target, targetInput, updater] =
-          update.length === 2
-            ? [update[0], undefined, update[1]]
-            : [update[0], update[1], update[2]];
-        const targetKey = resolveTargetKey(
-          routeMeta,
-          target,
-          targetInput,
-          baseURL,
-          defaultHeaders,
-          transport ? baseURL : undefined,
-        );
-        if (!targetKey) continue;
-
-        const targetEntry = getValidCacheEntry(cacheState, targetKey, now);
-        const currentEntry = cacheState.get(targetKey);
-        let stack = optimisticState.get(targetKey);
-        if (stack && !reconcileOptimisticInvalidation(cacheState, targetKey, stack)) {
-          stack = undefined;
+      const policy = cacheOptions?.policy ?? (cacheOptions ? "cache-first" : "network-only");
+      const staleTime = cacheOptions?.staleTime ?? 0;
+      const hasReliableDefaultCacheKey =
+        methodUpper !== "QUERY" || !isFormData(input?.body) || configuredCacheKey !== undefined;
+      const isCacheEnabled =
+        Boolean(cacheOptions) &&
+        (methodUpper === "GET" || methodUpper === "QUERY") &&
+        hasReliableDefaultCacheKey;
+      const needsCacheState =
+        isCacheEnabled ||
+        Boolean(clientOptions?.optimistic?.update?.length) ||
+        Boolean(clientOptions?.invalidate);
+      let requestCacheContext = requestContextError ? `invalid:${requestId}` : undefined;
+      if (needsCacheState && !requestContextError) {
+        try {
+          requestCacheContext = getRequestCacheContext(
+            { headers: defaultHeaders, credentials: options.credentials },
+            input,
+            cacheOptions?.scope,
+          );
+        } catch (error) {
+          requestCacheContext = `invalid:${requestId}`;
+          requestContextError = normalizeError(error);
         }
-        if (!stack) {
-          stack = {
-            entry: targetEntry ? { ...targetEntry } : undefined,
-            layers: [],
-            renderedEntry: currentEntry,
-          };
-          optimisticState.set(targetKey, stack);
-        }
+      }
 
-        let snapshot = snapshots.get(targetKey);
-        if (!snapshot) {
-          const previousEntry = stack.layers.length === 0 ? stack.entry : stack.renderedEntry;
-          const layer: OptimisticLayer = {
-            updaters: [],
-            updatedAt: now,
-            staleAt:
-              targetEntry?.staleAt ??
-              now + (cacheOptions?.staleTime ?? options.cacheDefaults?.staleTime ?? 0),
-            gcAt:
-              targetEntry?.gcAt ??
-              getGcAt(now, cacheOptions?.gcTime ?? options.cacheDefaults?.gcTime),
-          };
-          stack.layers.push(layer);
-          snapshot = {
-            key: targetKey,
-            stack,
-            layer,
-          };
-          snapshots.set(targetKey, snapshot);
+      let cacheState = sharedCacheState;
+      let inflightState = sharedInflightState;
+      let requestScopedState: ScopedRequestState | undefined;
+      if (requestCacheContext !== undefined) {
+        if (scopedRequestState && scopedRequestState.context !== requestCacheContext) {
+          scopedRequestState.retired = true;
+          if (scopedRequestState.inflight.size === 0) scopedRequestState.cache.dispose();
+          scopedRequestState = undefined;
+        }
+        scopedRequestState ??= {
+          context: requestCacheContext,
+          cache: new FarmClientDataCache({ subscribeToInvalidation: !transport }),
+          inflight: new Map(),
+          retired: false,
+        };
+        requestScopedState = scopedRequestState;
+        cacheState = requestScopedState.cache;
+        localCaches?.add(cacheState);
+        inflightState = requestScopedState.inflight;
+      }
+      const optimisticState = getOptimisticState(cacheState);
+
+      const entry = getValidCacheEntry(cacheState, cacheKey, now);
+      const isStale = entry ? isEntryStale(entry, now) : true;
+
+      const applyOptimisticUpdates = () => {
+        if (!clientOptions?.optimistic?.update?.length) return [] as OptimisticSnapshot[];
+
+        const snapshots = new Map<string, OptimisticSnapshot>();
+        for (const update of clientOptions.optimistic.update) {
+          const [target, targetInput, updater] =
+            update.length === 2
+              ? [update[0], undefined, update[1]]
+              : [update[0], update[1], update[2]];
+          const targetKey = resolveTargetKey(
+            routeMeta,
+            target,
+            targetInput,
+            baseURL,
+            defaultHeaders,
+            transport ? baseURL : undefined,
+          );
+          if (!targetKey) continue;
+
+          const targetEntry = getValidCacheEntry(cacheState, targetKey, now);
+          const currentEntry = cacheState.get(targetKey);
+          let stack = optimisticState.get(targetKey);
+          if (stack && !reconcileOptimisticInvalidation(cacheState, targetKey, stack)) {
+            stack = undefined;
+          }
+          if (!stack) {
+            stack = {
+              entry: targetEntry ? { ...targetEntry } : undefined,
+              layers: [],
+              renderedEntry: currentEntry,
+            };
+            optimisticState.set(targetKey, stack);
+          }
+
+          let snapshot = snapshots.get(targetKey);
+          if (!snapshot) {
+            const previousEntry = stack.layers.length === 0 ? stack.entry : stack.renderedEntry;
+            const layer: OptimisticLayer = {
+              updaters: [],
+              updatedAt: now,
+              staleAt:
+                targetEntry?.staleAt ??
+                now + (cacheOptions?.staleTime ?? options.cacheDefaults?.staleTime ?? 0),
+              gcAt:
+                targetEntry?.gcAt ??
+                getGcAt(now, cacheOptions?.gcTime ?? options.cacheDefaults?.gcTime),
+            };
+            stack.layers.push(layer);
+            snapshot = {
+              key: targetKey,
+              stack,
+              layer,
+            };
+            snapshots.set(targetKey, snapshot);
+            snapshot.layer.updaters.push(updater);
+            const nextEntry = applyOptimisticLayer(previousEntry, {
+              ...snapshot.layer,
+              updaters: [updater],
+            });
+            storeOptimisticEntry(cacheState, targetKey, stack, nextEntry);
+            continue;
+          }
           snapshot.layer.updaters.push(updater);
-          const nextEntry = applyOptimisticLayer(previousEntry, {
+          const nextEntry = applyOptimisticLayer(stack.renderedEntry, {
             ...snapshot.layer,
             updaters: [updater],
           });
           storeOptimisticEntry(cacheState, targetKey, stack, nextEntry);
-          continue;
-        }
-        snapshot.layer.updaters.push(updater);
-        const nextEntry = applyOptimisticLayer(stack.renderedEntry, {
-          ...snapshot.layer,
-          updaters: [updater],
-        });
-        storeOptimisticEntry(cacheState, targetKey, stack, nextEntry);
-      }
-
-      return Array.from(snapshots.values());
-    };
-
-    const rollbackOptimisticUpdates = (snapshots: OptimisticSnapshot[]) => {
-      if (!clientOptions?.optimistic?.rollbackOnError) return;
-      settleOptimisticUpdates(cacheState, optimisticState, snapshots, "rollback");
-    };
-
-    const invalidateUncommittedOptimisticUpdates = (snapshots: OptimisticSnapshot[]) => {
-      if (clientOptions?.optimistic?.rollbackOnError) return;
-      for (const key of settleOptimisticUpdates(
-        cacheState,
-        optimisticState,
-        snapshots,
-        "invalidate",
-      )) {
-        emitStatus("invalidated", { key });
-      }
-    };
-
-    const executeNetwork = async (opts?: { isBackground?: boolean; callCallbacks?: boolean }) => {
-      const dedupeMs = cacheOptions?.dedupeMs ?? 0;
-      const inflight = inflightState.get(cacheKey);
-      const allowDedupe = isCacheEnabled && dedupeMs > 0;
-
-      if (allowDedupe && inflight && now - inflight.startedAt < dedupeMs) {
-        emitStatus("pending", { isBackground: opts?.isBackground, data: entry?.data });
-        const result = await inflight.promise;
-
-        if (result.error) {
-          emitStatus("error", { error: result.error, isBackground: opts?.isBackground });
-          if (opts?.callCallbacks !== false) {
-            clientOptions?.onError?.(result.error);
-          }
-        } else {
-          emitStatus("success", { data: result.data, isBackground: opts?.isBackground });
-          if (opts?.callCallbacks !== false) {
-            clientOptions?.onSuccess?.(result.data as any);
-          }
         }
 
-        return result;
-      }
+        return Array.from(snapshots.values());
+      };
 
-      emitStatus(opts?.isBackground ? "revalidating" : "pending", {
-        isBackground: opts?.isBackground,
-      });
+      const rollbackOptimisticUpdates = (snapshots: OptimisticSnapshot[]) => {
+        if (!clientOptions?.optimistic?.rollbackOnError) return;
+        settleOptimisticUpdates(cacheState, optimisticState, snapshots, "rollback");
+      };
 
-      const promise = (async () => {
-        const maxRetries = Math.max(0, clientOptions?.retry?.count ?? 0);
-        let attempt = 0;
+      const invalidateUncommittedOptimisticUpdates = (snapshots: OptimisticSnapshot[]) => {
+        if (clientOptions?.optimistic?.rollbackOnError) return;
+        for (const key of settleOptimisticUpdates(
+          cacheState,
+          optimisticState,
+          snapshots,
+          "invalidate",
+        )) {
+          emitStatus("invalidated", { key });
+        }
+      };
 
-        // eslint-disable-next-line no-constant-condition
-        while (true) {
-          clientOptions?.onRequest?.({
-            requestId,
-            method: methodUpper,
-            key: cacheKey,
-            path,
-            input,
-            attempt,
-            timestamp: Date.now(),
+      const executeNetwork = async (opts?: { isBackground?: boolean; callCallbacks?: boolean }) => {
+        const release = cancellation.hold();
+        try {
+          const dedupeMs = cacheOptions?.dedupeMs ?? 0;
+          const inflight = inflightState.get(cacheKey);
+          const allowDedupe =
+            isCacheEnabled && dedupeMs > 0 && !cancellation.signal && !requestContextError;
+
+          if (
+            allowDedupe &&
+            inflight &&
+            !inflight.cancellable &&
+            now - inflight.startedAt < dedupeMs
+          ) {
+            emitStatus("pending", { isBackground: opts?.isBackground, data: entry?.data });
+            const result = await inflight.promise;
+
+            if (result.error) {
+              emitStatus("error", { error: result.error, isBackground: opts?.isBackground });
+              if (opts?.callCallbacks !== false) {
+                clientOptions?.onError?.(result.error);
+              }
+            } else {
+              emitStatus("success", { data: result.data, isBackground: opts?.isBackground });
+              if (opts?.callCallbacks !== false) {
+                clientOptions?.onSuccess?.(result.data as any);
+              }
+            }
+
+            return result;
+          }
+
+          emitStatus(opts?.isBackground ? "revalidating" : "pending", {
+            isBackground: opts?.isBackground,
           });
+
+          const promise = (async () => {
+            const maxRetries = Math.max(0, clientOptions?.retry?.count ?? 0);
+            let attempt = 0;
+
+            // eslint-disable-next-line no-constant-condition
+            while (true) {
+              clientOptions?.onRequest?.({
+                requestId,
+                method: methodUpper,
+                key: cacheKey,
+                path,
+                input,
+                attempt,
+                timestamp: Date.now(),
+              });
+
+              try {
+                if (requestContextError) throw requestContextError;
+                const { response, data, decodeError } = await cancellation.run(() =>
+                  fetchClient(
+                    path,
+                    {
+                      ...input,
+                      method: methodUpper,
+                    },
+                    defaultHeaders,
+                    cancellation,
+                  ),
+                );
+
+                const error = response.ok ? null : createResponseError(response, data, decodeError);
+
+                const responseEvent: ResponseEvent<any, Error> = {
+                  requestId,
+                  method: methodUpper,
+                  key: cacheKey,
+                  path,
+                  input,
+                  attempt,
+                  timestamp: Date.now(),
+                  response,
+                  data: response.ok ? data : undefined,
+                  error: error ?? undefined,
+                  ok: response.ok,
+                  status: response.status,
+                };
+
+                notifyResponseObserver(
+                  clientOptions?.onResponse,
+                  response.ok ? data : undefined,
+                  error,
+                  responseEvent,
+                );
+
+                if (!error) {
+                  cancellation.check();
+                  return { data, error: null, key: cacheKey } as APIResult<any, Error>;
+                }
+
+                if (attempt >= maxRetries) {
+                  return { data: undefined, error, key: cacheKey } as APIResult<any, Error>;
+                }
+              } catch (err: any) {
+                const error = normalizeCallError(err);
+                const responseEvent: ResponseEvent<any, Error> = {
+                  requestId,
+                  method: methodUpper,
+                  key: cacheKey,
+                  path,
+                  input,
+                  attempt,
+                  timestamp: Date.now(),
+                  error,
+                  ok: false,
+                };
+
+                notifyResponseObserver(clientOptions?.onResponse, undefined, error, responseEvent);
+
+                if (attempt >= maxRetries || requestContextError || cancellation.signal?.aborted) {
+                  return { data: undefined, error, key: cacheKey } as APIResult<any, Error>;
+                }
+              }
+
+              attempt += 1;
+              const delay =
+                typeof clientOptions?.retry?.delay === "function"
+                  ? clientOptions.retry.delay(attempt)
+                  : (clientOptions?.retry?.delay ?? 0);
+
+              if (delay > 0) {
+                try {
+                  await cancellation.delay(delay);
+                } catch (error) {
+                  return { data: undefined, error: normalizeCallError(error), key: cacheKey };
+                }
+              }
+            }
+          })();
+
+          const inflightEntry = {
+            promise,
+            startedAt: now,
+            cancellable: !!cancellation.signal || !!requestContextError,
+          };
+          inflightState.set(cacheKey, inflightEntry);
 
           try {
-            if (requestContextError) throw requestContextError;
-            const { response, data, decodeError } = await fetchClient(
-              path,
-              {
-                ...input,
-                method: methodUpper,
-              },
-              defaultHeaders,
-            );
+            const result = await promise;
 
-            const error = response.ok ? null : createResponseError(response, data, decodeError);
+            if (
+              inflightState.get(cacheKey) === inflightEntry &&
+              !result.error &&
+              isCacheEnabled &&
+              !isFarmAPIStream(result.data)
+            ) {
+              const updatedAt = Date.now();
+              cacheState.set(cacheKey, {
+                data: result.data,
+                updatedAt,
+                staleAt: updatedAt + staleTime,
+                gcAt: getGcAt(updatedAt, cacheOptions?.gcTime),
+                invalidatedAt: undefined,
+              });
+            }
 
-            const responseEvent: ResponseEvent<any, Error> = {
-              requestId,
-              method: methodUpper,
-              key: cacheKey,
-              path,
-              input,
-              attempt,
-              timestamp: Date.now(),
-              response,
-              data: response.ok ? data : undefined,
-              error: error ?? undefined,
-              ok: response.ok,
-              status: response.status,
+            if (result.error) {
+              emitStatus("error", { error: result.error, isBackground: opts?.isBackground });
+              if (opts?.callCallbacks !== false) {
+                clientOptions?.onError?.(result.error);
+              }
+            } else {
+              emitStatus("success", { data: result.data, isBackground: opts?.isBackground });
+              if (opts?.callCallbacks !== false) {
+                clientOptions?.onSuccess?.(result.data as any);
+              }
+            }
+
+            return result;
+          } finally {
+            if (inflightState.get(cacheKey) === inflightEntry) {
+              inflightState.delete(cacheKey);
+            }
+            if (requestContextError && requestScopedState) {
+              requestScopedState.retired = true;
+              if (scopedRequestState === requestScopedState) scopedRequestState = undefined;
+            }
+            if (requestScopedState?.retired && requestScopedState.inflight.size === 0) {
+              requestScopedState.cache.dispose();
+            }
+          }
+        } finally {
+          release();
+        }
+      };
+
+      const invalidateTargets = async () => {
+        if (!clientOptions?.invalidate) return;
+
+        const invalidateOptions = Array.isArray(clientOptions.invalidate)
+          ? { targets: clientOptions.invalidate, refetch: false }
+          : {
+              targets: clientOptions.invalidate.targets,
+              refetch: clientOptions.invalidate.refetch ?? false,
             };
 
-            notifyResponseObserver(
-              clientOptions?.onResponse,
-              response.ok ? data : undefined,
-              error,
-              responseEvent,
-            );
+        for (const target of invalidateOptions.targets) {
+          const targetKey = resolveTargetKey(
+            routeMeta,
+            target,
+            undefined,
+            baseURL,
+            defaultHeaders,
+            transport ? baseURL : undefined,
+          );
+          if (!targetKey) continue;
 
-            if (!error) {
-              return { data, error: null, key: cacheKey } as APIResult<any, Error>;
-            }
-
-            if (attempt >= maxRetries) {
-              return { data: undefined, error, key: cacheKey } as APIResult<any, Error>;
-            }
-          } catch (err: any) {
-            const error = normalizeError(err);
-            const responseEvent: ResponseEvent<any, Error> = {
-              requestId,
-              method: methodUpper,
-              key: cacheKey,
-              path,
-              input,
-              attempt,
-              timestamp: Date.now(),
-              error,
-              ok: false,
-            };
-
-            notifyResponseObserver(clientOptions?.onResponse, undefined, error, responseEvent);
-
-            if (attempt >= maxRetries) {
-              return { data: undefined, error, key: cacheKey } as APIResult<any, Error>;
+          const existing = cacheState.get(targetKey);
+          if (existing) {
+            const invalidatedAt = Date.now();
+            const stack = optimisticState.get(targetKey);
+            cacheState.invalidate(targetKey, invalidatedAt);
+            if (stack?.renderedEntry === existing) {
+              stack.invalidatedAt = invalidatedAt;
+              stack.renderedEntry = cacheState.get(targetKey);
             }
           }
 
-          attempt += 1;
-          const delay =
-            typeof clientOptions?.retry?.delay === "function"
-              ? clientOptions.retry.delay(attempt)
-              : (clientOptions?.retry?.delay ?? 0);
+          emitStatus("invalidated", { key: targetKey });
 
-          if (delay > 0) {
-            await new Promise((resolve) => setTimeout(resolve, delay));
+          if (invalidateOptions.refetch && existing && targetKey === cacheKey) {
+            void executeNetwork({ isBackground: true, callCallbacks: false });
           }
         }
-      })();
+      };
 
-      const inflightEntry = { promise, startedAt: now };
-      inflightState.set(cacheKey, inflightEntry);
+      const optimisticSnapshots = requestContextError ? [] : applyOptimisticUpdates();
 
-      try {
-        const result = await promise;
-
-        if (
-          inflightState.get(cacheKey) === inflightEntry &&
-          !result.error &&
-          isCacheEnabled &&
-          !isFarmAPIStream(result.data)
-        ) {
-          const updatedAt = Date.now();
-          cacheState.set(cacheKey, {
-            data: result.data,
-            updatedAt,
-            staleAt: updatedAt + staleTime,
-            gcAt: getGcAt(updatedAt, cacheOptions?.gcTime),
-            invalidatedAt: undefined,
-          });
+      if (isCacheEnabled && !requestContextError && !cancellation.signal?.aborted) {
+        if (entry && !isStale && policy !== "network-only") {
+          emitStatus("success", { data: entry.data });
+          clientOptions?.onSuccess?.(entry.data);
+          clientOptions?.onSettled?.(entry.data, null);
+          return { data: entry.data, error: null, key: cacheKey };
         }
 
-        if (result.error) {
-          emitStatus("error", { error: result.error, isBackground: opts?.isBackground });
-          if (opts?.callCallbacks !== false) {
-            clientOptions?.onError?.(result.error);
-          }
-        } else {
-          emitStatus("success", { data: result.data, isBackground: opts?.isBackground });
-          if (opts?.callCallbacks !== false) {
-            clientOptions?.onSuccess?.(result.data as any);
-          }
-        }
+        if (entry && isStale && policy === "stale-while-revalidate") {
+          emitStatus("success", { data: entry.data });
+          clientOptions?.onSuccess?.(entry.data);
+          clientOptions?.onSettled?.(entry.data, null);
 
-        return result;
-      } finally {
-        if (inflightState.get(cacheKey) === inflightEntry) {
-          inflightState.delete(cacheKey);
-        }
-        if (requestContextError && requestScopedState) {
-          requestScopedState.retired = true;
-          if (scopedRequestState === requestScopedState) scopedRequestState = undefined;
-        }
-        if (requestScopedState?.retired && requestScopedState.inflight.size === 0) {
-          requestScopedState.cache.dispose();
-        }
-      }
-    };
-
-    const invalidateTargets = async () => {
-      if (!clientOptions?.invalidate) return;
-
-      const invalidateOptions = Array.isArray(clientOptions.invalidate)
-        ? { targets: clientOptions.invalidate, refetch: false }
-        : {
-            targets: clientOptions.invalidate.targets,
-            refetch: clientOptions.invalidate.refetch ?? false,
-          };
-
-      for (const target of invalidateOptions.targets) {
-        const targetKey = resolveTargetKey(
-          routeMeta,
-          target,
-          undefined,
-          baseURL,
-          defaultHeaders,
-          transport ? baseURL : undefined,
-        );
-        if (!targetKey) continue;
-
-        const existing = cacheState.get(targetKey);
-        if (existing) {
-          const invalidatedAt = Date.now();
-          const stack = optimisticState.get(targetKey);
-          cacheState.invalidate(targetKey, invalidatedAt);
-          if (stack?.renderedEntry === existing) {
-            stack.invalidatedAt = invalidatedAt;
-            stack.renderedEntry = cacheState.get(targetKey);
-          }
-        }
-
-        emitStatus("invalidated", { key: targetKey });
-
-        if (invalidateOptions.refetch && existing && targetKey === cacheKey) {
           void executeNetwork({ isBackground: true, callCallbacks: false });
+          return { data: entry.data, error: null, key: cacheKey };
         }
       }
-    };
 
-    const optimisticSnapshots = requestContextError ? [] : applyOptimisticUpdates();
-
-    if (isCacheEnabled) {
-      if (entry && !isStale && policy !== "network-only") {
-        emitStatus("success", { data: entry.data });
-        clientOptions?.onSuccess?.(entry.data);
-        clientOptions?.onSettled?.(entry.data, null);
-        return { data: entry.data, error: null, key: cacheKey };
+      const result = await executeNetwork();
+      if (result.error) {
+        if (cancellation.signal?.aborted) {
+          settleOptimisticUpdates(cacheState, optimisticState, optimisticSnapshots, "rollback");
+        } else {
+          rollbackOptimisticUpdates(optimisticSnapshots);
+          invalidateUncommittedOptimisticUpdates(optimisticSnapshots);
+        }
+      } else {
+        settleOptimisticUpdates(cacheState, optimisticState, optimisticSnapshots, "commit");
+        await invalidateTargets();
       }
-
-      if (entry && isStale && policy === "stale-while-revalidate") {
-        emitStatus("success", { data: entry.data });
-        clientOptions?.onSuccess?.(entry.data);
-        clientOptions?.onSettled?.(entry.data, null);
-
-        void executeNetwork({ isBackground: true, callCallbacks: false });
-        return { data: entry.data, error: null, key: cacheKey };
-      }
+      clientOptions?.onSettled?.(result.data, result.error);
+      return result;
+    } finally {
+      cancellation.dispose();
     }
-
-    const result = await executeNetwork();
-    if (result.error) {
-      rollbackOptimisticUpdates(optimisticSnapshots);
-      invalidateUncommittedOptimisticUpdates(optimisticSnapshots);
-    } else {
-      settleOptimisticUpdates(cacheState, optimisticState, optimisticSnapshots, "commit");
-      await invalidateTargets();
-    }
-    clientOptions?.onSettled?.(result.data, result.error);
-    return result;
   };
 
   // Return nested proxy (starts with empty path, user adds to it)
@@ -1568,6 +1640,7 @@ export function createServerAPIClient<
 type CacheEntry = FarmClientCacheEntry<any>;
 
 type InflightEntry = {
+  cancellable?: boolean;
   promise: Promise<APIResult<any, Error>>;
   startedAt: number;
 };

--- a/packages/farm/src/client-cancellation.ts
+++ b/packages/farm/src/client-cancellation.ts
@@ -1,0 +1,91 @@
+/** One call budget, shared by header resolution, dispatch, decoding, and retry waits. */
+export function createClientCancellation(
+  signal?: AbortSignal,
+  timeoutMs = 0,
+  parent?: AbortSignal,
+) {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let invalid: Error | undefined;
+  let timeoutReason: DOMException | undefined;
+  const signals = [signal, parent].filter((value): value is AbortSignal => !!value);
+  if (!Number.isInteger(timeoutMs) || timeoutMs < 0 || timeoutMs > 2_147_483_647) {
+    invalid = new RangeError(
+      "timeoutMs must be an integer between 0 and 2147483647 (0 disables the deadline).",
+    );
+  } else if (timeoutMs > 0) {
+    const controller = new AbortController();
+    signals.push(controller.signal);
+    timer = setTimeout(() => {
+      timeoutReason = new DOMException("Client request timed out", "TimeoutError");
+      controller.abort(timeoutReason);
+    }, timeoutMs);
+  }
+  const combined = signals.length > 1 ? AbortSignal.any(signals) : signals[0];
+  let active = 0;
+  let closed = false;
+  const cleanup = () => {
+    if (closed && active === 0 && timer !== undefined) {
+      clearTimeout(timer);
+      timer = undefined;
+    }
+  };
+  const check = () => {
+    if (invalid) throw invalid;
+    combined?.throwIfAborted();
+  };
+  return {
+    signal: combined,
+    get timedOut() {
+      return timeoutReason !== undefined && combined?.reason === timeoutReason;
+    },
+    check,
+    hold() {
+      active++;
+      return () => {
+        active--;
+        cleanup();
+      };
+    },
+    // A race also bounds cooperative local dispatch and custom HTTP implementations.
+    // Late completion is consumed, but cannot turn a cancelled result into success.
+    async run<T>(work: () => T | PromiseLike<T>): Promise<T> {
+      check();
+      active++;
+      let abort: (() => void) | undefined;
+      try {
+        if (!combined) return await work();
+        return await new Promise<T>((resolve, reject) => {
+          abort = () => reject(combined.reason);
+          combined.addEventListener("abort", abort, { once: true });
+          Promise.resolve()
+            .then(() => {
+              check();
+              return work();
+            })
+            .then(resolve, reject);
+        });
+      } finally {
+        if (abort) combined?.removeEventListener("abort", abort);
+        active--;
+        cleanup();
+      }
+    },
+    async delay(ms: number) {
+      let retryTimer: ReturnType<typeof setTimeout> | undefined;
+      try {
+        await this.run(
+          () =>
+            new Promise<void>((resolve) => {
+              retryTimer = setTimeout(resolve, ms);
+            }),
+        );
+      } finally {
+        if (retryTimer !== undefined) clearTimeout(retryTimer);
+      }
+    },
+    dispose() {
+      closed = true;
+      cleanup();
+    },
+  };
+}

--- a/packages/farm/src/integration-client.ts
+++ b/packages/farm/src/integration-client.ts
@@ -6,6 +6,7 @@ import type {
 import type { FarmIntegration as FarmIntegrationDefinition } from "./integrations";
 import { resolveFarmAPIRequestURL } from "./api/config";
 import { resolveClientHeaders, type ClientHeaders } from "./client-headers";
+import { createClientCancellation } from "./client-cancellation";
 
 /**
  * Small per-call integration metadata. When sent from a browser, values are
@@ -17,6 +18,8 @@ export type IntegrationClientOptions = {
   baseURL?: string;
   headers?: ClientHeaders;
   credentials?: RequestCredentials;
+  /** Whole-call deadline in milliseconds; 0 disables it. */
+  timeoutMs?: number;
   data?: IntegrationClientData;
   isServer?: false | undefined;
 };
@@ -24,6 +27,7 @@ export type IntegrationClientOptions = {
 type IntegrationRequestOptionsBase = {
   headers?: Record<string, string>;
   signal?: AbortSignal;
+  timeoutMs?: number;
   credentials?: RequestCredentials;
   data?: IntegrationClientData;
 };
@@ -707,74 +711,87 @@ async function finalizeOperationResponse(
 async function executeClientOperation(
   operation: FarmIntegrationAPIOperation<any, any, any>,
   input: Record<string, unknown>,
-  options: Pick<IntegrationClientOptions, "baseURL" | "headers" | "credentials" | "data">,
+  options: Pick<
+    IntegrationClientOptions,
+    "baseURL" | "headers" | "credentials" | "data" | "timeoutMs"
+  >,
   requestOptions?: IntegrationClientRequestOptions,
 ) {
+  const cancellation = createClientCancellation(
+    requestOptions?.signal,
+    requestOptions?.timeoutMs ?? options.timeoutMs,
+  );
   try {
-    if (!operation.path) {
+    return await cancellation.run(async () => {
+      if (!operation.path) {
+        return {
+          data: null,
+          error: new Error(
+            "Integration API operation path is missing. Pass a path to api.get/post/... or wrap pathless methods with api.route(path, { ... }).",
+          ),
+        };
+      }
+
+      const baseURL =
+        options.baseURL ||
+        (typeof window !== "undefined" ? window.location.origin : "http://localhost:3000");
+      const url = resolveFarmAPIRequestURL(operation.path, baseURL);
+      appendQuery(url, input.query as Record<string, unknown> | undefined);
+
+      const resolved = resolveClientHeaders(options.headers);
+      const headers = resolved instanceof Headers ? resolved : await resolved;
+      cancellation.check();
+      appendHeaders(headers, operation.headers);
+      appendHeaders(headers, requestOptions?.headers);
+      headers.set("x-farm-integration-client", "1");
+
+      if (operation.responseFormat !== "response") {
+        headers.set("accept", "application/json");
+      }
+
+      appendIntegrationClientDataHeader(
+        headers,
+        mergeIntegrationClientData(options.data, requestOptions?.data),
+      );
+
+      const body = createOperationBody(operation, input.body, headers);
+      const response = await fetch(url.toString(), {
+        method: operation.method,
+        headers,
+        body,
+        credentials:
+          requestOptions?.credentials ?? operation.credentials ?? options.credentials ?? "include",
+        signal: cancellation.signal,
+      });
+      cancellation.check();
+
+      if (!response.ok) {
+        const errorData = await safeParseResponseData(response);
+        return {
+          data: null,
+          error: createResponseError(response, errorData),
+        };
+      }
+
+      if (operation.responseFormat === "response") {
+        return {
+          data: response,
+          error: null,
+        };
+      }
+
       return {
-        data: null,
-        error: new Error(
-          "Integration API operation path is missing. Pass a path to api.get/post/... or wrap pathless methods with api.route(path, { ... }).",
-        ),
-      };
-    }
-
-    const baseURL =
-      options.baseURL ||
-      (typeof window !== "undefined" ? window.location.origin : "http://localhost:3000");
-    const url = resolveFarmAPIRequestURL(operation.path, baseURL);
-    appendQuery(url, input.query as Record<string, unknown> | undefined);
-
-    const resolved = resolveClientHeaders(options.headers);
-    const headers = resolved instanceof Headers ? resolved : await resolved;
-    appendHeaders(headers, operation.headers);
-    appendHeaders(headers, requestOptions?.headers);
-    headers.set("x-farm-integration-client", "1");
-
-    if (operation.responseFormat !== "response") {
-      headers.set("accept", "application/json");
-    }
-
-    appendIntegrationClientDataHeader(
-      headers,
-      mergeIntegrationClientData(options.data, requestOptions?.data),
-    );
-
-    const body = createOperationBody(operation, input.body, headers);
-    const response = await fetch(url.toString(), {
-      method: operation.method,
-      headers,
-      body,
-      credentials:
-        requestOptions?.credentials ?? operation.credentials ?? options.credentials ?? "include",
-      signal: requestOptions?.signal,
-    });
-
-    if (!response.ok) {
-      const errorData = await safeParseResponseData(response);
-      return {
-        data: null,
-        error: createResponseError(response, errorData),
-      };
-    }
-
-    if (operation.responseFormat === "response") {
-      return {
-        data: response,
+        data: (await parseResponseData(response)) as unknown,
         error: null,
       };
-    }
-
-    return {
-      data: (await parseResponseData(response)) as unknown,
-      error: null,
-    };
+    });
   } catch (error) {
     return {
       data: null,
       error: normalizeExecutionError(error),
     };
+  } finally {
+    cancellation.dispose();
   }
 }
 
@@ -783,117 +800,135 @@ async function executeServerOperation(
   input: Record<string, unknown>,
   options: Pick<
     IntegrationServerClientOptions,
-    "baseURL" | "headers" | "credentials" | "data" | "request" | "forwardHeaders"
+    "baseURL" | "headers" | "credentials" | "data" | "request" | "forwardHeaders" | "timeoutMs"
   >,
   requestOptions?: IntegrationServerClientRequestOptions,
   integrationKey?: string,
   source?: FarmIntegrationDefinition | FarmIntegrationAPI,
 ) {
+  // Capture the request before any asynchronous work (including header resolvers).
+  const currentRequest =
+    requestOptions?.request instanceof Request
+      ? requestOptions.request
+      : options.request instanceof Request
+        ? options.request
+        : resolveCurrentRequestLocal();
+  const cancellation = createClientCancellation(
+    requestOptions?.signal,
+    requestOptions?.timeoutMs ?? options.timeoutMs,
+    currentRequest?.signal,
+  );
   try {
-    if (!operation.path) {
-      return {
-        data: null,
-        error: new Error(
-          "Integration API operation path is missing. Pass a path to api.get/post/... or wrap pathless methods with api.route(path, { ... }).",
-        ),
-      };
-    }
+    return await cancellation.run(async () => {
+      if (!operation.path) {
+        return {
+          data: null,
+          error: new Error(
+            "Integration API operation path is missing. Pass a path to api.get/post/... or wrap pathless methods with api.route(path, { ... }).",
+          ),
+        };
+      }
 
-    const serverRequestOptions =
-      requestOptions &&
-      ("request" in requestOptions ||
-        "baseURL" in requestOptions ||
-        "forwardHeaders" in requestOptions)
-        ? requestOptions
-        : undefined;
-    const currentRequest =
-      serverRequestOptions?.request instanceof Request
-        ? serverRequestOptions.request
-        : options.request instanceof Request
-          ? options.request
-          : resolveCurrentRequestLocal();
-    const request = resolveRequestLike(
-      serverRequestOptions?.request ?? options.request ?? currentRequest,
-    );
-    const baseURL = resolveServerBaseURL(serverRequestOptions?.baseURL ?? options.baseURL, request);
-    const url = new URL(operation.path, baseURL);
-    appendQuery(url, input.query as Record<string, unknown> | undefined);
-
-    const headers = new Headers();
-    appendHeaders(
-      headers,
-      resolveForwardHeaders(
+      const serverRequestOptions =
+        requestOptions &&
+        ("request" in requestOptions ||
+          "baseURL" in requestOptions ||
+          "forwardHeaders" in requestOptions)
+          ? requestOptions
+          : undefined;
+      const request = resolveRequestLike(
+        serverRequestOptions?.request ?? options.request ?? currentRequest,
+      );
+      const baseURL = resolveServerBaseURL(
+        serverRequestOptions?.baseURL ?? options.baseURL,
         request,
-        serverRequestOptions?.forwardHeaders ?? options.forwardHeaders,
-      ),
-    );
-    const resolved = resolveClientHeaders(options.headers);
-    appendHeaders(headers, resolved instanceof Headers ? resolved : await resolved);
-    appendHeaders(headers, operation.headers);
-    appendHeaders(headers, requestOptions?.headers);
-    headers.set("x-farm-integration-client", "1");
+      );
+      const url = new URL(operation.path, baseURL);
+      appendQuery(url, input.query as Record<string, unknown> | undefined);
 
-    if (operation.responseFormat !== "response") {
-      headers.set("accept", "application/json");
-    }
+      const headers = new Headers();
+      appendHeaders(
+        headers,
+        resolveForwardHeaders(
+          request,
+          serverRequestOptions?.forwardHeaders ?? options.forwardHeaders,
+        ),
+      );
+      const resolved = resolveClientHeaders(options.headers);
+      appendHeaders(headers, resolved instanceof Headers ? resolved : await resolved);
+      cancellation.check();
+      appendHeaders(headers, operation.headers);
+      appendHeaders(headers, requestOptions?.headers);
+      headers.set("x-farm-integration-client", "1");
 
-    const data = mergeIntegrationClientData(options.data, requestOptions?.data);
+      if (operation.responseFormat !== "response") {
+        headers.set("accept", "application/json");
+      }
 
-    if (integrationKey) {
-      const runtime =
-        "kind" in (source || {}) &&
-        (source as FarmIntegrationDefinition).kind === "farm-integration"
-          ? getRegisteredIntegrationRuntimeLocal(integrationKey) || {
-              integration: source as FarmIntegrationDefinition,
-              config: {},
-              isDev: process.env.NODE_ENV !== "production",
-              isProd: process.env.NODE_ENV === "production",
-            }
-          : getRegisteredIntegrationRuntimeLocal(integrationKey);
+      const data = mergeIntegrationClientData(options.data, requestOptions?.data);
 
-      if (runtime) {
-        const dispatchIntegrationRequest = resolveIntegrationRequestDispatcherLocal();
-        const body = createOperationBody(operation, input.body, headers);
-        const directResponse = dispatchIntegrationRequest
-          ? await dispatchIntegrationRequest(
-              runtime,
-              new Request(url.toString(), {
-                method: operation.method,
-                headers,
-                body,
-              }),
-              {
-                currentRequest,
-                data,
-                internal: true,
-              },
-            )
-          : null;
+      if (integrationKey) {
+        const runtime =
+          "kind" in (source || {}) &&
+          (source as FarmIntegrationDefinition).kind === "farm-integration"
+            ? getRegisteredIntegrationRuntimeLocal(integrationKey) || {
+                integration: source as FarmIntegrationDefinition,
+                config: {},
+                isDev: process.env.NODE_ENV !== "production",
+                isProd: process.env.NODE_ENV === "production",
+              }
+            : getRegisteredIntegrationRuntimeLocal(integrationKey);
 
-        if (directResponse) {
-          return await finalizeOperationResponse(operation, directResponse);
+        if (runtime) {
+          const dispatchIntegrationRequest = resolveIntegrationRequestDispatcherLocal();
+          const body = createOperationBody(operation, input.body, headers);
+          const directResponse = dispatchIntegrationRequest
+            ? await dispatchIntegrationRequest(
+                runtime,
+                new Request(url.toString(), {
+                  method: operation.method,
+                  headers,
+                  body,
+                  signal: cancellation.signal,
+                }),
+                {
+                  currentRequest,
+                  data,
+                  internal: true,
+                },
+              )
+            : null;
+
+          cancellation.check();
+
+          if (directResponse) {
+            return await finalizeOperationResponse(operation, directResponse);
+          }
         }
       }
-    }
 
-    appendIntegrationClientDataHeader(headers, data);
+      appendIntegrationClientDataHeader(headers, data);
 
-    const body = createOperationBody(operation, input.body, headers);
-    const response = await fetch(url.toString(), {
-      method: operation.method,
-      headers,
-      body,
-      credentials:
-        requestOptions?.credentials ?? operation.credentials ?? options.credentials ?? "include",
-      signal: requestOptions?.signal,
+      const body = createOperationBody(operation, input.body, headers);
+      const response = await fetch(url.toString(), {
+        method: operation.method,
+        headers,
+        body,
+        credentials:
+          requestOptions?.credentials ?? operation.credentials ?? options.credentials ?? "include",
+        signal: cancellation.signal,
+      });
+      cancellation.check();
+
+      return await finalizeOperationResponse(operation, response);
     });
-
-    return await finalizeOperationResponse(operation, response);
   } catch (error) {
     return {
       data: null,
       error: normalizeExecutionError(error),
     };
+  } finally {
+    cancellation.dispose();
   }
 }
 
@@ -1133,6 +1168,7 @@ function isIntegrationClientOptionsInput(value: unknown): value is IntegrationCl
     ("baseURL" in value ||
       "headers" in value ||
       "credentials" in value ||
+      "timeoutMs" in value ||
       "data" in value ||
       "isServer" in value)
   );
@@ -1148,6 +1184,7 @@ function resolveIntegrationServerOptions(
     baseURL: clientOptions.baseURL,
     headers: clientOptions.headers,
     credentials: clientOptions.credentials,
+    timeoutMs: clientOptions.timeoutMs,
     ...serverOptions,
     ...(data ? { data } : {}),
   };

--- a/packages/farm/types/client.d.ts
+++ b/packages/farm/types/client.d.ts
@@ -627,6 +627,7 @@ declare module "@farm.js/core/client" {
 
   export type APIClientSystemError =
     | APIClientError<"http_error", unknown, number>
+    | APIClientError<"aborted" | "timeout", unknown, 0>
     | APIClientError<"network_error", unknown, 0>;
 
   export type RequestEvent = {
@@ -704,6 +705,8 @@ declare module "@farm.js/core/client" {
     TUpdates extends readonly unknown[] = readonly OptimisticUpdate[],
   > = {
     key?: CacheKey<TData> | RouteDataCacheKey;
+    signal?: AbortSignal;
+    timeoutMs?: number;
     cache?: CacheOptions;
     retry?: RetryOptions;
     invalidate?: InvalidateOptions;
@@ -1338,6 +1341,7 @@ declare module "@farm.js/core/client" {
   export type IntegrationClientData = Record<string, unknown>;
 
   export interface IntegrationClientOptions {
+    timeoutMs?: number;
     baseURL?: string;
     headers?: ClientHeaders;
     credentials?: RequestCredentials;
@@ -1346,6 +1350,7 @@ declare module "@farm.js/core/client" {
   }
 
   interface IntegrationRequestOptionsBase {
+    timeoutMs?: number;
     headers?: Record<string, string>;
     signal?: AbortSignal;
     credentials?: RequestCredentials;

--- a/skills/farmjs/SKILL.md
+++ b/skills/farmjs/SKILL.md
@@ -226,6 +226,13 @@ modules. See `docs/src/app/docs/api-client/page.md#header-defaults` and the inte
 
 ## Typed APIs and Server Data
 
+Caller instances accept `timeoutMs` (0 disables it); individual calls accept `signal` and a
+deadline override. The budget includes header resolution, dispatch, decoding, and retry waits.
+Cancelled app routes return `aborted`/`timeout` errors without retries or optimistic commits;
+cancellable requests do not share in-flight work. Server dispatch combines the incoming and
+per-call signals. Handlers must cooperate: abort cannot undo external side effects. Streams/raw
+responses end the deadline at handoff, while the caller signal still reaches HTTP body reads.
+
 API routes live under `src/app/api/**/route.ts`. Prefer `createEndpoint` from
 `@farm.js/core/api` when input validation and generated caller types matter; plain HTTP method
 exports remain supported. Endpoint input accepts Zod or standard-schema validators for body, query,


### PR DESCRIPTION
## Problem

Typed app-route callers cannot cancel an individual operation or bound slow header resolution and retries. Integration callers accept a signal over HTTP but drop it during local server dispatch.

## Root cause

The route fetch options have no signal, retry waits are uninterruptible, and local integration Requests are constructed without the call signal. Existing coverage tests successful dispatch, not independently cancelled callers or non-cooperative transports.

## Change

- Add instance `timeoutMs` and per-call `signal`/`timeoutMs` across paired route and integration callers and the existing factories.
- Share one call budget across header resolution, dispatch, eager decoding, and retry waits; combine incoming server request cancellation with the call signal.
- Return normal error results, stop retries, prevent late cache writes, and roll back cancelled optimistic layers.
- Keep cancellable operations out of in-flight deduplication; preserve background revalidation budgets and dispose timers/listeners.

## Safety and compatibility

Opt-in, renderer-neutral, with deadlines disabled by default. Per-call zero disables an instance deadline. Accepted deadlines are integers between 0 and 2147483647. Existing result shapes remain intact; route system errors add `aborted` and `timeout` codes (status 0). Integration cancellation uses normalized abort reasons, including `TimeoutError` for a Farm deadline.

Cancellation is cooperative: it stops waiting but cannot undo writes or force a provider to stop. Stream/raw-response deadlines end at handoff, while caller signals continue to reach HTTP body consumption. Local API dispatch remains local. No new retry policy, deployment target, dependency, or release change.

## Verification

macOS arm64, Node 23.11.0, pnpm 8.12.1:

- Focused core tests: 112 passing across cancellation, existing app/paired/integration callers, and header resolvers.
- Published declaration compilation: cancellation typing test passes.
- `pnpm --filter @farm.js/core type-check`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @farm.js/core build`
- `pnpm --filter @farm.js/cli build`
- `pnpm docs:check-navigation`
- `pnpm --dir docs exec farm generate --check`
- `pnpm docs:build`
- Focused formatting and lint (0 errors; existing unused `resolveSourceAPI` warning).

All 14 cancellation regression tests fail against unchanged main commit `58973a81` and pass with this implementation. The control run uses a shorter test-runner timeout to expose unsupported cancellation promptly; deadline/retry tests themselves use fake timers and deterministic readiness promises.

CI exposed five mixed-realm failures on Node 24 (Linux/Windows): the DOM-free caller tests combined jsdom AbortSignal with native Node Request. Reproduced all five locally on Node 24.21.0, then kept these tests in the Node environment with their existing explicit browser-window stubs. All 86 affected caller/cancellation tests pass on Node 24.21.0; no assertions, signal forwarding, platform jobs, or timeouts were removed. Real browser coverage remains in Playwright.

Production browser verification uses `pnpm exec playwright test tests/e2e/framework-features.spec.ts --grep 'runs integration handlers' --config playwright.production.config.ts` with the maintained basic app and a Node production build. The initial launch lacked the required Chromium shell; install it with `pnpm exec playwright install chromium --only-shell` before running.

## Documentation and release

Updated API-client and integration guides, Farm skill, and existing basic shared caller examples. Published client declarations updated. No versions, tags, generated route changes, or new packages.
