### PR TITLE
feat(client): compose shared lifecycle observers

### DIFF
--- a/docs/src/app/docs/api-client/page.md
+++ b/docs/src/app/docs/api-client/page.md
@@ -172,6 +172,55 @@ App-route caches stay private to instances with a custom transport, even with
 see. If a wrapper changes users internally, also reflect that identity in the caller's
 header resolver or create a new instance; Farm cannot detect hidden identity changes.
 
+## Shared lifecycle hooks
+
+Set `onRequest`, `onResponse`, or `onError` on the caller instance for shared logging or error
+reporting. These are ordinary callbacks, not React hooks:
+
+```ts
+export const { api, apiClient } = createApiClients<APIRouter>({
+  routes: apiRoutes,
+  onRequest(event) {
+    console.debug(event.method, event.path);
+  },
+  onResponse(_data, _error, event) {
+    console.debug("Status:", event.status);
+  },
+  onError(error) {
+    console.error(error.message);
+  },
+});
+
+await apiClient.hello.get(
+  {},
+  {
+    onError(error) {
+      // Handle this call's error in the UI as well as shared reporting.
+      console.debug("Could not load greeting:", error.message);
+    },
+  },
+);
+```
+
+Shared hooks run first, then the corresponding per-call hook. Per-call route response types
+remain inferred. Shared hooks use `unknown` data because one instance covers many routes;
+`ClientLifecycleHooks`, `ClientRequestEvent`, and `ClientResponseEvent` are exported for reusable
+observers. Return values are ignored. Promises are not awaited, and thrown/rejected shared
+hooks are reported through `globalThis.reportError` (or console) without failing the call.
+Asynchronous work may finish out of order even though callbacks are invoked shared-first.
+
+`onRequest`/`onResponse` observe execution attempts, including retries and background refreshes,
+not cache hits. Deduplicated requests share attempt events. `onError` runs once on final failure
+for each logical call, including background failures; it does not run for each failed retry.
+An attempt can fail before HTTP dispatch, such as header resolution or cancellation. A response
+event observes a completed attempt; aborting inside it cannot retroactively cancel that result.
+These hooks do not add retries or replace existing per-call success, settlement, or status hooks.
+
+Shared defaults apply to integration callers too. `integrations.onRequest`, `onResponse`, and
+`onError` replace the corresponding shared default for integrations; per-call hooks still compose.
+Local server calls run their hooks on the server; HTTP callers run them where invoked. Keep
+shared observers browser-safe and avoid logging credentials, request bodies, or personal data.
+
 ## Call a route
 
 **Browser usage**

--- a/docs/src/app/docs/integrations/page.md
+++ b/docs/src/app/docs/integrations/page.md
@@ -379,6 +379,28 @@ integration-only factories accept it too. With combined route/integration caller
 and preserve request credentials, headers, and signals. Return a Web `Response`; do not put
 provider SDKs or server credentials in a shared module.
 
+## Shared lifecycle hooks
+
+Integration callers accept the same [`onRequest`, `onResponse`, and `onError`
+observers](/docs/api-client#shared-lifecycle-hooks) on the instance and in the second, per-call
+argument. Shared hooks run before per-call hooks; neither replaces the other. Per-call
+`onResponse` data is inferred from the operation's response type, while instance data is `unknown`.
+On failure the observer receives `undefined` data; the operation result still uses `{ data: null, error }`.
+
+Hooks cover browser HTTP, server HTTP fallback, and registered local dispatch. Response events
+include the path, method, request ID, timestamp, and available response/status. Integrations
+have one attempt (`attempt: 0`); these hooks do not introduce automatic retries. Resolver and
+cancellation failures are reported too, even when no HTTP request was sent.
+
+`onError` runs on final failure. Hook return values are ignored; throwing or rejecting hooks are
+reported without changing the result, and promises are not awaited. Do not rely on observer
+completion for authorization, transactions, or required background work.
+
+The separate server-options argument replaces the corresponding instance hook for `api`;
+`createApiClients`'s `integrations` options can override shared defaults in the same way.
+Per-call hooks still compose after the effective instance hook. Shared observer modules must
+remain browser-safe and should log only intentional, non-sensitive metadata.
+
 ## Shared data
 
 `createIntegrations({ data })` adds small per-call metadata to integration requests. It is useful for tenant IDs, locale, analytics context, or feature flags.

--- a/examples/basic/src/lib/integration-lab-api.ts
+++ b/examples/basic/src/lib/integration-lab-api.ts
@@ -6,6 +6,16 @@ export const {
   apiClient: integrationApiClient,
 } = createIntegrations<typeof integrationLab>({
   timeoutMs: 30_000,
+  onRequest({ method, path }) {
+    if (typeof window !== 'undefined') {
+      window.dispatchEvent(new CustomEvent('integration-lab:request', { detail: { method, path } }));
+    }
+  },
+  onResponse(_data, _error, { method, path, status }) {
+    if (typeof window !== 'undefined') {
+      window.dispatchEvent(new CustomEvent('integration-lab:response', { detail: { method, path, status } }));
+    }
+  },
   fetch: (url, init) => {
     const headers = new Headers(init?.headers);
     headers.set('x-integration-lab-transport', 'custom-fetch');

--- a/packages/farm/src/__tests__/client-lifecycle-hooks.test.ts
+++ b/packages/farm/src/__tests__/client-lifecycle-hooks.test.ts
@@ -1,0 +1,286 @@
+// @vitest-environment node
+import { afterEach, expect, it, vi } from "vitest";
+import { createApiClients } from "../api/client";
+import { createEndpoint } from "../api/endpoint";
+import { createIntegrations } from "../integration-client";
+import { endpoint } from "../integration-api";
+import { _runWithAPIRequestRuntime } from "../api/server-context";
+import { _runWithCurrentRequest } from "../server/request";
+import { defineIntegration, integrationRoute, resolveIntegrationPlugins } from "../integrations";
+import { PluginManager } from "../plugin";
+
+const get = createEndpoint({ method: "GET" }, () => ({ value: 1 }));
+type Router = { value: { get: typeof get } };
+const sources = { demo: { read: endpoint.get<{ value: number }>("/api/demo/read") } };
+afterEach(() => vi.unstubAllGlobals());
+
+it("composes route attempt and terminal-error hooks, shared before per-call", async () => {
+  const events: string[] = [];
+  const fetch = vi.fn(async () => Response.json({}, { status: 503 }));
+  const { apiClient } = createApiClients<Router>({
+    fetch,
+    onRequest: (event) => events.push(`shared:request:${event.attempt}`),
+    onResponse: (_data, _error, event) => events.push(`shared:response:${event.status}`),
+    onError: () => events.push("shared:error"),
+  });
+  const result = await apiClient.value.get(
+    {},
+    {
+      retry: { count: 1 },
+      onRequest: (event) => events.push(`local:request:${event.attempt}`),
+      onResponse: (_data, _error, event) => events.push(`local:response:${event.status}`),
+      onError: () => events.push("local:error"),
+    },
+  );
+  expect(result.error).toMatchObject({ status: 503 });
+  expect(events).toEqual([
+    "shared:request:0",
+    "local:request:0",
+    "shared:response:503",
+    "local:response:503",
+    "shared:request:1",
+    "local:request:1",
+    "shared:response:503",
+    "local:response:503",
+    "shared:error",
+    "local:error",
+  ]);
+});
+
+it("does not run attempt hooks on cache hits or duplicate a deduplicated transport", async () => {
+  let resolve!: (response: Response) => void;
+  const fetch = vi.fn(
+    () =>
+      new Promise<Response>((done) => {
+        resolve = done;
+      }),
+  );
+  const onRequest = vi.fn();
+  const onResponse = vi.fn();
+  const { apiClient } = createApiClients<Router>({ fetch, onRequest, onResponse });
+  const cache = { staleTime: 60_000, dedupeMs: 60_000 };
+  const first = apiClient.value.get({}, { cache });
+  const second = apiClient.value.get({}, { cache });
+  resolve(Response.json({ value: 1 }));
+  await Promise.all([first, second]);
+  await apiClient.value.get({}, { cache });
+  expect(fetch).toHaveBeenCalledOnce();
+  expect(onRequest).toHaveBeenCalledOnce();
+  expect(onResponse).toHaveBeenCalledOnce();
+});
+
+it("isolates throwing and rejecting shared observers without waiting on them", async () => {
+  const report = vi.fn();
+  vi.stubGlobal("reportError", report);
+  const { apiClient } = createApiClients<Router>({
+    fetch: async () => Response.json({ value: 1 }),
+    onRequest: () => {
+      throw new Error("logger failed");
+    },
+    onResponse: async () => {
+      throw new Error("async logger failed");
+    },
+  });
+  expect((await apiClient.value.get()).data).toEqual({ value: 1 });
+  await Promise.resolve();
+  expect(report).toHaveBeenCalledTimes(2);
+  const never = createApiClients<Router>({
+    fetch: async () => Response.json({ value: 2 }),
+    onRequest: () => new Promise(() => {}),
+  });
+  expect((await never.apiClient.value.get()).data).toEqual({ value: 2 });
+});
+
+it.each(["client", "server"] as const)(
+  "composes integration %s hooks with response metadata",
+  async (side) => {
+    if (side === "client") vi.stubGlobal("window", { location: { origin: "https://farm.test" } });
+    const events: string[] = [];
+    const pair = createIntegrations(sources, {
+      fetch: async () => Response.json({}, { status: 503 }),
+      onRequest: (event) => events.push(`shared:${event.method}:${event.path}`),
+      onResponse: (_data, error, event) => {
+        expect(error).toBeInstanceOf(Error);
+        events.push(`shared:response:${event.status}`);
+      },
+      onError: () => events.push("shared:error"),
+    });
+    const result = await (side === "server" ? pair.api : pair.apiClient).demo.read(
+      {},
+      {
+        onRequest: () => events.push("local:request"),
+        onResponse: () => events.push("local:response"),
+        onError: () => events.push("local:error"),
+      },
+    );
+    expect(result.error).toMatchObject({ status: 503 });
+    expect(events).toEqual([
+      "shared:GET:/api/demo/read",
+      "local:request",
+      "shared:response:503",
+      "local:response",
+      "shared:error",
+      "local:error",
+    ]);
+  },
+);
+
+it("recognizes hook-only automatic integration options and paired defaults", async () => {
+  vi.stubGlobal("window", {
+    location: { origin: "https://farm.test" },
+    __FARM_INTEGRATION_API_MANIFEST__: sources,
+  });
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => Response.json({ value: 1 })),
+  );
+  const onRequest = vi.fn();
+  const automatic = createIntegrations<typeof sources>({ onRequest });
+  await automatic.apiClient.demo.read();
+  const { apiClient } = createApiClients<Router, typeof sources>({ onRequest });
+  await apiClient.integrations.demo.read();
+  expect(onRequest).toHaveBeenCalledTimes(2);
+});
+
+it("reports cancellation once and preserves local onError when the shared hook throws", async () => {
+  vi.stubGlobal("reportError", vi.fn());
+  const shared = vi.fn(() => {
+    throw new Error("reporter failed");
+  });
+  const local = vi.fn();
+  const { apiClient } = createApiClients<Router>({ onError: shared });
+  const result = await apiClient.value.get({}, { signal: AbortSignal.abort(), onError: local });
+  expect(result.error).toMatchObject({ code: "aborted" });
+  expect(shared).toHaveBeenCalledOnce();
+  expect(local).toHaveBeenCalledOnce();
+});
+
+it("observes local app-route and registered integration dispatch without HTTP", async () => {
+  const fetch = vi.fn();
+  vi.stubGlobal("fetch", fetch);
+  const onRequest = vi.fn();
+  const onResponse = vi.fn();
+  const integration = defineIntegration({
+    category: "custom",
+    type: "hook-demo",
+    instance: {},
+    routes: [
+      integrationRoute.get("/api/hook-demo/read", {
+        responseFormat: "json",
+        handler: () => Response.json({ value: 2 }, { status: 201 }),
+      }),
+    ],
+  });
+  const manager = new PluginManager({
+    config: { integrations: { hookDemo: integration } } as any,
+    isDev: true,
+    isProd: false,
+  });
+  manager.addPlugins(resolveIntegrationPlugins({ hookDemo: integration }));
+  await manager.runHookParallel("init");
+  const pair = createApiClients<Router, { hookDemo: typeof integration }>({
+    onRequest,
+    onResponse,
+  });
+  await _runWithAPIRequestRuntime(
+    { basePath: "/api", dispatch: async () => Response.json({ value: 1 }) },
+    () =>
+      _runWithCurrentRequest(new Request("https://farm.test/page"), async () => {
+        expect((await pair.api.value.get()).data).toEqual({ value: 1 });
+        expect((await pair.api.integrations.hookDemo.read.get()).data).toEqual({ value: 2 });
+      }),
+  );
+  expect(onRequest).toHaveBeenCalledTimes(2);
+  expect(onResponse).toHaveBeenCalledTimes(2);
+  expect(onResponse.mock.calls[1][2]).toMatchObject({
+    status: 201,
+    ok: true,
+    path: "/api/hook-demo/read",
+  });
+  expect(fetch).not.toHaveBeenCalled();
+});
+
+it("runs error observers after a failed resolver without dispatch", async () => {
+  vi.stubGlobal("window", { location: { origin: "https://farm.test" } });
+  vi.stubGlobal("reportError", vi.fn());
+  const fetch = vi.fn();
+  const failure = new Error("headers failed");
+  const onResponse = vi.fn();
+  const onError = vi.fn(async () => {
+    throw new Error("report failed");
+  });
+  const local = vi.fn();
+  const pair = createIntegrations(sources, {
+    fetch,
+    headers: () => {
+      throw failure;
+    },
+    onResponse,
+    onError,
+  });
+  expect((await pair.apiClient.demo.read({}, { onError: local })).error).toBe(failure);
+  expect(onResponse).toHaveBeenCalledWith(
+    undefined,
+    failure,
+    expect.objectContaining({ ok: false, status: undefined }),
+  );
+  expect(onError).toHaveBeenCalledOnce();
+  expect(local).toHaveBeenCalledOnce();
+  expect(fetch).not.toHaveBeenCalled();
+});
+
+it("allows integration instance/server overrides while still composing per-call hooks", async () => {
+  const shared = vi.fn();
+  const integration = vi.fn();
+  const server = vi.fn();
+  const local = vi.fn();
+  const fetch = async () => Response.json({ value: 1 });
+  const pair = createIntegrations(sources, { fetch, onRequest: shared }, { onRequest: server });
+  await pair.api.demo.read({}, { onRequest: local });
+  expect(shared).not.toHaveBeenCalled();
+  expect(server).toHaveBeenCalledOnce();
+  vi.stubGlobal("window", {
+    location: { origin: "https://farm.test" },
+    __FARM_INTEGRATION_API_MANIFEST__: sources,
+  });
+  const combined = createApiClients<Router, typeof sources>({
+    fetch,
+    onRequest: shared,
+    integrations: { onRequest: integration },
+  });
+  await combined.apiClient.integrations.demo.read({}, { onRequest: local });
+  expect(integration).toHaveBeenCalledOnce();
+  expect(shared).not.toHaveBeenCalled();
+  expect(local).toHaveBeenCalledTimes(2);
+});
+
+it("does not emit a second response when an observer aborts an already-completed attempt", async () => {
+  const controller = new AbortController();
+  const onResponse = vi.fn(() => controller.abort());
+  const { apiClient } = createApiClients<Router>({
+    fetch: async () => Response.json({ value: 1 }),
+    onResponse,
+  });
+  expect((await apiClient.value.get({}, { signal: controller.signal })).data).toEqual({ value: 1 });
+  expect(onResponse).toHaveBeenCalledOnce();
+});
+
+it("reports background failures globally without calling foreground-only callbacks", async () => {
+  let finish!: () => void;
+  const reported = new Promise<void>((resolve) => {
+    finish = resolve;
+  });
+  const onError = vi.fn(finish);
+  const local = vi.fn();
+  const fetch = vi
+    .fn()
+    .mockResolvedValueOnce(Response.json({ value: 1 }))
+    .mockResolvedValueOnce(Response.json({}, { status: 503 }));
+  const { apiClient } = createApiClients<Router>({ fetch, onError });
+  const cache = { policy: "stale-while-revalidate" as const, staleTime: 0 };
+  await apiClient.value.get({}, { cache });
+  expect((await apiClient.value.get({}, { cache, onError: local })).data).toEqual({ value: 1 });
+  await reported;
+  expect(onError).toHaveBeenCalledOnce();
+  expect(local).not.toHaveBeenCalled();
+});

--- a/packages/farm/src/__tests__/client-lifecycle-hooks.typing.test.ts
+++ b/packages/farm/src/__tests__/client-lifecycle-hooks.typing.test.ts
@@ -1,0 +1,57 @@
+// @vitest-environment node
+import path from "node:path";
+import ts from "typescript";
+import { expect, it } from "vitest";
+
+it("exposes shared lifecycle hooks through the published client declarations", () => {
+  // TypeScript normalizes compiler filenames to forward slashes, including on Windows.
+  const filename = path.resolve("client-lifecycle-hooks.type-test.ts").replace(/\\/g, "/");
+  const source = `
+import { createApiClients, createIntegrations, endpoint, type ClientLifecycleHooks } from "@farm.js/core/client";
+type Router = { hello: { get: { __types: { body: never; query: never; response: { message: string } } } } };
+const sources = { demo: { read: endpoint.get<{ value: number }>("/api/demo/read") } };
+const hooks: ClientLifecycleHooks = {
+  onRequest(event) { const method: string = event.method; },
+  onResponse(data, error, event) { const status: number | undefined = event.status;
+    // @ts-expect-error a shared observer cannot assume one route's shape
+    data.message;
+  },
+  onError(error) { const message: string = error.message; }
+};
+const { api, apiClient } = createApiClients<Router, typeof sources>({ ...hooks, integrations: hooks });
+api.hello.get({}, { onResponse(data) { const message: string | undefined = data?.message; } });
+apiClient.integrations.demo.read({}, { onResponse(data) {
+  const value: number | undefined = data?.value;
+  // @ts-expect-error integration per-call response data remains typed
+  data?.missing;
+} });
+const pair = createIntegrations(sources, hooks, hooks);
+pair.api.demo.read({}, { onResponse(data) { const value: number | undefined = data?.value; } });
+createIntegrations<typeof sources>({ onError: hooks.onError }).apiClient.demo.read();
+// @ts-expect-error a request observer receives an event, not a number
+createApiClients<Router>({ onRequest: (value: number) => {} });
+`;
+  const options: ts.CompilerOptions = {
+    strict: true,
+    noEmit: true,
+    skipLibCheck: true,
+    target: ts.ScriptTarget.ES2020,
+    module: ts.ModuleKind.ESNext,
+    moduleResolution: ts.ModuleResolutionKind.Bundler,
+    baseUrl: process.cwd(),
+    paths: { "@farm.js/core/client": ["./types/client.d.ts"] },
+  };
+  const host = ts.createCompilerHost(options);
+  const getSourceFile = host.getSourceFile.bind(host);
+  host.getSourceFile = (name, languageVersion, onError, shouldCreateNewSourceFile) =>
+    name === filename
+      ? ts.createSourceFile(name, source, languageVersion, true)
+      : getSourceFile(name, languageVersion, onError, shouldCreateNewSourceFile);
+  const program = ts.createProgram({ rootNames: [filename], options, host });
+  const diagnostics = ts.formatDiagnosticsWithColorAndContext(ts.getPreEmitDiagnostics(program), {
+    getCanonicalFileName: (name) => name,
+    getCurrentDirectory: () => process.cwd(),
+    getNewLine: () => "\n",
+  });
+  expect(diagnostics).toBe("");
+}, 30_000);

--- a/packages/farm/src/api/client.ts
+++ b/packages/farm/src/api/client.ts
@@ -25,6 +25,7 @@ import type { RoutePathParams } from "./route";
 import { _resolveCurrentRequest } from "../server/request-bridge";
 import { resolveClientHeaders, type ClientHeaders } from "../client-headers";
 import { createClientCancellation } from "../client-cancellation";
+import { notifyClientObserver, type ClientLifecycleHooks } from "../client-observers";
 import { resolveAPIRequestRuntime, type APIRequestRuntime } from "./server-client-bridge";
 export type { APIRouteManifest } from "./client-routes";
 import {
@@ -44,7 +45,7 @@ export type APIRouteRefMetadata = {
   sameOrigin: boolean;
 };
 
-export type APIClientOptions = {
+export type APIClientOptions = ClientLifecycleHooks & {
   /** Generated path/method metadata required for dynamic shorthand and $params scopes. */
   routes?: APIRouteManifest;
   baseURL?: string;
@@ -554,6 +555,9 @@ export function createApiClients<
             credentials: options.credentials,
             timeoutMs: options.timeoutMs,
             fetch: options.fetch,
+            onRequest: options.onRequest,
+            onResponse: options.onResponse,
+            onError: options.onError,
             ...options.integrations,
           }),
         },
@@ -646,6 +650,9 @@ function createAPIClientRuntime<
           credentials: options.credentials,
           timeoutMs: options.timeoutMs,
           fetch: httpFetch,
+          onRequest: options.onRequest,
+          onResponse: options.onResponse,
+          onError: options.onError,
           ...(typeof options.integrations === "object" ? options.integrations : {}),
         };
   const rootAliases =
@@ -1065,6 +1072,7 @@ function createAPIClientRuntime<
 
             if (result.error) {
               emitStatus("error", { error: result.error, isBackground: opts?.isBackground });
+              notifyClientObserver(options.onError, [result.error]);
               if (opts?.callCallbacks !== false) {
                 clientOptions?.onError?.(result.error);
               }
@@ -1088,15 +1096,19 @@ function createAPIClientRuntime<
 
             // eslint-disable-next-line no-constant-condition
             while (true) {
-              clientOptions?.onRequest?.({
-                requestId,
-                method: methodUpper,
-                key: cacheKey,
-                path,
-                input,
-                attempt,
-                timestamp: Date.now(),
-              });
+              if (options.onRequest || clientOptions?.onRequest) {
+                const requestEvent: RequestEvent = {
+                  requestId,
+                  method: methodUpper,
+                  key: cacheKey,
+                  path,
+                  input,
+                  attempt,
+                  timestamp: Date.now(),
+                };
+                notifyClientObserver(options.onRequest, [requestEvent]);
+                clientOptions?.onRequest?.(requestEvent);
+              }
 
               try {
                 if (requestContextError) throw requestContextError;
@@ -1129,6 +1141,11 @@ function createAPIClientRuntime<
                   status: response.status,
                 };
 
+                notifyClientObserver(options.onResponse, [
+                  response.ok ? data : undefined,
+                  error,
+                  responseEvent,
+                ]);
                 notifyResponseObserver(
                   clientOptions?.onResponse,
                   response.ok ? data : undefined,
@@ -1137,7 +1154,6 @@ function createAPIClientRuntime<
                 );
 
                 if (!error) {
-                  cancellation.check();
                   return { data, error: null, key: cacheKey } as APIResult<any, Error>;
                 }
 
@@ -1158,6 +1174,7 @@ function createAPIClientRuntime<
                   ok: false,
                 };
 
+                notifyClientObserver(options.onResponse, [undefined, error, responseEvent]);
                 notifyResponseObserver(clientOptions?.onResponse, undefined, error, responseEvent);
 
                 if (attempt >= maxRetries || requestContextError || cancellation.signal?.aborted) {
@@ -1209,6 +1226,7 @@ function createAPIClientRuntime<
 
             if (result.error) {
               emitStatus("error", { error: result.error, isBackground: opts?.isBackground });
+              notifyClientObserver(options.onError, [result.error]);
               if (opts?.callCallbacks !== false) {
                 clientOptions?.onError?.(result.error);
               }
@@ -1897,34 +1915,7 @@ function notifyResponseObserver(
   error: unknown,
   event: ResponseEvent<any, any>,
 ): void {
-  if (!observer) return;
-
-  try {
-    const result = observer(data, error, event) as unknown;
-    if (result && typeof (result as PromiseLike<unknown>).then === "function") {
-      void Promise.resolve(result).catch(reportResponseObserverError);
-    }
-  } catch (observerError) {
-    reportResponseObserverError(observerError);
-  }
-}
-
-function reportResponseObserverError(error: unknown): void {
-  const reportError = (globalThis as typeof globalThis & { reportError?: (error: unknown) => void })
-    .reportError;
-  if (typeof reportError === "function") {
-    try {
-      reportError.call(globalThis, error);
-      return;
-    } catch {
-      // Fall through to the console when the platform reporter itself fails.
-    }
-  }
-  try {
-    console.error("[Farm.js] API client onResponse callback failed:", error);
-  } catch {
-    // Observers and their reporting fallbacks must never affect the request.
-  }
+  notifyClientObserver(observer, [data, error, event], "API client onResponse");
 }
 
 function isFormData(value: unknown): value is FormData {

--- a/packages/farm/src/client-observers.ts
+++ b/packages/farm/src/client-observers.ts
@@ -1,0 +1,60 @@
+/** Metadata shared by app-route and integration execution attempts. */
+export type ClientRequestEvent = {
+  requestId: string;
+  method: string;
+  path: string;
+  attempt: number;
+  timestamp: number;
+};
+
+export type ClientResponseEvent<TData = unknown> = ClientRequestEvent & {
+  response?: Response;
+  data?: TData;
+  error?: Error;
+  ok?: boolean;
+  status?: number;
+};
+
+/** Observers compose with per-call hooks; return values never replace the result. */
+export type ClientLifecycleHooks<TData = unknown> = {
+  onRequest?: (event: ClientRequestEvent) => void;
+  onResponse?: (
+    data: TData | undefined,
+    error: Error | null,
+    event: ClientResponseEvent<TData>,
+  ) => void;
+  onError?: (error: Error) => void;
+};
+
+export function notifyClientObserver(
+  observer: ((...args: any[]) => unknown) | undefined,
+  args: unknown[],
+  label = "Client lifecycle",
+): void {
+  if (!observer) return;
+  const report = (error: unknown) => {
+    const reportError = (
+      globalThis as typeof globalThis & { reportError?: (error: unknown) => void }
+    ).reportError;
+    if (typeof reportError === "function") {
+      try {
+        reportError.call(globalThis, error);
+        return;
+      } catch {
+        /* Try the console fallback. */
+      }
+    }
+    try {
+      console.error(`[Farm.js] ${label} callback failed:`, error);
+    } catch {
+      /* Reporting must not affect a call. */
+    }
+  };
+  try {
+    const result = observer(...args);
+    if (result && typeof (result as PromiseLike<unknown>).then === "function")
+      void Promise.resolve(result).catch(report);
+  } catch (error) {
+    report(error);
+  }
+}

--- a/packages/farm/src/client.ts
+++ b/packages/farm/src/client.ts
@@ -17,6 +17,11 @@ export type {
 } from "./api/client";
 export type { FarmAPIStream } from "./api/transport";
 export type { ClientHeaders } from "./client-headers";
+export type {
+  ClientLifecycleHooks,
+  ClientRequestEvent,
+  ClientResponseEvent,
+} from "./client-observers";
 export { useMutation } from "./mutation-client";
 export type {
   AnyMutationTarget,

--- a/packages/farm/src/integration-client.ts
+++ b/packages/farm/src/integration-client.ts
@@ -7,6 +7,12 @@ import type { FarmIntegration as FarmIntegrationDefinition } from "./integration
 import { resolveFarmAPIRequestURL } from "./api/config";
 import { resolveClientHeaders, type ClientHeaders } from "./client-headers";
 import { createClientCancellation } from "./client-cancellation";
+import {
+  notifyClientObserver,
+  type ClientLifecycleHooks,
+  type ClientRequestEvent,
+  type ClientResponseEvent,
+} from "./client-observers";
 
 /**
  * Small per-call integration metadata. When sent from a browser, values are
@@ -14,7 +20,7 @@ import { createClientCancellation } from "./client-cancellation";
  */
 export type IntegrationClientData = Record<string, unknown>;
 
-export type IntegrationClientOptions = {
+export type IntegrationClientOptions = ClientLifecycleHooks & {
   baseURL?: string;
   headers?: ClientHeaders;
   credentials?: RequestCredentials;
@@ -26,7 +32,7 @@ export type IntegrationClientOptions = {
   isServer?: false | undefined;
 };
 
-type IntegrationRequestOptionsBase = {
+type IntegrationRequestOptionsBase<TData = unknown> = ClientLifecycleHooks<TData> & {
   headers?: Record<string, string>;
   signal?: AbortSignal;
   timeoutMs?: number;
@@ -34,7 +40,7 @@ type IntegrationRequestOptionsBase = {
   data?: IntegrationClientData;
 };
 
-export type IntegrationClientRequestOptions = IntegrationRequestOptionsBase;
+export type IntegrationClientRequestOptions<TData = unknown> = IntegrationRequestOptionsBase<TData>;
 
 export type IntegrationServerRequestLike =
   | Request
@@ -49,11 +55,12 @@ export type IntegrationServerClientOptions = Omit<IntegrationClientOptions, "isS
   forwardHeaders?: boolean | readonly string[];
 };
 
-export type IntegrationServerClientRequestOptions = IntegrationRequestOptionsBase & {
-  baseURL?: string;
-  request?: IntegrationServerRequestLike;
-  forwardHeaders?: boolean | readonly string[];
-};
+export type IntegrationServerClientRequestOptions<TData = unknown> =
+  IntegrationRequestOptionsBase<TData> & {
+    baseURL?: string;
+    request?: IntegrationServerRequestLike;
+    forwardHeaders?: boolean | readonly string[];
+  };
 
 export class IntegrationClientError<TData = unknown> extends Error {
   readonly status: number;
@@ -112,12 +119,12 @@ type OperationInput<T> =
 
 type ClientOperation<T> = (
   options?: OperationInput<T>,
-  requestOptions?: IntegrationClientRequestOptions,
+  requestOptions?: IntegrationClientRequestOptions<ExtractOperationResponse<T>>,
 ) => Promise<IntegrationOperationResult<ExtractOperationResponse<T>>>;
 
 type ServerOperation<T> = (
   options?: OperationInput<T>,
-  requestOptions?: IntegrationServerClientRequestOptions,
+  requestOptions?: IntegrationServerClientRequestOptions<ExtractOperationResponse<T>>,
 ) => Promise<IntegrationOperationResult<ExtractOperationResponse<T>>>;
 
 type IsUnion<T, U = T> = T extends any ? ([U] extends [T] ? false : true) : never;
@@ -710,21 +717,78 @@ async function finalizeOperationResponse(
   };
 }
 
+let integrationRequestCounter = 0;
+const noIntegrationObservers = {
+  response(_response: Response) {},
+  finish<T extends IntegrationOperationResult>(result: T): T {
+    return result;
+  },
+};
+
+function createIntegrationObservers(
+  operation: FarmIntegrationAPIOperation<any, any, any>,
+  options: ClientLifecycleHooks,
+  requestOptions?: ClientLifecycleHooks,
+) {
+  if (
+    !options.onRequest &&
+    !options.onResponse &&
+    !options.onError &&
+    !requestOptions?.onRequest &&
+    !requestOptions?.onResponse &&
+    !requestOptions?.onError
+  ) {
+    return noIntegrationObservers;
+  }
+  const requestEvent: ClientRequestEvent = {
+    requestId: `integration-${Date.now()}-${++integrationRequestCounter}`,
+    method: operation.method,
+    path: operation.path ?? "",
+    attempt: 0,
+    timestamp: Date.now(),
+  };
+  let response: Response | undefined;
+  notifyClientObserver(options.onRequest, [requestEvent]);
+  notifyClientObserver(requestOptions?.onRequest, [requestEvent]);
+  return {
+    response(value: Response) {
+      response = value;
+    },
+    finish<T extends IntegrationOperationResult>(result: T): T {
+      const data = result.error ? undefined : result.data;
+      const event: ClientResponseEvent = {
+        ...requestEvent,
+        timestamp: Date.now(),
+        response,
+        data,
+        error: result.error ?? undefined,
+        ok: !result.error,
+        status: response?.status,
+      };
+      notifyClientObserver(options.onResponse, [data, result.error, event]);
+      notifyClientObserver(requestOptions?.onResponse, [data, result.error, event]);
+      if (result.error) {
+        notifyClientObserver(options.onError, [result.error]);
+        notifyClientObserver(requestOptions?.onError, [result.error]);
+      }
+      return result;
+    },
+  };
+}
+
 async function executeClientOperation(
   operation: FarmIntegrationAPIOperation<any, any, any>,
   input: Record<string, unknown>,
-  options: Pick<
-    IntegrationClientOptions,
-    "baseURL" | "headers" | "credentials" | "data" | "timeoutMs" | "fetch"
-  >,
+  options: IntegrationClientOptions,
   requestOptions?: IntegrationClientRequestOptions,
 ) {
   const cancellation = createClientCancellation(
     requestOptions?.signal,
     requestOptions?.timeoutMs ?? options.timeoutMs,
   );
+  const observers = createIntegrationObservers(operation, options, requestOptions);
   try {
-    return await cancellation.run(async () => {
+    const result = await cancellation.run(async () => {
       if (!operation.path) {
         return {
           data: null,
@@ -767,6 +831,7 @@ async function executeClientOperation(
       });
       cancellation.check();
 
+      observers.response(response);
       if (!response.ok) {
         const errorData = await safeParseResponseData(response);
         return {
@@ -787,11 +852,12 @@ async function executeClientOperation(
         error: null,
       };
     });
+    return observers.finish(result);
   } catch (error) {
-    return {
+    return observers.finish({
       data: null,
       error: normalizeExecutionError(error),
-    };
+    });
   } finally {
     cancellation.dispose();
   }
@@ -800,17 +866,7 @@ async function executeClientOperation(
 async function executeServerOperation(
   operation: FarmIntegrationAPIOperation<any, any, any>,
   input: Record<string, unknown>,
-  options: Pick<
-    IntegrationServerClientOptions,
-    | "baseURL"
-    | "headers"
-    | "credentials"
-    | "data"
-    | "request"
-    | "forwardHeaders"
-    | "timeoutMs"
-    | "fetch"
-  >,
+  options: Omit<IntegrationServerClientOptions, "isServer">,
   requestOptions?: IntegrationServerClientRequestOptions,
   integrationKey?: string,
   source?: FarmIntegrationDefinition | FarmIntegrationAPI,
@@ -827,8 +883,9 @@ async function executeServerOperation(
     requestOptions?.timeoutMs ?? options.timeoutMs,
     currentRequest?.signal,
   );
+  const observers = createIntegrationObservers(operation, options, requestOptions);
   try {
-    return await cancellation.run(async () => {
+    const result = await cancellation.run(async () => {
       if (!operation.path) {
         return {
           data: null,
@@ -911,6 +968,7 @@ async function executeServerOperation(
           cancellation.check();
 
           if (directResponse) {
+            observers.response(directResponse);
             return await finalizeOperationResponse(operation, directResponse);
           }
         }
@@ -929,13 +987,15 @@ async function executeServerOperation(
       });
       cancellation.check();
 
+      observers.response(response);
       return await finalizeOperationResponse(operation, response);
     });
+    return observers.finish(result);
   } catch (error) {
-    return {
+    return observers.finish({
       data: null,
       error: normalizeExecutionError(error),
-    };
+    });
   } finally {
     cancellation.dispose();
   }
@@ -1179,6 +1239,9 @@ function isIntegrationClientOptionsInput(value: unknown): value is IntegrationCl
       "credentials" in value ||
       "timeoutMs" in value ||
       "fetch" in value ||
+      "onRequest" in value ||
+      "onResponse" in value ||
+      "onError" in value ||
       "data" in value ||
       "isServer" in value)
   );
@@ -1196,6 +1259,9 @@ function resolveIntegrationServerOptions(
     credentials: clientOptions.credentials,
     timeoutMs: clientOptions.timeoutMs,
     fetch: clientOptions.fetch,
+    onRequest: clientOptions.onRequest,
+    onResponse: clientOptions.onResponse,
+    onError: clientOptions.onError,
     ...serverOptions,
     ...(data ? { data } : {}),
   };

--- a/packages/farm/types/client.d.ts
+++ b/packages/farm/types/client.d.ts
@@ -22,6 +22,9 @@ import type {
   RouteAPIClient as CoreRouteAPIClient,
   APIClientOptions as CoreAPIClientOptions,
   ClientHeaders as CoreClientHeaders,
+  ClientLifecycleHooks as CoreClientLifecycleHooks,
+  ClientRequestEvent as CoreClientRequestEvent,
+  ClientResponseEvent as CoreClientResponseEvent,
   ApiClients as CoreApiClients,
   APIClientWithoutIntegrationsOptions as CoreAPIClientWithoutIntegrationsOptions,
 } from "../dist/client";
@@ -562,6 +565,9 @@ declare module "@farm.js/core/client" {
   export function installChunkErrorRecovery(options?: FarmChunkRecoveryOptions): () => void;
 
   export type ClientHeaders = CoreClientHeaders;
+  export type ClientLifecycleHooks<TData = unknown> = CoreClientLifecycleHooks<TData>;
+  export type ClientRequestEvent = CoreClientRequestEvent;
+  export type ClientResponseEvent<TData = unknown> = CoreClientResponseEvent<TData>;
 
   export interface APIClientOptions extends CoreAPIClientOptions {
     baseURL?: string;
@@ -1340,7 +1346,7 @@ declare module "@farm.js/core/client" {
    */
   export type IntegrationClientData = Record<string, unknown>;
 
-  export interface IntegrationClientOptions {
+  export interface IntegrationClientOptions extends ClientLifecycleHooks {
     fetch?: typeof globalThis.fetch;
     timeoutMs?: number;
     baseURL?: string;
@@ -1350,7 +1356,7 @@ declare module "@farm.js/core/client" {
     isServer?: false | undefined;
   }
 
-  interface IntegrationRequestOptionsBase {
+  interface IntegrationRequestOptionsBase<TData = unknown> extends ClientLifecycleHooks<TData> {
     timeoutMs?: number;
     headers?: Record<string, string>;
     signal?: AbortSignal;
@@ -1358,7 +1364,9 @@ declare module "@farm.js/core/client" {
     data?: IntegrationClientData;
   }
 
-  export interface IntegrationClientRequestOptions extends IntegrationRequestOptionsBase {}
+  export interface IntegrationClientRequestOptions<
+    TData = unknown,
+  > extends IntegrationRequestOptionsBase<TData> {}
 
   export type IntegrationServerRequestLike =
     | Request
@@ -1376,7 +1384,9 @@ declare module "@farm.js/core/client" {
     forwardHeaders?: boolean | readonly string[];
   }
 
-  export interface IntegrationServerClientRequestOptions extends IntegrationRequestOptionsBase {
+  export interface IntegrationServerClientRequestOptions<
+    TData = unknown,
+  > extends IntegrationRequestOptionsBase<TData> {
     baseURL?: string;
     request?: IntegrationServerRequestLike;
     forwardHeaders?: boolean | readonly string[];
@@ -1434,7 +1444,7 @@ declare module "@farm.js/core/client" {
 
   type IntegrationOperationMethod<T> = (
     options?: IntegrationOperationInput<T>,
-    requestOptions?: IntegrationClientRequestOptions,
+    requestOptions?: IntegrationClientRequestOptions<ExtractIntegrationOperationResponse<T>>,
   ) => Promise<IntegrationOperationResult<ExtractIntegrationOperationResponse<T>>>;
 
   type IsUnion<T, U = T> = T extends any ? ([U] extends [T] ? false : true) : never;
@@ -1507,7 +1517,7 @@ declare module "@farm.js/core/client" {
 
   type IntegrationServerOperationMethod<T> = (
     options?: IntegrationOperationInput<T>,
-    requestOptions?: IntegrationServerClientRequestOptions,
+    requestOptions?: IntegrationServerClientRequestOptions<ExtractIntegrationOperationResponse<T>>,
   ) => Promise<IntegrationOperationResult<ExtractIntegrationOperationResponse<T>>>;
 
   type ServerOperationKeys<TAPI> = {

--- a/skills/farmjs/SKILL.md
+++ b/skills/farmjs/SKILL.md
@@ -226,6 +226,13 @@ modules. See `docs/src/app/docs/api-client/page.md#header-defaults` and the inte
 
 ## Typed APIs and Server Data
 
+Caller instances support `onRequest`, `onResponse`, and `onError` observers. Shared hooks are
+invoked before per-call hooks; their return values are ignored and failures are reported without
+breaking calls. Attempt hooks skip cache hits and deduplicated transports; final error hooks run
+per logical call, including background failures. Integration/server overrides replace the
+corresponding default hook, not per-call composition. Shared data is unknown; per-call data stays
+typed. Do not use non-awaited observers for required work or import server secrets into them.
+
 Caller `fetch` options replace HTTP only, including integration server fallback. Local route and
 registered integration dispatch remain local. Forward the supplied RequestInit/signal and return
 a Web Response. Custom-transport route caches are instance-private even with shared scope;

--- a/tests/e2e/framework-features.spec.ts
+++ b/tests/e2e/framework-features.spec.ts
@@ -493,6 +493,14 @@ test.describe("Framework feature integration", () => {
     await page.goto("/feature-lab/integrations");
     await page.evaluate(() => {
       document.documentElement.lang = "fr";
+      const events: string[] = [];
+      (window as any).__integrationEvents = events;
+      for (const name of ["request", "response"]) {
+        window.addEventListener(`integration-lab:${name}`, (event) => {
+          const { method, path, status } = (event as CustomEvent).detail;
+          events.push(`${name}:${method}:${path}:${status ?? ""}`);
+        });
+      }
     });
 
     await page.getByTestId("call-integration-routes").click();
@@ -501,6 +509,10 @@ test.describe("Framework feature integration", () => {
     );
     await expect(page.getByTestId("integration-client-routes")).toContainText('"caller":"browser"');
     await expect(page.getByTestId("integration-client-routes")).toContainText('"language":"fr"');
+    expect(await page.evaluate(() => (window as any).__integrationEvents)).toEqual([
+      "request:POST:/api/route-lab/message:",
+      "response:POST:/api/route-lab/message:200",
+    ]);
     await expect(page.getByTestId("integration-client-routes")).toContainText(
       '"transport":"custom-fetch"',
     );


### PR DESCRIPTION
## Problem

Applications cannot configure lifecycle reporting once for a paired caller. App routes have per-call hooks, but integration callers have no equivalent, so adding a local UI callback cannot be combined consistently with global reporting.

## Root cause

Route callbacks belong only to individual calls and integration result handling has no observer boundary.

## Change

- Add shared `onRequest`, `onResponse`, and `onError` options across route/integration factories, plus typed per-call integration observers.
- Invoke the effective shared hook first and then the per-call hook; preserve route-specific and integration operation response inference.
- Reuse the existing safe response-observer policy: synchronous errors and rejected promises are reported, observer return values are ignored, and observers are not awaited.
- Observe attempts (including retries/background refresh) rather than cache hits; deduplicated transports share attempt events and final errors are reported once per logical call.
- Include actual response metadata for HTTP and direct integration dispatch, including resolver/cancellation failure paths. Avoid event creation on the disabled integration path.

Stacked on #971 (which is stacked on #969). This diff contains only lifecycle hooks; merge in that order. No merge or release is performed by this change.

## Safety and compatibility

Ordinary callbacks, not React hooks. Browser/server boundaries and local dispatch remain unchanged. Shared data is unknown; per-call data stays typed. Existing per-call app-route success/settlement/status behavior remains supported. Shared hooks and new integration observers cannot fail the request by throwing or rejecting; legacy per-call onResponse keeps its existing reporting format. Async observers are invoked in order but their completion is not awaited.

Integration/server instance overrides replace the corresponding shared default, while per-call hooks still compose. Attempt response events observe already-completed work; aborting from a response observer does not retroactively change it or emit a duplicate response event. Do not use observers for required background work or put server credentials in shared modules. No new retries, dependencies, targets, or versions.

## Verification

macOS arm64, Node 23.11.0 and Node 24.21.0, pnpm 8.12.1:

- 137 focused tests pass across API client typing, route/paired/integration callers, header resolvers, cancellation, custom fetch, and 12 lifecycle-hook cases.
- All 7 initial lifecycle regressions fail on the parent implementation; additional cases cover direct dispatch, resolver failure, overrides, completed-attempt aborts, and background failures.
- Published declaration compilation passes for lifecycle hooks, fetch, cancellation, and headers (4 tests), including inference and rejected invalid options.
- `pnpm --filter @farm.js/core type-check`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @farm.js/core build`
- `pnpm docs:check-navigation`
- `pnpm --dir docs exec farm generate --check`
- `pnpm docs:build` (Vercel output)
- `pnpm exec playwright test tests/e2e/framework-features.spec.ts --grep 'runs integration handlers' --config playwright.production.config.ts` (Node production build, Chromium): verifies ordered request/response events emitted by the real shared integration caller, plus custom-fetch HTTP and direct server behavior.
- Focused oxfmt/oxlint: 0 errors; existing unused integration helper warning.

The inherited Node 24 mixed-realm test correction belongs to #969. Vercel's hosted previews currently report the account build-rate limit; local production and documentation builds pass. Full GitHub CI is dispatched explicitly for feature-based PRs, since automatic PR CI targets main only.

## Documentation and release

Updated API-client and integration guides, published client facade, Farm skill, existing integration-lab example, and browser regression. No generated route churn, release versions, tags, or new packages.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds shared `onRequest`, `onResponse`, and `onError` lifecycle hooks to route and integration callers so apps can report execution lifecycle once instead of wiring per-call hooks. Shared hooks run before per-call hooks, and integration per-call response data stays inferred from the operation.

- Hooks observe attempts, including retries and background refreshes, rather than cache hits; deduplicated transports share attempt events and final errors report once per logical call.
- Return values are ignored, thrown or rejected hooks are reported without failing the call, and observers are not awaited.
- Integration and server option overrides replace the corresponding shared default; per-call hooks still compose.
- Response events include metadata for HTTP and direct dispatch, including resolver and cancellation failures; disabled integration paths emit no events.
- Shared data is typed as `unknown`; per-call data remains typed.
- Updates API-client and integration docs, the integration-lab example, the Farm skill, and an e2e assertion.
- No migration or release steps are required.

<sup>Written for commit 6567915992b6ad5ac3fc140bfaacce58aa0efdc6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/farming-labs/farm.js/pull/972?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

