### PR TITLE
perf(react): compile block-bodied keyed slice setters

### DIFF
--- a/docs/src/app/docs/renderers/react/page.md
+++ b/docs/src/app/docs/renderers/react/page.md
@@ -1128,16 +1128,20 @@ setItems((current) => current.slice(-5));
 const trimCount = pageSize * pagesToDiscard;
 setItems((current) => current.slice(trimCount));
 setItems((current) => current.slice(visible.start, visible.end));
+setItems((current) => {
+  return current.slice(visible.start, visible.end);
+});
 ```
 
-At build time, Farm recognizes a concise functional setter that directly calls native `slice()`
-with one or two safe-integer literals or compiler-safe runtime expressions. Identifiers, property
-reads, side-effect-free arithmetic and conditionals, and safe `Math` calls are supported.
-User-defined calls, assignments, update expressions, and other effectful forms are not transformed.
-Farm preserves the original method lookup and argument evaluation order, evaluates each bound once,
-and preserves the native call, coercion, return value, and thrown errors. Generated metadata records
-the normalized retained interval only when every evaluated bound is already a safe integer, and
-links multiple slice or filter updates queued before one compiler flush.
+At build time, Farm recognizes a concise functional setter or a setter block containing exactly one
+direct value-returning `return`. The returned expression must directly call native `slice()` with
+one or two safe-integer literals or compiler-safe runtime expressions. Identifiers, property reads,
+side-effect-free arithmetic and conditionals, and safe `Math` calls are supported. User-defined
+calls, assignments, update expressions, and other effectful forms are not transformed. Farm
+preserves the original method lookup and argument evaluation order, evaluates each bound once, and
+preserves the native call, coercion, return value, and thrown errors. Generated metadata records the
+normalized retained interval only when every evaluated bound is already a safe integer, and links
+multiple slice or filter updates queued before one compiler flush.
 
 At update time, Farm validates the native arrays, committed source, queued lengths, interval, and
 surviving item identities before changing the DOM. It removes only rows outside the interval,
@@ -1147,8 +1151,9 @@ does not rerun.
 
 The proof requires compiler-owned host rows whose render callback and key do not observe the row
 index. Effectful bound expressions, evaluated bounds that are fractional, non-numeric, or otherwise
-not safe integers, `slice()` without a bound, a literal no-op `slice(0)`, block-bodied or chained
-updaters, custom slice methods, sparse or subclassed arrays, collection-derived keys,
+not safe integers, `slice()` without a bound, a literal no-op `slice(0)`, updater blocks with extra
+statements, directives, conditional returns, or no value-returning `return`, chained updaters, custom
+slice methods, sparse or subclassed arrays, collection-derived keys,
 collection-reading bindings, React-owned row structures, nested host blocks, row conditionals,
 unrelated dirty dependencies, and failed runtime validation keep complete keyed reconciliation.
 A runtime bound that evaluates to a no-op still preserves the native result and uses complete

--- a/examples/react-compiler-dashboard/README.md
+++ b/examples/react-compiler-dashboard/README.md
@@ -127,14 +127,14 @@ modes must remain at least 2x faster than React and 1.25x faster than that contr
 checks survivor identity and order, the changed survivor value, the final mapped prefix, and cleanup
 of the removed row.
 
-Keyed array slices have an independent retained-window comparison. A concise
-`slice(trimCount)` uses an event-local runtime bound and is measured against bracketed React and an
-equivalent block-bodied compiled snapshot control. Both compiler modes must remain at least 3x
-faster than React while trimming 10,000- and 21,000-row arrays, and at least 1.25x faster than the
-compiled control at 10,000 rows. The report must contain a nonzero `keyedArraySliceHints` count;
-deterministic package tests separately require zero surviving key, descriptor, and binding reads,
-preserve surviving DOM identity, and cover safe and effectful bound expressions plus unsafe
-evaluated-bound fallback.
+Keyed array slices have an independent retained-window comparison. A single-return block-bodied
+`slice(trimCount)` uses an event-local runtime bound and is measured against bracketed React and a
+compiled snapshot control whose updater block has an extra local declaration. Both compiler modes
+must remain at least 3x faster than React while trimming 10,000- and 21,000-row arrays, and at least
+1.25x faster than the compiled control at 10,000 rows. The report must contain a nonzero
+`keyedArraySliceHints` count; deterministic package tests separately require zero surviving key,
+descriptor, and binding reads, preserve surviving DOM identity, and cover safe and effectful bound
+expressions plus unsafe evaluated-bound fallback.
 
 Rolling windows have separate single-update and queued 10,000-row persistence gates. A concise
 `[...current.slice(trimCount), ...incoming]` update uses an event-local runtime bound; the queued
@@ -428,8 +428,9 @@ The default JSON report is `/tmp/farm-react-dashboard-benchmark.json`; change it
 - The prepend snapshot control does the same work at the beginning of the array through an updater
   block with an extra local declaration. It isolates the saved suffix scan while the hinted path
   still creates and inserts every required new DOM row.
-- The slice snapshot control retains the same 9,000-row suffix through an unsupported block-bodied
-  updater. It isolates the saved survivor scan while both paths remove the same 1,000 DOM rows.
+- The slice snapshot control retains the same 9,000-row suffix through an updater block with an
+  extra local declaration. It isolates the saved survivor scan while both paths remove the same
+  1,000 DOM rows.
 - The exact-position controls pass event-local runtime position and delete-count variables to concise native
   `toSpliced()` updates and compare them with equivalent block-bodied compiled controls. Package
   tests cover the equivalent `with()` replacement path too.

--- a/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
+++ b/examples/react-compiler-dashboard/src/components/standard-table-benchmark.tsx
@@ -207,7 +207,9 @@ export function StandardTableBenchmark() {
           type="button"
           onClick={() => {
             const trimCount = 1_000;
-            setRows((current) => current.slice(trimCount));
+            setRows((current) => {
+              return current.slice(trimCount);
+            });
             setOperation("drop runtime-count prefix");
             setRevision((value) => value + 1);
           }}
@@ -220,7 +222,8 @@ export function StandardTableBenchmark() {
           onClick={() => {
             const trimCount = 1_000;
             setRows((current) => {
-              return current.slice(trimCount);
+              const next = current.slice(trimCount);
+              return next;
             });
             setOperation("drop runtime-count prefix (snapshot control)");
             setRevision((value) => value + 1);
@@ -1074,7 +1077,8 @@ export function StandardTableBenchmark() {
               status: "review" as const,
             };
             setRows((current) => {
-              return current.slice(1);
+              const retained = current.slice(1);
+              return retained;
             });
             setRows((current) => {
               return [incoming, ...current];
@@ -1128,7 +1132,8 @@ export function StandardTableBenchmark() {
               status: "review" as const,
             };
             setRows((current) => {
-              return current.slice(1);
+              const retained = current.slice(1);
+              return retained;
             });
             setRows((current) => {
               return [incoming, ...current];
@@ -1194,7 +1199,8 @@ export function StandardTableBenchmark() {
               status: "review" as const,
             };
             setRows((current) => {
-              return current.slice(1);
+              const retained = current.slice(1);
+              return retained;
             });
             setRows((current) => {
               return [...current, incoming];

--- a/packages/farm-react/README.md
+++ b/packages/farm-react/README.md
@@ -381,6 +381,9 @@ setItems((current) => current.slice(0, -1_000));
 setItems((current) => current.slice(2, 8));
 setItems((current) => current.slice(trimCount));
 setItems((current) => current.slice(visible.start, visible.end));
+setItems((current) => {
+  return current.slice(visible.start, visible.end);
+});
 ```
 
 For compiler-owned host rows whose render and key do not read the row index, Farm validates the
@@ -388,12 +391,14 @@ committed source and queued slice chain, preserves every surviving DOM row, and 
 outside the retained interval. A slice-only chain does not reread surviving keys, descriptors, or
 bindings. One or two safe-integer literals or compiler-safe runtime expressions are required.
 Identifiers, property reads, side-effect-free arithmetic and conditionals, and safe `Math` calls
-are supported. Farm preserves native method lookup, argument evaluation, coercion, results, and
-errors, then records metadata only when the evaluated bounds are already safe integers. Calls,
-assignments, updates, unsafe evaluated bounds, block-bodied or chained updates, custom slice
-methods, sparse or subclassed arrays, index-aware or collection-reading rows, React-owned
-structures, and failed validation keep complete keyed reconciliation. No option or component is
-added. The compiler report exposes the emitted-site count as `keyedArraySliceHints`.
+are supported. The setter may be concise or use a block containing exactly one direct
+value-returning `return`. Farm preserves native method lookup, argument evaluation, coercion,
+results, and errors, then records metadata only when the evaluated bounds are already safe integers.
+Calls, assignments, updates, unsafe evaluated bounds, updater blocks with extra statements,
+directives, conditional returns, or no value-returning `return`, chained updates, custom slice
+methods, sparse or subclassed arrays, index-aware or collection-reading rows, React-owned structures,
+and failed validation keep complete keyed reconciliation. No option or component is added. The
+compiler report exposes the emitted-site count as `keyedArraySliceHints`.
 
 A fixed-size feed can combine that retained tail with a new keyed suffix:
 

--- a/packages/farm-react/src/__tests__/compiler-keyed-array-slice-hints.test.ts
+++ b/packages/farm-react/src/__tests__/compiler-keyed-array-slice-hints.test.ts
@@ -65,6 +65,35 @@ describe("React AOT keyed-array slice hints", () => {
     expect(result.code).not.toContain("keyedRowsFilterPrependHintedRuntimeFeature");
   });
 
+  it("records a slice returned from a single-return updater block", async () => {
+    const result = await compile(`
+      import { useState } from "react";
+      export function Feed({ start, end }) {
+        const [rows, setRows] = useState([{ id: "a", label: "Alpha" }]);
+        return <main>
+          <button onClick={() => setRows((current) => {
+            return current.slice(start, end);
+          })}>Keep window</button>
+          <ul>{rows.map((row) => <li key={row.id}>{row.label}</li>)}</ul>
+        </main>;
+      }
+    `);
+
+    expect(result.compiled).toEqual(["Feed"]);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.optimizations.keyedArraySliceHints).toBe(1);
+    expect(result.code).toContain("createCompilerKeyedArraySlice");
+    expect(result.code).toContain("keyedRowsFilterHintedRuntimeFeature");
+    await expect(
+      transformWithEsbuild(result.code, "/app/KeyedArraySliceHints.tsx", {
+        loader: "tsx",
+        jsx: "automatic",
+      }),
+    ).resolves.toMatchObject({
+      code: expect.stringContaining("createCompilerKeyedArraySlice"),
+    });
+  });
+
   it("records compiler-safe runtime slice bounds", async () => {
     const result = await compile(`
       import { useState } from "react";
@@ -99,9 +128,24 @@ describe("React AOT keyed-array slice hints", () => {
       update: "current.slice(1)",
     },
     {
-      name: "a block-bodied updater",
+      name: "an updater block with a local declaration",
       row: "(row) => <li key={row.id}>{row.label}</li>",
-      update: "{ return current.slice(1); }",
+      update: "{ const next = current.slice(1); return next; }",
+    },
+    {
+      name: "an updater block with conditional returns",
+      row: "(row) => <li key={row.id}>{row.label}</li>",
+      update: "{ if (current.length > 1) return current.slice(1); return current; }",
+    },
+    {
+      name: "an updater block without a return",
+      row: "(row) => <li key={row.id}>{row.label}</li>",
+      update: "{ current.slice(1); }",
+    },
+    {
+      name: "an updater block with a directive",
+      row: "(row) => <li key={row.id}>{row.label}</li>",
+      update: '{ "use strict"; return current.slice(1); }',
     },
     {
       name: "a fractional start",

--- a/packages/farm-react/src/compiler.ts
+++ b/packages/farm-react/src/compiler.ts
@@ -3839,19 +3839,25 @@ function rewriteKeyedArraySliceHints(
         updater.async ||
         updater.generator ||
         updater.params.length !== 1 ||
-        !t.isIdentifier(updater.params[0]) ||
-        !t.isCallExpression(updater.body) ||
-        updater.body.arguments.length < 1 ||
-        updater.body.arguments.length > 2 ||
-        !t.isMemberExpression(updater.body.callee) ||
-        updater.body.callee.computed ||
-        !t.isIdentifier(updater.body.callee.object, { name: updater.params[0].name }) ||
-        !t.isIdentifier(updater.body.callee.property, { name: "slice" })
+        !t.isIdentifier(updater.params[0])
+      ) {
+        return;
+      }
+      const updateExpression = returnedExpression(updater);
+      if (
+        (t.isBlockStatement(updater.body) && updater.body.directives.length > 0) ||
+        !t.isCallExpression(updateExpression) ||
+        updateExpression.arguments.length < 1 ||
+        updateExpression.arguments.length > 2 ||
+        !t.isMemberExpression(updateExpression.callee) ||
+        updateExpression.callee.computed ||
+        !t.isIdentifier(updateExpression.callee.object, { name: updater.params[0].name }) ||
+        !t.isIdentifier(updateExpression.callee.property, { name: "slice" })
       ) {
         return;
       }
       const bounds: t.Expression[] = [];
-      for (const argument of updater.body.arguments) {
+      for (const argument of updateExpression.arguments) {
         if (!t.isExpression(argument)) return;
         if (validateKeyedArrayPositionExpression(argument, safeGlobals) !== undefined) return;
         bounds.push(argument);


### PR DESCRIPTION
## Problem

Farm already retains keyed DOM rows for concise native slice setters such as `setRows(current => current.slice(start, end))`. The equivalent common block form, `setRows(current => { return current.slice(start, end); })`, falls back to complete React reconciliation even though it has the same single returned expression and can use the same proof.

## Root cause

The keyed-slice compiler pass inspected the arrow function body directly and therefore required it to be a call expression. It did not use the compiler's existing `returnedExpression` proof, which accepts either a concise arrow body or a block containing exactly one direct value-returning `return`.

## Change

- Reuse `returnedExpression` when recognizing keyed native `slice()` setters.
- Keep blocks with directives, extra statements, conditional returns, or no value-returning return on the complete React fallback.
- Exercise the new form in the 10,000/21,000-row browser benchmark while retaining explicit unsupported snapshot controls.
- Document the supported form and its fallback boundary in the React renderer docs, package README, and benchmark README.

## Safety and compatibility

- No new public API, option, runtime feature, or runtime-size contribution.
- The existing runtime validates native arrays, the committed source and queued lengths, normalized bounds, and survivor identities before any DOM mutation.
- Native method lookup, argument evaluation order, one-time bound evaluation, coercion, results, and errors remain unchanged.
- Unsafe or ambiguous syntax and failed runtime validation continue through complete keyed reconciliation.
- The full React suite, deterministic/randomized slice controls, runtime-size fixtures, and React 18/19 compatibility checks pass.

## Verification

- `pnpm --filter @farm.js/react exec vitest run src/__tests__/compiler-keyed-array-slice-hints.test.ts src/__tests__/compiler-runtime-keyed-array-slice-hints.test.tsx` — 30 passed, including 2,000 deterministic queued slices and 1,000 randomized runtime-bound slices.
- `pnpm --filter @farm.js/react test` — 868 passed, 14 skipped; stress suite 23 passed, 132 skipped.
- `pnpm --filter @farm.js/react type-check`
- `pnpm --filter @farm.js/react test:runtime-size` — all checked fixture sizes unchanged.
- `pnpm --filter @farm.js/react test:compat` — React 18.3.1 and 19.2.8 passed.
- `pnpm --dir examples/react-compiler-dashboard type-check`
- `pnpm docs:check-navigation` — 83 pages and 12 plugins passed.
- `pnpm --dir docs exec farm generate --check`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm docs:build` — Vercel/Nitro production build passed.
- `pnpm exec oxfmt <changed files>`, focused `oxlint`, and `git diff --check` passed.

Browser benchmark on macOS with Chrome 153:

| Mode | 10k slice | vs React | vs snapshot control | 21k scale vs React |
| --- | ---: | ---: | ---: | ---: |
| Static | 6.30 ms | 9.60x | 3.21x | 18.70x |
| Hybrid | 5.10 ms | 11.85x | 3.10x | 20.38x |

Correctness, the general performance gate, and the 8x optimization-persistence gate passed. Compiler-owned dashboard/table executions remained zero. The complete benchmark command exited nonzero on two unrelated snapshot gates: multi-map retained 15.18–16.09x update speedups but its snapshot comparison was noisy, and hybrid structural append measured 3.18x but missed its snapshot threshold. No thresholds or controls were weakened and the keyed-slice gate passed without regressions.

## Documentation and release

Updated the React renderer docs, `@farm.js/react` README, and compiler dashboard benchmark README. No version, template, generated artifact, or release-flow changes.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Compiles block-bodied keyed array slice setters so `setRows(current => { return current.slice(...); })` gets the same retained-row optimization as the concise form, instead of falling back to complete React reconciliation.

- Reuses the compiler’s `returnedExpression` proof, so only blocks with exactly one direct value-returning `return` are optimized.
- Blocks with extra statements, directives, conditional returns, or no value-returning `return` still use complete reconciliation.
- Updates the `@farm.js/react` README, React renderer docs, and dashboard benchmark to document the supported form.
- Exercises the new form in the 10,000/21,000-row benchmark while keeping explicit snapshot controls for unsupported forms.
- Adds no public API, runtime feature, or runtime-size contribution; native method lookup, argument evaluation, coercion, results, and errors are unchanged.

<sup>Written for commit d0fd18c15b51c5ba44694d449b008a3fb4d26b15. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/970?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

