### PR TITLE
feat(client): allow instance HTTP fetch transports

### DIFF
--- a/docs/src/app/docs/api-client/page.md
+++ b/docs/src/app/docs/api-client/page.md
@@ -142,6 +142,36 @@ completed writes or external side effects.
 These defaults also reach integration callers; `integrations.timeoutMs` overrides the shared
 deadline. See [integration cancellation](/docs/integrations#cancellation-and-deadlines).
 
+## Custom HTTP transport
+
+Pass a fetch-compatible function when a caller needs an HTTP wrapper for testing or tracing:
+
+```ts
+export const { api, apiClient } = createApiClients<APIRouter>({
+  routes: apiRoutes,
+  fetch: async (url, init) => {
+    const response = await globalThis.fetch(url, init);
+    return response;
+  },
+});
+```
+
+The function has the same type as `globalThis.fetch` and receives Farm's resolved URL and
+`RequestInit`, including headers, credentials, body, and cancellation signal. Return a normal
+`Response` and forward the signal in wrappers. Farm still handles decoding, errors, retries,
+and deadlines. Without this option, Farm uses global fetch as before. Supply a bound function
+if your implementation requires a particular `this` value.
+
+This replaces HTTP only: `apiClient` uses it, but server `api` still dispatches app routes
+locally. Integration HTTP calls (including server HTTP fallback) inherit it;
+`integrations.fetch` overrides it for integrations. Registered local integration handlers
+do not use HTTP and are unchanged.
+
+App-route caches stay private to instances with a custom transport, even with
+`cache.scope: "shared"` or `credentials: "omit"`: wrappers can add identity that Farm cannot
+see. If a wrapper changes users internally, also reflect that identity in the caller's
+header resolver or create a new instance; Farm cannot detect hidden identity changes.
+
 ## Call a route
 
 **Browser usage**

--- a/docs/src/app/docs/integrations/page.md
+++ b/docs/src/app/docs/integrations/page.md
@@ -366,6 +366,19 @@ effects: handlers must pass the signal to their own work when supported. A handl
 can still finish or write data. For raw `Response` operations the deadline ends when the response
 is returned; use the signal to cancel subsequent HTTP body consumption.
 
+## Custom HTTP transport
+
+`createIntegrations<AppIntegrations>({ fetch: customFetch })` accepts the same fetch-compatible
+function as [`createApiClients`](/docs/api-client#custom-http-transport). Both HTTP callers and
+the server HTTP fallback use it; registered local integration handlers still dispatch directly.
+Farm supplies the resolved URL and `RequestInit`, including the cancellation signal.
+
+The separate server-options argument can replace `fetch` for `api`, and the existing
+integration-only factories accept it too. With combined route/integration callers, shared
+`fetch` is inherited unless `integrations.fetch` overrides it. Keep shared wrappers browser-safe
+and preserve request credentials, headers, and signals. Return a Web `Response`; do not put
+provider SDKs or server credentials in a shared module.
+
 ## Shared data
 
 `createIntegrations({ data })` adds small per-call metadata to integration requests. It is useful for tenant IDs, locale, analytics context, or feature flags.

--- a/examples/basic/src/lib/integration-lab-api.ts
+++ b/examples/basic/src/lib/integration-lab-api.ts
@@ -6,6 +6,11 @@ export const {
   apiClient: integrationApiClient,
 } = createIntegrations<typeof integrationLab>({
   timeoutMs: 30_000,
+  fetch: (url, init) => {
+    const headers = new Headers(init?.headers);
+    headers.set('x-integration-lab-transport', 'custom-fetch');
+    return globalThis.fetch(url, { ...init, headers });
+  },
   headers: async () => ({
     'Accept-Language':
       typeof document === 'undefined' ? 'en' : document.documentElement.lang || 'en',

--- a/examples/basic/src/lib/integration-lab.ts
+++ b/examples/basic/src/lib/integration-lab.ts
@@ -19,6 +19,7 @@ export interface IntegrationLabResult {
   caller: string;
   requestId: string;
   language?: string | null;
+  transport?: string | null;
   trace: string[];
   lifecycle?: {
     label: string;
@@ -135,6 +136,7 @@ const routeLab = defineIntegration({
           caller: readCaller(context),
           requestId: context.requestId,
           language: request.headers.get('accept-language'),
+          transport: request.headers.get('x-integration-lab-transport'),
           trace: readTrace(context),
           lifecycle: { ...routeLabState },
         } satisfies IntegrationLabResult);

--- a/packages/farm/src/__tests__/client-fetch.test.ts
+++ b/packages/farm/src/__tests__/client-fetch.test.ts
@@ -1,0 +1,103 @@
+// @vitest-environment node
+import { afterEach, expect, it, vi } from "vitest";
+import { createAPIClient, createApiClients } from "../api/client";
+import { createEndpoint } from "../api/endpoint";
+import { _runWithAPIRequestRuntime } from "../api/server-context";
+import { _runWithCurrentRequest } from "../server/request";
+import { createIntegrations } from "../integration-client";
+import { endpoint } from "../integration-api";
+
+const get = createEndpoint({ method: "GET" }, () => ({ value: 1 }));
+type Router = { value: { get: typeof get } };
+const sources = { demo: { read: endpoint.get<{ value: number }>("/api/demo/read") } };
+afterEach(() => vi.unstubAllGlobals());
+
+it("uses instance fetch for routes without binding this, preserving request options", async () => {
+  const globalFetch = vi.fn();
+  vi.stubGlobal("fetch", globalFetch);
+  const controller = new AbortController();
+  const custom = vi.fn(function (this: unknown, _url: RequestInfo | URL, init?: RequestInit) {
+    expect(this).toBeUndefined();
+    expect(init?.signal).toBe(controller.signal);
+    expect(init?.credentials).toBe("omit");
+    expect(new Headers(init?.headers).get("x-app")).toBe("demo");
+    return Promise.resolve(Response.json({ value: 2 }));
+  });
+  const { apiClient } = createApiClients<Router>({
+    baseURL: "https://farm.test/api",
+    fetch: custom,
+    credentials: "omit",
+    headers: { "x-app": "demo" },
+  });
+  expect((await apiClient.value.get({}, { signal: controller.signal })).data).toEqual({ value: 2 });
+  expect(custom.mock.calls[0][0]).toBe("https://farm.test/api/value");
+  expect(globalFetch).not.toHaveBeenCalled();
+});
+
+it("isolates custom-transport caches even when public shared caching is requested", async () => {
+  const firstFetch = vi.fn(async () => Response.json({ value: 1 }));
+  const secondFetch = vi.fn(async () => Response.json({ value: 2 }));
+  const first = createAPIClient<Router>({ fetch: firstFetch, credentials: "omit" });
+  const second = createAPIClient<Router>({ fetch: secondFetch, credentials: "omit" });
+  const cache = { scope: "shared" as const, staleTime: 60_000 };
+  expect((await first.value.get({}, { cache })).data).toEqual({ value: 1 });
+  expect((await second.value.get({}, { cache })).data).toEqual({ value: 2 });
+  expect((await first.value.get({}, { cache })).data).toEqual({ value: 1 });
+  expect(firstFetch).toHaveBeenCalledOnce();
+  expect(secondFetch).toHaveBeenCalledOnce();
+});
+
+it("keeps api route dispatch local despite a custom HTTP transport", async () => {
+  const custom = vi.fn(async () => Response.json({ value: 99 }));
+  const dispatch = vi.fn(async () => Response.json({ value: 1 }));
+  const { api } = createApiClients<Router>({ fetch: custom });
+  const result = await _runWithAPIRequestRuntime({ basePath: "/api", dispatch }, () =>
+    _runWithCurrentRequest(new Request("https://farm.test/page"), () => api.value.get()),
+  );
+  expect(result.data).toEqual({ value: 1 });
+  expect(dispatch).toHaveBeenCalledOnce();
+  expect(custom).not.toHaveBeenCalled();
+});
+
+it.each(["client", "server"] as const)(
+  "supports custom %s integration HTTP transports and overrides",
+  async (side) => {
+    if (side === "client") vi.stubGlobal("window", { location: { origin: "https://farm.test" } });
+    const globalFetch = vi.fn();
+    vi.stubGlobal("fetch", globalFetch);
+    const custom = vi.fn(async () => Response.json({ value: 1 }));
+    const serverFetch = vi.fn(async () => Response.json({ value: 2 }));
+    const pair = createIntegrations(sources, { fetch: custom }, { fetch: serverFetch });
+    const result = await (side === "server" ? pair.api : pair.apiClient).demo.read();
+    expect(result.data).toEqual({ value: side === "server" ? 2 : 1 });
+    expect(globalFetch).not.toHaveBeenCalled();
+  },
+);
+
+it("recognizes fetch-only automatic options and paired integration overrides", async () => {
+  vi.stubGlobal("window", {
+    location: { origin: "https://farm.test" },
+    __FARM_INTEGRATION_API_MANIFEST__: sources,
+  });
+  const shared = vi.fn(async () => Response.json({ value: 1 }));
+  const overridden = vi.fn(async () => Response.json({ value: 2 }));
+  const automatic = createIntegrations<typeof sources>({ fetch: shared });
+  expect((await automatic.apiClient.demo.read()).data).toEqual({ value: 1 });
+  const { apiClient } = createApiClients<Router, typeof sources>({
+    fetch: shared,
+    integrations: { fetch: overridden },
+  });
+  expect((await apiClient.value.get()).data).toEqual({ value: 1 });
+  expect((await apiClient.integrations.demo.read()).data).toEqual({ value: 2 });
+});
+
+it("keeps custom transport failures in the existing error result contract", async () => {
+  const failure = new Error("transport failed");
+  const custom = vi
+    .fn()
+    .mockRejectedValueOnce(failure)
+    .mockResolvedValueOnce(Response.json({}, { status: 503 }));
+  const api = createAPIClient<Router>({ fetch: custom });
+  expect((await api.value.get()).error).toMatchObject({ code: "network_error", cause: failure });
+  expect((await api.value.get()).error).toMatchObject({ code: "http_error", status: 503 });
+});

--- a/packages/farm/src/__tests__/client-fetch.typing.test.ts
+++ b/packages/farm/src/__tests__/client-fetch.typing.test.ts
@@ -1,0 +1,49 @@
+// @vitest-environment node
+import path from "node:path";
+import ts from "typescript";
+import { expect, it } from "vitest";
+
+it("exposes custom fetch through the published client declarations", () => {
+  // TypeScript normalizes compiler filenames to forward slashes, including on Windows.
+  const filename = path.resolve("client-fetch.type-test.ts").replace(/\\/g, "/");
+  const source = `
+import { createApiClients, createIntegrations, endpoint, type APIClientOptions, type IntegrationClientOptions } from "@farm.js/core/client";
+type Router = { hello: { get: { __types: { body: never; query: never; response: { message: string } } } } };
+const sources = { demo: { read: endpoint.get<{ value: number }>("/api/demo/read") } };
+const fetch: typeof globalThis.fetch = (input, init) => globalThis.fetch(input, init);
+const options: APIClientOptions = { fetch, integrations: { fetch } };
+const integrationOptions: IntegrationClientOptions = { fetch };
+const { api, apiClient } = createApiClients<Router, typeof sources>(options);
+api.hello.get();
+apiClient.integrations.demo.read();
+createIntegrations(sources, integrationOptions, { fetch }).api.demo.read();
+createIntegrations<typeof sources>({ fetch }).apiClient.demo.read();
+// @ts-expect-error a transport must return a Response
+createApiClients<Router>({ fetch: async () => ({ value: 1 }) });
+// @ts-expect-error fetch is an instance option, not a per-call option
+apiClient.hello.get({}, { fetch });
+`;
+  const options: ts.CompilerOptions = {
+    strict: true,
+    noEmit: true,
+    skipLibCheck: true,
+    target: ts.ScriptTarget.ES2020,
+    module: ts.ModuleKind.ESNext,
+    moduleResolution: ts.ModuleResolutionKind.Bundler,
+    baseUrl: process.cwd(),
+    paths: { "@farm.js/core/client": ["./types/client.d.ts"] },
+  };
+  const host = ts.createCompilerHost(options);
+  const getSourceFile = host.getSourceFile.bind(host);
+  host.getSourceFile = (name, languageVersion, onError, shouldCreateNewSourceFile) =>
+    name === filename
+      ? ts.createSourceFile(name, source, languageVersion, true)
+      : getSourceFile(name, languageVersion, onError, shouldCreateNewSourceFile);
+  const program = ts.createProgram({ rootNames: [filename], options, host });
+  const diagnostics = ts.formatDiagnosticsWithColorAndContext(ts.getPreEmitDiagnostics(program), {
+    getCanonicalFileName: (name) => name,
+    getCurrentDirectory: () => process.cwd(),
+    getNewLine: () => "\n",
+  });
+  expect(diagnostics).toBe("");
+}, 30_000);

--- a/packages/farm/src/api/client.ts
+++ b/packages/farm/src/api/client.ts
@@ -52,6 +52,8 @@ export type APIClientOptions = {
   credentials?: RequestCredentials;
   /** Whole-call deadline in milliseconds. 0 (default) disables it. */
   timeoutMs?: number;
+  /** HTTP transport only; local server dispatch does not use it. */
+  fetch?: typeof globalThis.fetch;
   cacheDefaults?: CacheOptions;
   integrations?: IntegrationClientOptions;
 };
@@ -551,6 +553,7 @@ export function createApiClients<
             headers: options.headers,
             credentials: options.credentials,
             timeoutMs: options.timeoutMs,
+            fetch: options.fetch,
             ...options.integrations,
           }),
         },
@@ -633,6 +636,7 @@ function createAPIClientRuntime<
 ): { client: APIClient<TRouter, TIntegrations>; request: APICall } {
   options ??= {};
   const baseURL = options.baseURL || getFarmAPIBaseURL();
+  const httpFetch = options.fetch;
   const integrationOptions =
     options.integrations === false
       ? false
@@ -641,6 +645,7 @@ function createAPIClientRuntime<
           headers: options.headers,
           credentials: options.credentials,
           timeoutMs: options.timeoutMs,
+          fetch: httpFetch,
           ...(typeof options.integrations === "object" ? options.integrations : {}),
         };
   const rootAliases =
@@ -810,7 +815,7 @@ function createAPIClientRuntime<
     }
 
     cancellation.check();
-    const response = await (transport?.fetch ?? fetch)(url.toString(), fetchOptions);
+    const response = await (transport?.fetch ?? httpFetch ?? fetch)(url.toString(), fetchOptions);
     cancellation.check();
     const invalidations = decodeFarmCacheInvalidations(
       response.headers?.get?.(FARM_CACHE_INVALIDATION_HEADER),
@@ -916,7 +921,9 @@ function createAPIClientRuntime<
           requestCacheContext = getRequestCacheContext(
             { headers: defaultHeaders, credentials: options.credentials },
             input,
-            cacheOptions?.scope,
+            // Custom transports can inject an identity outside visible headers.
+            // Never share their cached data with other client instances.
+            httpFetch ? "client" : cacheOptions?.scope,
           );
         } catch (error) {
           requestCacheContext = `invalid:${requestId}`;

--- a/packages/farm/src/integration-client.ts
+++ b/packages/farm/src/integration-client.ts
@@ -20,6 +20,8 @@ export type IntegrationClientOptions = {
   credentials?: RequestCredentials;
   /** Whole-call deadline in milliseconds; 0 disables it. */
   timeoutMs?: number;
+  /** HTTP transport, including server fallback; never replaces local dispatch. */
+  fetch?: typeof globalThis.fetch;
   data?: IntegrationClientData;
   isServer?: false | undefined;
 };
@@ -713,7 +715,7 @@ async function executeClientOperation(
   input: Record<string, unknown>,
   options: Pick<
     IntegrationClientOptions,
-    "baseURL" | "headers" | "credentials" | "data" | "timeoutMs"
+    "baseURL" | "headers" | "credentials" | "data" | "timeoutMs" | "fetch"
   >,
   requestOptions?: IntegrationClientRequestOptions,
 ) {
@@ -755,7 +757,7 @@ async function executeClientOperation(
       );
 
       const body = createOperationBody(operation, input.body, headers);
-      const response = await fetch(url.toString(), {
+      const response = await (options.fetch ?? fetch)(url.toString(), {
         method: operation.method,
         headers,
         body,
@@ -800,7 +802,14 @@ async function executeServerOperation(
   input: Record<string, unknown>,
   options: Pick<
     IntegrationServerClientOptions,
-    "baseURL" | "headers" | "credentials" | "data" | "request" | "forwardHeaders" | "timeoutMs"
+    | "baseURL"
+    | "headers"
+    | "credentials"
+    | "data"
+    | "request"
+    | "forwardHeaders"
+    | "timeoutMs"
+    | "fetch"
   >,
   requestOptions?: IntegrationServerClientRequestOptions,
   integrationKey?: string,
@@ -910,7 +919,7 @@ async function executeServerOperation(
       appendIntegrationClientDataHeader(headers, data);
 
       const body = createOperationBody(operation, input.body, headers);
-      const response = await fetch(url.toString(), {
+      const response = await (options.fetch ?? fetch)(url.toString(), {
         method: operation.method,
         headers,
         body,
@@ -1169,6 +1178,7 @@ function isIntegrationClientOptionsInput(value: unknown): value is IntegrationCl
       "headers" in value ||
       "credentials" in value ||
       "timeoutMs" in value ||
+      "fetch" in value ||
       "data" in value ||
       "isServer" in value)
   );
@@ -1185,6 +1195,7 @@ function resolveIntegrationServerOptions(
     headers: clientOptions.headers,
     credentials: clientOptions.credentials,
     timeoutMs: clientOptions.timeoutMs,
+    fetch: clientOptions.fetch,
     ...serverOptions,
     ...(data ? { data } : {}),
   };

--- a/packages/farm/types/client.d.ts
+++ b/packages/farm/types/client.d.ts
@@ -1341,6 +1341,7 @@ declare module "@farm.js/core/client" {
   export type IntegrationClientData = Record<string, unknown>;
 
   export interface IntegrationClientOptions {
+    fetch?: typeof globalThis.fetch;
     timeoutMs?: number;
     baseURL?: string;
     headers?: ClientHeaders;

--- a/skills/farmjs/SKILL.md
+++ b/skills/farmjs/SKILL.md
@@ -226,6 +226,11 @@ modules. See `docs/src/app/docs/api-client/page.md#header-defaults` and the inte
 
 ## Typed APIs and Server Data
 
+Caller `fetch` options replace HTTP only, including integration server fallback. Local route and
+registered integration dispatch remain local. Forward the supplied RequestInit/signal and return
+a Web Response. Custom-transport route caches are instance-private even with shared scope;
+reflect hidden identity changes in header defaults or create a new caller instance.
+
 Caller instances accept `timeoutMs` (0 disables it); individual calls accept `signal` and a
 deadline override. The budget includes header resolution, dispatch, decoding, and retry waits.
 Cancelled app routes return `aborted`/`timeout` errors without retries or optimistic commits;

--- a/tests/e2e/framework-features.spec.ts
+++ b/tests/e2e/framework-features.spec.ts
@@ -475,6 +475,7 @@ test.describe("Framework feature integration", () => {
           message: "server-routes",
           caller: "server",
           language: "en",
+          transport: null,
         }),
         endpoints: expect.objectContaining({
           source: "endpoints",
@@ -500,6 +501,9 @@ test.describe("Framework feature integration", () => {
     );
     await expect(page.getByTestId("integration-client-routes")).toContainText('"caller":"browser"');
     await expect(page.getByTestId("integration-client-routes")).toContainText('"language":"fr"');
+    await expect(page.getByTestId("integration-client-routes")).toContainText(
+      '"transport":"custom-fetch"',
+    );
     await page.evaluate(() => {
       document.documentElement.lang = "es";
     });


### PR DESCRIPTION
## Problem

Caller instances cannot supply their own fetch-compatible HTTP wrapper for testing or instrumentation without replacing global fetch.

## Root cause

App and integration HTTP dispatch call global fetch directly. Changing transports can also change identity outside the headers visible to Farm's shared cache.

## Change

Add instance `fetch` options to paired and existing route/integration callers. Forward shared defaults and integration/server overrides. Custom functions receive the normal resolved URL and RequestInit without an implicit `this` binding. Keep custom-transport app caches private to their instance even with explicit shared scope.

This PR is stacked on #969; its diff contains only the custom HTTP transport feature. Merge cancellation first, then this PR, then the lifecycle-hook follow-up.

## Safety and compatibility

No option means existing global-fetch behavior. Local app-route and registered integration dispatch stay local; integration HTTP fallback uses the injected function. Farm still owns result decoding, errors, cancellation, deadlines, and existing retry behavior. Wrappers should forward credentials, headers, bodies, and signals and return a Web Response. Hidden identity changes require a new caller or an identity reflected in header defaults.

Renderer-neutral, browser-safe, no new dependencies or deployment target changes.

## Verification

macOS arm64, Node 23.11.0, pnpm 8.12.1:

- 119 focused tests pass across custom fetch, cancellation, existing route/paired/integration callers, and header resolvers.
- Of 7 new tests, 6 fail against the parent implementation; the local-dispatch correctness control already passes.
- Published declaration compilation for custom fetch.
- `pnpm --filter @farm.js/core type-check`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @farm.js/core build`
- Focused formatting/lint (0 errors; existing unused integration helper warning).
- Maintained integration-lab browser test asserts the custom wrapper's header reaches HTTP handlers and is absent from local server dispatch; run against the Node production build.

## Documentation and release

Updated API-client and integration guides, published client types, Farm skill, existing integration-lab example, and production-compatible browser regression. No versions, tags, generated route changes, or new packages.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caller instances can now supply their own fetch-compatible HTTP transport for testing or instrumentation without replacing global fetch. Adds an instance `fetch` option to API client, integration client, and paired callers; without it, dispatch uses global fetch as before.

- Custom functions receive the resolved URL and `RequestInit` without implicit `this` binding; forward credentials, headers, bodies, and signals and return a Web `Response`.
- App-route caches stay private to instances with a custom transport, even with explicit shared scope; hidden identity changes require a new caller or identity in header defaults.
- Local app-route and registered integration dispatch stay local; only HTTP calls use the injected function, including integration server fallback.
- `integrations.fetch` overrides the shared option; Farm still owns decoding, errors, cancellation, deadlines, and retries.
- Docs, published `@farm.js/core/client` types, skill, example, and e2e coverage updated.

<sup>Written for commit 00c9408a30774a76ef403084457e816c7691dd98. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/971?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

